### PR TITLE
Allow participant summary api to query results using offset field

### DIFF
--- a/rest-api/api/base_api.py
+++ b/rest-api/api/base_api.py
@@ -106,6 +106,7 @@ class BaseApi(Resource):
     order_by = None
     missing_id_list = ['awardee', 'organization', 'site']
     include_total = request.args.get('_includeTotal', False)
+    offset = request.args.get('_offset', False)
 
     for key, value in request.args.iteritems(multi=True):
       if value in missing_id_list:
@@ -130,7 +131,7 @@ class BaseApi(Resource):
         if field_filter:
           field_filters.append(field_filter)
     return Query(field_filters, order_by, max_results, pagination_token,
-                 include_total=include_total)
+                 include_total=include_total, offset=offset)
 
   def _make_bundle(self, results, id_field, participant_id):
     import main

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -213,6 +213,8 @@ class BaseDao(object):
                                           first_descending)
     # Return one more than max_results, so that we know if there are more results.
     query = query.limit(query_def.max_results + 1)
+    if query_def.offset:
+      query = query.offset(query_def.offset)
     return query, order_by_field_names
 
   def _set_filters(self, query, filters):

--- a/rest-api/query.py
+++ b/rest-api/query.py
@@ -31,9 +31,10 @@ class OrderBy(object):
 
 class Query(object):
   def __init__(self, field_filters, order_by, max_results, pagination_token, a_id=None,
-               always_return_token=False, include_total=False):
+               always_return_token=False, include_total=False, offset=False):
     self.field_filters = field_filters
     self.order_by = order_by
+    self.offset = offset
     self.max_results = max_results
     self.pagination_token = pagination_token
     self.ancestor_id = a_id

--- a/rest-api/test/unit_test/api_test/participant_summary_api_test.py
+++ b/rest-api/test/unit_test/api_test/participant_summary_api_test.py
@@ -555,6 +555,18 @@ class ParticipantSummaryApiTest(FlaskTestBase):
     # Prove that first and last entry in response2 matches 3rd and 7th entry in response
     self.assertEqual(response2['entry'][0], response['entry'][2])
     self.assertEqual(response2['entry'][4], response['entry'][6])
+    # Verify participants count for response2
+    self.assertEqual(len(response2['entry']), 5)
+
+    response3 = self.send_get('ParticipantSummary?_count=5&_offset=6')
+    # Prove that only available participants are returned even if the count is greater than available participants after offset
+    self.assertEqual(len(response3['entry']), 4)
+
+    response4 = self.send_get('ParticipantSummary?_count=5&_offset=10')
+    response5 = self.send_get('ParticipantSummary?_count=5&_offset=12')
+    # Prove that zero participants are returned if offset is greater than or equal to total number of available participants
+    self.assertEqual(len(response4['entry']), 0)
+    self.assertEqual(len(response5['entry']), 0)
 
   def test_get_summary_with_skip_codes(self):
     # Set up the codes so they are mapped later.

--- a/rest-api/test/unit_test/api_test/participant_summary_api_test.py
+++ b/rest-api/test/unit_test/api_test/participant_summary_api_test.py
@@ -512,6 +512,50 @@ class ParticipantSummaryApiTest(FlaskTestBase):
     self.assertEqual(response2['total'], response['total'])
     self.assertEqual(response2['total'], num_participants)
 
+  def test_get_summary_list_returns_offset_results(self):
+    num_participants = 10
+    SqlTestBase.setup_codes([PMI_SKIP_CODE], code_type=CodeType.ANSWER)
+    questionnaire_id = self.create_demographics_questionnaire()
+
+    # generate participants to count
+    for _ in range(num_participants):
+      # Set up participant, questionnaire, and consent
+      participant = self.send_post('Participant', {"providerLink": [self.provider_link]})
+      participant_id = participant['participantId']
+      with FakeClock(TIME_1):
+        self.send_consent(participant_id)
+      # Populate some answers to the questionnaire
+      answers = {
+        'race': RACE_WHITE_CODE,
+        'genderIdentity': PMI_SKIP_CODE,
+        'firstName': self.fake.first_name(),
+        'middleName': self.fake.first_name(),
+        'lastName': self.fake.last_name(),
+        'zipCode': '78751',
+        'state': PMI_SKIP_CODE,
+        'streetAddress': '1234 Main Street',
+        'city': 'Austin',
+        'sex': PMI_SKIP_CODE,
+        'sexualOrientation': PMI_SKIP_CODE,
+        'phoneNumber': '512-555-5555',
+        'recontactMethod': PMI_SKIP_CODE,
+        'language': PMI_SKIP_CODE,
+        'education': PMI_SKIP_CODE,
+        'income': PMI_SKIP_CODE,
+        'dateOfBirth': datetime.date(1978, 10, 9),
+        'CABoRSignature': 'signature.pdf',
+      }
+      self.post_demographics_questionnaire(participant_id, questionnaire_id, **answers)
+
+    response = self.send_get('ParticipantSummary?_count=10')
+    # Pass offset query parameter
+    response2 = self.send_get('ParticipantSummary?_count=5&_offset=2')
+
+    # Verify offset results
+    # Prove that first and last entry in response2 matches 3rd and 7th entry in response
+    self.assertEqual(response2['entry'][0], response['entry'][2])
+    self.assertEqual(response2['entry'][4], response['entry'][6])
+
   def test_get_summary_with_skip_codes(self):
     # Set up the codes so they are mapped later.
     SqlTestBase.setup_codes([PMI_SKIP_CODE], code_type=CodeType.ANSWER)


### PR DESCRIPTION
This will optimize WorkQueue pagination in HealthPro.

Ex: When HealthPro sends _offset = 60 & _count = 10 the RDR then returns 10 results starting from 60.

cc: @jt2k 