### PR TITLE
[DA-652] Changing Cloud ETL and table exports to occur using replica DB.

### DIFF
--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -29,7 +29,6 @@ source tools/auth_setup.sh
 # main DB instance for the ETL.
 get_backup_instance_connection_name
 
-echo $INSTANCE_CONNECTION_NAME
 run_cloud_sql_proxy
 set_db_connection_string
 

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -24,6 +24,12 @@ fi
 CREDS_ACCOUNT=${ACCOUNT}
 
 source tools/auth_setup.sh
+
+# Set INSTANCE_CONNECTION_NAME to the replica database connection, so we use the replica instead of the
+# main DB instance for the ETL.
+get_backup_instance_connection_name
+
+echo $INSTANCE_CONNECTION_NAME
 run_cloud_sql_proxy
 set_db_connection_string
 

--- a/rest-api/offline/table_exporter.py
+++ b/rest-api/offline/table_exporter.py
@@ -88,7 +88,8 @@ class TableExporter(object):
       # No schemas in SQLite.
       sql_table = table_name
     SqlExporter(bucket_name, use_unicode=True).run_export(
-        output_path, 'SELECT * FROM {}'.format(sql_table), transformf=transformf)
+        output_path, 'SELECT * FROM {}'.format(sql_table), transformf=transformf,
+        backup=True)
     return '%s/%s' % (bucket_name, output_path)
 
   @staticmethod

--- a/rest-api/tools/auth_setup.sh
+++ b/rest-api/tools/auth_setup.sh
@@ -80,6 +80,13 @@ function cleanup {
 
 trap cleanup EXIT
 
+function get_backup_instance_connection_name {
+  echo "Getting replica database info..."
+  tools/install_config.sh --key db_config --instance $INSTANCE \
+      --creds_file ${CREDS_FILE} --config_output "$TMP_DB_INFO_FILE"
+  INSTANCE_CONNECTION_NAME=`grep \"backup_db_connection_name $TMP_DB_INFO_FILE | cut -d\" -f4`
+}
+
 function get_instance_connection_name {
   echo "Getting database info..."
   tools/install_config.sh --key db_config --instance $INSTANCE \


### PR DESCRIPTION
This will allow us to run them without interfering with live RDR serving.