### PR TITLE
[DA-403] Remove dead data_gen code and fix fake sample generation & test.

### DIFF
--- a/rdr_client/generate_fake_data.py
+++ b/rdr_client/generate_fake_data.py
@@ -31,8 +31,7 @@ def generate_fake_data(client, args):
     logging.info('Total participants created: %d', total_participants_created)
   if args.create_biobank_samples:
     logging.info('Requesting Biobank sample generation.')
-    request_body = {'create_biobank_samples': 'all'}
-    client.request_json('DataGen', 'POST', request_body)
+    client.request_json('DataGen', 'POST', {'create_biobank_samples': True})
     logging.info(
         'Biobank samples are being generated asynchronously.'
         ' Wait until done, then use the cron tab in AppEngine to start the samples pipeline.')

--- a/rest-api/api/data_gen_api.py
+++ b/rest-api/api/data_gen_api.py
@@ -14,6 +14,10 @@ from flask.ext.restful import Resource
 from werkzeug.exceptions import Forbidden
 
 
+# 10% of individual stored samples are missing by default.
+_SAMPLES_MISSING_FRACTION = 0.1
+
+
 def _auth_required_healthpro_or_config_admin(func):
   """A decorator that checks that the caller is a config admin for the app."""
   def wrapped(*args, **kwargs):
@@ -46,4 +50,6 @@ class DataGenApi(Resource):
                                                    include_biobank_orders,
                                                    requested_hpo)
     if resource_json.get('create_biobank_samples'):
-      deferred.defer(generate_samples)
+      deferred.defer(
+          generate_samples,
+          resource_json.get('samples_missing_fraction', _SAMPLES_MISSING_FRACTION))

--- a/rest-api/api/data_gen_api.py
+++ b/rest-api/api/data_gen_api.py
@@ -7,7 +7,7 @@ import api_util
 from api_util import nonprod, get_validated_user_info, HEALTHPRO
 from config_api import is_config_admin
 from data_gen.fake_participant_generator import FakeParticipantGenerator
-from data_gen.fake_biobank_samples_generator import generate_samples, FakeBiobankSamplesGenerator
+from data_gen.fake_biobank_samples_generator import generate_samples
 from data_gen.in_process_client import InProcessClient
 from flask import request
 from flask.ext.restful import Resource
@@ -48,12 +48,5 @@ class DataGenApi(Resource):
         participant_generator.generate_participant(include_physical_measurements,
                                                    include_biobank_orders,
                                                    requested_hpo)
-    biobank_samples_target = resource_json.get('create_biobank_samples', None)
-    if biobank_samples_target:
-      if biobank_samples_target == 'all':
-        deferred.defer(generate_samples)
-      else:
-        participant_id = from_client_participant_id(biobank_samples_target)
-        num_samples = FakeBiobankSamplesGenerator().generate_samples_for_participant(participant_id)
-        response['num_samples'] = num_samples
-    return response
+    if resource_json.get('create_biobank_samples'):
+      deferred.defer(generate_samples)

--- a/rest-api/api/data_gen_api.py
+++ b/rest-api/api/data_gen_api.py
@@ -14,9 +14,8 @@ from flask.ext.restful import Resource
 from model.utils import from_client_participant_id
 from werkzeug.exceptions import Forbidden
 
-DATE_FORMAT = '%Y-%m-%d'
 
-def auth_required_healthpro_or_config_admin(func):
+def _auth_required_healthpro_or_config_admin(func):
   """A decorator that checks that the caller is a config admin for the app."""
   def wrapped(*args, **kwargs):
     if not is_config_admin(api_util.get_oauth_id()):
@@ -31,7 +30,7 @@ def auth_required_healthpro_or_config_admin(func):
 
 class DataGenApi(Resource):
 
-  method_decorators = [auth_required_healthpro_or_config_admin]
+  method_decorators = [_auth_required_healthpro_or_config_admin]
 
   @nonprod
   def post(self):

