### PR TITLE
Remove unused "admin" role from configs.

### DIFF
--- a/rest-api/config/config_dev.json
+++ b/rest-api/config/config_dev.json
@@ -6,7 +6,7 @@
   ],
   "user_info": {
     "example@example.com": {
-      "roles": ["ptc", "healthpro", "admin"],
+      "roles": ["ptc", "healthpro"],
       "whitelisted_ip_ranges": {
         "ip6": ["::1/64"],
         "ip4": ["127.0.0.1/32"]

--- a/rest-api/config/config_dryrun.json
+++ b/rest-api/config/config_dryrun.json
@@ -10,7 +10,7 @@
       "whitelisted_appids": ["pmi-hpo-staging"]
     },
     "configurator@all-of-us-rdr-dryrun.iam.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro", "admin"]
+      "roles": ["ptc", "healthpro"]
     }
   },
   "biobank_samples_bucket_name": [

--- a/rest-api/config/config_prod.json
+++ b/rest-api/config/config_prod.json
@@ -6,7 +6,7 @@
       "whitelisted_appids": ["healthpro-prod"]
     },
     "configurator@all-of-us-rdr-prod.iam.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro", "admin"]
+      "roles": ["ptc", "healthpro"]
     }
   },
   "biobank_samples_bucket_name": [

--- a/rest-api/config/config_stable.json
+++ b/rest-api/config/config_stable.json
@@ -10,7 +10,7 @@
       "whitelisted_appids": ["pmi-hpo-test"]
     },
     "configurator@all-of-us-rdr-stable.iam.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro", "admin"]
+      "roles": ["ptc", "healthpro"]
     }
   },
   "biobank_samples_bucket_name": [

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -7,7 +7,7 @@
   "allow_faking_requests_from_server": true,
   "user_info": {
     "healthpro-staging@appspot.gserviceaccount.com": {
-      "roles": ["healthpro", "admin"],
+      "roles": ["healthpro"],
       "whitelisted_ip_ranges": {
         "ip6": [],
         "ip4": ["0.1.0.40"]
@@ -18,14 +18,14 @@
       "comment": "for HealthPro testing"
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro", "admin"],
+      "roles": ["ptc", "healthpro"],
       "whitelisted_ip_ranges": {
         "ip6": ["::0/0"],
         "ip4": ["0.0.0.0/0"]
       }
     },
     "circle-deploy@all-of-us-rdr-staging.iam.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro", "admin"]
+      "roles": ["ptc", "healthpro"]
     }
   },
   "biobank_samples_bucket_name": [

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -10,14 +10,14 @@
       "comment": "for HealthPro testing"
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro", "admin"],
+      "roles": ["ptc", "healthpro"],
       "whitelisted_ip_ranges": {
         "ip6": ["::0/0"],
         "ip4": ["0.0.0.0/0"]
       }
     },
     "circle-deploy@all-of-us-rdr-staging.iam.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro", "admin"]
+      "roles": ["ptc", "healthpro"]
     }
   },
   "biobank_samples_bucket_name": [


### PR DESCRIPTION
As far as I can tell this is obsolete, replaced by `config_admin.json`. Do you know if that's true? No tests break and I don't see any reference to "admin" in roles.