### PR TITLE
add a .editorconfig file for 2-space python indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+max_line_length = 100
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Any objections to this?  It will auto-config any compatible editor (such as mine) to use 2-space indents in our Python files, sets "textwrap" to 100, etc.

The failing test is that same unset awardee test, btw.