### PR TITLE
[RW-263] Add public_metrics_export endpoint

### DIFF
--- a/rest-api/dao/database_utils.py
+++ b/rest-api/dao/database_utils.py
@@ -9,6 +9,7 @@ _DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 # MySQL uses %i for minutes
 _MYSQL_DATE_FORMAT = '%Y-%m-%dT%H:%i:%SZ'
 _ISODATE_PATTERN = 'ISODATE\[([^\]]+)\]'
+_YEARS_OLD_PATTERN = 'YEARS_OLD\[([^\]]+)\]'
 
 
 def get_sql_and_params_for_array(arr, name_prefix):
@@ -36,9 +37,17 @@ def format_datetime(dt):
   aware_dt = dt if dt.tzinfo is None else pytz.utc.localize(dt)
   return aware_dt.strftime(_DATE_FORMAT)
 
+def replace_years_old(sql):
+  if _is_sqlite():
+    return re.sub(_YEARS_OLD_PATTERN,
+                  r"CAST(((JULIANDAY('now') - JULIANDAY(\1)) / 365) AS int)",
+                  sql)
+  return re.sub(_YEARS_OLD_PATTERN,
+                r"FLOOR(DATEDIFF(NOW(), \1) / 365)",
+                sql)
+
 def replace_isodate(sql):
   if _is_sqlite():
     return re.sub(_ISODATE_PATTERN, r"strftime('{}', \1)".format(_DATE_FORMAT), sql)
-  else:
-    return re.sub(_ISODATE_PATTERN, r"DATE_FORMAT(\1, '{}')".format(_MYSQL_DATE_FORMAT),
-                  sql)
+  return re.sub(_ISODATE_PATTERN, r"DATE_FORMAT(\1, '{}')".format(_MYSQL_DATE_FORMAT),
+                sql)

--- a/rest-api/dao/database_utils.py
+++ b/rest-api/dao/database_utils.py
@@ -9,7 +9,7 @@ _DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 # MySQL uses %i for minutes
 _MYSQL_DATE_FORMAT = '%Y-%m-%dT%H:%i:%SZ'
 _ISODATE_PATTERN = 'ISODATE\[([^\]]+)\]'
-_YEARS_OLD_PATTERN = 'YEARS_OLD\[([^\]]+)\]'
+_YEARS_OLD_PATTERN = 'YEARS_OLD\[([^\],]+), +([^\],]+)\]'
 
 
 def get_sql_and_params_for_array(arr, name_prefix):
@@ -40,10 +40,10 @@ def format_datetime(dt):
 def replace_years_old(sql):
   if _is_sqlite():
     return re.sub(_YEARS_OLD_PATTERN,
-                  r"CAST(((JULIANDAY('now') - JULIANDAY(\1)) / 365) AS int)",
+                  r"CAST(((JULIANDAY(\1) - JULIANDAY(\2)) / 365) AS int)",
                   sql)
   return re.sub(_YEARS_OLD_PATTERN,
-                r"FLOOR(DATEDIFF(NOW(), \1) / 365)",
+                r"FLOOR(DATEDIFF(\1, \2) / 365)",
                 sql)
 
 def replace_isodate(sql):

--- a/rest-api/offline/main.py
+++ b/rest-api/offline/main.py
@@ -13,6 +13,7 @@ from offline import biobank_samples_pipeline
 from offline.base_pipeline import send_failure_alert
 from offline.table_exporter import TableExporter
 from offline.metrics_export import MetricsExport
+from offline.public_metrics_export import PublicMetricsExport
 from api_util import EXPORTER
 from werkzeug.exceptions import BadRequest
 
@@ -64,6 +65,9 @@ def recalculate_metrics():
                                      int(config.getSetting(config.METRICS_SHARDS, 1)))
     return '{"metrics-pipeline-status": "started"}'
 
+@app_util.auth_required_cron
+def recalculate_public_metrics():
+  return json.dumps(PublicMetricsExport.export())
 
 @app_util.auth_required_cron
 @_alert_on_exceptions
@@ -110,6 +114,12 @@ def _build_pipeline_app():
       endpoint='metrics_recalc',
       view_func=recalculate_metrics,
       methods=['GET'])
