### PR TITLE
Changing install_config.sh to allow for project and account args

### DIFF
--- a/rest-api/tools/install_config.py
+++ b/rest-api/tools/install_config.py
@@ -44,7 +44,8 @@ def main(args):
 
     if not configs_match and args.update:
       print '-------------- Updating Server -------------------'
-      client.request_json(config_path, 'POST', combined_config,
+      method = 'POST' if args.key else 'PUT'
+      client.request_json(config_path, method, combined_config,
                           test_unauthenticated=False)
 
 def compare_configs(comparable_file, comparable_server):

--- a/rest-api/tools/install_config.sh
+++ b/rest-api/tools/install_config.sh
@@ -5,4 +5,39 @@
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 export PYTHONPATH=$PYTHONPATH:${BASE_DIR}:${BASE_DIR}/lib
 
-(cd ${BASE_DIR}; python tools/install_config.py $@)
+while true; do
+  case "$1" in
+    --account) ACCOUNT=$2; shift 2;;
+    --creds_account) CREDS_ACCOUNT=$2; shift 2;;
+    --project) PROJECT=$2; shift 2;;
+    --update) UPDATE=Y; shift 1;;
+    --config) CONFIG=$2; shift 2;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+if [ -z "${CREDS_ACCOUNT}" ]
+then
+  CREDS_ACCOUNT="${ACCOUNT}"
+fi
+
+EXTRA_ARGS="$@"
+if [ "${PROJECT}" ]
+then
+  echo "Getting credentials for ${PROJECT}..."
+  source tools/auth_setup.sh
+  EXTRA_ARGS="--creds_file ${CREDS_FILE} --instance ${INSTANCE}"
+  if [ "${CONFIG}" ]
+  then
+    EXTRA_ARGS+=" --config ${CONFIG}"
+  fi
+  if [ "${UPDATE}" ]
+  then
+    EXTRA_ARGS+=" --update"
+  fi
+  echo "ARGS = ${EXTRA_ARGS}"
+  
+fi
+
+(cd ${BASE_DIR}; python tools/install_config.py $EXTRA_ARGS)


### PR DESCRIPTION
that will cause creds to be retrieved and used automatically.

Changing install_config.py to use "PUT" for the main config, as that's what the
server in dryrun and stable currently supports.