### PR TITLE
[DA-237] Ping MySQL connections before use to avoid disconnect errors.

### DIFF
--- a/rest-api/model/database.py
+++ b/rest-api/model/database.py
@@ -68,7 +68,7 @@ def _ping_connection(connection, branch):
 
   Copied from SQLAlchemy 1.1 docs:
   http://docs.sqlalchemy.org/en/rel_1_1/core/pooling.html#disconnect-handling-pessimistic
-  Once SQLAlchemy v1.2 is out of development and released, switch to
+  TODO(DA-321) Once SQLAlchemy v1.2 is out of development and released, switch to
   create_engine(pool_pre_ping=True).
   """
   if branch:


### PR DESCRIPTION
Tested in Sandbox: set db wait_timeout to 20s; before this change, resulted in "MySQL server has gone away" errors leading to 500s; after this change, leads to logs stating the ping failed and the connection is reopened with an eventual 200.

It turns out SQLAlchemy / the pool_pre_ping option in SQLAlchemy v1.2 is still in dev, not a release we can get with pip.