### PR TITLE
In participant_dump, switch 90d => 30d for searching logs.

### DIFF
--- a/rest-api-client/participant_dump.py
+++ b/rest-api-client/participant_dump.py
@@ -13,7 +13,8 @@ from client import Client
 from main_util import configure_logging, get_parser
 
 
-_SERVER_LOG_FRESHNESS = '90d'
+# Server logs are searchable for at most 30 days (see DA-247).
+_SERVER_LOG_FRESHNESS = '30d'
 
 
 def log_debug_info(client, participant_id, project):


### PR DESCRIPTION
Saying "last 90 days" is misleading, since we only keep logs in a way that gcloud can fetch for the last 30 days.