### PR TITLE
Fixing data generation to re-fetch participant before updating status; updating metrics pipeline to run at 4 EST.

### DIFF
--- a/rdr_client/generate_fake_data.py
+++ b/rdr_client/generate_fake_data.py
@@ -12,7 +12,7 @@ import logging
 from client import Client
 from main_util import get_parser, configure_logging
 
-MAX_PARTICIPANTS_PER_REQUEST = 50
+MAX_PARTICIPANTS_PER_REQUEST = 25
 
 
 def generate_fake_data(client, args):

--- a/rest-api/cron.yaml
+++ b/rest-api/cron.yaml
@@ -1,7 +1,8 @@
 cron:
 - description: Daily metrics
   url: /offline/MetricsRecalculate
-  schedule: every day 01:00
+  schedule: every day 04:00
+  timezone: America/New_York
   target: offline
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -487,8 +487,9 @@ class FakeParticipantGenerator(object):
     result = self._update_participant(change_time, participant_response, participant_id)
     return change_time, result
 
-  def _submit_status_changes(self, participant_response, participant_id, last_request_time):
+  def _submit_status_changes(self, participant_id, last_request_time):
     if random.random() <= _SUSPENDED_PERCENT:
+      # Fetch the participant to ensure its version is up-to-date.
       participant_response = self._client.request_json(_participant_url(participant_id),
                                                        method='GET')
       participant_response['suspensionStatus'] = 'NO_CONTACT'
@@ -498,6 +499,7 @@ class FakeParticipantGenerator(object):
                                                       participant_id)
       last_request_time = change_time
     if random.random() <= _WITHDRAWN_PERCENT:
+      # Fetch the participant to ensure its version is up-to-date.
       participant_response = self._client.request_json(_participant_url(participant_id),
                                                        method='GET')
       participant_response['withdrawalStatus'] = 'NO_USE'
@@ -529,7 +531,7 @@ class FakeParticipantGenerator(object):
                                                                               participant_id,
                                                                               consent_time)
         last_request_time = max(last_request_time, last_hpo_change_time)
-      self._submit_status_changes(participant_response, participant_id, last_request_time)
+      self._submit_status_changes(participant_id, last_request_time)
 
   def _create_participant(self, hpo_name):
     participant_json = {}

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -489,6 +489,8 @@ class FakeParticipantGenerator(object):
 
   def _submit_status_changes(self, participant_response, participant_id, last_request_time):
     if random.random() <= _SUSPENDED_PERCENT:
+      participant_response = self._client.request_json(_participant_url(participant_id), 
+                                                       method='GET')
       participant_response['suspensionStatus'] = 'NO_CONTACT'
       days_delta = random.randint(0, _MAX_DAYS_BEFORE_SUSPENSION)
       change_time = last_request_time + datetime.timedelta(days=days_delta)
@@ -496,6 +498,8 @@ class FakeParticipantGenerator(object):
                                                       participant_id)
       last_request_time = change_time
     if random.random() <= _WITHDRAWN_PERCENT:
+      participant_response = self._client.request_json(_participant_url(participant_id), 
+                                                       method='GET')
       participant_response['withdrawalStatus'] = 'NO_USE'
       days_delta = random.randint(0, _MAX_DAYS_BEFORE_WITHDRAWAL)
       change_time = last_request_time + datetime.timedelta(days=days_delta)

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -489,7 +489,7 @@ class FakeParticipantGenerator(object):
 
   def _submit_status_changes(self, participant_response, participant_id, last_request_time):
     if random.random() <= _SUSPENDED_PERCENT:
-      participant_response = self._client.request_json(_participant_url(participant_id), 
+      participant_response = self._client.request_json(_participant_url(participant_id),
                                                        method='GET')
       participant_response['suspensionStatus'] = 'NO_CONTACT'
       days_delta = random.randint(0, _MAX_DAYS_BEFORE_SUSPENSION)
@@ -498,7 +498,7 @@ class FakeParticipantGenerator(object):
                                                       participant_id)
       last_request_time = change_time
     if random.random() <= _WITHDRAWN_PERCENT:
-      participant_response = self._client.request_json(_participant_url(participant_id), 
+      participant_response = self._client.request_json(_participant_url(participant_id),
                                                        method='GET')
       participant_response['withdrawalStatus'] = 'NO_USE'
       days_delta = random.randint(0, _MAX_DAYS_BEFORE_WITHDRAWAL)


### PR DESCRIPTION
Changing metrics pipeline to run at 4 AM, after biobank samples pipeline should have finished.