### PR TITLE
Add warmup handler, bump min_idle_instances to 10 in production.

### DIFF
--- a/rest-api/app_base.yaml
+++ b/rest-api/app_base.yaml
@@ -23,6 +23,9 @@ handlers:
   static_dir: app_data
   application_readable: true
   secure: always
+- url: /_ah/warmup
+  script: main.app
+  login: admin
 
 libraries:
 - name: pycrypto

--- a/rest-api/app_prod.yaml
+++ b/rest-api/app_prod.yaml
@@ -6,10 +6,10 @@ instance_class: F2
 automatic_scaling:
   min_idle_instances: 10
 
-#inbound_services:
-#- warmup
+inbound_services:
+- warmup
 
-#handlers:
-#- url: /_ah/warmup
-#  script: main.app
-#  login: admin
+handlers:
+- url: /_ah/warmup
+  script: main.app
+  login: admin

--- a/rest-api/app_prod.yaml
+++ b/rest-api/app_prod.yaml
@@ -2,6 +2,14 @@
 
 instance_class: F2
 
-# Since we expect low QPS, keep at least 1 idle instance to avoid high latency.
+# Have 10 idle instances to prepare for sudden traffic spikes.
 automatic_scaling:
-  min_idle_instances: 1
+  min_idle_instances: 10
+
+inbound_services:
+- warmup
+
+handlers:
+- url: /_ah/warmup
+  script: main.app
+  login: admin

--- a/rest-api/app_prod.yaml
+++ b/rest-api/app_prod.yaml
@@ -6,10 +6,10 @@ instance_class: F2
 automatic_scaling:
   min_idle_instances: 10
 
-inbound_services:
-- warmup
+#inbound_services:
+#- warmup
 
-handlers:
-- url: /_ah/warmup
-  script: main.app
-  login: admin
+#handlers:
+#- url: /_ah/warmup
+#  script: main.app
+#  login: admin

--- a/rest-api/app_prod.yaml
+++ b/rest-api/app_prod.yaml
@@ -6,5 +6,6 @@ instance_class: F2
 automatic_scaling:
   min_idle_instances: 10
 
+# Send warmup requests to instances on startup, which will initialize the app and load configs.
 inbound_services:
 - warmup

--- a/rest-api/app_prod.yaml
+++ b/rest-api/app_prod.yaml
@@ -8,8 +8,3 @@ automatic_scaling:
 
 inbound_services:
 - warmup
-
-handlers:
-- url: /_ah/warmup
-  script: main.app
-  login: admin

--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -26,6 +26,7 @@ from api.physical_measurements_api import PhysicalMeasurementsApi, sync_physical
 from api.metric_sets_api import MetricSetsApi
 from api.questionnaire_api import QuestionnaireApi
 from api.questionnaire_response_api import QuestionnaireResponseApi
+from config import get_config, get_db_config
 from model.utils import ParticipantIdConverter
 
 
@@ -34,6 +35,12 @@ PREFIX = '/rdr/v1/'
 app = Flask(__name__)
 app.url_map.converters['participant_id'] = ParticipantIdConverter
 
+
+def _warmup():
+  # Load configurations into the cache.
+  get_config()
+  get_db_config()
+  return '{ "success": "true" }'
 
 def _log_request_exception(sender, exception, **extra):  # pylint: disable=unused-argument
   """Logs HTTPExceptions.
@@ -158,6 +165,11 @@ app.add_url_rule(PREFIX + 'ImportCodebook',
                  endpoint='import_codebook',
                  view_func=import_codebook,
                  methods=['POST'])
+
+app.add_url_rule('/_ah/warmup',
+                 endpoint='warmup',
+                 view_func=_warmup,
+                 methods='GET')
 
 app.after_request(app_util.add_headers)
 app.before_request(app_util.request_logging)

--- a/rest-api/tools/deploy_app.sh
+++ b/rest-api/tools/deploy_app.sh
@@ -154,7 +154,7 @@ then
 
   if [ "$TARGET" == "app" ] || [ "$TARGET" == "all" ]
   then
-    if [ "${PROJECT}" = "all-of-us-rdr-prod" ]
+    if [ "${PROJECT}" = "all-of-us-rdr-sandbox" ]
     then
       echo "Using ${BOLD}prod${NONE} app.yaml for project $PROJECT."
       APP_YAML=app_prod.yaml

--- a/rest-api/tools/deploy_app.sh
+++ b/rest-api/tools/deploy_app.sh
@@ -154,7 +154,7 @@ then
 
   if [ "$TARGET" == "app" ] || [ "$TARGET" == "all" ]
   then
-    if [ "${PROJECT}" = "all-of-us-rdr-sandbox" ]
+    if [ "${PROJECT}" = "all-of-us-rdr-prod" ]
     then
       echo "Using ${BOLD}prod${NONE} app.yaml for project $PROJECT."
       APP_YAML=app_prod.yaml


### PR DESCRIPTION
This should make us quicker to handle requests in the event of a big spike in traffic at national launch.