### PR TITLE
[DA-384] SQL to backfill HPO based on BiobankOrder/PhysicalMeasurements.

### DIFF
--- a/rest-api/tools/participant_hpo_backfill.sql
+++ b/rest-api/tools/participant_hpo_backfill.sql
@@ -1,5 +1,7 @@
 # This SELECT mirrors the UPDATE below, to serve as pre-validation.
 # See https://precisionmedicineinitiative.atlassian.net/browse/DA-384 .
+# TODO(markfickett) Delete this file once the backfill has been run (it only
+# serves as a record / for review).
 
 SELECT
   participant.hpo_id old_hpo_id,
@@ -30,6 +32,28 @@ JOIN
   # We will run it once with biobank_order as the `site_src` table, expecting to update
   # 110 rows; and then again using physical_measurements which will update 1 more row.
   biobank_order site_src USING(participant_id)
+JOIN
+  site ON site.site_id = site_src.finalized_site_id
+JOIN
+  hpo ON site.hpo_id = hpo.hpo_id
+SET
+  participant.hpo_id = hpo.hpo_id,
+  participant.provider_link = CONCAT("[{\"primary\":true,\"organization\":{\"reference\":\"Organization/", hpo.name, "\"}}]"),
+  participant_summary.hpo_id = hpo.hpo_id
+WHERE
+  participant.hpo_id = 0
+  AND hpo.hpo_id IS NOT NULL
+;
+
+
+# 2nd copy of the update.
+UPDATE
+  participant
+JOIN
+  participant_summary USING(participant_id)
+JOIN
+  # biobank_order changed to physical_measurements
+  physical_measurements site_src USING(participant_id)
 JOIN
   site ON site.site_id = site_src.finalized_site_id
 JOIN

--- a/rest-api/tools/participant_hpo_backfill.sql
+++ b/rest-api/tools/participant_hpo_backfill.sql
@@ -1,0 +1,44 @@
+# This SELECT mirrors the UPDATE below, to serve as pre-validation.
+# See https://precisionmedicineinitiative.atlassian.net/browse/DA-384 .
+
+SELECT
+  participant.hpo_id old_hpo_id,
+  hpo.hpo_id new_hpo_id,
+  CONCAT("[{\"primary\":true,\"organization\":{\"reference\":\"Organization/", hpo.name, "\"}}]") provider_link
+FROM
+  participant
+JOIN
+  participant_summary USING(participant_id)
+JOIN
+  biobank_order site_src USING(participant_id)
+JOIN
+  site ON site.site_id = site_src.finalized_site_id
+JOIN
+  hpo ON site.hpo_id = hpo.hpo_id
+WHERE
+  participant.hpo_id = 0
+  AND hpo.hpo_id IS NOT NULL
+ORDER BY new_hpo_id
+;
+
+
+UPDATE
+  participant
+JOIN
+  participant_summary USING(participant_id)
+JOIN
+  # We will run it once with biobank_order as the `site_src` table, expecting to update
+  # 110 rows; and then again using physical_measurements which will update 1 more row.
+  biobank_order site_src USING(participant_id)
+JOIN
+  site ON site.site_id = site_src.finalized_site_id
+JOIN
+  hpo ON site.hpo_id = hpo.hpo_id
+SET
+  participant.hpo_id = hpo.hpo_id,
+  participant.provider_link = CONCAT("[{\"primary\":true,\"organization\":{\"reference\":\"Organization/", hpo.name, "\"}}]"),
+  participant_summary.hpo_id = hpo.hpo_id
+WHERE
+  participant.hpo_id = 0
+  AND hpo.hpo_id IS NOT NULL
+;


### PR DESCRIPTION
What do you think of this option?

Example output from the SELECT (demonstrating that the `providerLink` JSON is valid and HPO ID is going from 0 to nonzero):
```
+------------+------------+----------------------------------------------------------------------------+
| old_hpo_id | new_hpo_id | provider_link                                                              |
+------------+------------+----------------------------------------------------------------------------+
|          0 |          1 | [{"primary":true,"organization":{"reference":"Organization/PITT"}}]        |
|          0 |          1 | [{"primary":true,"organization":{"reference":"Organization/PITT"}}]        |
|          0 |          1 | [{"primary":true,"organization":{"reference":"Organization/PITT"}}]        |
...
|          0 |          5 | [{"primary":true,"organization":{"reference":"Organization/COMM_HEALTH"}}] |
|          0 |         12 | [{"primary":true,"organization":{"reference":"Organization/CAL_PMC"}}]     |
|          0 |         12 | [{"primary":true,"organization":{"reference":"Organization/CAL_PMC"}}]     |
|          0 |         14 | [{"primary":true,"organization":{"reference":"Organization/TRANS_AM"}}]    |
+------------+------------+----------------------------------------------------------------------------+
18 rows in set (0.04 sec)
```

Since there are only ~200 participants with no HPO pairing, it would also be easy to write a script that iterates over all them, and for each (within its own transaction) verifies that it's still not paired and updates it using DAO methods.

SQL: Pro: already written / fast to write. Easy to audit by querying before/after state. Con: Slightly less formal.
DAO: Pro: easier to follow logic. Con: More to write.