### PR TITLE
[DA-402] Changing elapsed time in reconcilation report to be based on creation…

### DIFF
--- a/rest-api/offline/README.md
+++ b/rest-api/offline/README.md
@@ -66,7 +66,7 @@ different subsets of the rows:
     a case where the same test was ordered twice and received twice for a
     participant.
 1.  `report_$DATE_over_24h.csv` Rows where the elapsed time between ordered
-    sample collection and sample receipt confirmation is more than 24 hours.
+    sample collection and sample creation is more than 24 hours.
     This may include cases where there is a mismatch in samples ordered/sent
     and samples received. Last 7 days only.
 1.  `report_$DATE_missing.csv` Any case of order and receipt mismatch. This may
@@ -108,5 +108,5 @@ Column | Description | Example
 `received_sample_id` | Received sample's ID, from "Sample Id" column. | 3663123 or "1685731,1809762"
 `received_time` | Received sample's confirmed timestamp, ISO-8601 format. (Converted from Central time.) | 2016-09-22T08:38:42+00:00
 `Sample Family Create Date` | Received sample's created timestamp, ISO-8601 format. (Converted from Central time.) | 2016-09-22T08:38:42+00:00
-`elapsed_hours` | Elapsed integer hours between `sent_collection_time` and `received_time`. | 20
+`elapsed_hours` | Elapsed integer hours between `sent_collection_time` and `Sample Family Create Date`. | 20
 

--- a/rest-api/offline/biobank_samples_pipeline.py
+++ b/rest-api/offline/biobank_samples_pipeline.py
@@ -216,7 +216,7 @@ def _query_and_write_reports(exporter, now, path_received, path_late, path_missi
 
   # Gets orders for which the samples arrived, but they arrived late, within the past 7 days.
   late_predicate = lambda result: (result[_ELAPSED_HOURS_INDEX] and
-                                    int(result[_ELAPSED_HOURS_INDEX]) > 24 and
+                                    int(result[_ELAPSED_HOURS_INDEX]) >= 24 and
                                     in_past_week(result, now))
 
   # Gets samples or orders where something has gone missing within the past 7 days, and if an order
@@ -338,7 +338,7 @@ _RECONCILIATION_REPORT_SQL = ("""
     GROUP_CONCAT(DISTINCT biobank_stored_sample_id) received_sample_id,
     ISODATE[MAX(confirmed)] received_time,
     ISODATE[MAX(created)] 'Sample Family Create Date',
-    TIMESTAMPDIFF(HOUR, MAX(collected), MAX(confirmed)) elapsed_hours,
+    TIMESTAMPDIFF(HOUR, MAX(collected), MAX(created)) elapsed_hours,
     GROUP_CONCAT(DISTINCT biospecimen_kit_id) biospecimen_kit_id,
     GROUP_CONCAT(DISTINCT fedex_tracking_number) fedex_tracking_number
   FROM

--- a/rest-api/test/unit_test/offline_test/biobank_samples_pipeline_mysql_test.py
+++ b/rest-api/test/unit_test/offline_test/biobank_samples_pipeline_mysql_test.py
@@ -171,14 +171,14 @@ class MySqlReconciliationTest(FlaskTestBase):
     o_late_and_missing = self._insert_order(
         p_late_and_missing, 'SlowOrder', BIOBANK_TESTS[:3], order_time)
     self._insert_samples(p_late_and_missing, [BIOBANK_TESTS[0]], ['LateSample'], late_time,
-                         late_time - datetime.timedelta(hours=1))
+                         late_time - datetime.timedelta(minutes=59))
 
     # Late order and samples from 10 days ago; shows up in rx (but not missing, as it was too
     # long ago.
     p_old_late_and_missing = self._insert_participant()
     self._insert_order(p_old_late_and_missing, 'OldSlowOrder', BIOBANK_TESTS[:2], old_order_time)
     self._insert_samples(p_old_late_and_missing, [BIOBANK_TESTS[0]], ['OldLateSample'],
-                         old_late_time, old_late_time - datetime.timedelta(hours=1))
+                         old_late_time, old_late_time - datetime.timedelta(minutes=59))
 
 
     # Order with missing sample from 2 days ago; shows up in rx and missing.
@@ -190,7 +190,7 @@ class MySqlReconciliationTest(FlaskTestBase):
     # Recent samples with no matching order; shows up in missing.
     p_extra = self._insert_participant(race_codes=[RACE_WHITE_CODE])
     self._insert_samples(p_extra, [BIOBANK_TESTS[-1]], ['NobodyOrderedThisSample'], order_time,
-                         order_time - datetime.timedelta(hours=1))
+                         order_time - datetime.timedelta(minutes=59))
 
     # Old samples with no matching order; shows up in rx.
     p_old_extra = self._insert_participant(race_codes=[RACE_AIAN_CODE])
@@ -212,7 +212,7 @@ class MySqlReconciliationTest(FlaskTestBase):
                        order_time)
     self._insert_samples(p_withdrawn_late_and_missing, [BIOBANK_TESTS[0]],
                          ['WithdrawnLateSample'], late_time,
-                         late_time - datetime.timedelta(hours=1))
+                         late_time - datetime.timedelta(minutes=59))
     self._withdraw(p_withdrawn_late_and_missing, within_24_hours)
 
     p_withdrawn_old_late_and_missing = self._insert_participant()
@@ -220,7 +220,7 @@ class MySqlReconciliationTest(FlaskTestBase):
                        old_order_time)
     self._insert_samples(p_withdrawn_old_late_and_missing, [BIOBANK_TESTS[0]],
                          ['WithdrawnOldLateSample'], old_late_time,
-                         old_late_time - datetime.timedelta(hours=1))
+                         old_late_time - datetime.timedelta(minutes=59))
     self._withdraw(p_withdrawn_old_late_and_missing, old_late_time)
 
     p_withdrawn_extra = self._insert_participant(race_codes=[RACE_WHITE_CODE])
@@ -318,10 +318,10 @@ class MySqlReconciliationTest(FlaskTestBase):
     exporter.assertHasRow(late, {
         'biobank_id': to_client_biobank_id(p_late_and_missing.biobankId),
         'sent_order_id': 'O%s' % o_late_and_missing.biobankOrderId,
-        'elapsed_hours': '25'})
+        'elapsed_hours': '24'})
     exporter.assertHasRow(late, {
         'biobank_id': to_client_biobank_id(p_repeated.biobankId),
-        'elapsed_hours': '46'})
+        'elapsed_hours': '45'})
 
     # orders/samples where something went wrong; don't include orders/samples from more than 7
     # days ago, or where 24 hours hasn't elapsed yet.


### PR DESCRIPTION
… time ending rather than

confirmed time.

Adjusting logic to count 24+ hours as late as opposed to 25+ hours.