### PR TITLE
[RW-263] Add public metrics cron specification

### DIFF
--- a/rest-api/cron.yaml
+++ b/rest-api/cron.yaml
@@ -6,7 +6,7 @@ cron:
   target: offline
 - description: Daily public metrics
   url: /offline/PublicMetricsRecalculate
-  schedule: every day 03:30
+  schedule: every day 05:00
   timezone: America/New_York
   target: offline
 - description: Daily Biobank sample import and order reconciliation

--- a/rest-api/cron.yaml
+++ b/rest-api/cron.yaml
@@ -4,6 +4,11 @@ cron:
   schedule: every day 04:00
   timezone: America/New_York
   target: offline
+- description: Daily public metrics
+  url: /offline/PublicMetricsRecalculate
+  schedule: every day 03:30
+  timezone: America/New_York
+  target: offline
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport
   schedule: every day 03:00


### PR DESCRIPTION
Actual offline endpoint does not persist metrics yet, just returns them.