### PR TITLE
Adds a participant summary endpoint.

### DIFF
--- a/rest-api/biobank_order.py
+++ b/rest-api/biobank_order.py
@@ -4,12 +4,9 @@
 import api_util
 
 import data_access_object
-import identifier
 import participant
 
-from protorpc import messages
 from google.appengine.ext import ndb
-from google.appengine.ext.ndb import msgprop
 
 class BiobankOrderIdentifier(ndb.Model):
   """An identifier for a Biobank order"""

--- a/rest-api/data_access_object.py
+++ b/rest-api/data_access_object.py
@@ -123,7 +123,7 @@ class DataAccessObject(object):
       raise Conflict('{} with key {} already exists'.format(
           self.model_name, model.key))
     return self.store(model, date, client_id)
-  
+
   @ndb.transactional
   def update(self, model, date=None, client_id=None):
     if not model.key.get():
@@ -143,6 +143,16 @@ class DataAccessObject(object):
 
   def get_all_history(self, ancestor_key):
     return self.history_model.query(ancestor=ancestor_key).fetch()
+
+  def children(self, parent):
+    """Gets all objects that have parent as an ancestor."""
+    return self.model_type.query(ancestor=parent.key).fetch()
+
+  def last_history(self, obj):
+    """Gets the history object associated with the last update to obj."""
+    query = self.history_model.query(ancestor=obj.key).order(-self.history_model.date)
+    hists = query.fetch(limit=1)
+    return hists and hists[0] or None
 
   def _make_key(self, id_, ancestor_id):
     if ancestor_id:

--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -34,6 +34,12 @@ api.add_resource(
     endpoint='participant.evaluation',
     methods=['GET', 'POST',])
 
+api.add_resource(
+    participants_api.ParticipantSummaryAPI,
+    PREFIX + 'Participant/<string:id_>/Summary',
+    endpoint='participant.summary',
+    methods=['GET',])
+
 api.add_resource(ppi_api.QuestionnaireAPI,
                  PREFIX + 'Questionnaire',
                  PREFIX + 'Questionnaire/<string:id_>',

--- a/rest-api/offline/metrics_config.py
+++ b/rest-api/offline/metrics_config.py
@@ -51,14 +51,14 @@ METRICS_CONFIGS = {
                 FieldDef('gender_identity',
                          extraction.simple_field_extractor('gender_identity')),
                 FieldDef('age_range', participant.extract_bucketed_age),
-                FieldDef('hpo_id', participant.extract_HPO_id)            
+                FieldDef('hpo_id', participant.extract_HPO_id)
             ],
             'QuestionnaireResponseHistory': [
                 FieldDef('race', questionnaire_response.extract_race),
                 FieldDef('ethnicity', questionnaire_response.extract_ethnicity),
                 # The presence of a response means that some have been submitted.
                 FieldDef('survey', lambda h: ExtractionResult('SUBMITTED_SOME')),
-                FieldDef('state',  questionnaire_response.extract_state_of_residence),
+                FieldDef('state', questionnaire_response.extract_state_of_residence),
                 FieldDef('census_region', questionnaire_response.extract_census_region)
             ],
             'EvaluationHistory': [

--- a/rest-api/offline/metrics_pipeline.py
+++ b/rest-api/offline/metrics_pipeline.py
@@ -60,21 +60,15 @@ import pipeline
 
 import api_util
 import config
-import extraction
 import metrics
-import metrics_config
-import participant
-import questionnaire
-import questionnaire_response
+import offline.metrics_config
 
 from datetime import datetime
 from collections import Counter
-from google.appengine.api import app_identity
 from google.appengine.ext import ndb
 from mapreduce import mapreduce_pipeline
-from mapreduce import util
 from mapreduce import operation as op
-from protorpc import messages
+
 
 from metrics import MetricsBucket
 
@@ -88,7 +82,7 @@ TOTAL_SENTINEL = '__total_sentinel__'
 
 # This can be overridden for unit-tests, however, this hardcoded config will be
 # used whenever a mapper starts up in a new app engine instance.
-METRICS_CONFIGS=metrics_config.METRICS_CONFIGS
+METRICS_CONFIGS=offline.metrics_config.METRICS_CONFIGS
 
 class MetricsPipeline(pipeline.Pipeline):
   def run(self, *args, **kwargs):

--- a/rest-api/questionnaire_response.py
+++ b/rest-api/questionnaire_response.py
@@ -10,7 +10,6 @@ from participant import Participant
 from participant import GenderIdentity
 from questionnaire import DAO as questionnaireDAO
 from questionnaire import QuestionnaireExtractor
-from werkzeug.exceptions import NotFound
 
 class QuestionnaireResponse(ndb.Model):
   """The questionnaire response."""
@@ -76,24 +75,24 @@ class QuestionnaireResponseExtractor(extraction.FhirExtractor):
         extraction.Concept('http://terminology.pmi-ops.org/ppi/gender-identity',
                            'female'): GenderIdentity.FEMALE,
         extraction.Concept('http://terminology.pmi-ops.org/ppi/gender-identity',
-                           'female-to-male-transgender'): GenderIdentity.FEMALE_TO_MALE_TRANSGENDER,                              
+                           'female-to-male-transgender'): GenderIdentity.FEMALE_TO_MALE_TRANSGENDER,
         extraction.Concept('http://terminology.pmi-ops.org/ppi/gender-identity',
-                           'male'): GenderIdentity.MALE,                              
+                           'male'): GenderIdentity.MALE,
         extraction.Concept('http://terminology.pmi-ops.org/ppi/gender-identity',
                            'male-to-female-transgender'): GenderIdentity.MALE_TO_FEMALE_TRANSGENDER,
         extraction.Concept('http://terminology.pmi-ops.org/ppi/gender-identity',
-                           'intersex'): GenderIdentity.INTERSEX,                              
+                           'intersex'): GenderIdentity.INTERSEX,
         extraction.Concept('http://terminology.pmi-ops.org/ppi/gender-identity',
                            'other'): GenderIdentity.OTHER,
         extraction.Concept('http://hl7.org/fhir/v3/NullFlavor',
                           'ASKU'): GenderIdentity.PREFER_NOT_TO_SAY,
   }
