### PR TITLE
[DA-385] Switch hpo_assigner to read combined CSV with participant IDs and HPOs.

### DIFF
--- a/rdr_client/README.md
+++ b/rdr_client/README.md
@@ -16,19 +16,3 @@ source venv/bin/activate
 # Install client deps into venv/lib/.
 pip install -r requirements.txt
 ```
-
-## Example of assigning participants to a test HPO:
-
-```
-./run_client.sh --project <PROJECT> --account <ACCOUNT> hpo_assigner.py --file participant_ids.csv [--hpo <HPO>]
-```
-
-where participant_ids.csv is a file containing a list of participant IDs without the leading 'P', e.g.:
-
-```
-123456789
-234567890
-```
-
-and <HPO> is the name of a HPO, e.g. PITT; defaults to TEST.
-


### PR DESCRIPTION
If Asmita is OK with formatting the requests as one CSV with participant_id,HPO rows, this will let us just feed that directly to the tool.