--- a/rest-api/api/data_gen_api.py
+++ b/rest-api/api/data_gen_api.py
@@ -11,7 +11,6 @@ from data_gen.fake_biobank_samples_generator import generate_samples
 from data_gen.in_process_client import InProcessClient
 from flask import request
 from flask.ext.restful import Resource
-from model.utils import from_client_participant_id
 from werkzeug.exceptions import Forbidden
 
 
@@ -37,7 +36,6 @@ class DataGenApi(Resource):
     resource = request.get_data()
     resource_json = json.loads(resource)
     num_participants = int(resource_json.get('num_participants', 0))
-    response = {}
     include_physical_measurements = bool(resource_json.get('include_physical_measurements', False))
     include_biobank_orders = bool(resource_json.get('include_biobank_orders', False))
     requested_hpo = resource_json.get('hpo', None)

--- a/rest-api/api/data_gen_api.py
+++ b/rest-api/api/data_gen_api.py
@@ -1,8 +1,9 @@
-import api_util
-import executors
 import json
 import logging
 
+from google.appengine.ext import deferred
+
+import api_util
 from api_util import nonprod, get_validated_user_info, HEALTHPRO
 from config_api import is_config_admin
 from data_gen.fake_participant_generator import FakeParticipantGenerator
@@ -50,7 +51,7 @@ class DataGenApi(Resource):
     biobank_samples_target = resource_json.get('create_biobank_samples', None)
     if biobank_samples_target:
       if biobank_samples_target == 'all':
-        executors.defer(generate_samples)
+        deferred.defer(generate_samples)
       else:
         participant_id = from_client_participant_id(biobank_samples_target)
         num_samples = FakeBiobankSamplesGenerator().generate_samples_for_participant(participant_id)

--- a/rest-api/data_gen/fake_biobank_samples_generator.py
+++ b/rest-api/data_gen/fake_biobank_samples_generator.py
@@ -58,6 +58,11 @@ def generate_samples():
                                                           _PARTICIPANTS_WITH_STORED_SAMPLES,
                                                           _BATCH_SIZE)
       for biobank_id, collected_time, test in rows:
+        if collected_time is None:
+          logging.warning(
+              '%s test %s has no collected time, omitting', to_client_biobank_id(biobank_id), test)
+          # TODO(mwf) Is this OK?
+          continue
         if random.random() <= _MISSING_STORED_SAMPLE:
           continue
         minutes_delta = random.randint(0, _MAX_MINUTES_BETWEEN_SAMPLE_COLLECTED_AND_CONFIRMED)

--- a/rest-api/data_gen/fake_biobank_samples_generator.py
+++ b/rest-api/data_gen/fake_biobank_samples_generator.py
@@ -81,24 +81,3 @@ def generate_samples():
                            to_client_biobank_id(biobank_id), test])
           num_rows += 1
   logging.info("Generated %d samples in %s.", num_rows, file_name)
-
-class FakeBiobankSamplesGenerator(object):
-  """Generates fake biobank samples for the participants in the database."""
-
-  def generate_samples_for_participant(self, participant_id):
-    participant = ParticipantDao().get(participant_id)
-    if not participant:
-      raise NotFound('No participant with ID %d found' % participant_id)
-    ordered_samples = BiobankOrderDao().get_ordered_samples_for_participant(participant_id)
-    if not ordered_samples:
-      raise NotFound('No ordered samples found for participant %d' % participant_id)
-    now = clock.CLOCK.now()
-    stored_samples = [BiobankStoredSample(biobankStoredSampleId='%d-%s' %
-                                          (participant_id, sample.test),
-                                          biobankId=participant.biobankId,
-                                          test=sample.test,
-                                          confirmed=now) for sample in ordered_samples]
-
-    BiobankStoredSampleDao().upsert_all(stored_samples)
-    ParticipantSummaryDao().update_from_biobank_stored_samples(participant_id)
-    return len(stored_samples)

