### PR TITLE
Adding doc for awardee API

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,6 +773,162 @@ resources. Once these are created, a client can query for available samples:
 
 #### TODO `GET /Participant/:pid/BiobankSamples
 
+## Organization API
+
+Retrieves metadata about awardees / organizations / sites.
+
+#### `GET /Awardee`
+
+Retrieves a JSON bundle of metadata for all awardees, with nested resources for child
+organizations and sites within them, representing the full hierarchy of
+awardees > organizations > sites. No pagination, syncing, or filtering is currently
+supported on this endpoint.
+
+Example response:
+
+```
+{
+  "entry": [
+    {
+      "fullUrl": "http://localhost:8080/rdr/v1/Awardee/AZ_TUCSON",
+      "resource": {
+        "displayName": "Arizona",
+        "id": "AZ_TUCSON",
+        "organizations": [
+          {
+            "displayName": "Banner Health",
+            "id": "AZ_TUCSON_BANNER_HEALTH",
+            "sites": [
+              {
+                "address": {
+                  "city": "Phoenix",
+                  "line": [
+                    "567 Cherry Lane"
+                  ],
+                  "postalCode": "66666"
+                },
+                "directions": "",
+                "displayName": "Banner University Medical Center - Tucson",
+                "id": "hpo-site-bannernew",
+                "launchDate": "2017-10-02",
+                "link": "http://www.example.com/",
+                "mayolinkClientNumber": 5678392,
+                "notes": "Formerly University of Arizona CATS Research  ",
+                "phoneNumber": "666-666-6666",
+                "physicalLocationName": "",
+                "siteStatus": "INACTIVE"
+              },
+              {
+                "address": {
+                  "city": "Tucson",
+                  "line": [
+                    "1234 Main Street",
+                    "Suite 400"
+                  ],
+                  "postalCode": "55555"
+                },
+                "adminEmails": [
+                  "bob@example.com",
+                  "alice@example.com"
+                ],
+                "directions": "Turn left on south street.",
+                "displayName": "Banner University Medical Center - Tucson",
+                "id": "hpo-site-bannertucson",
+                "launchDate": "2017-10-02",
+                "link": "http://www.example.com/",
+                "mayolinkClientNumber": 7035650,
+                "notes": "Formerly University of Arizona CATS Research  ",
+                "phoneNumber": "555-555-5555",
+                "physicalLocationName": "Building 23",
+                "siteStatus": "ACTIVE"
+              }
+            ]
+          }
+        ],
+        "type": "HPO"
+      }
+    },
+    {
+      "fullUrl": "http://localhost:8080/rdr/v1/Awardee/COMM_HEALTH",
+      "resource": {
+        "displayName": "Community Health Center, Inc",
+        "id": "COMM_HEALTH",
+        "type": "FQHC"
+      }
+    }
+    ...
+  ],
+  "resourceType": "Bundle",
+  "type": "searchset"
+}
+```
+
+#### `GET /Awardee/:aid
+
+Retrieves metadata about an individual awardee, with nested resources for child
+organizations and sites within them.
+
+Example response:
+
+```
+{
+  "displayName": "Arizona",
+  "id": "AZ_TUCSON",
+  "organizations": [
+    {
+      "displayName": "Banner Health",
+      "id": "AZ_TUCSON_BANNER_HEALTH",
+      "sites": [
+        {
+          "address": {
+            "city": "Phoenix",
+            "line": [
+              "567 Cherry Lane"
+            ],
+            "postalCode": "66666"
+          },
+          "directions": "",
+          "displayName": "Banner University Medical Center - Tucson",
+          "id": "hpo-site-bannernew",
+          "launchDate": "2017-10-02",
+          "link": "http://www.example.com/",
+          "mayolinkClientNumber": 5678392,
+          "notes": "Formerly University of Arizona CATS Research  ",
+          "phoneNumber": "666-666-6666",
+          "physicalLocationName": "",
+          "siteStatus": "INACTIVE"
+        },
+        {
+          "address": {
+            "city": "Tucson",
+            "line": [
+              "1234 Main Street",
+              "Suite 400"
+            ],
+            "postalCode": "55555"
+          },
+          "adminEmails": [
+            "bob@example.com",
+            "alice@example.com"
+          ],
+          "directions": "Turn left on south street.",
+          "displayName": "Banner University Medical Center - Tucson",
+          "id": "hpo-site-bannertucson",
+          "launchDate": "2017-10-02",
+          "link": "http://www.example.com/",
+          "mayolinkClientNumber": 7035650,
+          "notes": "Formerly University of Arizona CATS Research  ",
+          "phoneNumber": "555-555-5555",
+          "physicalLocationName": "Building 23",
+          "siteStatus": "ACTIVE"
+        }
+      ]
+    }
+  ],
+  "type": "HPO"
+}
+```
+
 ## Configuration APIs
 
 `POST /CheckPpiData` Non-prod. Verifies data created during tests.


### PR DESCRIPTION
Somehow this got dropped when rebasing https://github.com/all-of-us/raw-data-repository/pull/545.

Adding it back in.