### PR TITLE
Pylint: Disable scoring and excess parallelism. Log timing and version.

### DIFF
--- a/ci/test_pre_push.sh
+++ b/ci/test_pre_push.sh
@@ -22,7 +22,7 @@ ENABLE_FOR_TESTS="\
   --enable=unused-argument,redefined-outer-name,redefined-builtin,superfluous-parens \
   --enable=trailing-whitespace,unused-import,unused-variable,undefined-variable"
 ENABLE_FOR_ALL="$ENABLE_FOR_TESTS --enable=bad-whitespace,line-too-long,unused-import,unused-variable"
-PYLINT_OPTS="-r n --disable=all"
+PYLINT_OPTS="-r n --disable=all --score false"
 git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' -e '_test' | \
     parallel pylint $PYLINT_OPTS $ENABLE_FOR_ALL
 git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' | \

--- a/ci/test_pre_push.sh
+++ b/ci/test_pre_push.sh
@@ -16,13 +16,14 @@ echo "No keys found!"
 
 # Pylint checks. Use pylint --list-msgs to see more available messages.
 # More options are set in rest-api/pylintrc.
-echo "Linting..."
+PYLINT_VERSION=`pylint --version | head -1 | sed 's/pylint \([0-9.]*\),/\1/g'`
+echo "Linting with pylint ${PYLINT_VERSION}..."
 ENABLE_FOR_TESTS="\
   --enable=bad-indentation,broad-except,bare-except,logging-too-many-args \
   --enable=unused-argument,redefined-outer-name,redefined-builtin,superfluous-parens \
   --enable=trailing-whitespace,unused-import,unused-variable,undefined-variable"
 ENABLE_FOR_ALL="$ENABLE_FOR_TESTS --enable=bad-whitespace,line-too-long,unused-import,unused-variable"
-PYLINT_OPTS="-r n --disable=all --score false"
+PYLINT_OPTS="-r n --disable=all --score=n"
 git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' -e '_test' | \
     parallel pylint $PYLINT_OPTS $ENABLE_FOR_ALL
 git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' | \

--- a/ci/test_pre_push.sh
+++ b/ci/test_pre_push.sh
@@ -25,9 +25,9 @@ ENABLE_FOR_TESTS="\
 ENABLE_FOR_ALL="$ENABLE_FOR_TESTS --enable=bad-whitespace,line-too-long,unused-import,unused-variable"
 PYLINT_OPTS="-r n --disable=all --score=n"
 echo "`date -u` Linting application files..."
-git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' -e '_test' | \
-    parallel --eta pylint $PYLINT_OPTS $ENABLE_FOR_ALL
+FILES_NON_TEST=`git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' -e '_test'`
+pylint $PYLINT_OPTS $ENABLE_FOR_ALL $FILES_NON_TEST
 echo "`date -u` Linting test files..."
-git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' | \
-    parallel --eta pylint $PYLINT_OPTS $ENABLE_FOR_TESTS
+FILES_TEST=`git ls-files | grep '.py$' | grep -v -e 'alembic/versions/'`
+pylint $PYLINT_OPTS $ENABLE_FOR_TESTS $FILES_TEST
 echo "`date -u` No lint errors!"

--- a/ci/test_pre_push.sh
+++ b/ci/test_pre_push.sh
@@ -17,15 +17,17 @@ echo "No keys found!"
 # Pylint checks. Use pylint --list-msgs to see more available messages.
 # More options are set in rest-api/pylintrc.
 PYLINT_VERSION=`pylint --version | head -1 | sed 's/pylint \([0-9.]*\),/\1/g'`
-echo "Linting with pylint ${PYLINT_VERSION}..."
+echo "`date -u` Linting with pylint ${PYLINT_VERSION}..."
 ENABLE_FOR_TESTS="\
   --enable=bad-indentation,broad-except,bare-except,logging-too-many-args \
   --enable=unused-argument,redefined-outer-name,redefined-builtin,superfluous-parens \
   --enable=trailing-whitespace,unused-import,unused-variable,undefined-variable"
 ENABLE_FOR_ALL="$ENABLE_FOR_TESTS --enable=bad-whitespace,line-too-long,unused-import,unused-variable"
 PYLINT_OPTS="-r n --disable=all --score=n"
+echo "`date -u` Linting application files..."
 git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' -e '_test' | \
-    parallel pylint $PYLINT_OPTS $ENABLE_FOR_ALL
+    parallel --eta pylint $PYLINT_OPTS $ENABLE_FOR_ALL
+echo "`date -u` Linting test files..."
 git ls-files | grep '.py$' | grep -v -e 'alembic/versions/' | \
-    parallel pylint $PYLINT_OPTS $ENABLE_FOR_TESTS
-echo "No lint errors!"
+    parallel --eta pylint $PYLINT_OPTS $ENABLE_FOR_TESTS
+echo "`date -u` No lint errors!"

--- a/ci/test_pre_push.sh
+++ b/ci/test_pre_push.sh
@@ -16,6 +16,8 @@ echo "No keys found!"
 
 # Pylint checks. Use pylint --list-msgs to see more available messages.
 # More options are set in rest-api/pylintrc.
+# On CircleCI, increasing parallelism with `-j 0` (or the `parallel` command)
+# reduces performance significantly (10s becomes about 1m).
 PYLINT_VERSION=`pylint --version | head -1 | sed 's/pylint \([0-9.]*\),/\1/g'`
 echo "`date -u` Linting with pylint ${PYLINT_VERSION}..."
 ENABLE_FOR_TESTS="\


### PR DESCRIPTION
On my Google workstation, I had pylint 1.1.x which has scoring off by default and does not recognize the `--score` flag. Upgrade with `sudo pip install --upgrade pylint`. CircleCI uses the latest (1.7.2).

Setting `--score n` reduces log output, but only reduced the test time from 7:30 (previous run) to 7:10; scoring was not causing the slowness.

Switching from `parallel` to passing the file lists directly to `pylint` significantly sped thigns up, especially on CircleCI. Using `pylint -j 0` for pylint's own parallelism speeds things up slightly (10s -> 8s) locally, but slows things down significantly on CircleCI (11s -> 1m). So I think the moral is parallelism in a constrained / VM environment is not a benefit (even if tools think the machine has 32 cores).