### PR TITLE
[DA-45] Switch consent PDF errors from 200 / logged error to BadRequest.

### DIFF
--- a/rest-api/dao/questionnaire_response_dao.py
+++ b/rest-api/dao/questionnaire_response_dao.py
@@ -68,11 +68,7 @@ class QuestionnaireResponseDao(BaseDao):
       return result
 
   def _validate_model(self, session, obj):
-    try:
-      _validate_consent_pdfs(json.loads(obj.resource))
-    except BadRequest as e:
-      # TODO(DA-45) Stop catching the BadRequest once we test against PTC.
-      logging.error('Invalid consent PDF: %s', e.description, exc_info=True)
+    _validate_consent_pdfs(json.loads(obj.resource))
     if not obj.questionnaireId:
       raise BadRequest('QuestionnaireResponse.questionnaireId is required.')
     if not obj.questionnaireVersion:

--- a/rest-api/test/unit_test/dao_test/questionnaire_response_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/questionnaire_response_dao_test.py
@@ -489,9 +489,8 @@ class QuestionnaireResponseDaoTest(FlaskTestBase):
   def test_consent_pdf_file_invalid(self, mock_gcloud_check):
     mock_gcloud_check.side_effect = BadRequest('Test should raise this.')
     qr = self._get_questionnaire_response_with_consents('/nobucket/no/file.pdf')
-    # TODO(DA-45) Except exception here when we switch from logging to raising BadError.
-    #with self.assertRaises(BadRequest):
-    self.questionnaire_response_dao.insert(qr)
+    with self.assertRaises(BadRequest):
+      self.questionnaire_response_dao.insert(qr)
 
   @mock.patch('dao.questionnaire_response_dao._raise_if_gcloud_file_missing')
   def test_consent_pdf_checks_multiple_extensions(self, mock_gcloud_check):


### PR DESCRIPTION
In prod logs, recent 400s are all the mising first/last/email error, and searching for "Invalid consent PDF" logs doesn't turn anything up (back to June 9th; June 8th and earlier do have errors, but I think that's when we were first introducing/fixing the validation).

I pinged #ptc on Slack to check whether Vibrent is OK with this; I'll wait to submit until Jason Cao approves.