### PR TITLE
[DA-280] Remove deprecated BiobankOrder parsing.

### DIFF
--- a/rest-api/dao/biobank_order_dao.py
+++ b/rest-api/dao/biobank_order_dao.py
@@ -1,5 +1,3 @@
-import logging
-
 from code_constants import BIOBANK_TESTS_SET, SITE_ID_SYSTEM, HEALTHPRO_USERNAME_SYSTEM
 from dao.base_dao import BaseDao, FhirMixin, FhirProperty
 from dao.participant_dao import ParticipantDao, raise_if_withdrawn
@@ -207,8 +205,6 @@ class BiobankOrderDao(BaseDao):
     order = BiobankOrder(
         participantId=participant_id,
         created=resource.created.date)
-
-    site_dao = SiteDao()
 
     if not resource.created_info:
       raise BadRequest('Created Info is required, but was missing in request.')

--- a/rest-api/dao/biobank_order_dao.py
+++ b/rest-api/dao/biobank_order_dao.py
@@ -18,6 +18,7 @@ from fhirclient.models import fhirdate
 from sqlalchemy.orm import subqueryload
 from werkzeug.exceptions import BadRequest, Conflict
 
+
 def _ToFhirDate(dt):
   if not dt:
     return None
@@ -46,6 +47,7 @@ class _FhirBiobankOrderedSample(FhirMixin, BackboneElement):
     FhirProperty('finalized', fhirdate.FHIRDate),
   ]
 
+
 class _FhirBiobankOrderHandlingInfo(FhirMixin, BackboneElement):
   """Information about what user and site handled an order."""
   resource_name = "BiobankOrderHandlingInfo"
@@ -54,27 +56,23 @@ class _FhirBiobankOrderHandlingInfo(FhirMixin, BackboneElement):
     FhirProperty('site', Identifier),
   ]
 
+
 class _FhirBiobankOrder(FhirMixin, DomainResource):
   """FHIR client definition of the expected JSON structure for a BiobankOrder resource."""
   resource_name = 'BiobankOrder'
   _PROPERTIES = [
     FhirProperty('subject', str, required=True),
-    # TODO: get rid of this once HealthPro switches over (DA-280)
-    FhirProperty('author', Identifier),
     FhirProperty('identifier', Identifier, is_list=True, required=True),
     FhirProperty('created', fhirdate.FHIRDate, required=True),
     FhirProperty('samples', _FhirBiobankOrderedSample, is_list=True, required=True),
     FhirProperty('notes', _FhirBiobankOrderNotes),
-    # TODO: get rid of this once HealthPro switches over (DA-280)
-    FhirProperty('source_site', Identifier),
-    # TODO: get rid of this once HealthPro switches over (DA-280)
-    FhirProperty('finalized_site', Identifier),
 
     FhirProperty('created_info', _FhirBiobankOrderHandlingInfo),
     FhirProperty('collected_info', _FhirBiobankOrderHandlingInfo),
     FhirProperty('processed_info', _FhirBiobankOrderHandlingInfo),
     FhirProperty('finalized_info', _FhirBiobankOrderHandlingInfo)
   ]
+
 
 class BiobankOrderDao(BaseDao):
   def __init__(self):
@@ -212,49 +210,16 @@ class BiobankOrderDao(BaseDao):
 
     site_dao = SiteDao()
 
