### PR TITLE
[DA-401] Changing short value to be the first 50 chars of value...

### DIFF
--- a/rest-api/dao/code_dao.py
+++ b/rest-api/dao/code_dao.py
@@ -51,7 +51,7 @@ class CodeBookDao(BaseDao):
     property_dict = {p['code']: p['valueCode'] for p in concept['property']}
     topic = property_dict['concept-topic']
     value = concept['code']
-    short_value = property_dict.get('short-code')
+    short_value = property_dict.get('short-code') or value[:50]
     display = concept['display']
     code_type = _CODE_TYPE_MAP.get(property_dict['concept-type'])
     if code_type is None:

--- a/rest-api/model/code.py
+++ b/rest-api/model/code.py
@@ -43,7 +43,8 @@ class _CodeBase(object):
   system = Column('system', String(255), nullable=False)
   value = Column('value', String(80), nullable=False)
   # OMOP codes are supposed to be at most 50 characters long; for legacy codes that exceeded this
-  # limit, we populate a shortened version for use in OMOP here. Otherwise, shortValue is NULL.
+  # limit, we populate a shortened version for use in OMOP here. Otherwise, shortValue is identical
+  # to value.
   shortValue = Column('short_value', String(50))
   display = Column('display', UnicodeText)
   topic = Column('topic', UnicodeText)

--- a/rest-api/test/unit_test/dao_test/code_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/code_dao_test.py
@@ -191,29 +191,30 @@ class CodeDaoTest(SqlTestBase):
                                 system=system)
     self.assertEquals(expectedCodeBook.asdict(), self.code_book_dao.get(1).asdict())
 
-    expectedModule1 = Code(codeBookId=1, codeId=1, system=system, value="m1", display=u"d7",
-                           topic=u"mt1", codeType=CodeType.MODULE, mapped=True, created=TIME)
+    expectedModule1 = Code(codeBookId=1, codeId=1, system=system, value="m1", shortValue="m1",
+                           display=u"d7", topic=u"mt1", codeType=CodeType.MODULE, mapped=True, 
+                           created=TIME)
     self.assertEquals(expectedModule1.asdict(), self.code_dao.get(1).asdict())
 
     expectedModuleHistory1 = CodeHistory(codeHistoryId=1, codeBookId=1, codeId=1, system=system,
-                                         value="m1", display=u"d7",
+                                         value="m1", shortValue="m1", display=u"d7",
                                          topic=u"mt1", codeType=CodeType.MODULE, mapped=True,
                                          created=TIME)
     self.assertEquals(expectedModuleHistory1.asdict(), self.code_history_dao.get(1).asdict())
 
-    expectedTopic1 = Code(codeBookId=1, codeId=2, system=system, value="t1", display=u"d6",
-                          topic=u"t1", codeType=CodeType.TOPIC, mapped=True, created=TIME,
-                          parentId=1)
+    expectedTopic1 = Code(codeBookId=1, codeId=2, system=system, value="t1", shortValue="t1",
+                          display=u"d6", topic=u"t1", codeType=CodeType.TOPIC, mapped=True, 
+                          created=TIME, parentId=1)
     self.assertEquals(expectedTopic1.asdict(), self.code_dao.get(2).asdict())
 
-    expectedQuestion1 = Code(codeBookId=1, codeId=3, system=system, value="q1", display=u"d4",
-                             topic=u"t1", codeType=CodeType.QUESTION, mapped=True, created=TIME,
-                             parentId=2)
+    expectedQuestion1 = Code(codeBookId=1, codeId=3, system=system, value="q1", shortValue="q1",
+                             display=u"d4", topic=u"t1", codeType=CodeType.QUESTION, mapped=True, 
+                             created=TIME, parentId=2)
     self.assertEquals(expectedQuestion1.asdict(), self.code_dao.get(3).asdict())
 
-    expectedAnswer1 = Code(codeBookId=1, codeId=4, system=system, value="c1", display=u"d1",
-                          topic=u"t1", codeType=CodeType.ANSWER, mapped=True, created=TIME,
-                          parentId=3)
+    expectedAnswer1 = Code(codeBookId=1, codeId=4, system=system, value="c1", shortValue="c1",
+                           display=u"d1", topic=u"t1", codeType=CodeType.ANSWER, mapped=True, 
+                           created=TIME, parentId=3)
     self.assertEquals(expectedAnswer1.asdict(), self.code_dao.get(4).asdict())
 
 def _make_concept(concept_topic, concept_type, code, display, child_concepts=None):

--- a/rest-api/test/unit_test/dao_test/code_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/code_dao_test.py
@@ -192,7 +192,7 @@ class CodeDaoTest(SqlTestBase):
     self.assertEquals(expectedCodeBook.asdict(), self.code_book_dao.get(1).asdict())
 
     expectedModule1 = Code(codeBookId=1, codeId=1, system=system, value="m1", shortValue="m1",
-                           display=u"d7", topic=u"mt1", codeType=CodeType.MODULE, mapped=True, 
+                           display=u"d7", topic=u"mt1", codeType=CodeType.MODULE, mapped=True,
                            created=TIME)
     self.assertEquals(expectedModule1.asdict(), self.code_dao.get(1).asdict())
 
@@ -203,17 +203,17 @@ class CodeDaoTest(SqlTestBase):
     self.assertEquals(expectedModuleHistory1.asdict(), self.code_history_dao.get(1).asdict())
 
     expectedTopic1 = Code(codeBookId=1, codeId=2, system=system, value="t1", shortValue="t1",
-                          display=u"d6", topic=u"t1", codeType=CodeType.TOPIC, mapped=True, 
+                          display=u"d6", topic=u"t1", codeType=CodeType.TOPIC, mapped=True,
                           created=TIME, parentId=1)
     self.assertEquals(expectedTopic1.asdict(), self.code_dao.get(2).asdict())
 
     expectedQuestion1 = Code(codeBookId=1, codeId=3, system=system, value="q1", shortValue="q1",
-                             display=u"d4", topic=u"t1", codeType=CodeType.QUESTION, mapped=True, 
+                             display=u"d4", topic=u"t1", codeType=CodeType.QUESTION, mapped=True,
                              created=TIME, parentId=2)
     self.assertEquals(expectedQuestion1.asdict(), self.code_dao.get(3).asdict())
 
     expectedAnswer1 = Code(codeBookId=1, codeId=4, system=system, value="c1", shortValue="c1",
-                           display=u"d1", topic=u"t1", codeType=CodeType.ANSWER, mapped=True, 
+                           display=u"d1", topic=u"t1", codeType=CodeType.ANSWER, mapped=True,
                            created=TIME, parentId=3)
     self.assertEquals(expectedAnswer1.asdict(), self.code_dao.get(4).asdict())
 


### PR DESCRIPTION
when short-code isn't set.

This way we can just use the "short_value" column in our ETL, etc. without conditional logic.