### PR TITLE
Optimize import_codebook: Fetch all existing codes within session and keep them in memory.

### DIFF
--- a/rest-api/dao/cache_all_dao.py
+++ b/rest-api/dao/cache_all_dao.py
@@ -65,7 +65,7 @@ class CacheAllDao(UpdatableDao):
   def get(self, obj_id):
     return self._get_cache().id_to_entity.get(obj_id)
 
-  def invalidate_cache(self):
+  def _invalidate_cache(self):
     with self.singleton_cache.lock:
       try:
         del self.singleton_cache[SINGLETON_KEY]
@@ -75,11 +75,11 @@ class CacheAllDao(UpdatableDao):
 
   def insert_with_session(self, session, obj):
     super(CacheAllDao, self).insert_with_session(session, obj)
-    self.invalidate_cache()
+    self._invalidate_cache()
 
   def update_with_session(self, session, obj):
     super(CacheAllDao, self).update_with_session(session, obj)
-    self.invalidate_cache()
+    self._invalidate_cache()
 
   def get_with_ids(self, ids):
     if ids is None:

--- a/rest-api/dao/code_dao.py
+++ b/rest-api/dao/code_dao.py
@@ -135,6 +135,7 @@ class CodeDao(CacheAllDao):
       raise BadRequest("codeBookId must be set to a new value when updating a code")
 
   def _do_update(self, session, obj, existing_obj):
+    obj.created = existing_obj.created
     super(CodeDao, self)._do_update(session, obj, existing_obj)
     self._add_history(session, obj)
 

--- a/rest-api/tools/setup_env.sh
+++ b/rest-api/tools/setup_env.sh
@@ -5,9 +5,9 @@
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 cd ${BASE_DIR};
 
-#echo "Removing old libs..."
-#rm -rf lib
-#find . | grep \.pyc | xargs rm -if $*
+echo "Removing old libs..."
+rm -rf lib
+find . | grep \.pyc | xargs rm -if $*
 
 echo "Installing libs..."
 # If this fails due to missing mysql_config, try `sudo apt-get install libmysqlclient-dev`.


### PR DESCRIPTION
Not intending to merge this branch.

Since we want to make `import_codebook.py` essentially executable in a REST API endpoint, I profiled it to see why it's slow. Here's how I profiled it, for your entertainment.

The result:
```
main import_codebook call 1 * 461.44s = 461.44s
  extract JSON details 1 * 0.00s = 0.00s
  create CodeBook model 1 * 0.03s = 0.03s
  open session and insert 1 * 461.41s = 461.41s
    insert codebook model 1 * 3.69s = 3.69s
    flush session (codebook model) 1 * 0.10s = 0.10s
    import one root concept 1 * 457.25s = 457.25s
      extract concept JSON details 997 * 0.00s = 0.03s
      get concept type 997 * 0.00s = 0.01s
      create Code model for concept 997 * 0.00s = 0.24s
      look up existing Code 997 * 0.42s = 420.32s (max 22.05s)
      update Code 997 * 0.00s = 1.23s
      flush for child Concepts 192 * 0.18s = 34.80s
      remainder 0.63s
    remainder 0.36s
  remainder 0.01s
```
Looking up existing codes (which we currently do one at a time) is where most of the execution time is spent. I think I can take that out with a simple in-process cache; I'll just fetch everything in one request ahead of time. Let me know if that sounds like a bad idea!
