### PR TITLE
Warn when logging HTTPExceptions we raised (400s).

### DIFF
--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -34,9 +34,10 @@ def _log_request_exception(sender, exception, **extra):  # pylint: disable=unuse
   for HTTPExceptions.
   """
   if isinstance(exception, HTTPException):
-    # Log everything at warning. This handles 400s which, since we have few/predefined clients,
-    # we want to notice (and we don't see client-side logs). (500s are logged with stacks by Flask.)
-    logging.warning('%s: %s', exception, exception.description)
+    # Log everything at error. This handles 400s which, since we have few/predefined clients,
+    # we want to notice (and we don't see client-side logs); Stackdriver error reporting only
+    # reports error logs with stack traces. (500s are logged with stacks by Flask automatically.)
+    logging.error('%s: %s', exception, exception.description, exc_info=True)
 
 got_request_exception.connect(_log_request_exception, app)
 


### PR DESCRIPTION
Example log:

WARNING  2017-05-02 17:58:25,725 main.py:39] 403: Forbidden: You don't have the permission to access the requested resource. It is either read-protected or not readable by the server.

It'd be easy to include the stack trace there, what do you think? Usually our 4xx messages are fairly specific.