### PR TITLE
Adding service accounts to non-prod environment configs

### DIFF
--- a/rest-api/config/config_stable.json
+++ b/rest-api/config/config_stable.json
@@ -10,6 +10,9 @@
     },
     "test-client@pmi-rdr-api-test.iam.gserviceaccount.com": {
       "roles": ["ptc", "healthpro"]
+    },
+    "configurator@all-of-us-rdr-stable.iam.gserviceaccount.com": {
+      "roles": ["ptc", "healthpro", "admin"]
     }
   },
   "biobank_samples_bucket_name": [

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -25,6 +25,9 @@
         "ip6": ["::0/0"],
         "ip4": ["0.0.0.0/0"]
       }
+    },
+    "circle-deploy@all-of-us-rdr-staging.iam.gserviceaccount.com": {
+      "roles": ["ptc", "healthpro", "admin"]
     }
   },
   "biobank_samples_bucket_name": [

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -24,6 +24,9 @@
         "ip6": ["::0/0"],
         "ip4": ["0.0.0.0/0"]
       }
+    },
+    "circle-deploy@all-of-us-rdr-staging.iam.gserviceaccount.com": {
+      "roles": ["ptc", "healthpro", "admin"]
     }
   },
   "biobank_samples_bucket_name": [


### PR DESCRIPTION
allowing them to play any role.

(This is necessary to get import_participants.py or requests from the command
line working in general.)