### PR TITLE
Fix staging and test configs for HealthPro.

### DIFF
--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -14,7 +14,7 @@
     },
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
-      "comment": "for HealthPro testing",
+      "comment": "for HealthPro testing"
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {
       "roles": ["ptc", "healthpro", "admin"],

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -6,7 +6,7 @@
   "user_info": {
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
-      "comment": "for HealthPro testing",
+      "comment": "for HealthPro testing"
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {
       "roles": ["ptc", "healthpro", "admin"],


### PR DESCRIPTION
Remove `pmi-hpo-staging` which is not used in those environments.
Add `healthpro-staging` for the main staging connection, and `pmi-hpo-dev` for testing against both staging and test.

I also added a "comment" field which is not parsed by the server, for future information.

(Dan, copying you FYI, but Jason has verified that the new configs do what they need.)