### PR TITLE
Add _validate_model in base DAO. Incidental whitespace/wrapping.

### DIFF
--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -29,7 +29,7 @@ class BaseDao(object):
 
   def _validate_insert(self, session, obj):
     """Override to validate a new model before inserting it (not applied to updates)."""
-    self._validate_model(self, session, obj)
+    self._validate_model(session, obj)
 
   def insert_with_session(self, session, obj):
     """Adds the object into the session to be inserted."""


### PR DESCRIPTION
FYI, the one docstring I reformatted I did to follow the convention of:

```
"""The first line is the summary, which would show up prominently in a pydoc.

After a newline, there are paragraphs
of extra documentation. The closing quotes go on their own line.
"""
```