### PR TITLE
Adding pmi-hpo-dev (HPRO) to sandbox ACL.

### DIFF
--- a/rest-api/config/config_sandbox.json
+++ b/rest-api/config/config_sandbox.json
@@ -10,6 +10,9 @@
     },
     "exporter@all-of-us-rdr-sandbox.iam.gserviceaccount.com": {
       "roles": ["exporter"]
+    },
+    "pmi-hpo-dev@appspot.gserviceaccount.com": {
+      "roles": ["healthpro"]
     }
   },
   "biobank_samples_bucket_name": [

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -125,7 +125,8 @@ _CONSTANT_CODES = [PMI_PREFER_NOT_TO_ANSWER_CODE, PMI_OTHER_CODE]
 
 class FakeParticipantGenerator(object):
 
-  def __init__(self, client):
+  def __init__(self, client, use_local_files=None):
+    self._use_local_files = use_local_files
     self._client = client
     self._hpos = HPODao().get_all()
     self._sites = SiteDao().get_all()
@@ -136,7 +137,7 @@ class FakeParticipantGenerator(object):
     self._setup_data()
     self._setup_questionnaires()
     self._min_birth_date = self._now - datetime.timedelta(days=_MAX_PARTICIPANT_AGE * 365)
-    self._max_days_for_birth_date = 365 * (_MAX_PARTICIPANT_AGE - _MIN_PARTICIPANT_AGE)
+    self._max_days_for_birth_date = 365 * (_MAX_PARTICIPANT_AGE - _MIN_PARTICIPANT_AGE)    
 
   def _days_ago(self, num_days):
     return self._now - datetime.timedelta(days=num_days)
@@ -219,7 +220,7 @@ class FakeParticipantGenerator(object):
     self._city_names = self._read_all_lines('city_names.txt')
     self._street_names = self._read_all_lines('street_names.txt')
     measurement_specs = self._read_json('measurement_specs.json')
-    if app_identity.get_application_id() == 'None':
+    if self._use_local_files or app_identity.get_application_id() == 'None':
       # Read CSV from a local file when running dev_appserver.
       answer_specs = self._read_csv_from_file(_ANSWER_SPECS_FILE)
     else:

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -137,7 +137,7 @@ class FakeParticipantGenerator(object):
     self._setup_data()
     self._setup_questionnaires()
     self._min_birth_date = self._now - datetime.timedelta(days=_MAX_PARTICIPANT_AGE * 365)
-    self._max_days_for_birth_date = 365 * (_MAX_PARTICIPANT_AGE - _MIN_PARTICIPANT_AGE)    
+    self._max_days_for_birth_date = 365 * (_MAX_PARTICIPANT_AGE - _MIN_PARTICIPANT_AGE)
 
   def _days_ago(self, num_days):
     return self._now - datetime.timedelta(days=num_days)

--- a/rest-api/tools/load_test.sh
+++ b/rest-api/tools/load_test.sh
@@ -48,7 +48,27 @@ set_db_connection_string
 # gcloud libraries added by set_path.sh include an older version.
 OLDPATH=$PYTHONPATH
 . tools/set_path.sh;
-export PYTHONPATH=/usr/local/lib/python2.7/dist-packages:$OLDPATH:$PYTHONPATH
+GCLOUD_PATH=$(which gcloud)
+CLOUDSDK_ROOT_DIR=${GCLOUD_PATH%/bin/gcloud}
+GAE_SDK_ROOT="${CLOUDSDK_ROOT_DIR}/platform/google_appengine"
+
+# The next line enables Python libraries for Google Cloud SDK
+GAEPATH=${GAE_SDK_ROOT}
+
+# * OPTIONAL STEP *
+# If you wish to import all Python modules, you may iterate in the directory
+# tree and import each module.
+#
+# * WARNING *
+# Some modules have two or more versions available (Ex. django), so the loop
+# will import always its latest version.
+for module in ${GAE_SDK_ROOT}/lib/*; do
+  if [ -r ${module} ];
+  then
+    GAEPATH=${module}:${GAEPATH}
+  fi
+done
+export PYTHONPATH=/usr/local/lib/python2.7/dist-packages:$OLDPATH:$PYTHONPATH:${GAEPATH}
 
 LOCUST_CREDS_FILE="$CREDS_FILE" \
 LOCUST_TARGET_INSTANCE="https://$PROJECT.appspot.com" \

--- a/rest-api/tools/load_test_locustfile.py
+++ b/rest-api/tools/load_test_locustfile.py
@@ -81,7 +81,7 @@ class _AuthenticatedLocust(Locust):
     # The "client" field gets copied to TaskSet instances.
     self.client = _ReportingClient(
         creds_file=creds_file, default_instance=instance, parse_cli=False)
-    self.participant_generator = FakeParticipantGenerator(self.client)
+    self.participant_generator = FakeParticipantGenerator(self.client, use_local_files=True)
 
 
 class VersionCheckUser(_AuthenticatedLocust):


### PR DESCRIPTION
Making FakeParticipantGenerator not depend on app_identity at runtime when run in the context of a load test, as that doesn't work.

Changing load_test.sh to include GAE deps like it used to. (Refactoring FakeParticipantGenerator to not depend on any AppEngine APIs is a bunch of work that I'd like to defer for now; tracked at https://precisionmedicineinitiative.atlassian.net/browse/DA-500)