### PR TITLE
Throttle the logging output during unit test runs

### DIFF
--- a/rest-api/README.md
+++ b/rest-api/README.md
@@ -89,6 +89,16 @@ test/run_tests.sh -g $sdk_dir
 
 This will run both the unit tests and the client tests.
 
+If a test breaks and you would like to enable the output of Python's `logging`
+module for debugging purposes, you can comment out the following two lines in
+the file `./test/runner.py` to re-enable printing of log statements to the
+console:
+
+```Python
+import logging
+logging.disable(logging.CRITICAL)
+```
+
 If you want to be super slick, and have the tests run every time you change a
 source file, you can do this.
 

--- a/rest-api/test/runner.py
+++ b/rest-api/test/runner.py
@@ -73,6 +73,10 @@ def main(sdk_path, test_path, test_pattern):
 
 
 if __name__ == '__main__':
+  # Disables logging for the duration of the tests
+  import logging
+  logging.disable(logging.CRITICAL)
+
   parser = argparse.ArgumentParser(
     description=__doc__,
     formatter_class=argparse.RawDescriptionHelpFormatter)


### PR DESCRIPTION
The test output can be a bit spammy with logging messages; this should alleviate that.