### PR TITLE
Fixing setup_database to set connection string after setting passwords.

### DIFF
--- a/rest-api/tools/setup_database.sh
+++ b/rest-api/tools/setup_database.sh
@@ -79,10 +79,6 @@ then
     BACKUP_INSTANCE_NAME=$INSTANCE_CONNECTION_NAME
 fi
 
-# TODO(calbach): Drop DB_NAME from here, once #549 has been deployed.
-CONNECTION_STRING="mysql+mysqldb://${RDR_DB_USER}:${RDR_PASSWORD}@/$DB_NAME?unix_socket=/cloudsql/$INSTANCE_CONNECTION_NAME&charset=utf8"
-BACKUP_CONNECTION_STRING="mysql+mysqldb://${RDR_DB_USER}:${RDR_PASSWORD}@/$DB_NAME?unix_socket=/cloudsql/$BACKUP_INSTANCE_NAME&charset=utf8"
-
 UPDATE_DB_FILE=/tmp/update_db.sql
 
 function finish {
@@ -91,16 +87,20 @@ function finish {
 }
 trap finish EXIT
 
+run_cloud_sql_proxy
 if [ "${UPDATE_PASSWORDS}" = "Y" ] || [ "${CREATE_INSTANCE}" = "Y" ]
-  then
-    	echo "Updating database user passwords..."
+  then  
+ 	echo "Updating database user passwords..."
 	randpw
 	ROOT_PASSWORD=$new_password
 	randpw
 	RDR_PASSWORD=$new_password
 	randpw
 	READONLY_PASSWORD=$new_password
-
+  
+  CONNECTION_STRING="mysql+mysqldb://${RDR_DB_USER}:${RDR_PASSWORD}@/$DB_NAME?unix_socket=/cloudsql/$INSTANCE_CONNECTION_NAME&charset=utf8"
+  BACKUP_CONNECTION_STRING="mysql+mysqldb://${RDR_DB_USER}:${RDR_PASSWORD}@/$DB_NAME?unix_socket=/cloudsql/$BACKUP_INSTANCE_NAME&charset=utf8"
+  
 	echo '{"db_connection_string": "'$CONNECTION_STRING'", ' \
 	     ' "backup_db_connection_string": "'$BACKUP_CONNECTION_STRING'", '\
 	     ' "rdr_db_password": "'$RDR_PASSWORD'", ' \
@@ -111,11 +111,9 @@ if [ "${UPDATE_PASSWORDS}" = "Y" ] || [ "${CREATE_INSTANCE}" = "Y" ]
 	     ' "db_user": "'$RDR_DB_USER'", '\
 	     ' "db_name": "'$DB_NAME'" }' > $TMP_DB_INFO_FILE
 
-	echo "Setting root password..."
-	#gcloud sql instances set-root-password $INSTANCE_NAME --password $ROOT_PASSWORD
+	echo "Setting root password..."	
 	gcloud sql users set-password root % --instance $INSTANCE_NAME --password $ROOT_PASSWORD
-
-	run_cloud_sql_proxy
+	
 	if [ "${UPDATE_PASSWORDS}" = "Y" ]
 	    then
 		echo "updating passwords for database"
@@ -132,11 +130,13 @@ if [ "${UPDATE_PASSWORDS}" = "Y" ] || [ "${CREATE_INSTANCE}" = "Y" ]
 	mysql -u "$ROOT_DB_USER" -p"$ROOT_PASSWORD" --host 127.0.0.1 --port ${PORT} < ${UPDATE_DB_FILE}
 	echo "Setting database configuration..."
 	tools/install_config.sh --key db_config --config ${TMP_DB_INFO_FILE} --instance $INSTANCE --update --creds_file ${CREDS_FILE}
-  else
+else
 	echo "Setting permissions for database"
 	for db_name in "rdr" "metrics"; do
 	   cat tools/grant_permissions.sql | envsubst > $UPDATE_DB_FILE
 	done
+	get_db_password $ROOT_DB_USER
+	mysql -u "$ROOT_DB_USER" -p"${PASSWORD}" --host 127.0.0.1 --port ${PORT} < ${UPDATE_DB_FILE}
 fi
 
 echo "Done."


### PR DESCRIPTION
Also fixing run_cloud_sql_proxy to run (and mysql be invoked with root password) in the grant_permissions.sql case.