### PR TITLE
Remove unused datastore admin handler (previously used for db backups).

### DIFF
--- a/rest-api/app.yaml
+++ b/rest-api/app.yaml
@@ -8,10 +8,6 @@ builtins:
 - deferred: on  
 
 handlers:
-- url: /_ah/datastore_admin.*
-  script: google.appengine.ext.datastore_admin.main
-  login: admin  
-  secure: always
 - url: /_ah/queue/deferred
   script: google.appengine.ext.deferred.deferred.application
   login: admin


### PR DESCRIPTION
I believe this was only for the Datastore backups, and is no longer needed. (We keep history but not separate backups of config values in Datastore). Removing to obviate security concerns in b/32226026 .