-  
+
   _STATE_MAPPING = {
     extraction.Concept('http://terminology.pmi-ops.org/ppi/state', state): state
-    for state in census_regions.keys()      
+    for state in census_regions.keys()
   }
-  
+
   CONFIGS = {
       extraction.ETHNICITY_CONCEPT: Config('valueCoding', _ETHNICITY_MAPPING),
       extraction.RACE_CONCEPT: Config('valueCoding', _RACE_MAPPING),
@@ -128,21 +127,21 @@ def extract_ethnicity(qr_hist_obj):
   return extract_field(qr_hist_obj.obj, extraction.ETHNICITY_CONCEPT)
 
 def extract_gender_identity(qr_hist_obj):
-  """Returns ExtractionResult for gender identity answer from questionnaire response."""  
+  """Returns ExtractionResult for gender identity answer from questionnaire response."""
   return extract_field(qr_hist_obj.obj, extraction.GENDER_IDENTITY_CONCEPT)
 
 def extract_state_of_residence(qr_hist_obj):
-  """Returns ExtractionResult for state of residence answer from questionnaire response."""  
+  """Returns ExtractionResult for state of residence answer from questionnaire response."""
   return extract_field(qr_hist_obj.obj, extraction.STATE_OF_RESIDENCE_CONCEPT)
 
 def extract_census_region(qr_hist_obj):
-  """Returns ExtractionResult for census region from questionnaire response."""  
+  """Returns ExtractionResult for census region from questionnaire response."""
   state_result = extract_state_of_residence(qr_hist_obj)
   if state_result.extracted:
     census_region = census_regions.get(state_result.value)
     if census_region:
       return extraction.ExtractionResult(census_region, True)
-  return extraction.ExtractionResult(None, False)  
+  return extraction.ExtractionResult(None, False)
 
 @ndb.non_transactional
 def extract_field(obj, concept):
@@ -156,7 +155,7 @@ def extract_field(obj, concept):
             questionnaire_id, response_extractor.extract_id()))
   questionnaire_extractor = QuestionnaireExtractor(questionnaire.resource)
   link_ids = questionnaire_extractor.extract_link_id_for_concept(concept)
