### PR TITLE
[DA-384] Auto-pair UNSET participants based on PMs or orders.

### DIFF
--- a/rest-api/api/biobank_order_api.py
+++ b/rest-api/api/biobank_order_api.py
@@ -1,7 +1,6 @@
 from api.base_api import BaseApi
 from api_util import auth_required, HEALTHPRO, PTC_AND_HEALTHPRO
 from dao.biobank_order_dao import BiobankOrderDao
-from dao.participant_dao import ParticipantDao
 
 
 class BiobankOrderApi(BaseApi):
@@ -10,9 +9,7 @@ class BiobankOrderApi(BaseApi):
 
   @auth_required(HEALTHPRO)
   def post(self, p_id):
-    order = super(BiobankOrderApi, self).post(participant_id=p_id)
-    ParticipantDao().add_missing_hpo_from_site(p_id, order.finalizedSiteId)
-    return order
+    return super(BiobankOrderApi, self).post(participant_id=p_id)
 
   @auth_required(PTC_AND_HEALTHPRO)
   def get(self, p_id, bo_id=None):  # pylint: disable=unused-argument

--- a/rest-api/api/biobank_order_api.py
+++ b/rest-api/api/biobank_order_api.py
@@ -1,6 +1,7 @@
 from api.base_api import BaseApi
 from api_util import auth_required, HEALTHPRO, PTC_AND_HEALTHPRO
 from dao.biobank_order_dao import BiobankOrderDao
+from dao.participant_dao import ParticipantDao
 
 
 class BiobankOrderApi(BaseApi):
@@ -9,7 +10,9 @@ class BiobankOrderApi(BaseApi):
 
   @auth_required(HEALTHPRO)
   def post(self, p_id):
-    return super(BiobankOrderApi, self).post(participant_id=p_id)
+    order = super(BiobankOrderApi, self).post(participant_id=p_id)
+    ParticipantDao().add_missing_hpo_from_site(p_id, order.finalizedSiteId)
+    return order
 
   @auth_required(PTC_AND_HEALTHPRO)
   def get(self, p_id, bo_id=None):  # pylint: disable=unused-argument

--- a/rest-api/api/physical_measurements_api.py
+++ b/rest-api/api/physical_measurements_api.py
@@ -7,6 +7,7 @@ from flask import request
 from dao.physical_measurements_dao import PhysicalMeasurementsDao
 from query import Query, Operator, FieldFilter
 
+
 class PhysicalMeasurementsApi(BaseApi):
   def __init__(self):
     super(PhysicalMeasurementsApi, self).__init__(PhysicalMeasurementsDao())
@@ -17,15 +18,14 @@ class PhysicalMeasurementsApi(BaseApi):
 
   @api_util.auth_required(HEALTHPRO)
   def post(self, p_id):
-    measurement = super(PhysicalMeasurementsApi, self).post(p_id)
-    ParticipantDao().add_missing_hpo_from_site(p_id, measurement.finalizedSiteId)
-    return measurement
+    return super(PhysicalMeasurementsApi, self).post(p_id)
 
   def list(self, participant_id=None):
     query = Query([FieldFilter('participantId', Operator.EQUALS, participant_id)],
                   None, DEFAULT_MAX_RESULTS, request.args.get('_token'))
     results = self.dao.query(query)
     return self._make_bundle(results, 'id', participant_id)
+
 
 @api_util.auth_required(PTC)
 def sync_physical_measurements():

--- a/rest-api/api/physical_measurements_api.py
+++ b/rest-api/api/physical_measurements_api.py
@@ -17,7 +17,9 @@ class PhysicalMeasurementsApi(BaseApi):
 
   @api_util.auth_required(HEALTHPRO)
   def post(self, p_id):
-    return super(PhysicalMeasurementsApi, self).post(p_id)
+    measurement = super(PhysicalMeasurementsApi, self).post(p_id)
+    ParticipantDao().add_missing_hpo_from_site(p_id, measurement.finalizedSiteId)
+    return measurement
 
   def list(self, participant_id=None):
     query = Query([FieldFilter('participantId', Operator.EQUALS, participant_id)],

--- a/rest-api/dao/biobank_order_dao.py
+++ b/rest-api/dao/biobank_order_dao.py
@@ -108,7 +108,7 @@ class BiobankOrderDao(BaseDao):
         raise Conflict('Order with ID %s already exists' % obj.biobankOrderId)
     inserted_obj = super(BiobankOrderDao, self).insert_with_session(session, obj)
     ParticipantDao().add_missing_hpo_from_site(
-        inserted_obj.participantId, inserted_obj.finalizedSiteId)
+        session, inserted_obj.participantId, inserted_obj.finalizedSiteId)
     return inserted_obj
 
   def _validate_model(self, session, obj):

--- a/rest-api/dao/biobank_order_dao.py
+++ b/rest-api/dao/biobank_order_dao.py
@@ -106,8 +106,10 @@ class BiobankOrderDao(BaseDao):
         return existing_order
       else:
         raise Conflict('Order with ID %s already exists' % obj.biobankOrderId)
-    ParticipantDao().add_missing_hpo_from_site(obj.participantId, obj.finalizedSiteId)
-    return super(BiobankOrderDao, self).insert_with_session(session, obj)
+    inserted_obj = super(BiobankOrderDao, self).insert_with_session(session, obj)
+    ParticipantDao().add_missing_hpo_from_site(
+        inserted_obj.participantId, inserted_obj.finalizedSiteId)
+    return inserted_obj
 
   def _validate_model(self, session, obj):
     if obj.participantId is None:

--- a/rest-api/dao/biobank_order_dao.py
+++ b/rest-api/dao/biobank_order_dao.py
@@ -106,6 +106,7 @@ class BiobankOrderDao(BaseDao):
         return existing_order
       else:
         raise Conflict('Order with ID %s already exists' % obj.biobankOrderId)
+    ParticipantDao().add_missing_hpo_from_site(obj.participantId, obj.finalizedSiteId)
     return super(BiobankOrderDao, self).insert_with_session(session, obj)
 
   def _validate_model(self, session, obj):

--- a/rest-api/dao/cache_all_dao.py
+++ b/rest-api/dao/cache_all_dao.py
@@ -69,8 +69,9 @@ class CacheAllDao(UpdatableDao):
     singletons.invalidate(self.cache_index)
 
   def insert_with_session(self, session, obj):
-    super(CacheAllDao, self).insert_with_session(session, obj)
+    created_obj = super(CacheAllDao, self).insert_with_session(session, obj)
     self._invalidate_cache()
+    return created_obj
 
   def update_with_session(self, session, obj):
     super(CacheAllDao, self).update_with_session(session, obj)

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -248,7 +248,10 @@ def raise_if_withdrawn(obj):
 
 
 def make_primary_provider_link(hpo_name=None, hpo_id=None, hpo=None):
