### PR TITLE
Run participant summary pipeline every 48 hours.

### DIFF
--- a/rest-api/cron.yaml
+++ b/rest-api/cron.yaml
@@ -5,6 +5,9 @@ cron:
 - description: Hourly biosample reconciliation
   url: /rdr/v1/BiobankSamplesReload
   schedule: every 1 hours
+- description: Regeneration of participant summaries
+  url: /rdr/v1/RegenerateParticipantSummaries
+  schedule: every 48 hours
 - description: Daily age summary updates
   url: /rdr/v1/AgeRangeUpdate
   schedule: every 24 hours


### PR DESCRIPTION
This makes sure that it works for when we need it, and will regenerate summaries
should we forget to run backfill manually.

(Post-launch, I would recommend only running this pipeline when we actually
change something.)