### PR TITLE
[DA-485] sleep after IAM key creation

### DIFF
--- a/rest-api/tools/auth_setup.sh
+++ b/rest-api/tools/auth_setup.sh
@@ -46,6 +46,14 @@ else
   gcloud iam service-accounts keys create $CREDS_FILE \
       --iam-account=$SERVICE_ACCOUNT --account=$CREDS_ACCOUNT
   TMP_PRIVATE_KEY=`grep private_key_id $CREDS_FILE | cut -d\" -f4`
+
+  # There appears to be a propagation delay after creating a new service account
+  # key during which attempts to use it result in "Invalid JWT grant". Sleeping
+  # here mitigates this issue. This appears to be environmental, so at times
+  # tooling may become unusable without this sleep (especially for composite)
+  # scripts (e.g. deploy) which invoke this method multiple times.
+  # See https://precisionmedicineinitiative.atlassian.net/browse/DA-485
+  sleep 3
 fi
 
 REPO_ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"

--- a/rest-api/tools/auth_setup.sh
+++ b/rest-api/tools/auth_setup.sh
@@ -49,8 +49,8 @@ else
 
   # There appears to be a propagation delay after creating a new service account
   # key during which attempts to use it result in "Invalid JWT grant". Sleeping
-  # here mitigates this issue. This appears to be environmental, so at times
-  # tooling may become unusable without this sleep (especially for composite)
+  # here mitigates this issue. This appears to be environmental so at times
+  # tooling may become unusable without this sleep, especially for composite
   # scripts (e.g. deploy) which invoke this method multiple times.
   # See https://precisionmedicineinitiative.atlassian.net/browse/DA-485
   sleep 3


### PR DESCRIPTION
Local testing showed the following (though highly dependent on *when* I ran the tests):
- no sleep: ~75% failure
- 1s sleep: ~13% failure
- 3s sleep: ~2% failure  <--
- 5s sleep: ~1% failure
- 10s sleep: ~0 failures

10s is too slow for a developer tool and 5s didn't seem much better than 3s. Note: this is hardly scientifically sound as tests were run back-to-back with a sample size of only 30-60 attempts and the cause is entirely environmental.