### PR TITLE
[DA-477] Add client for running biobank samples import

### DIFF
--- a/rdr_client/import_biobank_samples.py
+++ b/rdr_client/import_biobank_samples.py
@@ -1,0 +1,19 @@
+"""Runs biobank samples pipeline, to develop metrics with full participants"""
+
+import json
+import logging
+
+from main_util import configure_logging
+
+from client import Client
+
+
+def main():
+    client = Client(base_path='offline')
+    response = client.request_json('BiobankSamplesImport', 'GET', cron=True)
+    logging.info(json.dumps(response, indent=2, sort_keys=True))
+
+
+if __name__ == '__main__':
+    configure_logging()
+    main()

--- a/rdr_client/import_biobank_samples.py
+++ b/rdr_client/import_biobank_samples.py
@@ -9,11 +9,11 @@ from client import Client
 
 
 def main():
-    client = Client(base_path='offline')
-    response = client.request_json('BiobankSamplesImport', 'GET', cron=True)
-    logging.info(json.dumps(response, indent=2, sort_keys=True))
+  client = Client(base_path='offline')
+  response = client.request_json('BiobankSamplesImport', 'GET', cron=True)
+  logging.info(json.dumps(response, indent=2, sort_keys=True))
 
 
 if __name__ == '__main__':
-    configure_logging()
-    main()
+  configure_logging()
+  main()


### PR DESCRIPTION
This script eases development of the Metrics API by running the BiobankSamplesImport endpoint, which marks biobank samples as received and thus ensures full participants are in the local test database.

Example:
```
cd raw-data-repository/rdr_client/
./run_client.sh import_biobank_samples.py
```