### PR TITLE
Turn off the endpoints auth check.

### DIFF
--- a/rest-api/metrics_api.py
+++ b/rest-api/metrics_api.py
@@ -13,6 +13,13 @@ from protorpc import messages
 from protorpc import protojson
 from protorpc import remote
 
+# Note that auth_level is missing.  This makes sure that the user is
+# authenticated before the endpoint is called.  This is unnecessary as this
+# check is insufficient, and we we are doing a string account whitelisting in
+# check_auth().  Ideally we would turn it on anyway, but at the moment, it
+# causes errors saying that this API is not enabled for the service account's
+# project... And there is no way to enable the API. This API enabling should
+# work fine once we upgrade to Cloud Endpoints 2.0.
 metrics_api = endpoints.api(
     name='metrics',
     version='v1',

--- a/rest-api/participants_api.py
+++ b/rest-api/participants_api.py
@@ -71,6 +71,13 @@ participants_api = endpoints.api(
     allowed_client_ids=config.getSettingList(config.ALLOWED_CLIENT_ID),
     scopes=[endpoints.EMAIL_SCOPE])
 
+# Note that auth_level is missing.  This makes sure that the user is
+# authenticated before the endpoint is called.  This is unnecessary as this
+# check is insufficient, and we we are doing a string account whitelisting in
+# check_auth().  Ideally we would turn it on anyway, but at the moment, it
+# causes errors saying that this API is not enabled for the service account's
+# project... And there is no way to enable the API. This API enabling should
+# work fine once we upgrade to Cloud Endpoints 2.0.
 @participants_api
 class ParticipantApi(remote.Service):
   @endpoints.method(


### PR DESCRIPTION
It tries to get you to enable the API in the cloud console before
calling the API..  But the API isn't in cloud console yet.
