### PR TITLE
[DA-394] [DA-438] Add more columns to the participant view

### DIFF
--- a/rest-api/alembic/versions/9a5c2ef1038f_add_participant_view_columns.py
+++ b/rest-api/alembic/versions/9a5c2ef1038f_add_participant_view_columns.py
@@ -1,0 +1,133 @@
+"""add participant view columns
+
+Revision ID: 9a5c2ef1038f
+Revises: f2aa951ca1a7
+Create Date: 2017-11-03 10:55:56.523876
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import model.utils
+
+
+from participant_enums import PhysicalMeasurementsStatus, QuestionnaireStatus, OrderStatus
+from participant_enums import WithdrawalStatus, SuspensionStatus
+from participant_enums import EnrollmentStatus, Race, SampleStatus, OrganizationType
+from model.code import CodeType
+
+# revision identifiers, used by Alembic.
+revision = '9a5c2ef1038f'
+down_revision = 'f2aa951ca1a7'
+branch_labels = None
+depends_on = None
+
+
+_PARTICIPANT_VIEW_SQL = """
+CREATE OR REPLACE VIEW participant_view AS
+ SELECT
+   p.sign_up_time,
+   p.withdrawal_status,
+   p.withdrawal_time,
+   p.suspension_status,
+   p.suspension_time,
+   hpo.name hpo,
+   ps.zip_code,
+   state_code.value state,
+   recontact_method_code.value recontact_method,
+   language_code.value language,
+   TIMESTAMPDIFF(YEAR, ps.date_of_birth, CURDATE()) age_years,
+   gender_code.value gender,
+   sex_code.value sex,
+   sexual_orientation_code.value sexual_orientation,
+   education_code.value education,
+   income_code.value income,
+   ps.enrollment_status,
+   ps.race,
+   ps.physical_measurements_status,
+   ps.physical_measurements_finalized_time,
+   ps.physical_measurements_time,
+   ps.physical_measurements_created_site_id,
+   ps.physical_measurements_finalized_site_id,
+   ps.consent_for_study_enrollment,
+   ps.consent_for_study_enrollment_time,
+   ps.consent_for_electronic_health_records,
+   ps.consent_for_electronic_health_records_time,
+   ps.questionnaire_on_overall_health,
+   ps.questionnaire_on_overall_health_time,
+   ps.questionnaire_on_lifestyle,
+   ps.questionnaire_on_lifestyle_time,
+   ps.questionnaire_on_the_basics,
+   ps.questionnaire_on_the_basics_time,
+   ps.questionnaire_on_healthcare_access,
+   ps.questionnaire_on_healthcare_access_time,
+   ps.questionnaire_on_medical_history,
+   ps.questionnaire_on_medical_history_time,
+   ps.questionnaire_on_medications,
+   ps.questionnaire_on_medications_time,
+   ps.questionnaire_on_family_health,
+   ps.questionnaire_on_family_health_time,
+   ps.biospecimen_status,
+   ps.biospecimen_order_time,
+   ps.biospecimen_source_site_id,
+   ps.biospecimen_collected_site_id,
+   ps.biospecimen_processed_site_id,
+   ps.biospecimen_finalized_site_id,
+   ps.sample_order_status_1sst8,
+   ps.sample_order_status_1sst8_time,
+   ps.sample_order_status_1pst8,
+   ps.sample_order_status_1pst8_time,
+   ps.sample_order_status_1hep4,
+   ps.sample_order_status_1hep4_time,
+   ps.sample_order_status_1ed04,
+   ps.sample_order_status_1ed04_time,
+   ps.sample_order_status_1ed10,
+   ps.sample_order_status_1ed10_time,
+   ps.sample_order_status_2ed10,
+   ps.sample_order_status_2ed10_time,
+   ps.sample_order_status_1ur10,
+   ps.sample_order_status_1ur10_time,
+   ps.sample_order_status_1sal,
+   ps.sample_order_status_1sal_time,
+   ps.sample_status_1sst8,
+   ps.sample_status_1sst8_time,
+   ps.sample_status_1pst8,
+   ps.sample_status_1pst8_time,
+   ps.sample_status_1hep4,
+   ps.sample_status_1hep4_time,
+   ps.sample_status_1ed04,
+   ps.sample_status_1ed04_time,
+   ps.sample_status_1ed10,
+   ps.sample_status_1ed10_time,
+   ps.sample_status_2ed10,
+   ps.sample_status_2ed10_time,
+   ps.sample_status_1ur10,
+   ps.sample_status_1ur10_time,
+   ps.sample_status_1sal,
+   ps.sample_status_1sal_time,
+   ps.num_completed_baseline_ppi_modules,
+   ps.num_completed_ppi_modules,
+   ps.num_baseline_samples_arrived,
+   ps.samples_to_isolate_dna,
+   ps.consent_for_cabor,
+   ps.consent_for_cabor_time
+ FROM
+   participant p
+     LEFT OUTER JOIN hpo ON p.hpo_id = hpo.hpo_id
+     LEFT OUTER JOIN participant_summary ps ON p.participant_id = ps.participant_id
+     LEFT OUTER JOIN code state_code ON ps.state_id = state_code.code_id
+     LEFT OUTER JOIN code recontact_method_code ON ps.recontact_method_id = recontact_method_code.code_id
+     LEFT OUTER JOIN code language_code ON ps.language_id = language_code.code_id
+     LEFT OUTER JOIN code gender_code ON ps.gender_identity_id = gender_code.code_id
+     LEFT OUTER JOIN code sex_code ON ps.sex_id = sex_code.code_id
+     LEFT OUTER JOIN code sexual_orientation_code ON ps.sexual_orientation_id = sexual_orientation_code.code_id
+     LEFT OUTER JOIN code education_code ON ps.education_id = education_code.code_id
+     LEFT OUTER JOIN code income_code ON ps.income_id = income_code.code_id
+     WHERE (ps.email IS NULL OR ps.email NOT LIKE '%@example.com') AND
+           (hpo.name IS NULL OR hpo.name != 'TEST')
+"""
+def upgrade():
+    op.execute(_PARTICIPANT_VIEW_SQL)
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Tested locally after generating fake participants:

```
SELECT race_codes,hispanic FROM participant_view;
+-------------------+----------+
| race_codes        | hispanic |
+-------------------+----------+
| None              |        1 |
| None              |        0 |
| None              |        0 |
| None              |        0 |
| PMI_Other         |        0 |
| PreferNotToAnswer |        0 |
| None              |        0 |
| NHPI              |        0 |
| None              |        0 |
| None              |        0 |
| None              |        0 |
| None              |        0 |
| None              |        0 |
| NHPI              |        0 |
| Black             |        0 |
| MENA              |        0 |
| MENA,AIAN         |        0 |
| None              |        0 |
| NHPI              |        0 |
+-------------------+----------+
```

@danqrodney would you prefer I just stripped both PMI_ and WhatRaceEthnicity_ prefixes? I noticed "PMI_Other" above.