### PR TITLE
[DA-317] Allow updates of withdrawn participants, apart from withdrawal status.

### DIFF
--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -77,9 +77,9 @@ class ParticipantDao(UpdatableDao):
       raise BadRequest('missing suspension status in update')
     super(ParticipantDao, self)._validate_update(session, obj, existing_obj)
     # Once a participant marks their withdrawal status as NO_USE, it can't be changed back.
-    if (existing_obj.withdrawalStatus == WithdrawalStatus.NO_USE 
+    if (existing_obj.withdrawalStatus == WithdrawalStatus.NO_USE
         and obj.withdrawalStatus != WithdrawalStatus.NO_USE):
-      raise Forbidden('Participant %d has withdrawn, cannot unwithdraw' % obj.participantId)  
+      raise Forbidden('Participant %d has withdrawn, cannot unwithdraw' % obj.participantId)
 
   def get_for_update(self, session, obj_id):
     # Fetch the participant summary at the same time as the participant, as we are potentially

--- a/rest-api/test/unit_test/dao_test/participant_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/participant_dao_test.py
@@ -208,7 +208,7 @@ class ParticipantDaoTest(SqlTestBase):
 
     p.version = 1
     p.providerLink = test_data.primary_provider_link('PITT')
-    self.dao.update(p)      
+    self.dao.update(p)
 
   def test_update_withdrawn_status_fails(self):
     p = Participant(withdrawalStatus=WithdrawalStatus.NO_USE)


### PR DESCRIPTION
This will allow us to change test participants that have withdrawn to be associated with the test HPO.