### PR TITLE
Whitelisting HPRO app IDs, Vibrent IPs for use in RDR in our non-prod

### DIFF
--- a/rest-api/config/config_stable.json
+++ b/rest-api/config/config_stable.json
@@ -6,7 +6,7 @@
   ],
   "user_info": {
     "pmi-hpo-test@appspot.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro"],
+      "roles": ["healthpro"],
       "whitelisted_appids": ["pmi-hpo-test"]
     },
     "vibrent-drc-stable@vibrent-drc-stable-165017.iam.gserviceaccount.com": {

--- a/rest-api/config/config_stable.json
+++ b/rest-api/config/config_stable.json
@@ -6,10 +6,14 @@
   ],
   "user_info": {
     "pmi-hpo-test@appspot.gserviceaccount.com": {
-      "roles": ["ptc", "healthpro"]
+      "roles": ["ptc", "healthpro"],
+      "whitelisted_appids": ["pmi-hpo-test"]
     },
     "vibrent-drc-stable@vibrent-drc-stable-165017.iam.gserviceaccount.com": {
-      "roles": ["ptc"]
+      "roles": ["ptc"],
+      "whitelisted_ip_ranges": {
+        "ip4": ["52.4.219.3"]
+      }
     },
     "configurator@all-of-us-rdr-stable.iam.gserviceaccount.com": {
       "roles": ["ptc", "healthpro"]

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -7,7 +7,7 @@
   "user_info": {
     "healthpro-staging@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
-      "whitelisted_appids": ["healthpro-staging"],
+      "whitelisted_appids": ["healthpro-staging"]
     },
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -6,14 +6,19 @@
   ],
   "user_info": {
     "healthpro-staging@appspot.gserviceaccount.com": {
-      "roles": ["healthpro"]
+      "roles": ["healthpro"],
+      "whitelisted_appids": ["healthpro-staging"],
     },
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
-      "comment": "for HealthPro testing"
+      "comment": "for HealthPro testing",
+      "whitelisted_appids": ["pmi-hpo-dev"]
     },
     "vibrent-drc-staging@vibrent-drc-staging-165017.iam.gserviceaccount.com": {
-      "roles": ["ptc"]
+      "roles": ["ptc"],
+      "whitelisted_ip_ranges": {
+        "ip4": ["52.203.93.76"]
+      }
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {
       "roles": ["ptc", "healthpro"],

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -7,7 +7,7 @@
   "user_info": {
     "healthpro-staging@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
-      "whitelisted_appids": ["healthpro-staging"]
+      "whitelisted_appids": ["healthpro-staging", "healthpro-beta"]
     },
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -8,15 +8,12 @@
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
       "comment": "for HealthPro testing",
-      "whitelisted_appids": ["pmi-hpo-dev"],
+      "whitelisted_appids": ["pmi-hpo-dev"]
     },
     "vibrent-drc-qa@vibrent-drc-qa-165017.iam.gserviceaccount.com": {
-      "roles": ["ptc"]
+      "roles": ["ptc"],
       "whitelisted_ip_ranges": {
-        "ip4": ["34.206.2.13",
-        		"34.233.5.6",
-        		"34.228.109.175",
-        		"34.205.219.39"]
+        "ip4": ["34.206.2.13", "34.233.5.6", "34.228.109.175", "34.205.219.39"]
       }
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -7,14 +7,10 @@
   "user_info": {
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
-      "comment": "for HealthPro testing",
-      "whitelisted_appids": ["pmi-hpo-dev"]
+      "comment": "for HealthPro testing"
     },
     "vibrent-drc-qa@vibrent-drc-qa-165017.iam.gserviceaccount.com": {
-      "roles": ["ptc"],
-      "whitelisted_ip_ranges": {
-        "ip4": ["34.206.2.13", "34.233.5.6", "34.228.109.175", "34.205.219.39"]
-      }
+      "roles": ["ptc"]
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {
       "roles": ["ptc", "healthpro"],

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -7,10 +7,17 @@
   "user_info": {
     "pmi-hpo-dev@appspot.gserviceaccount.com": {
       "roles": ["healthpro"],
-      "comment": "for HealthPro testing"
+      "comment": "for HealthPro testing",
+      "whitelisted_appids": ["pmi-hpo-dev"],
     },
     "vibrent-drc-qa@vibrent-drc-qa-165017.iam.gserviceaccount.com": {
       "roles": ["ptc"]
+      "whitelisted_ip_ranges": {
+        "ip4": ["34.206.2.13",
+        		"34.233.5.6",
+        		"34.228.109.175",
+        		"34.205.219.39"]
+      }
     },
     "vibrent@pmi-ptc-drc-test-harness.iam.gserviceaccount.com": {
       "roles": ["ptc", "healthpro"],


### PR DESCRIPTION
environments.

(Once we verify this works, we can configure prod as well.)