### PR TITLE
Changing number of shards for metrics pipelines to 10. (100 seems lik…

### DIFF
--- a/rest-api/config/config_stable.json
+++ b/rest-api/config/config_stable.json
@@ -15,6 +15,6 @@
     "stable_biobank_samples_upload_bucket"
   ],
   "metrics_shards": [
-    "100"
+    "10"
   ]
 }

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -29,6 +29,6 @@
     "staging_biobank_samples_upload_bucket"
   ],
   "metrics_shards": [
-    "100"
+    "10"
   ]
 }

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -32,6 +32,6 @@
     "test_biobank_samples_upload_bucket"
   ],
   "metrics_shards": [
-    "100"
+    "10"
   ]
 }

--- a/rest-api/data_access_object.py
+++ b/rest-api/data_access_object.py
@@ -185,9 +185,12 @@ class DataAccessObject(object):
       self.make_history(model, date, client_id).put()
     return model.put()
 
-  def get_all_history(self, ancestor_key):
+  def get_all_history(self, ancestor_key, now=None):
     assert self.keep_history
-    return self.history_model.query(ancestor=ancestor_key).fetch()
+    result = self.history_model.query(ancestor=ancestor_key).fetch()
+    if now:
+      return [hist_obj for hist_obj in result if hist_obj.date <= now]
+    return result
 
   def children(self, parent):
     """Gets all objects that have parent as an ancestor."""

--- a/rest-api/participant.py
+++ b/rest-api/participant.py
@@ -110,7 +110,7 @@ def load_history_entities(participant_key, now):
     - Injects synthetic entries for when the participant's age changes.
     - Loads related QuestionnaireResponseHistory objects.
   """
-  history = list(DAO.get_all_history(participant_key))
+  history = list(DAO.get_all_history(participant_key, now))
   modify_participant_history(history, participant_key, now)
   return history
 
@@ -138,11 +138,11 @@ def modify_participant_history(history, participant_key, now):
       date = date + year
 
   import questionnaire_response
-  history.extend(questionnaire_response.DAO.get_all_history(participant_key))
+  history.extend(questionnaire_response.DAO.get_all_history(participant_key, now))
   import evaluation
-  history.extend(evaluation.DAO.get_all_history(participant_key))
+  history.extend(evaluation.DAO.get_all_history(participant_key, now))
   import biobank_order
-  history.extend(biobank_order.DAO.get_all_history(participant_key))
+  history.extend(biobank_order.DAO.get_all_history(participant_key, now))
   import biobank_sample
   samples = biobank_sample.DAO.load_if_present(biobank_sample.SINGLETON_SAMPLES_ID,
                                                participant_key.id())

--- a/rest-api/test/client_test/metrics.py
+++ b/rest-api/test/client_test/metrics.py
@@ -16,10 +16,10 @@ class MetricsTest(unittest.TestCase):
     self.maxDiff = None
     self.client = test_util.get_client('rdr/v1')
 
-  def testMembershipTier(self):
+  def testMetrics(self):
     request = {
-        'metric': 'PARTICIPANT_MEMBERSHIP_TIER',
-        'facets': ['HPO_ID'],
+        'start_date': '2017-01-21',
+        'end_date': '2017-01-22'
     }
     try:
       response = self.client.request_json('Metrics', 'POST', request)
@@ -27,20 +27,6 @@ class MetricsTest(unittest.TestCase):
     except client.client.HttpException as ex:
       if ex.code == 404:
         print "No metrics loaded"
-      else:
-        raise ex
-
-  def testParticipantTotal(self):
-    request = {
-        'metric': 'PARTICIPANT_TOTAL',
-        'bucket_by': 'NONE'
-    }
-    try:
-      response = self.client.request_json('Metrics', 'POST', request)
-      pprint.pprint(response)
-    except client.client.HttpException as ex:
-      if ex.code == 404:
-        print "No Metrics loaded"
       else:
         raise ex
 

--- a/rest-api/test/unit_test/data_access_object_test.py
+++ b/rest-api/test/unit_test/data_access_object_test.py
@@ -217,6 +217,10 @@ class DataAccessObjectTest(NdbTestBase):
     self.assertEquals(sorted(client_ids),
                       sorted(h.client_id for h in actual_history))
     self.assertEquals(range(3), sorted(int(h.obj.foo) for h in actual_history))
+    new_history = PARENT_DAO.get_all_history(key, dates[0])
+    self.assertEquals(actual_history, new_history)
+    empty_history = PARENT_DAO.get_all_history(key, datetime(2016, 9, 30))
+    self.assertEquals(0, len(empty_history))
 
   def test_history_child(self):
     dates = [datetime(2016, 10, 1) for i in range(3)]


### PR DESCRIPTION
…e maybe too many.)

Changing DataAccessObject.getAllHistory() to optionally filter based on date.

Changing participant history used by metrics pipeline to filter out everything after current time.

Prior to this change, the metrics pipeline would produce buckets for dates in the future (for data generated by load_fake_participants with future timestamps), without populating all the fields. We don't need metrics from the future, so we can ignore any participant history with a future timestamp... in practice there shouldn't be any data with future timestamps anyway.