--- a/rest-api/data_gen/fake_biobank_samples_generator.py
+++ b/rest-api/data_gen/fake_biobank_samples_generator.py
@@ -8,13 +8,9 @@ import random
 from cloudstorage import cloudstorage_api
 from code_constants import BIOBANK_TESTS
 from dao.biobank_order_dao import BiobankOrderDao
-from dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from dao.participant_dao import ParticipantDao
-from dao.participant_summary_dao import ParticipantSummaryDao
-from model.biobank_stored_sample import BiobankStoredSample
 from model.utils import to_client_biobank_id
 from offline.biobank_samples_pipeline import INPUT_CSV_TIME_FORMAT
-from werkzeug.exceptions import NotFound
 
 # 80% of participants with orders have corresponding stored samples.
 _PARTICIPANTS_WITH_STORED_SAMPLES = 0.8

--- a/rest-api/data_gen/fake_biobank_samples_generator.py
+++ b/rest-api/data_gen/fake_biobank_samples_generator.py
@@ -54,12 +54,7 @@ def generate_samples():
                                                           _PARTICIPANTS_WITH_STORED_SAMPLES,
                                                           _BATCH_SIZE)
       for biobank_id, collected_time, test in rows:
-        if collected_time is None:
-          logging.warning(
-              '%s test %s has no collected time, omitting', to_client_biobank_id(biobank_id), test)
-          # TODO(mwf) Is this OK?
-          continue
-        if random.random() <= _MISSING_STORED_SAMPLE:
+        if collected_time is None or random.random() <= _MISSING_STORED_SAMPLE:
           continue
         minutes_delta = random.randint(0, _MAX_MINUTES_BETWEEN_SAMPLE_COLLECTED_AND_CONFIRMED)
         confirmed_time = collected_time + datetime.timedelta(minutes=minutes_delta)

--- a/rest-api/executors.py
+++ b/rest-api/executors.py
@@ -1,9 +1,0 @@
-"""Executor utility functions. Can override to change test behavior."""
-
-from google.appengine.ext import deferred
-
-def defer(fn, *args, **kwargs):
-  _do_defer(fn, *args, **kwargs)
-
-def _do_defer(fn, *args, **kwargs):
-  deferred.defer(fn, *args, **kwargs)

--- a/rest-api/offline/metrics_export.py
+++ b/rest-api/offline/metrics_export.py
@@ -1,7 +1,7 @@
+from google.appengine.ext import deferred
 
 import clock
 import config
-import executors
 
 from offline.sql_exporter import SqlExporter
 from dao.code_dao import CodeDao
@@ -149,7 +149,7 @@ class MetricsExport(object):
     """Entry point to exporting data for use by the metrics pipeline. Begins the export of
     the first shard of the participant data."""
     filename_prefix = '%s/' % clock.CLOCK.now().isoformat()
