### PR TITLE
Simple extractors for Participant, QuestionnaireResponse

### DIFF
--- a/rest-api/extraction.py
+++ b/rest-api/extraction.py
@@ -1,0 +1,116 @@
+from fhirclient.models.fhirelementfactory import FHIRElementFactory
+from questionnaire_response import DAO as QuestionnaireResponseDAO, QuestionnaireResponse
+from participant import DAO as ParticipantDAO, Participant, GenderIdentity, MembershipTier
+import json
+import os
+
+# TODO: Grab this from a database
+gender_mappings = {
+    "Questionnaire/{questionnaire_id}": {
+        "linkId": "sex",
+        "values": [{
+            "from": {
+                "valueCoding": {"code": "f"}
+                },
+            "to": "FEMALE"
+            },{
+            "from": {
+                "valueCoding": {"code": "m"}
+                },
+            "to": "MALE"
+        }]
+    }
+}
+
+def as_list(v):
+    if type(v) != list:
+        return [v]
+    return v
+
+def get_questions_by_link_id(qr, target_link_id):
+    ret = []
+    if hasattr(qr, 'linkId') and qr.linkId == target_link_id:
+        ret += [qr]
+    for prop in ('question', 'group', 'answer'):
+        if hasattr(qr, prop):
+            ret += [v
+                    for q in as_list(getattr(qr, prop))
+                    for v in get_questions_by_link_id(q, target_link_id)]
+    return ret
+
+
+def answer_matches(answer, template):
+    for k,v in template.iteritems():
+        if not hasattr(answer, k):
+            return False
+        if type(v) == dict:
+            if not answer_matches(getattr(answer, k), v):
+                return False
+        elif v != getattr(answer, k):
+            return False
+    return True
+
+class Extractor(object): pass
+
+class PropertyExtractor(Extractor):
+    model = Participant
+    def __init__(self, property):
+        self.property = property
+    def extract(self, participant):
+        # return getattr(participant, self.property)
+        return str(getattr(participant, self.property))
+
+
+class QuestionnaireResponseExtractor(Extractor):
+    model = QuestionnaireResponse
+    def __init__(self, target_type, mappings):
+        self.target_type = target_type
+        self.mappings = mappings
+
+    def extract(self, obj):
+        r = obj.resource
+        r_fhir = FHIRElementFactory.instantiate(r['resourceType'], r)
+        source_questionnaire = r_fhir.questionnaire.reference
+        if source_questionnaire not in self.mappings:
+            raise BaseException('No mappings for %s'%source_questionnaire)
+
+        mapping = self.mappings[source_questionnaire]
+        link_id = mapping['linkId']
+        qs = get_questions_by_link_id(r_fhir, link_id)
+        if len(qs) == 1 and len(qs[0].answer) == 1:
+            answer = qs[0].answer[0]
+            for v in mapping['values']:
+                if answer_matches(answer, v['from']):
+                    #return self.target_type(v['to'])
+                    return str(v['to'])
+
+extractors = {
+        'gender': QuestionnaireResponseExtractor(GenderIdentity, gender_mappings),
+        'membership_tier': PropertyExtractor("membership_tier"),
+        }
+
+
+# Hacky way to test this, by adding an API endpoint
+
+from flask import Flask, request
+from flask.ext.restful import Resource, reqparse, abort
+
+
+def extract_from_history(q):
+    return {
+        'date': q.date.isoformat(),
+        'properties': {
+            ename: extractor.extract(q.obj)
+            for ename, extractor in extractors.iteritems()
+            if type(q.obj) == extractor.model
+        }
+    }
+
+class Extraction(Resource):
+    def get(self):
+        sources = (ParticipantDAO, QuestionnaireResponseDAO)
+        ret = [extract_from_history(q)
+                for dao in sources
+                for q in dao.history_model.query()
+                ]
+        return ret

--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -7,6 +7,7 @@ import metrics_api
 import participants_api
 import ppi_api
 
+
 from flask import Flask, jsonify
 from flask_restful import Api
 
@@ -45,3 +46,9 @@ api.add_resource(metrics_api.MetricsApi,
                  '/metrics/v1/metrics',
                  endpoint='metrics',
                  methods=['POST'])
+
+import extraction
+api.add_resource(extraction.Extraction,
+                 '/extraction',
+                 endpoint='extraction',
+                 methods=['get'])

