### PR TITLE
Adding .gitattributes

### DIFF
--- a/rest-api/.gitattributes
+++ b/rest-api/.gitattributes
@@ -1,0 +1,4 @@
+*.py -text eol=lf
+*.sh -text eol=lf
+*.sql -text eol=lf
+*.csv -text eol=lf


### PR DESCRIPTION
This should hopefully force github to do SQL diffs as text, handle newlines as LF everywhere.