### PR TITLE
Change script which updates JIRA release trackers to look in the "PD" project when updating stable/prod.

### DIFF
--- a/rest-api/tools/update_release_tracker.py
+++ b/rest-api/tools/update_release_tracker.py
@@ -15,7 +15,9 @@ import sys
 from tools.main_util import get_parser, configure_logging
 
 _JIRA_INSTANCE_URL = 'https://precisionmedicineinitiative.atlassian.net/'
-_JIRA_PROJECT_ID = 'DA'
+# Release tickets are moved from our usual project, DA, to the PD project
+# for change approval, so for stable/prod releases look for tickets there.
+_JIRA_PROJECT_ID = 'PD'
 
 def _connect_to_jira(jira_username, jira_password):
   return jira.JIRA(_JIRA_INSTANCE_URL, basic_auth=(jira_username, jira_password))
@@ -37,10 +39,11 @@ def main(args):
           ', '.join('[%s] %s' % (issue.key, issue.fields().summary) for issue in issues))
     issue = issues[0]
     jira_connection.add_comment(issue, args.comment)
-    logging.info("Updated issue %s" % issue.key)
+    logging.info('Updated issue %s', issue.key)
     sys.exit(0)
   else:
-    logging.error('No issue found with summary "%s"; exiting.' % summary)
+    logging.error(
+        'No issue found with summary %r in project %r; exiting.', summary, _JIRA_PROJECT_ID)
     sys.exit(-1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
We're using our release tracker tickets for change approval, so they will be moved from DA to PD (according to the process we're ironing out in https://docs.google.com/document/d/1FkzFyc_neXn4gAQfdaCoe91mogD4frIAOFtXDeDM-sU/edit#heading=h.y0s8grqe8lqe ).

So, I think the steps will be:
* Tag a release, CircleCI creates a JIRA release tracker in DA with commit history.
* If that looks good, move the issue to PD and request change approval.
* Pushes to stable and prod now look for the ticket in PD.