-  """Returns serialized FHIR JSON for a primary provider link based on HPO information."""
+  """Returns serialized FHIR JSON for a primary provider link based on HPO information.
+
+  Exactly one of hpo_name, hpo_id, or hpo (a model.HPO) must be provided.
+  """
   if len([v for v in hpo_name, hpo_id, hpo if v is not None]) != 1:
     raise ValueError(
         'Exactly one of hpo_name=%r hpo_id=%r or hpo=%r must be defined.'

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -210,7 +210,7 @@ class ParticipantDao(UpdatableDao):
       if site is None:
         raise BadRequest('Invalid siteId reference %r.' % site_id)
 
-      participant = self.get_for_update(participant_id)
+      participant = self.get_for_update(session, participant_id)
       if participant.hpoId != UNSET_HPO_ID:
         return
 
@@ -244,22 +244,22 @@ def raise_if_withdrawn(obj):
     raise Forbidden('Participant %d has withdrawn' % obj.participantId)
 
 
-def make_primary_provider_link(given_hpo_name=None, hpo_id=None, hpo=None):
+def make_primary_provider_link(hpo_name=None, hpo_id=None, hpo=None):
   """Returns serialized FHIR JSON for a primary provider link based on HPO information."""
-  if len([v for v in given_hpo_name, hpo_id, hpo if v is not None]) != 1:
+  if len([v for v in hpo_name, hpo_id, hpo if v is not None]) != 1:
     raise ValuError(
         'Exactly one of hpo_name=%r hpo_id=%r or hpo=%r must be defined.'
         % (given_hpo_name, hpo_id, hpo))
-  if given_hpo_name is not None:
-    hpo_name = given_hpo_name
+  if hpo_name is not None:
+    name = hpo_name
   elif hpo_id is not None:
-    hpo_name = HPODao().get(hpo_id).name
+    name = HPODao().get(hpo_id).name
   else:
-    hpo_name = hpo.name
+    name = hpo.name
 
   return json.dumps([{
       'primary': True,
       'organization': {
-          'reference': 'Organization/%s' % hpo_name
+          'reference': 'Organization/%s' % name
       }
   }])

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -211,6 +211,8 @@ class ParticipantDao(UpdatableDao):
         raise BadRequest('Invalid siteId reference %r.' % site_id)
 
       participant = self.get_for_update(session, participant_id)
+      if participant is None:
+        raise BadRequest('No participant %r for HPO ID udpate.' % participant_id)
       if participant.hpoId != UNSET_HPO_ID:
         return
 

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -251,9 +251,9 @@ def raise_if_withdrawn(obj):
 def make_primary_provider_link(hpo_name=None, hpo_id=None, hpo=None):
   """Returns serialized FHIR JSON for a primary provider link based on HPO information."""
   if len([v for v in hpo_name, hpo_id, hpo if v is not None]) != 1:
-    raise ValuError(
+    raise ValueError(
         'Exactly one of hpo_name=%r hpo_id=%r or hpo=%r must be defined.'
-        % (given_hpo_name, hpo_id, hpo))
+        % (hpo_name, hpo_id, hpo))
   if hpo_name is not None:
     name = hpo_name
   elif hpo_id is not None:

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -218,6 +218,8 @@ class ParticipantDao(UpdatableDao):
 
       participant.hpoId = site.hpoId
       participant.providerLink = make_primary_provider_link(hpo_id=site.hpoId)
+      if participant.participantSummary is None:
+        raise RuntimeError('No ParticipantSummary available for P%d.' % participant_id)
       participant.participantSummary.hpoId = site.hpoId
 
 

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -202,25 +202,24 @@ class ParticipantDao(UpdatableDao):
         withdrawalStatus=resource_json.get('withdrawalStatus'),
         suspensionStatus=resource_json.get('suspensionStatus'))
 
-  def add_missing_hpo_from_site(self, participant_id, site_id):
+  def add_missing_hpo_from_site(self, session, participant_id, site_id):
     if site_id is None:
       raise BadRequest('No site ID given for auto-pairing participant.')
-    with self.session() as session:
-      site = SiteDao().get_with_session(session, site_id)
-      if site is None:
-        raise BadRequest('Invalid siteId reference %r.' % site_id)
+    site = SiteDao().get_with_session(session, site_id)
+    if site is None:
+      raise BadRequest('Invalid siteId reference %r.' % site_id)
 
-      participant = self.get_for_update(session, participant_id)
-      if participant is None:
-        raise BadRequest('No participant %r for HPO ID udpate.' % participant_id)
-      if participant.hpoId != UNSET_HPO_ID:
-        return
+    participant = self.get_for_update(session, participant_id)
+    if participant is None:
+      raise BadRequest('No participant %r for HPO ID udpate.' % participant_id)
+    if participant.hpoId != UNSET_HPO_ID:
+      return
 
-      participant.hpoId = site.hpoId
-      participant.providerLink = make_primary_provider_link(hpo_id=site.hpoId)
-      if participant.participantSummary is None:
-        raise RuntimeError('No ParticipantSummary available for P%d.' % participant_id)
-      participant.participantSummary.hpoId = site.hpoId
+    participant.hpoId = site.hpoId
+    participant.providerLink = make_primary_provider_link(hpo_id=site.hpoId)
+    if participant.participantSummary is None:
+      raise RuntimeError('No ParticipantSummary available for P%d.' % participant_id)
+    participant.participantSummary.hpoId = site.hpoId
 
 
 def _get_primary_provider_link(participant):

--- a/rest-api/dao/physical_measurements_dao.py
+++ b/rest-api/dao/physical_measurements_dao.py
@@ -250,7 +250,7 @@ class PhysicalMeasurementsDao(BaseDao):
     inserted_obj = super(PhysicalMeasurementsDao, self).insert_with_session(session, obj)
     if not is_amendment:  # Amendments aren't expected to have site ID extensions.
       ParticipantDao().add_missing_hpo_from_site(
-          inserted_obj.participantId, inserted_obj.finalizedSiteId)
+          session, inserted_obj.participantId, inserted_obj.finalizedSiteId)
 
     # Flush to assign an ID to the measurements, as the client doesn't provide one.
     session.flush()

--- a/rest-api/dao/physical_measurements_dao.py
+++ b/rest-api/dao/physical_measurements_dao.py
@@ -228,7 +228,6 @@ class PhysicalMeasurementsDao(BaseDao):
         continue
       self._update_amended(obj, extension, url, session)
       break