-    executors.defer(MetricsExport._start_participant_export, bucket_name, filename_prefix,
+    deferred.defer(MetricsExport._start_participant_export, bucket_name, filename_prefix,
                     num_shards, 0)
 
   @staticmethod
@@ -160,12 +160,12 @@ class MetricsExport(object):
     shard_number += 1
     if shard_number == num_shards:
       if next_type_methodname:
-        executors.defer(getattr(MetricsExport, next_type_methodname), bucket_name, filename_prefix,
+        deferred.defer(getattr(MetricsExport, next_type_methodname), bucket_name, filename_prefix,
                         num_shards, 0)
       else:
         getattr(MetricsExport, finish_methodname)(bucket_name, filename_prefix, num_shards)
     else:
-      executors.defer(getattr(MetricsExport, next_shard_methodname), bucket_name, filename_prefix,
+      deferred.defer(getattr(MetricsExport, next_shard_methodname), bucket_name, filename_prefix,
                       num_shards, shard_number)
 
 

--- a/rest-api/test/test-data/biobank_order_1.json
+++ b/rest-api/test/test-data/biobank_order_1.json
@@ -64,23 +64,33 @@
   }, {
     "test": "2ED10",
     "description": "Test 2ED10",
-    "processingRequired":true
+    "processingRequired":true,
+    "collected": "2016-01-04T09:45:49Z",
+    "finalized": "2016-01-04T10:55:41Z"
   }, {
     "test": "1SST8",
     "description": "Test 1SST8",
-    "processingRequired":false
+    "processingRequired":false,
+    "collected": "2016-01-04T09:45:49Z",
+    "finalized": "2016-01-04T10:55:41Z"
   }, {
     "test": "1HEP4",
     "description": "Test IHEP4",
-    "processingRequired":false
+    "processingRequired":false,
+    "collected": "2016-01-04T09:45:49Z",
+    "finalized": "2016-01-04T10:55:41Z"
   }, {
     "test": "1UR10",
     "description": "Test 1UR10",
-    "processingRequired":false
+    "processingRequired":false,
+    "collected": "2016-01-04T09:45:49Z",
+    "finalized": "2016-01-04T10:55:41Z"
   }, {
     "test": "1SAL",
     "description": "Test 1SAL",
-    "processingRequired":false
+    "processingRequired":false,
+    "collected": "2016-01-04T09:45:49Z",
+    "finalized": "2016-01-04T10:55:41Z"
   }],
   "notes": {
     "collected": "Only got 7mL in the ED10 tubes",

--- a/rest-api/test/unit_test/api_test/data_gen_api_test.py
+++ b/rest-api/test/unit_test/api_test/data_gen_api_test.py
@@ -4,13 +4,11 @@ from testlib import testutil
 
 from dao.biobank_order_dao import BiobankOrderDao
 from dao.biobank_stored_sample_dao import BiobankStoredSampleDao
-from dao.participant_dao import ParticipantDao
 from dao.participant_summary_dao import ParticipantSummaryDao
 from model.utils import from_client_participant_id
-from model.participant import Participant
 from offline.biobank_samples_pipeline import upsert_from_latest_csv
 from participant_enums import SampleStatus
-from test.unit_test.unit_test_util import FlaskTestBase, CloudStorageSqlTestBase
+from test.unit_test.unit_test_util import FlaskTestBase
 from test.test_data import load_biobank_order_json
 
 
@@ -40,7 +38,7 @@ class DataGenApiTest(testutil.CloudStorageTestBase, FlaskTestBase):
     self.assertEquals(7, len(bo_dao.get_with_children(order.biobankOrderId).samples))
 
     self.send_post('DataGen', {'create_biobank_samples': True, 'samples_missing_fraction': 0.0})
-    upsert_from_latest_csv()
+    upsert_from_latest_csv()  # Run the (usually offline) Biobank CSV import job.
 
     self.assertEquals(7, BiobankStoredSampleDao().count())
     ps = ParticipantSummaryDao().get(from_client_participant_id(participant_id))

--- a/rest-api/test/unit_test/unit_test_util.py
+++ b/rest-api/test/unit_test/unit_test_util.py
@@ -22,7 +22,6 @@ from testlib import testutil
 import api_util
 import config
 import config_api
-import executors
 import main
 import dao.base_dao
 import singletons
@@ -469,13 +468,6 @@ def sort_lists(obj):
     if type(val) is list:
       obj[key] = sorted(val)
   return obj
-
-
-def make_deferred_run():
-  executors.defer = executors._do_defer
-
-def make_deferred_not_run():
-  executors.defer = (lambda fn, *args, **kwargs: None)
 
 
 def make_questionnaire_response_json(participant_id, questionnaire_id, code_answers=None,


### PR DESCRIPTION
* Remove unused single-participant sample generation mode.
* Rewrite sample generation test from single participant to deferred behavior.
* Remove unused make_deferred[_not]_run.
* Add missing column to fake generated CSV.
* Add timestamps to fake BiobankOrder JSON.
* Skip missing timestamps gracefully in data generation.

I should be able to follow the sample generation model fairly directly for PPI generation: Create data for some fraction of participants in deferred execution, test by sending API requests & making the deferred run immediately.