### PR TITLE
Fix data gen: Deserialize provider link value. Exercise data gen on CircleCI.

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -41,7 +41,7 @@ done
 
 # Verify that data generation works.
 ./tools/generate_fake_data.sh \
-    --num_participants 100 \
+    --num_participants 10 \
     --include_physical_measurements --include_biobank_orders --create_biobank_samples
 
 cd ../rdr_client

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -41,7 +41,7 @@ done
 
 # Verify that data generation works.
 ./tools/generate_fake_data.sh \
-    --num_participants 10 \
+    --num_participants 3 \
     --include_physical_measurements --include_biobank_orders --create_biobank_samples
 
 cd ../rdr_client

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -39,6 +39,11 @@ done
 ./tools/install_config.sh --config=config/config_dev.json --update
 ./tools/setup_local_database.sh --nopassword --db_user ubuntu --db_name circle_test
 
+# Verify that data generation works.
+./tools/generate_fake_data.sh \
+    --num_participants 100 \
+    --include_physical_measurements --include_biobank_orders --create_biobank_samples
+
 cd ../rdr_client
 activate_local_venv
 

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -256,7 +256,10 @@ def make_primary_provider_link_for_hpo(hpo):
 
 
 def make_primary_provider_link_for_name(hpo_name):
-  """Returns serialized FHIR JSON for a primary provider link based on HPO information."""
+  """Returns serialized FHIR JSON for a provider link based on HPO information.
+
+  The returned JSON represents a list containing the one primary provider.
+  """
   return json.dumps([{
       'primary': True,
       'organization': {

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -451,7 +451,7 @@ class FakeParticipantGenerator(object):
     if random.random() <= _NO_HPO_CHANGE:
       return consent_time, participant_response
     hpo = random.choice(self._hpos)
-    participant_response['providerLink'] = [make_primary_provider_link_for_hpo(hpo)]
+    participant_response['providerLink'] = json.loads(make_primary_provider_link_for_hpo(hpo))
     days_delta = random.randint(0, _MAX_DAYS_BEFORE_HPO_CHANGE)
     change_time = consent_time + datetime.timedelta(days=days_delta)
     result = self._update_participant(change_time, participant_response, participant_id)
@@ -507,7 +507,7 @@ class FakeParticipantGenerator(object):
         hpo = random.choice(self._hpos)
     if hpo:
       if hpo.hpoId != UNSET_HPO_ID:
-        participant_json['providerLink'] = [make_primary_provider_link_for_hpo(hpo)]
+        participant_json['providerLink'] = json.loads(make_primary_provider_link_for_hpo(hpo))
     creation_time = self._days_ago(random.randint(0, _MAX_DAYS_HISTORY))
     participant_response = self._client.request_json(
         'Participant', method='POST', body=participant_json, pretend_date=creation_time)


### PR DESCRIPTION
Shows up in the CircleCI logs:
```
INFO     2017-09-20 20:34:18,575 module.py:832] testing: "POST /rdr/v1/DataGen HTTP/1.1" 200 3
2017-09-20 20:34:18,576 INFO: 200 for POST to http://localhost:8080/rdr/v1/DataGen
2017-09-20 20:34:18,577 INFO: Total participants created: 100
INFO     2017-09-20 20:34:18,580 app_util.py:34] Request protocol: HTTPS=off
INFO     2017-09-20 20:34:18,598 module.py:832] testing: "POST /rdr/v1/DataGen HTTP/1.1" 200 3
2017-09-20 20:34:18,600 INFO: 200 for POST to http://localhost:8080/rdr/v1/DataGen
INFO     2017-09-20 20:34:18,597 deferred.py:311] X-Appengine-Tasketa:1505939658.58, X-Appengine-Country:ZZ, X-Appengine-Current-Namespace:, X-Appengine-Taskretrycount:0, X-Appengine-Queuename:default, X-Appengine-Taskexecutioncount:0, X-Appengine-Taskname:task1
2017-09-20 20:34:18,600 INFO: Biobank samples are being generated asynchronously. Wait until done, then use the cron tab in AppEngine to start the samples pipeline.
2017-09-20 20:34:18,601 INFO: Done.
```