-    ParticipantDao().add_missing_hpo_from_site(obj.participantId, obj.finalizedSiteId)
     self._update_participant_summary(session, obj.created, obj.participantId)
     existing_measurements = (session.query(PhysicalMeasurements)
                              .filter(PhysicalMeasurements.participantId == obj.participantId)
@@ -242,7 +241,9 @@ class PhysicalMeasurementsDao(BaseDao):
           return measurements
     PhysicalMeasurementsDao.set_measurement_ids(obj)
 
-    super(PhysicalMeasurementsDao, self).insert_with_session(session, obj)
+    inserted_obj = super(PhysicalMeasurementsDao, self).insert_with_session(session, obj)
+    ParticipantDao().add_missing_hpo_from_site(
+        inserted_obj.participantId, inserted_obj.finalizedSiteId)
 
     # Flush to assign an ID to the measurements, as the client doesn't provide one.
     session.flush()

--- a/rest-api/dao/physical_measurements_dao.py
+++ b/rest-api/dao/physical_measurements_dao.py
@@ -228,6 +228,7 @@ class PhysicalMeasurementsDao(BaseDao):
         continue
       self._update_amended(obj, extension, url, session)
       break
+    ParticipantDao().add_missing_hpo_from_site(obj.participantId, obj.finalizedSiteId)
     self._update_participant_summary(session, obj.created, obj.participantId)
     existing_measurements = (session.query(PhysicalMeasurements)
                              .filter(PhysicalMeasurements.participantId == obj.participantId)
@@ -242,6 +243,7 @@ class PhysicalMeasurementsDao(BaseDao):
     PhysicalMeasurementsDao.set_measurement_ids(obj)
 
     super(PhysicalMeasurementsDao, self).insert_with_session(session, obj)
+
     # Flush to assign an ID to the measurements, as the client doesn't provide one.
     session.flush()
     # Update the resource to contain the ID.

--- a/rest-api/dao/physical_measurements_dao.py
+++ b/rest-api/dao/physical_measurements_dao.py
@@ -485,10 +485,10 @@ class PhysicalMeasurementsDao(BaseDao):
                 created_site_id = PhysicalMeasurementsDao.get_location_site_id(value_reference)
               elif url == _FINALIZED_LOC_EXTENSION:
                 finalized_site_id = PhysicalMeasurementsDao.get_location_site_id(value_reference)
-              else:
+              elif url not in _ALL_EXTENSIONS:
                 logging.warning(
-                    'Unrecognized extension URL: %r (should be %r or %r)',
-                    url, _CREATED_LOC_EXTENSION, _FINALIZED_LOC_EXTENSION)
+                    'Unrecognized extension URL: %r (should be one of %s)',
+                    url, _ALL_EXTENSIONS)
             else:
               logging.warning('No valueReference in extension, skipping: %r', extension)
           authors = resource.get('author')

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -26,6 +26,7 @@ from field_mappings import QUESTION_CODE_TO_FIELD
 
 from dao.code_dao import CodeDao
 from dao.hpo_dao import HPODao
+from dao.participant_dao import make_primary_provider_link
 from dao.site_dao import SiteDao
 from dao.questionnaire_dao import QuestionnaireDao
 from dao.physical_measurements_dao import _CREATED_LOC_EXTENSION, _FINALIZED_LOC_EXTENSION,\
@@ -450,7 +451,7 @@ class FakeParticipantGenerator(object):
     if random.random() <= _NO_HPO_CHANGE:
       return consent_time, participant_response
     hpo = random.choice(self._hpos)
-    participant_response['providerLink'] = [_make_primary_provider_link(hpo)]
+    participant_response['providerLink'] = [make_primary_provider_link(hpo=hpo)]
     days_delta = random.randint(0, _MAX_DAYS_BEFORE_HPO_CHANGE)
     change_time = consent_time + datetime.timedelta(days=days_delta)
     result = self._update_participant(change_time, participant_response, participant_id)
@@ -506,7 +507,7 @@ class FakeParticipantGenerator(object):
         hpo = random.choice(self._hpos)
     if hpo:
       if hpo.hpoId != UNSET_HPO_ID:
-        participant_json['providerLink'] = [_make_primary_provider_link(hpo)]
+        participant_json['providerLink'] = [make_primary_provider_link(hpo=hpo)]
     creation_time = self._days_ago(random.randint(0, _MAX_DAYS_HISTORY))
     participant_response = self._client.request_json(
         'Participant', method='POST', body=participant_json, pretend_date=creation_time)
@@ -674,6 +675,3 @@ def _string_answer(value):
 
 def _code_answer(code):
   return {"valueCoding": {"system": PPI_SYSTEM, "code": code}}
-
-def _make_primary_provider_link(hpo):
-  return {'primary': True, 'organization': {'reference': 'Organization/' + hpo.name}}

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -26,7 +26,7 @@ from field_mappings import QUESTION_CODE_TO_FIELD
 
 from dao.code_dao import CodeDao
 from dao.hpo_dao import HPODao
-from dao.participant_dao import make_primary_provider_link
+from dao.participant_dao import make_primary_provider_link_for_hpo
 from dao.site_dao import SiteDao
 from dao.questionnaire_dao import QuestionnaireDao
 from dao.physical_measurements_dao import _CREATED_LOC_EXTENSION, _FINALIZED_LOC_EXTENSION,\
@@ -451,7 +451,7 @@ class FakeParticipantGenerator(object):
     if random.random() <= _NO_HPO_CHANGE:
       return consent_time, participant_response
     hpo = random.choice(self._hpos)
-    participant_response['providerLink'] = [make_primary_provider_link(hpo=hpo)]
+    participant_response['providerLink'] = [make_primary_provider_link_for_hpo(hpo)]
     days_delta = random.randint(0, _MAX_DAYS_BEFORE_HPO_CHANGE)
     change_time = consent_time + datetime.timedelta(days=days_delta)
     result = self._update_participant(change_time, participant_response, participant_id)
@@ -507,7 +507,7 @@ class FakeParticipantGenerator(object):
         hpo = random.choice(self._hpos)
     if hpo:
       if hpo.hpoId != UNSET_HPO_ID:
-        participant_json['providerLink'] = [make_primary_provider_link(hpo=hpo)]
+        participant_json['providerLink'] = [make_primary_provider_link_for_hpo(hpo)]
     creation_time = self._days_ago(random.randint(0, _MAX_DAYS_HISTORY))
     participant_response = self._client.request_json(
         'Participant', method='POST', body=participant_json, pretend_date=creation_time)

--- a/rest-api/model/participant.py
+++ b/rest-api/model/participant.py
@@ -20,6 +20,8 @@ class ParticipantBase(object):
 
   lastModified = Column('last_modified', UTCDateTime, nullable=False)
   signUpTime = Column('sign_up_time', UTCDateTime, nullable=False)
+
+  # One or more HPO IDs in FHIR JSON. (The primary link is separately stored as hpoId.)
   providerLink = Column('provider_link', BLOB)
 
   # Both HealthPro and PTC can mutate participants; we use clientId to track

--- a/rest-api/test/test-data/measurements-as-fhir.json
+++ b/rest-api/test/test-data/measurements-as-fhir.json
@@ -10,6 +10,16 @@
         ],
         "date": "%(authored_time)s",
         "resourceType": "Composition",
