### PR TITLE
[DA-342] Revise load test ParticipantSummary query to reproduce 500s/timeouts from prod.

### DIFF
--- a/rest-api/tools/load_test.sh
+++ b/rest-api/tools/load_test.sh
@@ -1,18 +1,5 @@
 #!/bin/bash -e
-# Runs a load test against a deployed RDR.
-#
-# Instructions:
-# *   Run this script, which starts a locust server.
-# *   Once started, locust prints "Starting web monitor at *:8089". Open
-#     http://localhost:8089 to view the control/status page.
-# *   Set the number of users to 100 and hatch/sec to 5. (This is to match
-#     weights/times in the locust file. For example, if users have the default
-#     min_wait = max_wait = 1000 (ms), setting the number of users to 100
-#     and hatch rate to 5 will ramp up to 100qps over 20s, and then sustain
-#     100qps until you click "stop".)
-# *   Click run, gather stats, click stop.
-#
-# Locust docs: http://docs.locust.io/en/latest/quickstart.html
+# Runs a load test against a deployed RDR. See load_test_locustfile for instructions.
 
 if ! which locust
 then

--- a/rest-api/tools/load_test_locustfile.py
+++ b/rest-api/tools/load_test_locustfile.py
@@ -1,7 +1,20 @@
 """User behavior definition for load-testing via Locust. Run using tools/load_test.sh.
 
+Locust docs: http://docs.locust.io/en/latest/writing-a-locustfile.html
+
+Instructions:
+*   Run load_test.sh, which wraps this and starts a locust server.
+*   Once started, locust prints "Starting web monitor at *:8089". Open
+    http://localhost:8089 to view the control/status page.
+*   Set the number of users to 100 (and hatch/sec to an arbitrary number, using 100 will start all
+    workers immediately). With 100 locusts, weights can be thought of as "number of workers."
+    *   Each worker will run a task and then pause (somewhere from `min_wait` to `max_wait`
+        milliseconds). It picks one of its class methods to run, which in turn are weighted by
+        the argument to `@task`.
+*   Click run, locusts hatch and run, gather stats, click stop.
+
 We expect very low traffic (100-1K qpd for most endpoints). These load tests generate much more
-traffic (around 10qps) to stress test the system / simulate traffic spikes.
+traffic to stress test the system / simulate traffic spikes.
 """
 
 import json
@@ -119,7 +132,8 @@ class HealthProUser(_AuthenticatedLocust):
   """Queries run by HealthPro: look up user by name + dob or ID, and get summaries."""
   weight = 94
   # As of 2017 August, in 24h we see about 1000 ParticipantSummary and a similar number of
-  # individual summary requests. Simulate more load than that.
+  # individual summary requests. Simulate more load than that (about 1M/day) to force resource
+  # contention.
   min_wait = 1000
   max_wait = 10000
 


### PR DESCRIPTION
Used with `tools/load_test.sh --project all-of-us-rdr-sandbox --account mark.fickett@pmi-ops.org` and setting locust count = 100 and hatch rate = 100.