### PR TITLE
Set charset for the local MySQL rdr database.

### DIFF
--- a/rest-api/tools/setup_local_database.sh
+++ b/rest-api/tools/setup_local_database.sh
@@ -50,7 +50,12 @@ echo '{"db_connection_string": "'$DB_CONNECTION_STRING'", ' \
      ' "db_connection_name": "", '\
      ' "db_user": "'$DB_USER'", '\
      ' "db_name": "'$DB_NAME'" }' > $DB_INFO_FILE
-echo 'DROP DATABASE IF EXISTS '$DB_NAME'; CREATE DATABASE '$DB_NAME > $CREATE_DB_FILE
+# Include charset here since mysqld defaults to Latin1 (even though CloudSQL
+# is configured with UTF8 as the default).
+cat <<EOSQL > $CREATE_DB_FILE
+DROP DATABASE IF EXISTS $DB_NAME;
+CREATE DATABASE $DB_NAME CHARACTER SET utf8 COLLATE utf8_general_ci;
+EOSQL
 
 echo "Creating empty database..."
 mysql -u "$DB_USER" $PASSWORD_ARGS < ${CREATE_DB_FILE}


### PR DESCRIPTION
Servers, connections, databases, tables, and columns can all have charsets. CloudSQL seems to have configured its mysqldb to default to utf8, but a vanilla MySQL5.7 defaults to Latin1. So, although our connection (and SQLAlchemy) were using utf8, the database (and therefore tables by default) on a local MySQL were using Latin1.