### PR TITLE
Bumping up prod instances to F2 to get more memory,

### DIFF
--- a/rest-api/app_prod.yaml
+++ b/rest-api/app_prod.yaml
@@ -1,5 +1,7 @@
 # app_base.yaml is concatenated to the beginning of this file for deployment.
 
+instance_class: F2
+
 # Since we expect low QPS, keep at least 1 idle instance to avoid high latency.
 automatic_scaling:
   min_idle_instances: 1


### PR DESCRIPTION
allow work queue requests for 5000 participants to succeed.