-  
+
   if not len(link_ids) == 1:
     return extraction.ExtractionResult(None, False)  # Failed to extract answer
   # Questionnaire unambiguously asked the desired question.

--- a/rest-api/test/client_test/__init__.py
+++ b/rest-api/test/client_test/__init__.py
@@ -1,0 +1,4 @@
+"""Tests that are intended to hit a running server.
+
+This file is here mainly to make pylint pick up the proper pylintrc.
+"""

--- a/rest-api/test/test-data/questionnaire_demographics.json
+++ b/rest-api/test/test-data/questionnaire_demographics.json
@@ -1,85 +1,85 @@
-{  
+{
    "resourceType":"Questionnaire",
    "status":"published",
    "date":"2016-10-17T16:12:30-04:00",
    "publisher":"admin",
-   "group":{  
+   "group":{
       "linkId":"root",
       "title":"demographics",
       "required":true,
       "repeats":false,
-      "group":[  
-         {  
+      "group":[
+         {
             "linkId":"1",
-            "group":[  
-               {  
+            "group":[
+               {
                   "linkId":"1.1",
-                  "question":[  
-                     {  
+                  "question":[
+                     {
                         "linkId":"1.1.1",
                         "text":"Birth Date",
                         "type":"date"
                      }
                   ]
                },
-               {  
+               {
                   "linkId":"1.2",
-                  "question":[  
-                     {  
+                  "question":[
+                     {
                         "linkId":"1.2.1",
                         "text":"Please provide whatever you feel comfortable providing. These are optional - Race",
                         "type":"choice",
-                        "option":[  
-                           {  
+                        "option":[
+                           {
                               "code":"American Indian or Alaskan Native",
                               "display":"American Indian or Alaskan Native"
                            },
-                           {  
+                           {
                               "code":"Asian",
                               "display":"Asian"
                            },
-                           {  
+                           {
                               "code":"Black or African American",
                               "display":"Black or African American"
                            },
-                           {  
+                           {
                               "code":"Native Hawaiian or Pacific Islander",
                               "display":"Native Hawaiian or Pacific Islander"
                            },
-                           {  
+                           {
                               "code":"White",
                               "display":"White"
                            },
-                           {  
+                           {
                               "code":"Other",
                               "display":"Other"
                            },
-                           {  
+                           {
                               "code":"Prefer not to answer",
                               "display":"Prefer not to answer"
                            }
                         ]
                      },
-                     {  
+                     {
                         "linkId":"1.2.2",
                         "text":"Please provide whatever you feel comfortable providing. These are optional - Ethnicity",
                         "type":"choice",
-                        "option":[  
-                           {  
+                        "option":[
+                           {
                               "code":"1",
                               "display":"Answer Choice 1"
                            },
-                           {  
+                           {
                               "code":"2",
                               "display":"Option 2"
                            },
-                           {  
+                           {
                               "code":"3",
                               "display":"Option 3"
                            }
                         ]
                      },
-                     {  
+                     {
                         "linkId":"1.2.3",
                         "text":"Please provide whatever you feel comfortable providing. These are optional- Gender",
                         "type":"choice",
@@ -88,38 +88,38 @@
                            "code": "76691-5",
                            "display": "Gender Identity"
                         }],
-                        "option":[  
-                           {  
+                        "option":[
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/gender-identity",
                               "code":"female",
                               "display":"Female"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/gender-identity",
                               "code":"female-to-male-transgender",
                               "display":"Female to Male Transgender   "
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/gender-identity",
                               "code":"male",
                               "display":"Male"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/gender-identity",
                               "code":"male-to-female-transgender",
                               "display":"Male to Female Transgender"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/gender-identity",
                               "code":"intersex",
                               "display":"Intersex"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/gender-identity",
                               "code":"other",
                               "display":"Other"
                            },
-                           {  
+                           {
                               "system": "http://hl7.org/fhir/v3/NullFlavor",
                               "code":"ASKU",
                               "display":"Prefer not to answer"
@@ -128,19 +128,19 @@
                      }
                   ]
                },
-               {  
+               {
                   "linkId":"1.3",
-                  "question":[  
-                     {  
-                        "extension":[  
-                           {  
+                  "question":[
+                     {
+                        "extension":[
+                           {
                               "url":"http://hl7.org/fhir/StructureDefinition/translation",
-                              "extension":[  
-                                 {  
+                              "extension":[
+                                 {
                                     "url":"lang",
                                     "valueCode":"es"
                                  },
-                                 {  
+                                 {
                                     "url":"content",
                                     "valueString":"Favor ingresar su código postal"
                                  }
@@ -159,259 +159,259 @@
                            "system": "http://loinc.org",
                            "code": "46499-0",
                            "display": "State of residence"
-                        }],                  
-                        "option":[  
-                           {  
+                        }],
+                        "option":[
+                           {
                               "system":"http://terminology.pmi-ops.org/ppi/state",
                               "code":"AL",
                               "display":"Alabama (AL)"
                            },
-                           {  
+                           {
                               "system":"http://terminology.pmi-ops.org/ppi/state",
                               "code":"AK",
                               "display":"Alaska (AK)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"AZ",
                               "display":"Arizona (AZ)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"AR",
                               "display":"Arkansas (AR)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"CA",
                               "display":"California (CA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"CO",
                               "display":"Colorado (CO)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"CT",
                               "display":"Connecticut (CT)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"DE",
                               "display":"Delaware (DE)"
                            },
-                                                      {  
+                                                      {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"FL",
                               "display":"Florida (FL)"
                            },
-                                                      {  
+                                                      {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"GA",
                               "display":"Georgia (GA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"HI",
                               "display":"Hawaii (HI)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"ID",
                               "display":"Idaho (ID)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"IL",
                               "display":"Illinois (IL)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"IN",
                               "display":"Indiana (IN)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"IA",
                               "display":"Iowa (IA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"KS",
                               "display":"Kansas (KS)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"KY",
                               "display":"Kentucky (KY)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"LA",
                               "display":"Louisiana (LA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"ME",
                               "display":"Maine (ME)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"MD",
                               "display":"Maryland (MA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"MA",
                               "display":"Massachusetts (MA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"MI",
                               "display":"Michigan (MI)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"MN",
                               "display":"Minnesota (MN)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"MS",
                               "display":"Mississippi (MS)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"MO",
                               "display":"Missouri (MO)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"MT",
                               "display":"Montana (MT)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"NE",
                               "display":"Nebraska (NE)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"NV",
                               "display":"Nevada (NV)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"NH",
                               "display":"New Hampshire (NH)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"NJ",
                               "display":"New Jersey (NJ)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"NM",
                               "display":"New Mexico (NM)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"NY",
                               "display":"New York (NY)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"NC",
                               "display":"North Carolina (NC)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"ND",
                               "display":"North Dakota (ND)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"OH",
                               "display":"Ohio (OH)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"OK",
                               "display":"Oklahoma (OK)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"OR",
                               "display":"Oregon (OR)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"PA",
                               "display":"Pennsylvania (PA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"RI",
                               "display":"Rhode Island (RI)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"SC",
                               "display":"South Carolina (SC)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"SD",
                               "display":"South Dakota (SD)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"TN",
                               "display":"Tennessee (TN)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"TX",
                               "display":"Texas (TX)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"UT",
                               "display":"Utah (UT)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"VT",
                               "display":"Vermont (VT)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"VA",
                               "display":"Virginia (VA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"WA",
                               "display":"Washington (WA)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"WV",
                               "display":"West Virginia (WV)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"WI",
                               "display":"Wisconsin (WI)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"WY",
                               "display":"Wyoming (WY)"
                            },
-                           {  
+                           {
                               "system": "http://terminology.pmi-ops.org/ppi/state",
                               "code":"ZZ",
                               "display":"Other / Unknown"
@@ -420,7 +420,7 @@
                      }
                   ]
                },
-               {  
+               {
                   "linkId":"1.4"
                }
             ]

--- a/rest-api/test/test-data/questionnaire_response_demographics.json
+++ b/rest-api/test/test-data/questionnaire_response_demographics.json
@@ -59,7 +59,10 @@
                 "linkId": "1.3.2",
                 "answer": [
                   {
-                    "valueString": "AL"
+                    "valueCoding": {
+                      "system": "http://terminology.pmi-ops.org/ppi/state",
+                      "code": "AL"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
This runs the metrics extractors on the current version of every object
for a participant, and returns a map of the 'Participant Summary'.
DA-57 #open