### PR TITLE
[DA-448] Switch sender of alert emails to pmi-drc-alerts, recipient for Biobank data errors to same.

### DIFF
--- a/rest-api/config/base_config.json
+++ b/rest-api/config/base_config.json
@@ -30,7 +30,7 @@
     "WhatRaceEthnicity_AIAN"
   ],
   "internal_status_email_sender": [
-    "all-of-us-rdr@googlegroups.com"
+    "pmi-drc-alerts@googlegroups.com"
   ],
   "internal_status_email_recipients": [
     "pmi-drc-alerts+nonprod@googlegroups.com"

--- a/rest-api/config/config_prod.json
+++ b/rest-api/config/config_prod.json
@@ -24,7 +24,7 @@
     "10"
   ],
   "biobank_status_mail_recipients" : [
-    "all-of-us-sample-alerts@googlegroups.com"
+    "pmi-drc-alerts+prod@googlegroups.com"
   ],
   "internal_status_email_recipients": [
     "pmi-drc-alerts+prod@googlegroups.com"

--- a/rest-api/offline/base_pipeline.py
+++ b/rest-api/offline/base_pipeline.py
@@ -10,6 +10,7 @@ import pipeline
 import config
 
 
+# TODO(DA-448) For more reliable delivery, switch to creating tickets via the JIRA API.
 def send_failure_alert(job_name, message, log_exc_info=False, extra_recipients=None):
   """Sends an alert email for a failed job."""
   subject = '%s failed in %s' % (job_name, app_identity.get_application_id())


### PR DESCRIPTION
I'm on the fence about the TODO to create JIRA tickets instead, but I figure if someone on GMail recommends tickets over e-mail for alerts, it's worth considering. Certainly getting synchronous errors if alert generation fails would be nice.