### PR TITLE
Add status badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Repository for code related to the PMI RDR
 
+![Build Status of master](https://circleci.com/gh/vanderbilt/pmi-data.png?circle-token=be5ab3e1a27746993aa0eca88d90f421b72a2b6e)
+
 (Precision Medicine Initiative - Raw Data Repository)
 
 This repository contains code for the APIs that run the RDR. The structure is:


### PR DESCRIPTION
Note "circle-token" is **narrowly scoped** to badge access only. This is considered public, non-sensitive info. From https://circleci.com/gh/vanderbilt/pmi-data/edit#api:

![image](https://cloud.githubusercontent.com/assets/313089/19523574/f0e2f534-95e8-11e6-88b4-3518cf57cc57.png)

Just this once, I'm going to propose we allow merging of a **broken** build (because it was already broken anyway, and this commit just adds visibility for the first time).