--- a/rest-api/test/ppi.py
+++ b/rest-api/test/ppi.py
@@ -29,9 +29,10 @@ class TestPPI(unittest.TestCase):
   def test_questionnaire_responses(self):
     questionnaire_response_files = [
         # Stripped down version of the official FHIR example
-        'test-data/questionnaire_response1.json',
+        #'test-data/questionnaire_response1.json',
         # Example response from vibrent.  Doesn't pass validation.
         #'test-data/questionnaire_response2.json',
+        'test-data/questionnaire_response3.json',
     ]
     participant_id = test_util.create_participant(
         'Bovine', 'Knickers', '1970-10-10')

--- a/rest-api/test/test-data/questionnaire_response3.json
+++ b/rest-api/test/test-data/questionnaire_response3.json
@@ -1,0 +1,149 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "status": "completed",
+  "subject": {
+    "reference": "Patient/{participant_id}"
+  },
+  "questionnaire": {
+    "reference": "Questionnaire/{questionnaire_id}"
+  },
+  "author": {
+    "reference": "http://hl7.org/fhir/Practitioner/example"
+  },
+  "authored": "2013-02-19T14:15:00+10:00",
+  "group": {
+    "linkId": "PHR",
+    "title": "NSW Government My Personal Health Record, january 2013",
+    "group": [
+      {
+        "linkId": "birthDetails",
+        "title": "Birth details - To be completed by health professional",
+        "group": [
+          {
+            "question": [
+              {
+                "linkId": "nameOfChild",
+                "text": "Name of child",
+                "answer": [
+                  {
+                    "valueString": "Cathy Jones"
+                  }
+                ]
+              },
+              {
+                "linkId": "sex",
+                "text": "Sex",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "code": "f"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "linkId": "neonatalInformation",
+            "title": "Neonatal Information",
+            "question": [
+              {
+                "linkId": "birthWeight",
+                "text": "Birth weight (kg)",
+                "answer": [
+                  {
+                    "valueDecimal": 3.25
+                  }
+                ]
+              },
+              {
+                "linkId": "birthLength",
+                "text": "Birth length (cm)",
+                "answer": [
+                  {
+                    "valueDecimal": 44.3
+                  }
+                ]
+              },
+              {
+                "linkId": "vitaminKgiven",
+                "text": "Vitamin K given",
+                "answer": [
+                  {
+                    "valueCoding": {
+                      "code": "INJECTION"
+                    },
+                    "group": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://example.org/Profile/questionnaire#visibilityCondition",
+                            "valueString": "HAS_VALUE(../choice/code) AND NEQ(../choice/code,'NO')"
+                          }
+                        ],
+                        "linkId": "vitaminKgivenDoses",
+                        "question": [
+                          {
+                            "linkId": "vitaminiKDose1",
+                            "text": "1st dose",
+                            "answer": [
+                              {
+                                "valueDate": "1972-11-30"
+                              }
+                            ]
+                          },
+                          {
+                            "linkId": "vitaminiKDose2",
+                            "text": "2nd dose",
+                            "answer": [
+                              {
+                                "valueDate": "1972-12-11"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "hepBgiven",
+                "text": "Hep B given y / n",
+                "answer": [
+                  {
+                    "valueBoolean": true,
+                    "group": [
+                      {
+                        "linkId": "hepBgivenDate",
+                        "question": [
+                          {
+                            "text": "Date given",
+                            "answer": [
+                              {
+                                "valueDate": "1972-12-04"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "abnormalitiesAtBirth",
+                "text": "Abnormalities noted at birth",
+                "answer": [
+                  {
+                    "valueString": "Already able to speak Chinese"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This isn't to merge at this point -- but playing with a model of extracting data from our various history entities. Currently: Participant (status) and QuestionnaireResponse (gender).

Given extractors like:

``` py
extractors = {
    'gender': QuestionnaireResponseExtractor(GenderIdentity, gender_mappings),
    'membership_tier': PropertyExtractor("membership_tier"),
}
```

Outputs structures like these:

```
$ curl -s  http://localhost:8080/extraction | json_pp
[
   {
      "properties" : {
         "membership_tier" : "None"
      },
      "date" : "2016-09-29T20:04:27.758599"
   },
   {
      "date" : "2016-09-29T19:09:26.830145",
      "properties" : {
         "membership_tier" : "CONSENTED"
      }
   },
   {
      "date" : "2016-09-29T20:21:35.892812",
      "properties" : {
         "gender" : "FEMALE"
      }
   }
]
```
