### PR TITLE
Tools fix for Rodete?

### DIFF
--- a/rest-api/tools/setup_env.sh
+++ b/rest-api/tools/setup_env.sh
@@ -11,7 +11,7 @@ find . | grep \.pyc | xargs rm -if $*
 
 echo "Installing libs..."
 # If this fails due to missing mysql_config, try `sudo apt-get install libmysqlclient-dev`.
-pip install -r requirements.txt -t lib/
+pip install --system --no-binary MySQL-python -r requirements.txt -t lib/
 
 # Needed to setup the local DB.
 pip install -r ../rdr_client/requirements.txt


### PR DESCRIPTION
I don't know that this will work on Mac / other environments, but changing this seemed to help get things working for me on the latest version of Goobuntu.

Without the --system flag, the pip install -r totally failed.