### PR TITLE
[DA-451] Whitelisting vibrent corp IPs for their use of their service account

### DIFF
--- a/rest-api/config/config_prod.json
+++ b/rest-api/config/config_prod.json
@@ -8,7 +8,7 @@
     "vibrent-drc-prod@vibrent-drc-prod-165017.iam.gserviceaccount.com": {
       "roles": ["ptc"],
       "whitelisted_ip_ranges": {
-        "ip4": ["34.204.157.148"],
+        "ip4": ["34.204.157.148", "72.194.199.150/32"],
         "ip6": []
       }
     },

--- a/rest-api/config/config_stable.json
+++ b/rest-api/config/config_stable.json
@@ -12,7 +12,7 @@
     "vibrent-drc-stable@vibrent-drc-stable-165017.iam.gserviceaccount.com": {
       "roles": ["ptc"],
       "whitelisted_ip_ranges": {
-        "ip4": ["52.4.219.3"],
+        "ip4": ["52.4.219.3", "72.194.199.150/32"],
         "ip6": []
       }
     },

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -17,7 +17,7 @@
     "vibrent-drc-staging@vibrent-drc-staging-165017.iam.gserviceaccount.com": {
       "roles": ["ptc"],
       "whitelisted_ip_ranges": {
-        "ip4": ["52.203.93.76"],
+        "ip4": ["52.203.93.76", "72.194.199.150/32"],
         "ip6": []
       }
     },


### PR DESCRIPTION
(This is needed to let them publish changes to the codebook.)