### PR TITLE
Add docs for _includeTotal from DA-508: Add Total to Paginated Partic…

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,31 +427,16 @@ Other supported parameters from the FHIR spec:
 * `_sort:desc`: the name of a field to sort results by, in descending order, followed by last name,
   first name, date of birth, and participant ID.
 
-If no sort order is requested, the default sort order is last name, first name, date of birth, and
-participant ID.
-
-The response is an FHIR Bundle containing participant summaries. If more than the requested number
- of participant summaries match the specified criteria, a "next" link will be returned that can
- be used in a follow on request to fetch more participant summaries.
-
-
-Other supported parameters from the FHIR spec:
-
-* `_count`: the maximum number of participant summaries to return; the default is 100, the maximum
-  supported value is 10,000
-
-* `_sort`: the name of a field to sort results by, in ascending order, followed by last name, first
-  name, date of birth, and participant ID.
-
-* `_sort:desc`: the name of a field to sort results by, in descending order, followed by last name,
-  first name, date of birth, and participant ID.
+We furthermore support an `_includeTotal` query parameter that will execute a
+count of the given set of summaries and attach that to the returned FHIR Bundle
+as a `total` key.
 
 If no sort order is requested, the default sort order is last name, first name, date of birth, and
 participant ID.
 
 The response is an FHIR Bundle containing participant summaries. If more than the requested number
- of participant summaries match the specified criteria, a "next" link will be returned that can
- be used in a follow on request to fetch more participant summaries.
+of participant summaries match the specified criteria, a "next" link will be returned that can
+be used in a follow on request to fetch more participant summaries.
 
 ## Questionnaire and QuestionnaireResponse API
 


### PR DESCRIPTION
…ipantSummaries

Update the README to reflect the addition of the _includeTotal query parameter. The param should work for any paginated resource, but since (I think) its only officially supported for ParticipantSummary, I've added the note to that section of the README.

Also removed a nearby section of the README which was duplicated.