-    # TODO: require this once HealthPro switches over (DA-280)
-    if resource.created_info:
-      order.sourceUsername, order.sourceSiteId = self._parse_handling_info(resource.created_info)
-
-    if resource.collected_info:
-      order.collectedUsername, order.collectedSiteId = \
-        self._parse_handling_info(resource.collected_info)
-    if resource.processed_info:
-      order.processedUsername, order.processedSiteId = \
-        self._parse_handling_info(resource.processed_info)
-    if resource.finalized_info:
-      order.finalizedUsername, order.finalizedSiteId = \
-        self._parse_handling_info(resource.finalized_info)
-
-    # TODO: get rid of this once HealthPro switches over (DA-280)
-    if resource.source_site:
-      if resource.source_site.system == SITE_ID_SYSTEM:
-        site = site_dao.get_by_google_group(resource.source_site.value)
-        if not site:
-          logging.warning('Unrecognized source site: %s', resource.source_site.value)
-        else:
-          order.sourceSiteId = site.siteId
-      else:
-        logging.warning('Unrecognized site system: %s', resource.source_site.system)
-
-    if not order.sourceSiteId:
-      raise BadRequest('Either createdInfo or sourceSite must be provided.')
-
-    # TODO: get rid of this once HealthPro switches over (DA-280)
-    if resource.finalized_site:
-      if resource.finalized_site.system != SITE_ID_SYSTEM:
-        raise BadRequest('Invalid site system: %s' % resource.finalized_site.system)
-      site = site_dao.get_by_google_group(resource.finalized_site.value)
-      if not site:
-        raise BadRequest('Unrecognized finalized site: %s' % resource.finalized_site.value)
-      order.finalizedSiteId = site.siteId
-
-    # TODO: get rid of this once HealthPro switches over (DA-280)
-    if resource.author:
-      if resource.author.system == HEALTHPRO_USERNAME_SYSTEM:
-        order.finalizedUsername = resource.author.value
-      else:
-        raise BadRequest('Unrecognized author system: %s' % resource.author.system)
+    if not resource.created_info:
+      raise BadRequest('Created Info is required, but was missing in request.')
+    order.sourceUsername, order.sourceSiteId = self._parse_handling_info(
+        resource.created_info)
+    order.collectedUsername, order.collectedSiteId = self._parse_handling_info(
+        resource.collected_info)
+    order.processedUsername, order.processedSiteId = self._parse_handling_info(
+        resource.processed_info)
+    order.finalizedUsername, order.finalizedSiteId = self._parse_handling_info(
+        resource.finalized_info)
 
     if resource.notes:
       order.collectedNote = resource.notes.collected
@@ -334,23 +299,6 @@ class BiobankOrderDao(BaseDao):
     resource.collected_info = self._to_handling_info(model.collectedUsername, model.collectedSiteId)
     resource.processed_info = self._to_handling_info(model.processedUsername, model.processedSiteId)
     resource.finalized_info = self._to_handling_info(model.finalizedUsername, model.finalizedSiteId)
-
-    # TODO: remove this once HealthPro switches over (DA-280)
-    if resource.created_info and resource.created_info.site:
-      resource.source_site = Identifier()
-      resource.source_site.system = resource.created_info.site.system
-      resource.source_site.value = resource.created_info.site.value
-
-    # TODO: remove this once HealthPro switches over (DA-280)
-    if resource.finalized_info:
-      if resource.finalized_info.site:
-        resource.finalized_site = Identifier()
-        resource.finalized_site.system = resource.finalized_info.site.system
-        resource.finalized_site.value = resource.finalized_info.site.value
-      if resource.finalized_info.author:
-        resource.author = Identifier()
-        resource.author.system = resource.finalized_info.author.system
-        resource.author.value = resource.finalized_info.author.value
 
     self._add_identifiers_to_resource(resource, model)
     self._add_samples_to_resource(resource, model)

--- a/rest-api/test/test-data/biobank_order_1.json
+++ b/rest-api/test/test-data/biobank_order_1.json
@@ -7,18 +7,6 @@
     "system": "https://orders.mayomedicallaboratories.com",
     "value": "WEB1YLHV%(participant_id)d"
   }],
-  "author": {
-    "system": "https://www.pmi-ops.org/healthpro-username",
-    "value": "bob@pmi-ops.org"
-  },
-  "sourceSite": {
-    "system": "https://www.pmi-ops.org/site-id",
-    "value": "hpo-site-monroeville"
-  },
-  "finalizedSite": {
-    "system": "https://www.pmi-ops.org/site-id",
-    "value": "hpo-site-monroeville"
-  },
   "createdInfo": {
     "author": {
       "system": "https://www.pmi-ops.org/healthpro-username",

--- a/rest-api/test/unit_test/dao_test/biobank_order_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/biobank_order_dao_test.py
@@ -55,8 +55,7 @@ class BiobankOrderDaoTest(SqlTestBase):
                                       processingRequired=True)])
     order_json = BiobankOrderDao().to_client_json(order)
     expected_order_json = load_biobank_order_json(self.participant.participantId)
-    for key in ['createdInfo', 'collectedInfo', 'processedInfo', 'finalizedInfo',
-                'sourceSite', 'finalizedSite', 'author']:
+    for key in ('createdInfo', 'collectedInfo', 'processedInfo', 'finalizedInfo'):
       self.assertEquals(expected_order_json[key], order_json.get(key))
 
   def test_duplicate_insert_ok(self):


### PR DESCRIPTION
This requires that only the new "createdInfo" keys appear in the request, and not "sourceSite".

Cleanup preparing for automatic pairing in orders/samples.