+
+  offline_app.add_url_rule(
+      PREFIX + 'PublicMetricsRecalculate',
+      endpoint='public_metrics_recalc',
+      view_func=recalculate_public_metrics,
+      methods=['POST'])
 
   offline_app.add_url_rule(
       PREFIX + 'ExportTables',

--- a/rest-api/offline/public_metrics_export.py
+++ b/rest-api/offline/public_metrics_export.py
@@ -51,7 +51,9 @@ _SQL_AGGREGATIONS = [
       WHERE {filter_test_sql}
       GROUP BY 1;
       """.format(filter_test_sql=_FILTER_TEST_SQL),
-      lambda v: EnrollmentStatus.lookup_by_number(v).name,
+      # Rewrite INTERESTED to CONSENTED, see note above.
+      lambda v: ('CONSENTED' if v is EnrollmentStatus.INTERESTED.number
+                 else EnrollmentStatus.lookup_by_number(v).name),
       None),
   # TODO(calbach): Verify whether we need to be conditionally trimming these
   # prefixes or leaving them unmodified. Unclear if all codes will have prefix

--- a/rest-api/offline/public_metrics_export.py
+++ b/rest-api/offline/public_metrics_export.py
@@ -181,13 +181,14 @@ class PublicMetricsExport(object):
     # Using a session here should put all following SQL invocations into a
     # non-locking read transaction per
     # https://dev.mysql.com/doc/refman/5.7/en/innodb-consistent-read.html
+    now = clock.CLOCK.now()
     test_hpo = HPODao().get_by_name(TEST_HPO_NAME)
     with database_factory.make_server_cursor_database().session() as session:
       for (key, sql, valuef, params) in _SQL_AGGREGATIONS:
         sql = replace_years_old(sql)
         out[key] = []
         p = {
-          'now': clock.CLOCK.now(),
+          'now': now,
           'test_hpo_id': test_hpo.hpoId,
           'test_email_pattern': TEST_EMAIL_PATTERN,
           'not_withdrawn_status': WithdrawalStatus.NOT_WITHDRAWN.number

--- a/rest-api/offline/public_metrics_export.py
+++ b/rest-api/offline/public_metrics_export.py
@@ -1,0 +1,145 @@
+from sqlalchemy import text
+from dao import database_factory
+from dao.database_utils import replace_years_old
+from participant_enums import EnrollmentStatus, OrderStatus, PhysicalMeasurementsStatus
+from participant_enums import Race, QuestionnaireStatus
+
+# TODO(calbach): consider whether we need to filter down to consented
+# individuals only.
+
+def _questionnaire_metric(name, col):
+  """Returns a metrics SQL aggregation tuple for the given key/column."""
+  return (
+      name,
+      """
+      SELECT {}, SUM(1)
+      FROM participant_summary
+      GROUP BY 1;
+      """.format(col),
+      lambda v: QuestionnaireStatus.lookup_by_number(v).name
+  )
+
+# Metrics definitions. 3-tuples of:
+# - (str) aggregation key name
+# - (str) SQL statement to select value, count for a metric (in that order)
+# - (func(str): str) optional function which takes the value from the above SQL
+#   output and converts it for presentation
+_SQL_AGGREGATIONS = [
+  ('enrollmentStatus',
+   """
+   SELECT enrollment_status, SUM(1)
+   FROM participant_summary
+   GROUP BY 1;
+   """,
+   lambda v: EnrollmentStatus.lookup_by_number(v).name),
+  # TODO(calbach): Verify whether we need to be conditionally trimming these
+  # prefixes or leaving them unmodified. Unclear if all codes will have prefix
+  # "PMI_".
+  ('gender',
+   """
+   SELECT code.value, ps.count
+   FROM (
+    SELECT gender_identity_id, SUM(1) count
+    FROM participant_summary
+    WHERE gender_identity_id IS NOT NULL
+    GROUP BY 1
+   ) ps LEFT JOIN code
+   ON ps.gender_identity_id = code.code_id;
+   """,
+   None),
+  ('race',
+   """
+   SELECT race, SUM(1)
+   FROM participant_summary
+   WHERE race IS NOT NULL
+   GROUP BY 1
+   """,
+   lambda v: Race.lookup_by_number(v).name),
+  ('state',
+   """
+   SELECT SUBSTR(code.value, {}), ps.count
+   FROM (
+    SELECT state_id, SUM(1) count
+    FROM participant_summary
+    WHERE state_id IS NOT NULL
+    GROUP BY 1
+   ) ps LEFT JOIN code
+   ON ps.state_id = code.code_id;
+   """.format(len('PIIState_') + 1),
+   None),
+  ('ageRange',
+   """
+   SELECT
+     CASE
+      WHEN YEARS_OLD[date_of_birth] < 0 THEN 'UNSET'
+      WHEN YEARS_OLD[date_of_birth] <= 17 THEN '0-17'
+      WHEN YEARS_OLD[date_of_birth] <= 25 THEN '18-25'
+      WHEN YEARS_OLD[date_of_birth] <= 35 THEN '26-35'
+      WHEN YEARS_OLD[date_of_birth] <= 45 THEN '36-45'
+      WHEN YEARS_OLD[date_of_birth] <= 55 THEN '46-55'
+      WHEN YEARS_OLD[date_of_birth] <= 65 THEN '56-65'
+      WHEN YEARS_OLD[date_of_birth] <= 75 THEN '66-75'
+      WHEN YEARS_OLD[date_of_birth] <= 85 THEN '76-85'
+      ELSE '86+'
+     END age_range,
+     SUM(1)
+   FROM participant_summary
+   GROUP BY 1;
+   """,
+   None),
+  ('physicalMeasurements',
+   """
+   SELECT physical_measurements_status, SUM(1)
+   FROM participant_summary
+   GROUP BY 1;
+   """,
+   lambda v: PhysicalMeasurementsStatus.lookup_by_number(v).name),
+  ('biospecimenSamples',
+   """
+   SELECT
+     CASE (biospecimen_status)
+      WHEN '{}' THEN 'UNSET'
+      WHEN '{}' THEN 'UNSET'
+      ELSE 'COLLECTED'
+     END, SUM(1)
+   FROM participant_summary
+   GROUP BY 1;
+   """.format(str(OrderStatus.UNSET.number), str(OrderStatus.CREATED.number)),
+   None),
+  _questionnaire_metric('questionnaireOnOverallHealth', 'questionnaire_on_overall_health'),
+  # Personal habits is a newer naming for lifestyle
+  _questionnaire_metric('questionnaireOnPersonalHabits', 'questionnaire_on_lifestyle'),
+  # Sociodemographics is a newer naming for 'the basics'
+  _questionnaire_metric('questionnaireOnSociodemographics', 'questionnaire_on_the_basics'),
+  _questionnaire_metric('questionnaireOnHealthcareAccess', 'questionnaire_on_healthcare_access'),
+  _questionnaire_metric('questionnaireOnMedicalHistory', 'questionnaire_on_medical_history'),
+  _questionnaire_metric('questionnaireOnMedications', 'questionnaire_on_medications'),
+  _questionnaire_metric('questionnaireOnFamilyHealth', 'questionnaire_on_family_health')
+]
+
+
+class PublicMetricsExport(object):
+  """Exports data from the database needed to generate public registration metrics."""
+
+  @staticmethod
+  def export():
+    # TODO(calbach): Write the output to a given target destination rather than
+    # returning it.
+    out = {}
+    # Using a session here should put all following SQL invocations into a
+    # non-locking read transaction per
+    # https://dev.mysql.com/doc/refman/5.7/en/innodb-consistent-read.html
+    with database_factory.make_server_cursor_database().session() as session:
+      for (key, sql, valuef) in _SQL_AGGREGATIONS:
+        sql = replace_years_old(sql)
+        out[key] = []
+        result = session.execute(text(sql))
+        for row in result:
+          v = row.items()[0][1]
+          if valuef:
+            v = valuef(v)
+          out[key].append({
+              'value': v,
+              'count': row.items()[1][1],
+          })
+    return out

--- a/rest-api/offline/public_metrics_export.py
+++ b/rest-api/offline/public_metrics_export.py
@@ -1,4 +1,5 @@
 import clock
+import collections
 
 from sqlalchemy import text
 from dao import database_factory
@@ -11,7 +12,7 @@ from participant_enums import TEST_EMAIL_PATTERN, TEST_HPO_NAME
 
 def _questionnaire_metric(name, col):
   """Returns a metrics SQL aggregation tuple for the given key/column."""
-  return (
+  return _SqlAggregation(
       name,
       """
       SELECT {col}, COUNT(*)
@@ -19,127 +20,143 @@ def _questionnaire_metric(name, col):
       WHERE {filter_test_sql}
       GROUP BY 1;
       """.format(col=col, filter_test_sql=_FILTER_TEST_SQL),
-      lambda v: QuestionnaireStatus.lookup_by_number(v).name
+      lambda v: QuestionnaireStatus.lookup_by_number(v).name,
+      None
   )
 
 _FILTER_TEST_SQL = """
-(NOT participant_summary.email LIKE '{test_email}'
+(NOT participant_summary.email LIKE :test_email_pattern
  AND NOT participant_summary.hpo_id = :test_hpo_id)
-""".format(test_email=TEST_EMAIL_PATTERN)
+"""
 
-# Metrics definitions. 3-tuples of:
-# - (str) aggregation key name
-# - (str) SQL statement to select value, count for a metric (in that order)
-# - (func(str): str) optional function which takes the value from the above SQL
-#   output and converts it for presentation
-#
+# Metrics SQL Aggregations. 4-tuples of:
+# - (str) key: aggregation key name
+# - (str) sql: statement to select value, count for a metric (in that order)
+# - (func(str): str) valuef: optional function which takes the value from the
+#   above SQL output and converts it for presentation
+# - (dict) params: optional extra SQL parameters to bind
+_SqlAggregation = collections.namedtuple(
+    '_SqlAggregation', ['key', 'sql', 'valuef', 'params'])
+
+
 # Note that we depend on the participant_summary table containing only consented
 # participants, by definition. Therefore these metrics only cover consented
 # individuals.
 _SQL_AGGREGATIONS = [
-  ('enrollmentStatus',
-   """
-   SELECT enrollment_status, COUNT(*)
-   FROM participant_summary
-   WHERE {filter_test_sql}
-   GROUP BY 1;
-   """.format(filter_test_sql=_FILTER_TEST_SQL),
-   lambda v: EnrollmentStatus.lookup_by_number(v).name),
+  _SqlAggregation(
+      'enrollmentStatus',
+      """
+      SELECT enrollment_status, COUNT(*)
+      FROM participant_summary
+      WHERE {filter_test_sql}
+      GROUP BY 1;
+      """.format(filter_test_sql=_FILTER_TEST_SQL),
+      lambda v: EnrollmentStatus.lookup_by_number(v).name,
+      None),
   # TODO(calbach): Verify whether we need to be conditionally trimming these
   # prefixes or leaving them unmodified. Unclear if all codes will have prefix
   # "PMI_".
-  ('gender',
-   """
-   SELECT
-     CASE
-      WHEN code.value IS NULL THEN 'UNSET'
-      ELSE code.value
-     END, ps.count
-   FROM (
-    SELECT gender_identity_id, COUNT(*) count
-    FROM participant_summary
-    WHERE {filter_test_sql}
-    GROUP BY 1
-   ) ps LEFT JOIN code
-   ON ps.gender_identity_id = code.code_id;
-   """.format(filter_test_sql=_FILTER_TEST_SQL),
-   None),
-  ('race',
-   """
-   SELECT
-     CASE
-      WHEN race IS NULL THEN 0
-      ELSE race
-     END, COUNT(*)
-   FROM participant_summary
-   WHERE {filter_test_sql}
-   GROUP BY 1
-   """.format(filter_test_sql=_FILTER_TEST_SQL),
-   lambda v: Race.lookup_by_number(v).name),
-  ('state',
-   """
-   SELECT
-     CASE
-      WHEN code.value IS NULL THEN 'UNSET'
-      WHEN code.value LIKE 'PIIState_%' THEN SUBSTR(code.value, LENGTH('PIIState_')+1)
-      ELSE code.value
-     END,
-     ps.count
-   FROM (
-    SELECT state_id, COUNT(*) count
-    FROM participant_summary
-    WHERE {filter_test_sql}
-    GROUP BY 1
-   ) ps LEFT JOIN code
-   ON ps.state_id = code.code_id;
-   """.format(filter_test_sql=_FILTER_TEST_SQL),
-   None),
-  ('ageRange',
-   """
-   SELECT
-     CASE
-      WHEN date_of_birth IS NULL THEN 'UNSET'
-      WHEN YEARS_OLD[:now, date_of_birth] < 0 THEN 'UNSET'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 17 THEN '0-17'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 25 THEN '18-25'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 35 THEN '26-35'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 45 THEN '36-45'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 55 THEN '46-55'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 65 THEN '56-65'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 75 THEN '66-75'
-      WHEN YEARS_OLD[:now, date_of_birth] <= 85 THEN '76-85'
-      ELSE '86+'
-     END age_range,
-     COUNT(*)
-   FROM participant_summary
-   WHERE {filter_test_sql}
-   GROUP BY 1;
-   """.format(filter_test_sql=_FILTER_TEST_SQL),
-   None),
-  ('physicalMeasurements',
-   """
-   SELECT physical_measurements_status, COUNT(*)
-   FROM participant_summary
-   WHERE {filter_test_sql}
-   GROUP BY 1;
-   """.format(filter_test_sql=_FILTER_TEST_SQL),
-   lambda v: PhysicalMeasurementsStatus.lookup_by_number(v).name),
-  ('biospecimenSamples',
-   """
-   SELECT
-     CASE
-      WHEN biospecimen_status IS NULL THEN 'UNSET'
-      WHEN biospecimen_status = '{unset}' THEN 'UNSET'
-      WHEN biospecimen_status = '{created}' THEN 'UNSET'
-      ELSE 'COLLECTED'
-     END, COUNT(*)
-   FROM participant_summary
-   WHERE {filter_test_sql}
-   GROUP BY 1;
-   """.format(unset=str(OrderStatus.UNSET.number),
-              created=str(OrderStatus.CREATED.number),
-              filter_test_sql=_FILTER_TEST_SQL),
-   None),
+  _SqlAggregation(
+      'gender',
+      """
+      SELECT
+        CASE
+         WHEN code.value IS NULL THEN 'UNSET'
+         ELSE code.value
+        END, ps.count
+      FROM (
+       SELECT gender_identity_id, COUNT(*) count
+       FROM participant_summary
+       WHERE {filter_test_sql}
+       GROUP BY 1
+      ) ps LEFT JOIN code
+      ON ps.gender_identity_id = code.code_id;
+      """.format(filter_test_sql=_FILTER_TEST_SQL),
+      None, None),
+  _SqlAggregation(
+      'race',
+      """
+      SELECT
+        CASE
+         WHEN race IS NULL THEN 0
+         ELSE race
+        END, COUNT(*)
+      FROM participant_summary
+      WHERE {filter_test_sql}
+      GROUP BY 1
+      """.format(filter_test_sql=_FILTER_TEST_SQL),
+      lambda v: Race.lookup_by_number(v).name, None),
+  _SqlAggregation(
+      'state',
+      """
+      SELECT
+        CASE
+         WHEN code.value IS NULL THEN 'UNSET'
+         WHEN code.value LIKE 'PIIState_%' THEN SUBSTR(code.value, LENGTH('PIIState_')+1)
+         ELSE code.value
+        END,
+        ps.count
+      FROM (
+       SELECT state_id, COUNT(*) count
+       FROM participant_summary
+       WHERE {filter_test_sql}
+       GROUP BY 1
+      ) ps LEFT JOIN code
+      ON ps.state_id = code.code_id;
+      """.format(filter_test_sql=_FILTER_TEST_SQL),
+      None, None),
+  _SqlAggregation(
+      'ageRange',
+      """
+      SELECT
+        CASE
+         WHEN date_of_birth IS NULL THEN 'UNSET'
+         WHEN YEARS_OLD[:now, date_of_birth] < 0 THEN 'UNSET'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 17 THEN '0-17'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 25 THEN '18-25'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 35 THEN '26-35'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 45 THEN '36-45'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 55 THEN '46-55'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 65 THEN '56-65'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 75 THEN '66-75'
+         WHEN YEARS_OLD[:now, date_of_birth] <= 85 THEN '76-85'
+         ELSE '86+'
+        END age_range,
+        COUNT(*)
+      FROM participant_summary
+      WHERE {filter_test_sql}
+      GROUP BY 1;
+      """.format(filter_test_sql=_FILTER_TEST_SQL),
+      None, None),
+  _SqlAggregation(
+      'physicalMeasurements',
+      """
+      SELECT physical_measurements_status, COUNT(*)
+      FROM participant_summary
+      WHERE {filter_test_sql}
+      GROUP BY 1;
+      """.format(filter_test_sql=_FILTER_TEST_SQL),
+      lambda v: PhysicalMeasurementsStatus.lookup_by_number(v).name,
+      None),
+  _SqlAggregation(
+      'biospecimenSamples',
+      """
+      SELECT
+        CASE
+         WHEN biospecimen_status IS NULL THEN 'UNSET'
+         WHEN biospecimen_status = :unset_status THEN 'UNSET'
+         WHEN biospecimen_status = :created_status THEN 'UNSET'
+         ELSE 'COLLECTED'
+        END, COUNT(*)
+      FROM participant_summary
+      WHERE {filter_test_sql}
+      GROUP BY 1;
+      """.format(filter_test_sql=_FILTER_TEST_SQL),
+      None,
+      params={
+        'unset_status': OrderStatus.UNSET.number,
+        'created_status': OrderStatus.CREATED.number
+      }),
   # TODO(calbach): Add healthcare_access, medical_history, medications,
   # family_health once available.
   _questionnaire_metric('questionnaireOnOverallHealth', 'questionnaire_on_overall_health'),
@@ -163,13 +180,17 @@ class PublicMetricsExport(object):
     # https://dev.mysql.com/doc/refman/5.7/en/innodb-consistent-read.html
     test_hpo = HPODao().get_by_name(TEST_HPO_NAME)
     with database_factory.make_server_cursor_database().session() as session:
-      for (key, sql, valuef) in _SQL_AGGREGATIONS:
+      for (key, sql, valuef, params) in _SQL_AGGREGATIONS:
         sql = replace_years_old(sql)
         out[key] = []
-        result = session.execute(text(sql), params={
-            'now': clock.CLOCK.now(),
-            'test_hpo_id': test_hpo.hpoId
-        })
+        p = {
+          'now': clock.CLOCK.now(),
+          'test_hpo_id': test_hpo.hpoId,
+          'test_email_pattern': TEST_EMAIL_PATTERN
+        }
+        if params:
+          p.update(params)
+        result = session.execute(text(sql), params=p)
         for row in result:
           v = row.items()[0][1]
           if valuef:

--- a/rest-api/offline/public_metrics_export.py
+++ b/rest-api/offline/public_metrics_export.py
@@ -3,74 +3,99 @@ from dao import database_factory
 from dao.database_utils import replace_years_old
 from participant_enums import EnrollmentStatus, OrderStatus, PhysicalMeasurementsStatus
 from participant_enums import Race, QuestionnaireStatus
+from participant_enums import TEST_EMAIL_PATTERN, TEST_HPO_NAME
 
-# TODO(calbach): consider whether we need to filter down to consented
-# individuals only.
 
 def _questionnaire_metric(name, col):
   """Returns a metrics SQL aggregation tuple for the given key/column."""
   return (
       name,
       """
-      SELECT {}, SUM(1)
+      SELECT {col}, COUNT(*)
       FROM participant_summary
+      WHERE {filter_test_sql}
       GROUP BY 1;
-      """.format(col),
+      """.format(col=col, filter_test_sql=_FILTER_TEST_SQL),
       lambda v: QuestionnaireStatus.lookup_by_number(v).name
   )
+
+_FILTER_TEST_SQL = """
+(NOT participant_summary.email LIKE '{test_email}'
+ AND NOT participant_summary.hpo_id = '{test_hpo}')
+""".format(test_email=TEST_EMAIL_PATTERN, test_hpo=TEST_HPO_NAME)
 
 # Metrics definitions. 3-tuples of:
 # - (str) aggregation key name
 # - (str) SQL statement to select value, count for a metric (in that order)
 # - (func(str): str) optional function which takes the value from the above SQL
 #   output and converts it for presentation
+#
+# Note that we depend on the participant_summary table containing only consented
+# participants, by definition. Therefore these metrics only cover consented
+# individuals.
 _SQL_AGGREGATIONS = [
   ('enrollmentStatus',
    """
-   SELECT enrollment_status, SUM(1)
+   SELECT enrollment_status, COUNT(*)
    FROM participant_summary
+   WHERE {filter_test_sql}
    GROUP BY 1;
-   """,
+   """.format(filter_test_sql=_FILTER_TEST_SQL),
    lambda v: EnrollmentStatus.lookup_by_number(v).name),
   # TODO(calbach): Verify whether we need to be conditionally trimming these
   # prefixes or leaving them unmodified. Unclear if all codes will have prefix
   # "PMI_".
   ('gender',
    """
-   SELECT code.value, ps.count
+   SELECT
+     CASE
+      WHEN code.value IS NULL THEN 'UNSET'
+      ELSE code.value
+     END, ps.count
    FROM (
-    SELECT gender_identity_id, SUM(1) count
+    SELECT gender_identity_id, COUNT(*) count
     FROM participant_summary
-    WHERE gender_identity_id IS NOT NULL
+    WHERE {filter_test_sql}
     GROUP BY 1
    ) ps LEFT JOIN code
    ON ps.gender_identity_id = code.code_id;
-   """,
+   """.format(filter_test_sql=_FILTER_TEST_SQL),
    None),
   ('race',
    """
-   SELECT race, SUM(1)
+   SELECT
+     CASE
+      WHEN race IS NULL THEN 0
+      ELSE race
+     END, COUNT(*)
    FROM participant_summary
-   WHERE race IS NOT NULL
+   WHERE {filter_test_sql}
    GROUP BY 1
-   """,
+   """.format(filter_test_sql=_FILTER_TEST_SQL),
    lambda v: Race.lookup_by_number(v).name),
   ('state',
    """
-   SELECT SUBSTR(code.value, {}), ps.count
+   SELECT
+     CASE
+      WHEN code.value IS NULL THEN 'UNSET'
+      WHEN code.value LIKE 'PIIState_%' THEN SUBSTR(code.value, LENGTH('PIIState_')+1)
+      ELSE code.value
+     END,
+     ps.count
    FROM (
-    SELECT state_id, SUM(1) count
+    SELECT state_id, COUNT(*) count
     FROM participant_summary
-    WHERE state_id IS NOT NULL
+    WHERE {filter_test_sql}
     GROUP BY 1
    ) ps LEFT JOIN code
    ON ps.state_id = code.code_id;
-   """.format(len('PIIState_') + 1),
+   """.format(filter_test_sql=_FILTER_TEST_SQL),
    None),
   ('ageRange',
    """
    SELECT
      CASE
+      WHEN date_of_birth IS NULL THEN 'UNSET'
       WHEN YEARS_OLD[date_of_birth] < 0 THEN 'UNSET'
       WHEN YEARS_OLD[date_of_birth] <= 17 THEN '0-17'
       WHEN YEARS_OLD[date_of_birth] <= 25 THEN '18-25'
@@ -82,39 +107,43 @@ _SQL_AGGREGATIONS = [
       WHEN YEARS_OLD[date_of_birth] <= 85 THEN '76-85'
       ELSE '86+'
      END age_range,
-     SUM(1)
+     COUNT(*)
    FROM participant_summary
+   WHERE {filter_test_sql}
    GROUP BY 1;
-   """,
+   """.format(filter_test_sql=_FILTER_TEST_SQL),
    None),
   ('physicalMeasurements',
    """
-   SELECT physical_measurements_status, SUM(1)
+   SELECT physical_measurements_status, COUNT(*)
    FROM participant_summary
+   WHERE {filter_test_sql}
    GROUP BY 1;
-   """,
+   """.format(filter_test_sql=_FILTER_TEST_SQL),
    lambda v: PhysicalMeasurementsStatus.lookup_by_number(v).name),
   ('biospecimenSamples',
    """
    SELECT
-     CASE (biospecimen_status)
-      WHEN '{}' THEN 'UNSET'
-      WHEN '{}' THEN 'UNSET'
+     CASE
+      WHEN biospecimen_status IS NULL THEN 'UNSET'
+      WHEN biospecimen_status = '{unset}' THEN 'UNSET'
+      WHEN biospecimen_status = '{created}' THEN 'UNSET'
       ELSE 'COLLECTED'
-     END, SUM(1)
+     END, COUNT(*)
    FROM participant_summary
+   WHERE {filter_test_sql}
    GROUP BY 1;
-   """.format(str(OrderStatus.UNSET.number), str(OrderStatus.CREATED.number)),
+   """.format(unset=str(OrderStatus.UNSET.number),
+              created=str(OrderStatus.CREATED.number),
+              filter_test_sql=_FILTER_TEST_SQL),
    None),
+  # TODO(calbach): Add healthcare_access, medical_history, medications,
+  # family_health once available.
   _questionnaire_metric('questionnaireOnOverallHealth', 'questionnaire_on_overall_health'),
   # Personal habits is a newer naming for lifestyle
   _questionnaire_metric('questionnaireOnPersonalHabits', 'questionnaire_on_lifestyle'),
   # Sociodemographics is a newer naming for 'the basics'
   _questionnaire_metric('questionnaireOnSociodemographics', 'questionnaire_on_the_basics'),
-  _questionnaire_metric('questionnaireOnHealthcareAccess', 'questionnaire_on_healthcare_access'),
-  _questionnaire_metric('questionnaireOnMedicalHistory', 'questionnaire_on_medical_history'),
-  _questionnaire_metric('questionnaireOnMedications', 'questionnaire_on_medications'),
-  _questionnaire_metric('questionnaireOnFamilyHealth', 'questionnaire_on_family_health')
 ]
 
 

--- a/rest-api/test/unit_test/offline_test/metrics_export_test.py
+++ b/rest-api/test/unit_test/offline_test/metrics_export_test.py
@@ -3,11 +3,10 @@ import json
 import offline.metrics_export
 
 from clock import FakeClock
-from code_constants import PPI_SYSTEM, CONSENT_PERMISSION_YES_CODE, CONSENT_PERMISSION_NO_CODE
+from code_constants import CONSENT_PERMISSION_YES_CODE, CONSENT_PERMISSION_NO_CODE
 from code_constants import GENDER_IDENTITY_QUESTION_CODE, EHR_CONSENT_QUESTION_CODE
 from code_constants import RACE_QUESTION_CODE, STATE_QUESTION_CODE, RACE_WHITE_CODE
 from code_constants import RACE_NONE_OF_THESE_CODE, PMI_PREFER_NOT_TO_ANSWER_CODE
-from concepts import Concept
 from field_mappings import FIELD_TO_QUESTIONNAIRE_MODULE_CODE
 from mapreduce import test_support
 from model.biobank_stored_sample import BiobankStoredSample
@@ -154,6 +153,12 @@ class MetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
           BiobankStoredSample(
               biobankStoredSampleId='def',
               biobankId=3,
+              test='1SAL',
+              confirmed=TIME_2))
+      sample_dao.insert(
+          BiobankStoredSample(
+              biobankStoredSampleId='xyz',
+              biobankId=4,
               test='1SAL',
               confirmed=TIME_2))
 

--- a/rest-api/test/unit_test/offline_test/metrics_export_test.py
+++ b/rest-api/test/unit_test/offline_test/metrics_export_test.py
@@ -54,33 +54,6 @@ class MetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
     super(MetricsExportTest, self).tearDown()
     FlaskTestBase.doTearDown(self)
 
-  def submit_questionnaire_response(self, participant_id, questionnaire_id,
-                                    race_code, gender_code, state,
-                                    date_of_birth):
-    code_answers = []
-    date_answers = []
-    if race_code:
-      code_answers.append(('race', Concept(PPI_SYSTEM, race_code)))
-    if gender_code:
-      code_answers.append(('genderIdentity', Concept(PPI_SYSTEM, gender_code)))
-    if date_of_birth:
-      date_answers.append(('dateOfBirth', date_of_birth))
-    if state:
-      code_answers.append(('state', Concept(PPI_SYSTEM, state)))
-    qr = make_questionnaire_response_json(
-        participant_id,
-        questionnaire_id,
-        code_answers=code_answers,
-        date_answers=date_answers)
-    self.send_post('Participant/%s/QuestionnaireResponse' % participant_id, qr)
-
-  def _submit_consent_questionnaire_response(
-      self, participant_id, questionnaire_id, ehr_consent_answer):
-    code_answers = [('ehrConsent', Concept(PPI_SYSTEM, ehr_consent_answer))]
-    qr = make_questionnaire_response_json(
-        participant_id, questionnaire_id, code_answers=code_answers)
-    self.send_post('Participant/%s/QuestionnaireResponse' % participant_id, qr)
-
   def _submit_empty_questionnaire_response(self, participant_id,
                                            questionnaire_id):
     qr = make_questionnaire_response_json(participant_id, questionnaire_id)
@@ -166,9 +139,9 @@ class MetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
                                          None, None)
       self.submit_questionnaire_response('P2', questionnaire_id_2, None, None,
                                          'PIIState_VA', None)
-      self._submit_consent_questionnaire_response('P1', questionnaire_id_3,
+      self.submit_consent_questionnaire_response('P1', questionnaire_id_3,
                                                   CONSENT_PERMISSION_NO_CODE)
-      self._submit_consent_questionnaire_response('P2', questionnaire_id_3,
+      self.submit_consent_questionnaire_response('P2', questionnaire_id_3,
                                                   CONSENT_PERMISSION_YES_CODE)
       sample_dao = BiobankStoredSampleDao()
       sample_dao.insert(

--- a/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
+++ b/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
@@ -14,6 +14,7 @@ from dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from dao.hpo_dao import HPODao
 from dao.participant_dao import ParticipantDao, make_primary_provider_link_for_name
 from offline.metrics_config import ANSWER_FIELD_TO_QUESTION_CODE
+from participant_enums import WithdrawalStatus
 from test_data import load_biobank_order_json, load_measurement_json
 from unit_test_util import FlaskTestBase, CloudStorageSqlTestBase, SqlTestBase, TestBase
 from unit_test_util import PITT_HPO_ID
@@ -94,6 +95,17 @@ class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
           providerLink=make_primary_provider_link_for_name('PITT'))
       participant_dao.insert(participant5)
       self.send_consent('P5', email='ch@gmail.com')
+
+      # A withdrawn participant should be excluded from metrics.
+      participant6 = Participant(
+          participantId=6,
+          biobankId=7,
+          providerLink=make_primary_provider_link_for_name('PITT')
+      )
+      participant_dao.insert(participant6)
+      self.send_consent('P6', email='cuphead@gmail.com')
+      participant6.withdrawalStatus=WithdrawalStatus.NO_USE
+      participant_dao.update(participant6)
 
       self.send_post('Participant/P2/PhysicalMeasurements',
                      load_measurement_json(2))

--- a/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
+++ b/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
@@ -124,6 +124,13 @@ class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
       participant_dao.insert(participant4)
       self.send_consent('P4', email='bob@example.com')
 
+      participant5 = Participant(
+          participantId=5,
+          biobankId=6,
+          providerLink=make_primary_provider_link_for_name('PITT'))
+      participant_dao.insert(participant5)
+      self.send_consent('P5', email='ch@gmail.com')
+
     with FakeClock(TIME_2):
       # This update to participant has no effect, as the HPO ID didn't change.
       participant = self._participant_with_defaults(
@@ -177,10 +184,6 @@ class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
   def test_metric_export(self):
     self._create_data()
     want = {
-        'questionnaireOnMedications': [{
-            'count': 4,
-            'value': 'UNSET'
-        }],
         'physicalMeasurements': [{
             'count': 3,
             'value': 'UNSET'
@@ -188,11 +191,10 @@ class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
             'count': 1,
             'value': 'COMPLETED'
         }],
-        'questionnaireOnHealthcareAccess': [{
-            'count': 4,
-            'value': 'UNSET'
-        }],
         'gender': [{
+            'count': 2,
+            'value': u'UNSET'
+        }, {
             'count': 1,
             'value': u'PMI_PreferNotToAnswer'
         }, {
@@ -221,11 +223,14 @@ class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
             'value': 'SUBMITTED'
         }],
         'state': [{
+            'count': 3,
+            'value': u'UNSET'
+        }, {
             'count': 1,
             'value': u'VA'
         }],
         'race': [{
-            'count': 2,
+            'count': 3,
             'value': 'UNSET'
         }, {
             'count': 1,
@@ -247,15 +252,7 @@ class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
             'value': u'36-45'
         }, {
             'count': 3,
-            'value': u'86+'
-        }],
-        'questionnaireOnFamilyHealth': [{
-            'count': 4,
-            'value': 'UNSET'
-        }],
-        'questionnaireOnMedicalHistory': [{
-            'count': 4,
-            'value': 'UNSET'
+            'value': u'UNSET'
         }]
     }
     self.assertEquals(want, PublicMetricsExport.export())

--- a/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
+++ b/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
@@ -192,8 +192,11 @@ class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
             'value': 'PREFER_NOT_TO_SAY'
         }],
         'enrollmentStatus': [{
-            'count': 3,
-            'value': 'INTERESTED'
+            'count': 2,
+            'value': 'CONSENTED'
+        }, {
+            'count': 1,
+            'value': 'MEMBER'
         }],
         'questionnaireOnSociodemographics': [{
             'count': 3,

--- a/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
+++ b/rest-api/test/unit_test/offline_test/public_metrics_export_test.py
@@ -1,0 +1,261 @@
+import datetime
+
+from offline.public_metrics_export import PublicMetricsExport
+from clock import FakeClock
+from code_constants import PPI_SYSTEM, CONSENT_PERMISSION_YES_CODE, CONSENT_PERMISSION_NO_CODE
+from code_constants import EHR_CONSENT_QUESTION_CODE, RACE_WHITE_CODE
+from code_constants import RACE_NONE_OF_THESE_CODE, PMI_PREFER_NOT_TO_ANSWER_CODE
+from concepts import Concept
+from field_mappings import FIELD_TO_QUESTIONNAIRE_MODULE_CODE
+from model.biobank_stored_sample import BiobankStoredSample
+from model.code import CodeType
+from model.hpo import HPO
+from model.participant import Participant
+from dao.biobank_stored_sample_dao import BiobankStoredSampleDao
+from dao.hpo_dao import HPODao
+from dao.participant_dao import ParticipantDao, make_primary_provider_link_for_name
+from offline.metrics_config import ANSWER_FIELD_TO_QUESTION_CODE
+from test_data import load_biobank_order_json, load_measurement_json
+from unit_test_util import FlaskTestBase, CloudStorageSqlTestBase, SqlTestBase, TestBase
+from unit_test_util import make_questionnaire_response_json, PITT_HPO_ID
+
+TIME = datetime.datetime(2016, 1, 1)
+TIME_2 = datetime.datetime(2016, 1, 2)
+TIME_3 = datetime.datetime(2016, 1, 3)
+TIME_4 = datetime.datetime(2016, 1, 4)
+
+
+class PublicMetricsExportTest(CloudStorageSqlTestBase, FlaskTestBase):
+  """Test the public metrics recalculation."""
+
+  def setUp(self):
+    super(PublicMetricsExportTest, self).setUp()
+    FlaskTestBase.doSetUp(self)
+    TestBase.setup_fake(self)
+    self.maxDiff = None
+
+  def tearDown(self):
+    super(PublicMetricsExportTest, self).tearDown()
+    FlaskTestBase.doTearDown(self)
+
+  def submit_questionnaire_response(self, participant_id, questionnaire_id,
+                                    race_code, gender_code, state,
+                                    date_of_birth):
+    code_answers = []
+    date_answers = []
+    if race_code:
+      code_answers.append(('race', Concept(PPI_SYSTEM, race_code)))
+    if gender_code:
+      code_answers.append(('genderIdentity', Concept(PPI_SYSTEM, gender_code)))
+    if date_of_birth:
+      date_answers.append(('dateOfBirth', date_of_birth))
+    if state:
+      code_answers.append(('state', Concept(PPI_SYSTEM, state)))
+    qr = make_questionnaire_response_json(
+        participant_id,
+        questionnaire_id,
+        code_answers=code_answers,
+        date_answers=date_answers)
+    self.send_post('Participant/%s/QuestionnaireResponse' % participant_id, qr)
+
+  def _submit_consent_questionnaire_response(
+      self, participant_id, questionnaire_id, ehr_consent_answer):
+    code_answers = [('ehrConsent', Concept(PPI_SYSTEM, ehr_consent_answer))]
+    qr = make_questionnaire_response_json(
+        participant_id, questionnaire_id, code_answers=code_answers)
+    self.send_post('Participant/%s/QuestionnaireResponse' % participant_id, qr)
+
+  def _submit_empty_questionnaire_response(self, participant_id,
+                                           questionnaire_id):
+    qr = make_questionnaire_response_json(participant_id, questionnaire_id)
+    self.send_post('Participant/%s/QuestionnaireResponse' % participant_id, qr)
+
+  def _create_data(self):
+    HPODao().insert(HPO(hpoId=PITT_HPO_ID + 1, name='AZ_TUCSON'))
+    HPODao().insert(HPO(hpoId=PITT_HPO_ID + 2, name='TEST'))
+    SqlTestBase.setup_codes(
+        ANSWER_FIELD_TO_QUESTION_CODE.values() + [EHR_CONSENT_QUESTION_CODE],
+        code_type=CodeType.QUESTION)
+    SqlTestBase.setup_codes(
+        FIELD_TO_QUESTIONNAIRE_MODULE_CODE.values(), code_type=CodeType.MODULE)
+    # Import codes for white and female, but not male or black.
+    SqlTestBase.setup_codes(
+        [
+            RACE_WHITE_CODE, CONSENT_PERMISSION_YES_CODE,
+            RACE_NONE_OF_THESE_CODE, PMI_PREFER_NOT_TO_ANSWER_CODE,
+            CONSENT_PERMISSION_NO_CODE, 'female', 'PIIState_VA'
+        ],
+        code_type=CodeType.ANSWER)
+    participant_dao = ParticipantDao()
+
+    questionnaire_id = self.create_questionnaire('questionnaire3.json')
+    questionnaire_id_2 = self.create_questionnaire('questionnaire4.json')
+    questionnaire_id_3 = self.create_questionnaire(
+        'all_consents_questionnaire.json')
+    with FakeClock(TIME):
+      participant = Participant(
+          participantId=1,
+          biobankId=2,
+          providerLink=make_primary_provider_link_for_name('AZ_TUCSON'))
+      participant_dao.insert(participant)
+      self.send_consent('P1', email='bob@gmail.com')
+
+    with FakeClock(TIME):
+      # Participant 2 starts out unpaired; later gets paired automatically when their physical
+      # measurements come in.
+      participant2 = Participant(participantId=2, biobankId=3)
+      participant_dao.insert(participant2)
+      self.send_consent('P2', email='bob@fexample.com')
+
+    with FakeClock(TIME):
+      # Test HPO affiliation; this test participant is ignored.
+      participant3 = Participant(
+          participantId=3,
+          biobankId=4,
+          providerLink=make_primary_provider_link_for_name('TEST'))
+      participant_dao.insert(participant3)
+      self.send_consent('P3', email='fred@gmail.com')
+
+      # example.com e-mail; this test participant is ignored, too.
+      participant4 = Participant(
+          participantId=4,
+          biobankId=5,
+          providerLink=make_primary_provider_link_for_name('PITT'))
+      participant_dao.insert(participant4)
+      self.send_consent('P4', email='bob@example.com')
+
+    with FakeClock(TIME_2):
+      # This update to participant has no effect, as the HPO ID didn't change.
+      participant = self._participant_with_defaults(
+          participantId=1,
+          version=1,
+          biobankId=2,
+          providerLink=make_primary_provider_link_for_name('AZ_TUCSON'))
+      participant_dao.update(participant)
+      self.submit_questionnaire_response('P1', questionnaire_id,
+                                         RACE_WHITE_CODE, 'male', None,
+                                         datetime.date(1980, 1, 2))
+      self.submit_questionnaire_response(
+          'P2', questionnaire_id, RACE_NONE_OF_THESE_CODE, None, None, None)
+
+    with FakeClock(TIME_3):
+      participant = self._participant_with_defaults(
+          participantId=1,
+          version=2,
+          biobankId=2,
+          providerLink=make_primary_provider_link_for_name('PITT'))
+      participant_dao.update(participant)
+      self.send_post('Participant/P2/PhysicalMeasurements',
+                     load_measurement_json(2))
+      self.send_post('Participant/P2/BiobankOrder', load_biobank_order_json(2))
+      self.submit_questionnaire_response('P1', questionnaire_id, 'black',
+                                         'female', None,
+                                         datetime.date(1980, 1, 3))
+      self.submit_questionnaire_response('P2', questionnaire_id, None,
+                                         PMI_PREFER_NOT_TO_ANSWER_CODE, None,
+                                         None)
+      self.submit_questionnaire_response('P2', questionnaire_id_2, None, None,
+                                         'PIIState_VA', None)
+      self._submit_consent_questionnaire_response('P1', questionnaire_id_3,
+                                                  CONSENT_PERMISSION_NO_CODE)
+      self._submit_consent_questionnaire_response('P2', questionnaire_id_3,
+                                                  CONSENT_PERMISSION_YES_CODE)
+      sample_dao = BiobankStoredSampleDao()
+      sample_dao.insert(
+          BiobankStoredSample(
+              biobankStoredSampleId='abc',
+              biobankId=2,
+              test='test',
+              confirmed=TIME_2))
+      sample_dao.insert(
+          BiobankStoredSample(
+              biobankStoredSampleId='def',
+              biobankId=3,
+              test='1SAL',
+              confirmed=TIME_2))
+
+  def test_metric_export(self):
+    self._create_data()
+    want = {
+        'questionnaireOnMedications': [{
+            'count': 4,
+            'value': 'UNSET'
+        }],
+        'physicalMeasurements': [{
+            'count': 3,
+            'value': 'UNSET'
+        }, {
+            'count': 1,
+            'value': 'COMPLETED'
+        }],
+        'questionnaireOnHealthcareAccess': [{
+            'count': 4,
+            'value': 'UNSET'
+        }],
+        'gender': [{
+            'count': 1,
+            'value': u'PMI_PreferNotToAnswer'
+        }, {
+            'count': 1,
+            'value': u'female'
+        }],
+        'questionnaireOnOverallHealth': [{
+            'count': 3,
+            'value': 'UNSET'
+        }, {
+            'count': 1,
+            'value': 'SUBMITTED'
+        }],
+        'biospecimenSamples': [{
+            'count': 1,
+            'value': u'COLLECTED'
+        }, {
+            'count': 3,
+            'value': u'UNSET'
+        }],
+        'questionnaireOnPersonalHabits': [{
+            'count': 3,
+            'value': 'UNSET'
+        }, {
+            'count': 1,
+            'value': 'SUBMITTED'
+        }],
+        'state': [{
+            'count': 1,
+            'value': u'VA'
+        }],
+        'race': [{
+            'count': 2,
+            'value': 'UNSET'
+        }, {
+            'count': 1,
+            'value': 'OTHER_RACE'
+        }],
+        'enrollmentStatus': [{
+            'count': 4,
+            'value': 'INTERESTED'
+        }],
+        'questionnaireOnSociodemographics': [{
+            'count': 2,
+            'value': 'UNSET'
+        }, {
+            'count': 2,
+            'value': 'SUBMITTED'
+        }],
+        'ageRange': [{
+            'count': 1,
+            'value': u'36-45'
+        }, {
+            'count': 3,
+            'value': u'86+'
+        }],
+        'questionnaireOnFamilyHealth': [{
+            'count': 4,
+            'value': 'UNSET'
+        }],
+        'questionnaireOnMedicalHistory': [{
+            'count': 4,
+            'value': 'UNSET'
+        }]
+    }
+    self.assertEquals(want, PublicMetricsExport.export())

--- a/rest-api/test/unit_test/unit_test_util.py
+++ b/rest-api/test/unit_test/unit_test_util.py
@@ -26,6 +26,7 @@ import dao.base_dao
 import singletons
 
 from code_constants import PPI_SYSTEM
+from concepts import Concept
 from dao.code_dao import CodeDao
 from dao.hpo_dao import HPODao
 from dao.participant_dao import ParticipantDao
@@ -98,6 +99,33 @@ class TestBase(unittest.TestCase):
     }
     common_args.update(kwargs)
     return ParticipantHistory(**common_args)
+
+  def submit_questionnaire_response(self, participant_id, questionnaire_id,
+                                    race_code, gender_code, state,
+                                    date_of_birth):
+    code_answers = []
+    date_answers = []
+    if race_code:
+      code_answers.append(('race', Concept(PPI_SYSTEM, race_code)))
+    if gender_code:
+      code_answers.append(('genderIdentity', Concept(PPI_SYSTEM, gender_code)))
+    if date_of_birth:
+      date_answers.append(('dateOfBirth', date_of_birth))
+    if state:
+      code_answers.append(('state', Concept(PPI_SYSTEM, state)))
+    qr = make_questionnaire_response_json(
+        participant_id,
+        questionnaire_id,
+        code_answers=code_answers,
+        date_answers=date_answers)
+    self.send_post('Participant/%s/QuestionnaireResponse' % participant_id, qr)
+
+  def submit_consent_questionnaire_response(
+      self, participant_id, questionnaire_id, ehr_consent_answer):
+    code_answers = [('ehrConsent', Concept(PPI_SYSTEM, ehr_consent_answer))]
+    qr = make_questionnaire_response_json(
+        participant_id, questionnaire_id, code_answers=code_answers)
+    self.send_post('Participant/%s/QuestionnaireResponse' % participant_id, qr)
 
   def participant_summary(self, participant):
     summary = ParticipantDao.create_summary_for_participant(participant)


### PR DESCRIPTION
For now, we just compute the metrics and return them directly in an approximation of the proposed metrics API.

Open questions:
- Prefixes on code values, e.g. "PMI_" for gender or "PIIState_" for states  - do we care about stripping them and if yes where can we assume a prefix?
- My solution to computing "years old" for both SQLite/MySQL is verbose using the SQL "NOW()" vs passing as parameter may not be ideal, alternative suggestions welcome
- Filter NULL values? Or pass through with a placeholder?
- Do we need to filter down participants first (e.g. check for consent) - or is presence in the particpant_summary table sufficient to include in the metrics?

Still TODO in follow-up PRs:
- Pending a decision on the [design doc](https://docs.google.com/document/d/1KqtsWU-GWd9tYjf8JbcxnmtlVen7O-PRkhJY-8tX5ig), this will later be modified to persist the output to either Cloud SQL or BigQuery
- Configure the cronjob 