### PR TITLE
[DA-471] Disable flakey data gen test

### DIFF
--- a/rest-api/test/unit_test/api_test/data_gen_api_test.py
+++ b/rest-api/test/unit_test/api_test/data_gen_api_test.py
@@ -1,4 +1,5 @@
 import mock
+import unittest
 
 from testlib import testutil
 
@@ -23,6 +24,7 @@ class DataGenApiTest(testutil.CloudStorageTestBase, FlaskTestBase):
     testutil.CloudStorageTestBase.setUp(self)
     FlaskTestBase.setUp(self)
 
+  @unittest.skip("DA-471")
   @mock.patch('google.appengine.ext.deferred.defer', new=_callthrough)
   def test_generate_samples(self):
     participant_id = self.send_post('Participant', {})['participantId']


### PR DESCRIPTION
The data gen endpoint appears to be for testing purposes, and looks to be very non-deterministic. Disable this for now - not sure if it is worth fixing.