### PR TITLE
[DA-252] Add reminder and link for updating JIRA tracker on deployment.

### DIFF
--- a/rest-api/tools/deploy_app.sh
+++ b/rest-api/tools/deploy_app.sh
@@ -115,3 +115,7 @@ then
 fi
 
 echo "${BOLD}Done!${NONE}"
+# NOTE(DA-252) We could auto-update the JIRA issue if we do the oauth dance.
+echo "Please update the release tracker JIRA issue to say:"
+echo "Version ${VERSION} is now deployed to environment ${PROJECT}."
+echo "Find the JIRA issue: https://precisionmedicineinitiative.atlassian.net/issues/?jql=project%20%3D%20DA%20AND%20text%20~%20%22${VERSION}%22"


### PR DESCRIPTION
My feeling is it's not worth dealing with oauth to auto-update the ticket, but if I'm overestimating the difficulty / updating the ticket ourselves becomes a pain, I can figure it out.