### PR TITLE
Don't include enum values in the where clause.

### DIFF
--- a/rest-api/data_access_object.py
+++ b/rest-api/data_access_object.py
@@ -287,8 +287,10 @@ class DataAccessObject(object):
 
     for col in obj_columns:
       val = getattr(obj, col, None)
-      if val:
-        field = getattr(self.resource, col)
+      field = getattr(self.resource, col)
+      # Enums will always have a default value. Only add an enum val to the
+      # query if the value is not the default.
+      if (type(field) != messages.EnumField and val) or val != field.default:
         cols.append(col)
         keys.append(_marshall_field(field, val))
 


### PR DESCRIPTION
Enums always have a default value, usually 0.  When an enum matches its
default value, it's not specified, so don't use it to restrict the where clause.