+        "extension": [
+          {
+            "url": "http://terminology.pmi-ops.org/StructureDefinition/authored-location",
+            "valueReference": "Location/hpo-site-monroeville"
+          },
+          {
+            "url": "http://terminology.pmi-ops.org/StructureDefinition/finalized-location",
+            "valueReference": "Location/hpo-site-bannerphoenix"
+          }
+        ],
         "section": [{
           "entry": [
             {

--- a/rest-api/test/test-data/physical_measurements_2.json
+++ b/rest-api/test/test-data/physical_measurements_2.json
@@ -28,7 +28,7 @@
           },
           {
             "url": "http://terminology.pmi-ops.org/StructureDefinition/finalized-location",
-            "valueReference": "Location/hpo-site-bannerphoenix"
+            "valueReference": "Location/hpo-site-bogussite-notindb"
           }
         ],
         "date": "2016-09-02T20:59:41Z",

--- a/rest-api/test/test-data/physical_measurements_2.json
+++ b/rest-api/test/test-data/physical_measurements_2.json
@@ -24,11 +24,11 @@
         "extension": [
           {
             "url": "http://terminology.pmi-ops.org/StructureDefinition/authored-location",
-            "valueReference": "Location/hpo-site-monroeville"
+            "valueReference": "Location/hpo-site-bogussite-notindb"
           },
           {
             "url": "http://terminology.pmi-ops.org/StructureDefinition/finalized-location",
-            "valueReference": "Location/hpo-site-bogussite-notindb"
+            "valueReference": "Location/hpo-site-monroeville"
           }
         ],
         "date": "2016-09-02T20:59:41Z",

--- a/rest-api/test/test_data.py
+++ b/rest-api/test/test_data.py
@@ -31,9 +31,6 @@ def data_path(filename):
   return os.path.join(os.path.dirname(__file__), 'test-data', filename)
 
 
-def primary_provider_link(hpo_name):
-  return '[ { "primary": true, "organization": { "reference": "Organization/%s" } } ]' % hpo_name
-
 def load_measurement_json(participant_id, now=None):
   """Loads a PhysicalMeasurement FHIR resource returns it as parsed JSON."""
   with open(data_path('measurements-as-fhir.json')) as measurements_file:

--- a/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
+++ b/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
@@ -6,7 +6,6 @@ import main
 from dao.participant_dao import ParticipantDao
 from dao.physical_measurements_dao import PhysicalMeasurementsDao
 from model.measurements import Measurement
-from model.participant import Participant
 from model.utils import from_client_participant_id
 from participant_enums import UNSET_HPO_ID
 from test.unit_test.unit_test_util import FlaskTestBase

--- a/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
+++ b/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
@@ -15,7 +15,7 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
     self.participant_id = self.create_participant()
     self.participant_id_2 = self.create_participant()
 
-  def insert_measurements(self, now=None):
+  def _insert_measurements(self, now=None):
     measurements_1 = load_measurement_json(self.participant_id, now)
     measurements_2 = load_measurement_json(self.participant_id_2, now)
     path_1 = 'Participant/%s/PhysicalMeasurements' % self.participant_id
@@ -32,7 +32,7 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
     self.send_consent(self.participant_id)
     self.send_consent(self.participant_id_2)
     now = datetime.datetime.now()
-    self.insert_measurements(now.isoformat())
+    self._insert_measurements(now.isoformat())
 
     response = self.send_get('Participant/%s/PhysicalMeasurements' % self.participant_id)
     self.assertEquals('Bundle', response['resourceType'])
@@ -44,9 +44,9 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
     physical_measurements_id = response['entry'][0]['resource']['id']
     pm_id = int(physical_measurements_id)
     physical_measurements = PhysicalMeasurementsDao().get_with_children(physical_measurements_id)
-    self.assertIsNone(physical_measurements.createdSiteId)
+    self.assertEquals(physical_measurements.createdSiteId, 1)
     self.assertIsNone(physical_measurements.createdUsername)
-    self.assertIsNone(physical_measurements.finalizedSiteId)
+    self.assertEquals(physical_measurements.finalizedSiteId, 2)
     self.assertIsNone(physical_measurements.finalizedUsername)
 
     em1 = Measurement(measurementId=pm_id * 1000,
@@ -226,7 +226,7 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
     self.assertIsNone(link)
     self.assertTrue(len(sync_response['entry']) == 0)
 
-    self.insert_measurements()
+    self._insert_measurements()
 
     sync_response = self.send_get('PhysicalMeasurements/_history?_count=1')
     self.assertTrue(sync_response.get('entry'))

--- a/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
+++ b/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
@@ -119,11 +119,11 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
     physical_measurements_id = response['entry'][0]['resource']['id']
     pm_id = int(physical_measurements_id)
     physical_measurements = PhysicalMeasurementsDao().get_with_children(physical_measurements_id)
-    self.assertEquals(1, physical_measurements.createdSiteId)
-    self.assertEquals('bob.jones@pmi-ops.org', physical_measurements.createdUsername)
-    # Site not present in DB, so we don't set it.
-    self.assertIsNone(physical_measurements.finalizedSiteId)
+    self.assertEquals(physical_measurements.finalizedSiteId, 1)
     self.assertEquals('fred.smith@pmi-ops.org', physical_measurements.finalizedUsername)
+    # Site not present in DB, so we don't set it.
+    self.assertIsNone(physical_measurements.createdSiteId)
+    self.assertEquals('bob.jones@pmi-ops.org', physical_measurements.createdUsername)
 
     em1_id = pm_id * 1000
     bp1 = Measurement(measurementId=pm_id * 1000 + 1,

--- a/rest-api/test/unit_test/dao_test/biobank_order_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/biobank_order_dao_test.py
@@ -12,7 +12,7 @@ from unit_test_util import SqlTestBase
 from werkzeug.exceptions import BadRequest, Forbidden, Conflict
 
 class BiobankOrderDaoTest(SqlTestBase):
-  _A_TEST = iter(BIOBANK_TESTS).next()
+  _A_TEST = BIOBANK_TESTS[0]
 
   def setUp(self):
     super(BiobankOrderDaoTest, self).setUp()
@@ -20,9 +20,36 @@ class BiobankOrderDaoTest(SqlTestBase):
     ParticipantDao().insert(self.participant)
     self.dao = BiobankOrderDao()
 
+  def _make_biobank_order(self, **kwargs):
+    """Makes a new BiobankOrder (same values every time) with valid/complete defaults.
+
+    Kwargs pass through to BiobankOrder constructor, overriding defaults.
+    """
+    for k, default_value in (
+        ('biobankOrderId', '1'),
+        ('created', clock.CLOCK.now()),
+        ('participantId', self.participant.participantId),
+        ('sourceSiteId', 1),
+        ('sourceUsername', 'fred@pmi-ops.org'),
+        ('collectedSiteId', 1),
+        ('collectedUsername', 'joe@pmi-ops.org'),
+        ('processedSiteId', 1),
+        ('processedUsername', 'sue@pmi-ops.org'),
+        ('finalizedSiteId', 1),
+        ('finalizedUsername', 'bob@pmi-ops.org'),
+        ('identifiers', [BiobankOrderIdentifier(system='a', value='c')]),
+        ('samples', [BiobankOrderedSample(
+            biobankOrderId='1',
+            test=self._A_TEST,
+            description='description',
+            processingRequired=True)])):
+      if k not in kwargs:
+        kwargs[k] = default_value
+    return BiobankOrder(**kwargs)
+
   def test_bad_participant(self):
     with self.assertRaises(BadRequest):
-      self.dao.insert(BiobankOrder(participantId=999))
+      self.dao.insert(self._make_biobank_order(participantId=999))
 
   def test_from_json(self):
     ParticipantSummaryDao().insert(self.participant_summary(self.participant))
@@ -38,21 +65,7 @@ class BiobankOrderDaoTest(SqlTestBase):
     self.assertEquals('bob@pmi-ops.org', order.finalizedUsername)
 
   def test_to_json(self):
-    order = BiobankOrder(
-        biobankOrderId='1',
-        created=clock.CLOCK.now(),
-        participantId=self.participant.participantId,
-        sourceSiteId=1,
-        sourceUsername='fred@pmi-ops.org',
-        collectedSiteId=1,
-        collectedUsername ='joe@pmi-ops.org',
-        processedSiteId=1,
-        processedUsername='sue@pmi-ops.org',
-        finalizedSiteId=1,
-        finalizedUsername='bob@pmi-ops.org',
-        identifiers=[BiobankOrderIdentifier(system='a', value='c')],
-        samples=[BiobankOrderedSample(biobankOrderId='1', test='blah', description='description',
-                                      processingRequired=True)])
+    order = self._make_biobank_order()
     order_json = BiobankOrderDao().to_client_json(order)
     expected_order_json = load_biobank_order_json(self.participant.participantId)
     for key in ('createdInfo', 'collectedInfo', 'processedInfo', 'finalizedInfo'):
@@ -60,44 +73,26 @@ class BiobankOrderDaoTest(SqlTestBase):
 
   def test_duplicate_insert_ok(self):
     ParticipantSummaryDao().insert(self.participant_summary(self.participant))
-    order_1 = self.dao.insert(BiobankOrder(
-        biobankOrderId='1',
-        participantId=self.participant.participantId,
-        created=clock.CLOCK.now(),
-        identifiers=[BiobankOrderIdentifier(system='a', value='b')]))
-    order_2 = self.dao.insert(BiobankOrder(
-        biobankOrderId='1',
-        created=clock.CLOCK.now(),
-        participantId=self.participant.participantId,
-        identifiers=[BiobankOrderIdentifier(system='a', value='b')]))
+    order_1 = self.dao.insert(self._make_biobank_order())
+    order_2 = self.dao.insert(self._make_biobank_order())
     self.assertEquals(order_1.asdict(), order_2.asdict())
 
   def test_same_id_different_identifier_not_ok(self):
     ParticipantSummaryDao().insert(self.participant_summary(self.participant))
-    self.dao.insert(BiobankOrder(
-        biobankOrderId='1',
-        participantId=self.participant.participantId,
-        created=clock.CLOCK.now(),
+    self.dao.insert(self._make_biobank_order(
         identifiers=[BiobankOrderIdentifier(system='a', value='b')]))
     with self.assertRaises(Conflict):
-      self.dao.insert(BiobankOrder(
-          biobankOrderId='1',
-          created=clock.CLOCK.now(),
-          participantId=self.participant.participantId,
+      self.dao.insert(self._make_biobank_order(
           identifiers=[BiobankOrderIdentifier(system='a', value='c')]))
 
   def test_reject_used_identifier(self):
     ParticipantSummaryDao().insert(self.participant_summary(self.participant))
-    self.dao.insert(BiobankOrder(
+    self.dao.insert(self._make_biobank_order(
         biobankOrderId='1',
-        participantId=self.participant.participantId,
-        created=clock.CLOCK.now(),
         identifiers=[BiobankOrderIdentifier(system='a', value='b')]))
     with self.assertRaises(BadRequest):
-      self.dao.insert(BiobankOrder(
+      self.dao.insert(self._make_biobank_order(
           biobankOrderId='2',
-          created=clock.CLOCK.now(),
-          participantId=self.participant.participantId,
           identifiers=[BiobankOrderIdentifier(system='a', value='b')]))
 
   def test_order_for_withdrawn_participant_fails(self):
@@ -105,19 +100,13 @@ class BiobankOrderDaoTest(SqlTestBase):
     ParticipantDao().update(self.participant)
     ParticipantSummaryDao().insert(self.participant_summary(self.participant))
     with self.assertRaises(Forbidden):
-      self.dao.insert(BiobankOrder(
-          biobankOrderId='1',
-          participantId=self.participant.participantId,
-          created=clock.CLOCK.now(),
-          identifiers=[BiobankOrderIdentifier(system='a', value='b')]))
+      self.dao.insert(self._make_biobank_order(participantId=self.participant.participantId))
 
   def test_get_for_withdrawn_participant_fails(self):
     ParticipantSummaryDao().insert(self.participant_summary(self.participant))
-    self.dao.insert(BiobankOrder(
+    self.dao.insert(self._make_biobank_order(
         biobankOrderId='1',
-        participantId=self.participant.participantId,
-        created=clock.CLOCK.now(),
-        identifiers=[BiobankOrderIdentifier(system='a', value='b')]))
+        participantId=self.participant.participantId))
     self.participant.withdrawalStatus = WithdrawalStatus.NO_USE
     ParticipantDao().update(self.participant)
     with self.assertRaises(Forbidden):
@@ -125,9 +114,6 @@ class BiobankOrderDaoTest(SqlTestBase):
 
   def test_store_invalid_test(self):
     with self.assertRaises(BadRequest):
-      self.dao.insert(BiobankOrder(
-          biobankOrderId='2',
-          participantId=self.participant.participantId,
-          identifiers=[BiobankOrderIdentifier(system='a', value='b')],
+      self.dao.insert(self._make_biobank_order(
           samples=[BiobankOrderedSample(
               test='InvalidTestName', processingRequired=True, description=u'tested it')]))

--- a/rest-api/test/unit_test/dao_test/participant_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/participant_dao_test.py
@@ -262,7 +262,8 @@ class ParticipantDaoTest(SqlTestBase):
     self.assertEquals(refetched.hpoId, UNSET_HPO_ID)  # sanity check
     self.participant_summary_dao.insert(self.participant_summary(refetched))
 
-    self.dao.add_missing_hpo_from_site(participant_id, self._test_db.site_id)
+    with self.dao.session() as session:
+      self.dao.add_missing_hpo_from_site(session, participant_id, self._test_db.site_id)
 
     paired = self.dao.get(participant_id)
     self.assertEquals(paired.hpoId, self._test_db.hpo_id)
@@ -286,7 +287,8 @@ class ParticipantDaoTest(SqlTestBase):
         googleGroup='a_site@googlegroups.com',
         consortiumName='The Arbitrary Site Consortium'))
 
-    self.dao.add_missing_hpo_from_site(participant_id, other_site.siteId)
+    with self.dao.session() as session:
+      self.dao.add_missing_hpo_from_site(session, participant_id, other_site.siteId)
 
     # Original Participant + summary is unaffected.
     refetched = self.dao.get(participant_id)

--- a/rest-api/test/unit_test/dao_test/participant_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/participant_dao_test.py
@@ -1,8 +1,7 @@
 import datetime
-import test_data
 
 from dao.base_dao import MAX_INSERT_ATTEMPTS
-from dao.participant_dao import ParticipantDao, ParticipantHistoryDao
+from dao.participant_dao import ParticipantDao, ParticipantHistoryDao, make_primary_provider_link
 from dao.participant_summary_dao import ParticipantSummaryDao
 from model.participant import Participant
 from participant_enums import WithdrawalStatus
@@ -90,7 +89,7 @@ class ParticipantDaoTest(SqlTestBase):
       with FakeClock(time):
         self.dao.insert(p)
 
-    p.providerLink = test_data.primary_provider_link('PITT')
+    p.providerLink = make_primary_provider_link(hpo_name='PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       self.dao.update(p)
@@ -124,7 +123,7 @@ class ParticipantDaoTest(SqlTestBase):
       with FakeClock(time):
         self.dao.insert(p)
 
-    p.providerLink = test_data.primary_provider_link('PITT')
+    p.providerLink = make_primary_provider_link(hpo_name='PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       self.dao.update(p)
@@ -166,7 +165,7 @@ class ParticipantDaoTest(SqlTestBase):
         self.dao.insert(p)
 
     p.version = 1
-    p.providerLink = test_data.primary_provider_link('PITT')
+    p.providerLink = make_primary_provider_link(hpo_name='PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       self.dao.update(p)
@@ -185,7 +184,7 @@ class ParticipantDaoTest(SqlTestBase):
         self.dao.insert(p)
 
     p.version = 2
-    p.providerLink = test_data.primary_provider_link('PITT')
+    p.providerLink = make_primary_provider_link(hpo_name='PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       with self.assertRaises(PreconditionFailed):
@@ -207,7 +206,7 @@ class ParticipantDaoTest(SqlTestBase):
     self.assertEquals(p.asdict(), p2.asdict())
 
     p.version = 1
-    p.providerLink = test_data.primary_provider_link('PITT')
+    p.providerLink = make_primary_provider_link(hpo_name='PITT')
     self.dao.update(p)
 
   def test_update_withdrawn_status_fails(self):
@@ -237,7 +236,7 @@ class ParticipantDaoTest(SqlTestBase):
 
   def test_bad_hpo_insert(self):
     p = Participant(participantId=1, version=1, biobankId=2,
-                    providerLink = test_data.primary_provider_link('FOO'))
+                    providerLink = make_primary_provider_link(hpo_name='FOO'))
     with self.assertRaises(BadRequest):
       self.dao.insert(p)
 
@@ -247,6 +246,6 @@ class ParticipantDaoTest(SqlTestBase):
     with FakeClock(time):
       self.dao.insert(p)
 
-    p.providerLink = test_data.primary_provider_link('FOO')
+    p.providerLink = make_primary_provider_link(hpo_name='FOO')
     with self.assertRaises(BadRequest):
       self.dao.update(p)

--- a/rest-api/test/unit_test/dao_test/participant_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/participant_dao_test.py
@@ -2,7 +2,9 @@ import datetime
 
 from dao.base_dao import MAX_INSERT_ATTEMPTS
 from dao.hpo_dao import HPODao
-from dao.participant_dao import ParticipantDao, ParticipantHistoryDao, make_primary_provider_link
+from dao.participant_dao import ParticipantDao, ParticipantHistoryDao
+from dao.participant_dao import make_primary_provider_link_for_name
+from dao.participant_dao import make_primary_provider_link_for_id
 from dao.participant_summary_dao import ParticipantSummaryDao
 from dao.site_dao import SiteDao
 from model.hpo import HPO
@@ -94,7 +96,7 @@ class ParticipantDaoTest(SqlTestBase):
       with FakeClock(time):
         self.dao.insert(p)
 
-    p.providerLink = make_primary_provider_link(hpo_name='PITT')
+    p.providerLink = make_primary_provider_link_for_name('PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       self.dao.update(p)
@@ -128,7 +130,7 @@ class ParticipantDaoTest(SqlTestBase):
       with FakeClock(time):
         self.dao.insert(p)
 
-    p.providerLink = make_primary_provider_link(hpo_name='PITT')
+    p.providerLink = make_primary_provider_link_for_name('PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       self.dao.update(p)
@@ -170,7 +172,7 @@ class ParticipantDaoTest(SqlTestBase):
         self.dao.insert(p)
 
     p.version = 1
-    p.providerLink = make_primary_provider_link(hpo_name='PITT')
+    p.providerLink = make_primary_provider_link_for_name('PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       self.dao.update(p)
@@ -189,7 +191,7 @@ class ParticipantDaoTest(SqlTestBase):
         self.dao.insert(p)
 
     p.version = 2
-    p.providerLink = make_primary_provider_link(hpo_name='PITT')
+    p.providerLink = make_primary_provider_link_for_name('PITT')
     time2 = datetime.datetime(2016, 1, 2)
     with FakeClock(time2):
       with self.assertRaises(PreconditionFailed):
@@ -211,7 +213,7 @@ class ParticipantDaoTest(SqlTestBase):
     self.assertEquals(p.asdict(), p2.asdict())
 
     p.version = 1
-    p.providerLink = make_primary_provider_link(hpo_name='PITT')
+    p.providerLink = make_primary_provider_link_for_name('PITT')
     self.dao.update(p)
 
   def test_update_withdrawn_status_fails(self):
@@ -241,7 +243,7 @@ class ParticipantDaoTest(SqlTestBase):
 
   def test_bad_hpo_insert(self):
     p = Participant(participantId=1, version=1, biobankId=2,
-                    providerLink = make_primary_provider_link(hpo_name='FOO'))
+                    providerLink = make_primary_provider_link_for_name('FOO'))
     with self.assertRaises(BadRequest):
       self.dao.insert(p)
 
@@ -251,7 +253,7 @@ class ParticipantDaoTest(SqlTestBase):
     with FakeClock(time):
       self.dao.insert(p)
 
-    p.providerLink = make_primary_provider_link(hpo_name='FOO')
+    p.providerLink = make_primary_provider_link_for_name('FOO')
     with self.assertRaises(BadRequest):
       self.dao.update(p)
 
@@ -267,7 +269,7 @@ class ParticipantDaoTest(SqlTestBase):
 
     paired = self.dao.get(participant_id)
     self.assertEquals(paired.hpoId, self._test_db.hpo_id)
-    self.assertEquals(paired.providerLink, make_primary_provider_link(hpo_id=self._test_db.hpo_id))
+    self.assertEquals(paired.providerLink, make_primary_provider_link_for_id(self._test_db.hpo_id))
     self.assertEquals(self.participant_summary_dao.get(participant_id).hpoId, self._test_db.hpo_id)
 
   def test_does_not_overwrite_existing_pairing(self):
@@ -276,7 +278,7 @@ class ParticipantDaoTest(SqlTestBase):
         participantId=participant_id,
         biobankId=2,
         hpoId=self._test_db.hpo_id,
-        providerLink=make_primary_provider_link(hpo_id=self._test_db.hpo_id)))
+        providerLink=make_primary_provider_link_for_id(self._test_db.hpo_id)))
     self.participant_summary_dao.insert(self.participant_summary(created))
     self.assertEquals(created.hpoId, self._test_db.hpo_id)  # sanity check
 

--- a/rest-api/test/unit_test/dao_test/participant_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/participant_dao_test.py
@@ -1,14 +1,19 @@
 import datetime
 
 from dao.base_dao import MAX_INSERT_ATTEMPTS
+from dao.hpo_dao import HPODao
 from dao.participant_dao import ParticipantDao, ParticipantHistoryDao, make_primary_provider_link
 from dao.participant_summary_dao import ParticipantSummaryDao
+from dao.site_dao import SiteDao
+from model.hpo import HPO
 from model.participant import Participant
-from participant_enums import WithdrawalStatus
+from model.site import Site
+from participant_enums import WithdrawalStatus, UNSET_HPO_ID
 from unit_test_util import SqlTestBase, PITT_HPO_ID, random_ids
 from clock import FakeClock
 from werkzeug.exceptions import BadRequest, NotFound, PreconditionFailed, ServiceUnavailable
 from werkzeug.exceptions import Forbidden
+
 
 class ParticipantDaoTest(SqlTestBase):
   def setUp(self):
@@ -129,7 +134,7 @@ class ParticipantDaoTest(SqlTestBase):
       self.dao.update(p)
 
     summary = self.participant_summary(p)
-    ParticipantSummaryDao().insert(summary)
+    self.participant_summary_dao.insert(summary)
 
     # lastModified, hpoId, version is updated on p after being passed in
     p2 = self.dao.get(1);
@@ -249,3 +254,42 @@ class ParticipantDaoTest(SqlTestBase):
     p.providerLink = make_primary_provider_link(hpo_name='FOO')
     with self.assertRaises(BadRequest):
       self.dao.update(p)
+
+  def test_pairs_unset(self):
+    participant_id = 22
+    self.dao.insert(Participant(participantId=participant_id, biobankId=2))
+    refetched = self.dao.get(participant_id)
+    self.assertEquals(refetched.hpoId, UNSET_HPO_ID)  # sanity check
+    self.participant_summary_dao.insert(self.participant_summary(refetched))
+
+    self.dao.add_missing_hpo_from_site(participant_id, self._test_db.site_id)
+
+    paired = self.dao.get(participant_id)
+    self.assertEquals(paired.hpoId, self._test_db.hpo_id)
+    self.assertEquals(paired.providerLink, make_primary_provider_link(hpo_id=self._test_db.hpo_id))
+    self.assertEquals(self.participant_summary_dao.get(participant_id).hpoId, self._test_db.hpo_id)
+
+  def test_does_not_overwrite_existing_pairing(self):
+    participant_id = 99
+    created = self.dao.insert(Participant(
+        participantId=participant_id,
+        biobankId=2,
+        hpoId=self._test_db.hpo_id,
+        providerLink=make_primary_provider_link(hpo_id=self._test_db.hpo_id)))
+    self.participant_summary_dao.insert(self.participant_summary(created))
+    self.assertEquals(created.hpoId, self._test_db.hpo_id)  # sanity check
+
+    other_hpo = HPODao().insert(HPO(hpoId=PITT_HPO_ID + 1, name='DIFFERENT_HPO'))
+    other_site = SiteDao().insert(Site(
+        hpoId=other_hpo.hpoId,
+        siteName='Arbitrary Site',
+        googleGroup='a_site@googlegroups.com',
+        consortiumName='The Arbitrary Site Consortium'))
+
+    self.dao.add_missing_hpo_from_site(participant_id, other_site.siteId)
+
+    # Original Participant + summary is unaffected.
+    refetched = self.dao.get(participant_id)
+    self.assertEquals(created.hpoId, refetched.hpoId)
+    self.assertEquals(created.providerLink, refetched.providerLink)
+    self.assertEquals(created.hpoId, self.participant_summary_dao.get(participant_id).hpoId)

--- a/rest-api/test/unit_test/dao_test/physical_measurements_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/physical_measurements_dao_test.py
@@ -34,6 +34,10 @@ class PhysicalMeasurementsDaoTest(SqlTestBase):
     self.assertIsNotNone(measurement.finalizedSiteId)
 
   def _make_physical_measurements(self, **kwargs):
+    """Makes a new PhysicalMeasurements (same values every time) with valid/complete defaults.
+
+    Kwargs pass through to PM constructor, overriding defaults.
+    """
     for k, default_value in (
         ('physicalMeasurementsId', 1),
         ('participantId', self.participant.participantId),

--- a/rest-api/test/unit_test/dao_test/physical_measurements_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/physical_measurements_dao_test.py
@@ -17,6 +17,7 @@ TIME_1 = datetime.datetime(2016, 1, 1)
 TIME_2 = datetime.datetime(2016, 1, 2)
 TIME_3 = datetime.datetime(2016, 1, 3)
 
+
 class PhysicalMeasurementsDaoTest(SqlTestBase):
   def setUp(self):
     super(PhysicalMeasurementsDaoTest, self).setUp()
@@ -27,13 +28,29 @@ class PhysicalMeasurementsDaoTest(SqlTestBase):
     self.measurement_json = json.dumps(load_measurement_json(self.participant.participantId,
                                                              TIME_1.isoformat()))
 
+  def test_from_client_json(self):
+    measurement = PhysicalMeasurementsDao.from_client_json(json.loads(self.measurement_json))
+    self.assertIsNotNone(measurement.createdSiteId)
+    self.assertIsNotNone(measurement.finalizedSiteId)
+
+  def _make_physical_measurements(self, **kwargs):
+    for k, default_value in (
+        ('physicalMeasurementsId', 1),
+        ('participantId', self.participant.participantId),
+        ('resource', self.measurement_json),
+        ('createdSiteId', 1),
+        ('finalizedSiteId', 2)):
+      if k not in kwargs:
+        kwargs[k] = default_value
+    return PhysicalMeasurements(**kwargs)
+
   def testInsert_noParticipantId(self):
     with self.assertRaises(BadRequest):
-      self.dao.insert(PhysicalMeasurements(resource=self.measurement_json))
+      self.dao.insert(self._make_physical_measurements(participantId=None))
 
   def testInsert_wrongParticipantId(self):
     with self.assertRaises(BadRequest):
-      self.dao.insert(PhysicalMeasurements(participantId=2, resource=self.measurement_json))
+      self.dao.insert(self._make_physical_measurements(participantId=2))
 
   def _with_id(self, resource, id_):
     measurements_json = json.loads(resource)
@@ -42,28 +59,28 @@ class PhysicalMeasurementsDaoTest(SqlTestBase):
 
   def testInsert_noSummary(self):
     with self.assertRaises(BadRequest):
-      self.dao.insert(PhysicalMeasurements(participantId=self.participant.participantId,
-                                           resource=self.measurement_json))
+      self.dao.insert(self._make_physical_measurements())
 
   def _make_summary(self):
     self.participant_summary_dao.insert(self.participant_summary(self.participant))
 
   def testInsert_rightParticipantId(self):
     self._make_summary()
-    measurements_to_insert = PhysicalMeasurements(physicalMeasurementsId=1,
-                                                  participantId=self.participant.participantId,
-                                                  resource=self.measurement_json)
     summary = ParticipantSummaryDao().get(self.participant.participantId)
     self.assertIsNone(summary.physicalMeasurementsStatus)
-    with FakeClock(TIME_2):
-      measurements = self.dao.insert(measurements_to_insert)
 
-    expected_measurements = PhysicalMeasurements(physicalMeasurementsId=1,
-                                                 participantId=self.participant.participantId,
-                                                 resource=self._with_id(self.measurement_json, '1'),
-                                                 created=TIME_2,
-                                                 final=True,
-                                                 logPositionId=1)
+    with FakeClock(TIME_2):
+      measurements = self.dao.insert(self._make_physical_measurements())
+
+    expected_measurements = PhysicalMeasurements(
+        physicalMeasurementsId=1,
+        participantId=self.participant.participantId,
+        resource=self._with_id(self.measurement_json, '1'),
+        created=TIME_2,
+        final=True,
+        logPositionId=1,
+        createdSiteId=1,
+        finalizedSiteId=2)
     self.assertEquals(expected_measurements.asdict(), measurements.asdict())
     measurements = self.dao.get(measurements.physicalMeasurementsId)
     self.assertEquals(expected_measurements.asdict(), measurements.asdict())
@@ -72,51 +89,32 @@ class PhysicalMeasurementsDaoTest(SqlTestBase):
     self.assertEquals(PhysicalMeasurementsStatus.COMPLETED, summary.physicalMeasurementsStatus)
     self.assertEquals(TIME_2, summary.physicalMeasurementsTime)
 
-  def test_backfill(self):
+  def test_backfill_is_noop(self):
     self._make_summary()
-    with open(data_path('physical_measurements_2.json')) as measurements_file:
-      json_text = measurements_file.read() % {
-        'participant_id': self.participant.participantId,
-        'authored_time': TIME_1.isoformat()
-      }
-    measurements_to_insert = PhysicalMeasurements(physicalMeasurementsId=1,
-                                                  participantId=self.participant.participantId,
-                                                  resource=json_text)
-    measurements = self.dao.insert(measurements_to_insert)
-    self.assertEquals(0, len(measurements.measurements))
-    self.assertIsNone(measurements.createdUsername)
-    self.assertIsNone(measurements.createdSiteId)
-    self.assertIsNone(measurements.finalizedUsername)
-    self.assertIsNone(measurements.finalizedSiteId)
-
+    measurements_id = self.dao.insert(self._make_physical_measurements()).physicalMeasurementsId
+    orig_measurements = self.dao.get_with_children(measurements_id).asdict()
     self.dao.backfill_measurements()
-    measurements = self.dao.get_with_children(measurements.physicalMeasurementsId)
-    self.assertEquals(17, len(measurements.measurements))
-    self.assertEquals('bob.jones@pmi-ops.org', measurements.createdUsername)
-    self.assertEquals(1, measurements.createdSiteId)
-    self.assertEquals('fred.smith@pmi-ops.org', measurements.finalizedUsername)
-    self.assertIsNone(measurements.finalizedSiteId)
+    backfilled_measurements = self.dao.get_with_children(measurements_id).asdict()
+    # Formatting of resource gets changed, so test it separately as parsed JSON.
+    self.assertEquals(
+        json.loads(orig_measurements['resource']),
+        json.loads(backfilled_measurements['resource']))
+    del orig_measurements['resource']
+    del backfilled_measurements['resource']
+    self.assertEquals(orig_measurements, backfilled_measurements)
 
   def testInsert_withdrawnParticipantFails(self):
     self.participant.withdrawalStatus = WithdrawalStatus.NO_USE
     ParticipantDao().update(self.participant)
     self._make_summary()
-    measurements_to_insert = PhysicalMeasurements(physicalMeasurementsId=1,
-                                                  participantId=self.participant.participantId,
-                                                  resource=self.measurement_json)
     summary = ParticipantSummaryDao().get(self.participant.participantId)
     self.assertIsNone(summary.physicalMeasurementsStatus)
     with self.assertRaises(Forbidden):
-      self.dao.insert(measurements_to_insert)
+      self.dao.insert(self._make_physical_measurements())
 
   def testInsert_getFailsForWithdrawnParticipant(self):
     self._make_summary()
-    measurements_to_insert = PhysicalMeasurements(physicalMeasurementsId=1,
-                                                  participantId=self.participant.participantId,
-                                                  resource=self.measurement_json)
-    summary = ParticipantSummaryDao().get(self.participant.participantId)
-    self.assertIsNone(summary.physicalMeasurementsStatus)
-    self.dao.insert(measurements_to_insert)
+    self.dao.insert(self._make_physical_measurements())
     self.participant.withdrawalStatus = WithdrawalStatus.NO_USE
     ParticipantDao().update(self.participant)
     with self.assertRaises(Forbidden):
@@ -128,34 +126,24 @@ class PhysicalMeasurementsDaoTest(SqlTestBase):
 
   def testInsert_duplicate(self):
     self._make_summary()
-    measurements_to_insert = PhysicalMeasurements(participantId=self.participant.participantId,
-                                                  resource=self.measurement_json)
     with FakeClock(TIME_2):
-      measurements = self.dao.insert(measurements_to_insert)
-
+      measurements = self.dao.insert(self._make_physical_measurements())
     with FakeClock(TIME_3):
-      measurements_2 = self.dao.insert(PhysicalMeasurements(
-                                       participantId=self.participant.participantId,
-                                       resource=self.measurement_json))
-
+      measurements_2 = self.dao.insert(self._make_physical_measurements())
     self.assertEquals(measurements.asdict(), measurements_2.asdict())
 
   def testInsert_amend(self):
     self._make_summary()
-    measurements_to_insert = PhysicalMeasurements(physicalMeasurementsId=1,
-                                                  participantId=self.participant.participantId,
-                                                  resource=self.measurement_json)
     with FakeClock(TIME_2):
-      measurements = self.dao.insert(measurements_to_insert)
+      measurements = self.dao.insert(self._make_physical_measurements(
+          physicalMeasurementsId=1))
 
     amendment_json = load_measurement_json_amendment(self.participant.participantId,
                                                      measurements.physicalMeasurementsId,
                                                      TIME_2)
-    measurements_2 = PhysicalMeasurements(physicalMeasurementsId=2,
-                                          participantId=self.participant.participantId,
-                                          resource=json.dumps(amendment_json))
     with FakeClock(TIME_3):
-      new_measurements = self.dao.insert(measurements_2)
+      new_measurements = self.dao.insert(self._make_physical_measurements(
+          physicalMeasurementsId=2, resource=json.dumps(amendment_json)))
 
     measurements = self.dao.get(measurements.physicalMeasurementsId)
     amended_json = json.loads(measurements.resource)
@@ -166,4 +154,3 @@ class PhysicalMeasurementsDaoTest(SqlTestBase):
     self.assertEquals('2', amendment_json['id'])
     self.assertTrue(new_measurements.final)
     self.assertEquals(TIME_3, new_measurements.created)
-

--- a/rest-api/test/unit_test/dao_test/physical_measurements_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/physical_measurements_dao_test.py
@@ -10,7 +10,7 @@ from dao.participant_summary_dao import ParticipantSummaryDao
 from dao.physical_measurements_dao import PhysicalMeasurementsDao
 from participant_enums import PhysicalMeasurementsStatus, WithdrawalStatus
 from test_data import load_measurement_json, load_measurement_json_amendment
-from unit_test_util import SqlTestBase, data_path
+from unit_test_util import SqlTestBase
 from werkzeug.exceptions import BadRequest, Forbidden
 
 TIME_1 = datetime.datetime(2016, 1, 1)

--- a/rest-api/test/unit_test/dao_test/site_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/site_dao_test.py
@@ -9,15 +9,15 @@ class SiteDaoTest(SqlTestBase):
     self.site_dao = SiteDao()
 
   def test_get_no_sites(self):
-    self.assertIsNone(self.site_dao.get(2))
+    self.assertIsNone(self.site_dao.get(9999))
     self.assertIsNone(self.site_dao.get_by_google_group('site@googlegroups.com'))
 
   def test_insert(self):
     site = Site(siteName='site', googleGroup='site@googlegroups.com',
                 consortiumName='consortium', mayolinkClientNumber=12345, hpoId=PITT_HPO_ID)
-    self.site_dao.insert(site)
-    new_site = self.site_dao.get(2)
-    site.siteId = 2
+    created_site = self.site_dao.insert(site)
+    new_site = self.site_dao.get(created_site.siteId)
+    site.siteId = created_site.siteId
     self.assertEquals(site.asdict(), new_site.asdict())
     self.assertEquals(site.asdict(),
                       self.site_dao.get_by_google_group('site@googlegroups.com').asdict())
@@ -25,11 +25,12 @@ class SiteDaoTest(SqlTestBase):
   def test_update(self):
     site = Site(siteName='site', googleGroup='site@googlegroups.com',
                 consortiumName='consortium', mayolinkClientNumber=12345, hpoId=PITT_HPO_ID)
-    self.site_dao.insert(site)
-    new_site = Site(siteId=2, siteName='site2', googleGroup='site2@googlegroups.com',
+    created_site = self.site_dao.insert(site)
+    new_site = Site(siteId=created_site.siteId, siteName='site2',
+                    googleGroup='site2@googlegroups.com',
                     consortiumName='consortium2', mayolinkClientNumber=123456, hpoId=UNSET_HPO_ID)
     self.site_dao.update(new_site)
-    fetched_site = self.site_dao.get(2)
+    fetched_site = self.site_dao.get(created_site.siteId)
     self.assertEquals(new_site.asdict(), fetched_site.asdict())
     self.assertEquals(new_site.asdict(),
                       self.site_dao.get_by_google_group('site2@googlegroups.com').asdict())

--- a/rest-api/test/unit_test/offline_test/metrics_export_test.py
+++ b/rest-api/test/unit_test/offline_test/metrics_export_test.py
@@ -15,7 +15,7 @@ from model.hpo import HPO
 from dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from dao.hpo_dao import HPODao
 from dao.metrics_dao import MetricsVersionDao, SERVING_METRICS_DATA_VERSION
-from dao.participant_dao import ParticipantDao, make_primary_provider_link
+from dao.participant_dao import ParticipantDao, make_primary_provider_link_for_name
 from model.metrics import MetricsVersion
 from model.participant import Participant
 from offline.metrics_config import ANSWER_FIELD_TO_QUESTION_CODE
@@ -110,7 +110,7 @@ class MetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
       participant = Participant(
           participantId=1,
           biobankId=2,
-          providerLink=make_primary_provider_link(hpo_name='AZ_TUCSON'))
+          providerLink=make_primary_provider_link_for_name('AZ_TUCSON'))
       participant_dao.insert(participant)
       self.send_consent('P1', email='bob@gmail.com')
 
@@ -118,20 +118,20 @@ class MetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
       participant2 = Participant(
           participantId=2,
           biobankId=3,
-          providerLink=make_primary_provider_link(hpo_name='PITT'))
+          providerLink=make_primary_provider_link_for_name('PITT'))
       participant_dao.insert(participant2)
       self.send_consent('P2', email='bob@fexample.com')
 
     with FakeClock(TIME):
       # Test HPO affiliation; this test participant is ignored.
       participant3 = Participant(participantId=3, biobankId=4,
-                                 providerLink=make_primary_provider_link(hpo_name='TEST'))
+                                 providerLink=make_primary_provider_link_for_name('TEST'))
       participant_dao.insert(participant3)
       self.send_consent('P3', email='fred@gmail.com')
 
       # example.com e-mail; this test participant is ignored, too.
       participant4 = Participant(participantId=4, biobankId=5,
-                                 providerLink=make_primary_provider_link(hpo_name='PITT'))
+                                 providerLink=make_primary_provider_link_for_name('PITT'))
       participant_dao.insert(participant4)
       self.send_consent('P4', email='bob@example.com')
 
@@ -139,7 +139,7 @@ class MetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
       # This update to participant has no effect, as the HPO ID didn't change.
       participant = self._participant_with_defaults(
           participantId=1, version=1, biobankId=2,
-          providerLink=make_primary_provider_link(hpo_name='AZ_TUCSON'))
+          providerLink=make_primary_provider_link_for_name('AZ_TUCSON'))
       participant_dao.update(participant)
       self.submit_questionnaire_response('P1', questionnaire_id,
                                          RACE_WHITE_CODE, 'male', None,
@@ -152,7 +152,7 @@ class MetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
           participantId=1,
           version=2,
           biobankId=2,
-          providerLink=make_primary_provider_link(hpo_name='PITT'))
+          providerLink=make_primary_provider_link_for_name('PITT'))
       participant_dao.update(participant)
       self.send_post('Participant/P2/PhysicalMeasurements',
                      load_measurement_json(2))

--- a/rest-api/test/unit_test/unit_test_util.py
+++ b/rest-api/test/unit_test/unit_test_util.py
@@ -167,17 +167,21 @@ class _TestDb(object):
     # Reconnecting to in-memory SQLite (because singletons are cleared above)
     # effectively clears the database.
 
-  @staticmethod
-  def _setup_hpos():
+  def _setup_hpos(self):
     hpo_dao = HPODao()
     hpo_dao.insert(HPO(hpoId=UNSET_HPO_ID, name='UNSET'))
     hpo_dao.insert(HPO(hpoId=PITT_HPO_ID, name='PITT', organizationType=OrganizationType.HPO))
+    self.hpo_id = PITT_HPO_ID
 
     site_dao = SiteDao()
-    site_dao.insert(Site(siteName='Monroeville Urgent Care Center',
-                         googleGroup='hpo-site-monroeville',
-                         consortiumName='Pittsburgh', mayolinkClientNumber=7035769,
-                         hpoId=PITT_HPO_ID))
+    created_site = site_dao.insert(Site(
+        siteName='Monroeville Urgent Care Center',
+        googleGroup='hpo-site-monroeville',
+        consortiumName='Pittsburgh',
+        mayolinkClientNumber=7035769,
+        hpoId=PITT_HPO_ID))
+    self.site_id = created_site.siteId
+
 
 class SqlTestBase(TestbedTestBase):
   """Base class for unit tests that use the SQL database."""

--- a/rest-api/test/unit_test/unit_test_util.py
+++ b/rest-api/test/unit_test/unit_test_util.py
@@ -181,6 +181,12 @@ class _TestDb(object):
         mayolinkClientNumber=7035769,
         hpoId=PITT_HPO_ID))
     self.site_id = created_site.siteId
+    site_dao.insert(Site(
+        siteName='Phoenix Urgent Care Center',
+        googleGroup='hpo-site-bannerphoenix',
+        consortiumName='Pittsburgh',
+        mayolinkClientNumber=7035770,
+        hpoId=PITT_HPO_ID))
 
 
 class SqlTestBase(TestbedTestBase):


### PR DESCRIPTION
* Require that all PhysicalMeasurements (except amendments)  and BiobankOrders have finalizedSiteId.
* Update tests to include site info.

After this is in, we will need to backfill Participant.hpoId and .providerLink, and ParticipantSummary.hpoId. (BiobankOrder and PhysicalMeasurements finalizedSiteId have already been backfilled.)