### PR TITLE
[PD-2076] Implementing script used to parse pairing data sent by PTSC and turn it into files

### DIFF
--- a/rdr_client/pairing_assigner.py
+++ b/rdr_client/pairing_assigner.py
@@ -73,6 +73,12 @@ def main(client):
         logging.info('%s unchanged (already %s)', participant_id, old_pairing)
         continue
 
+      if not client.args.override_site:
+        if participant.get('site'):
+          logging.info('Skipping participant %s already paired with site %s'
+                       % (participant_id, participant['site']))
+        continue
+
       logging.info('%s %s => %s', participant_id, old_pairing, new_pairing)
       if new_pairing == 'UNSET':
         for i in pairing_list:
@@ -110,4 +116,6 @@ if __name__ == '__main__':
   arg_parser.add_argument('--dry_run', action='store_true')
   arg_parser.add_argument('--pairing', help='set level of pairing as one of'
                           '[site|organization|awardee]', required=True)
+  arg_parser.add_argument('--override_site',
+                          help='Update pairings even on participants that have a site pairing already')
   main(Client(parser=arg_parser))

--- a/rdr_client/pairing_assigner.py
+++ b/rdr_client/pairing_assigner.py
@@ -117,5 +117,5 @@ if __name__ == '__main__':
   arg_parser.add_argument('--pairing', help='set level of pairing as one of'
                           '[site|organization|awardee]', required=True)
   arg_parser.add_argument('--override_site',
-                          help='Update pairings even on participants that have a site pairing already')
+                          help='Update pairings on participants that have a site pairing already')
   main(Client(parser=arg_parser))

--- a/rest-api/tools/process_ptsc_pairings.py
+++ b/rest-api/tools/process_ptsc_pairings.py
@@ -12,9 +12,9 @@ def strip(val):
     stripped_val = stripped_val[13:]
   return stripped_val
 
-def check_prev_entry(p_map, prefix, participant_id, id):
+def check_prev_entry(p_map, prefix, participant_id, obj_id):
   prev_entry = p_map.get(participant_id)
-  new_entry = prefix + id
+  new_entry = prefix + obj_id
   if prev_entry is not None:
     if prev_entry != new_entry:
       raise "Prev entry = %s; new entry = %s" % (prev_entry, new_entry)
@@ -24,20 +24,23 @@ def check_prev_entry(p_map, prefix, participant_id, id):
     return True
 
 def main(args):
-  with open(args.file, 'r') as input_file, open('hpos.csv', 'w') as hpos_file, open('orgs.csv', 'w') as orgs_file, open('sites.csv', 'w') as sites_file:
+  with open(args.file, 'r') as input_file, \
+    open('hpos.csv', 'w') as hpos_file, \
+    open('orgs.csv', 'w') as orgs_file, \
+    open('sites.csv', 'w') as sites_file:
     reader = UnicodeDictReader(input_file)
     hpo_writer = csv.writer(hpos_file)
     orgs_writer = csv.writer(orgs_file)
     sites_writer = csv.writer(sites_file)
     p_map = {}
-    for dict in reader:
-      participant_id = strip(dict.get('participant_id'))
+    for row in reader:
+      participant_id = strip(row.get('participant_id'))
       if participant_id is None:
         print "Skipping line with no participant_id, continuing."
         continue
-      awardee_id = strip(dict.get('awardee_code'))
-      org_id = strip(dict.get('org_code'))
-      site_id = strip(dict.get('donation_site_code'))
+      awardee_id = strip(row.get('awardee_code'))
+      org_id = strip(row.get('org_code'))
+      site_id = strip(row.get('donation_site_code'))
       if awardee_id is None and org_id is None and site_id is None:
         print "Skipping participant with no awardee, id = %s" % participant_id
         continue

--- a/rest-api/tools/process_ptsc_pairings.py
+++ b/rest-api/tools/process_ptsc_pairings.py
@@ -1,0 +1,59 @@
+from main_util import get_parser, configure_logging
+from unicode_csv import UnicodeDictReader
+import csv
+
+def strip(val):
+  if val is None:
+    return None
+  stripped_val = val.strip()
+  if stripped_val == '' or stripped_val == 'NULL' or 'UNSET' in stripped_val:
+    return None
+  if stripped_val.startswith('Organization/'):
+    stripped_val = stripped_val[13:]
+  return stripped_val
+
+def check_prev_entry(p_map, prefix, participant_id, id):
+  prev_entry = p_map.get(participant_id)
+  new_entry = prefix + id
+  if prev_entry is not None:
+    if prev_entry != new_entry:
+      raise "Prev entry = %s; new entry = %s" % (prev_entry, new_entry)
+    return False
+  else:
+    p_map[participant_id] = new_entry
+    return True
+
+def main(args):
+  with open(args.file, 'r') as input_file, open('hpos.csv', 'w') as hpos_file, open('orgs.csv', 'w') as orgs_file, open('sites.csv', 'w') as sites_file:
+    reader = UnicodeDictReader(input_file)
+    hpo_writer = csv.writer(hpos_file)
+    orgs_writer = csv.writer(orgs_file)
+    sites_writer = csv.writer(sites_file)
+    p_map = {}
+    for dict in reader:
+      participant_id = strip(dict.get('participant_id'))
+      if participant_id is None:
+        print "Skipping line with no participant_id, continuing."
+        continue
+      awardee_id = strip(dict.get('awardee_code'))
+      org_id = strip(dict.get('org_code'))
+      site_id = strip(dict.get('donation_site_code'))
+      if awardee_id is None and org_id is None and site_id is None:
+        print "Skipping participant with no awardee, id = %s" % participant_id
+        continue
+      if site_id is not None:
+        if check_prev_entry(p_map, 'site:', participant_id, site_id):
+          sites_writer.writerow([participant_id, site_id])
+      elif org_id is not None:
+        if check_prev_entry(p_map, 'org:', participant_id, org_id):
+          orgs_writer.writerow([participant_id, org_id])
+      else:
+        if check_prev_entry(p_map, 'hpo:', participant_id, awardee_id):
+          hpo_writer.writerow([participant_id, awardee_id])
+
+if __name__ == '__main__':
+  configure_logging()
+  parser = get_parser()
+  parser.add_argument('--file', help='Path to the CSV file containing the participant data.',
+                      required=True)
+  main(parser.parse_args())

--- a/rest-api/tools/process_ptsc_pairings.sh
+++ b/rest-api/tools/process_ptsc_pairings.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+USAGE="tools/process_ptsc_pairings.sh --file <INPUT_FILE>"
+
+while true; do
+  case "$1" in
+    --file) INPUT_FILE=$2; shift 2;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+if [ -z "${INPUT_FILE}" ]
+then
+  echo "Usage: $USAGE"
+  exit 1
+fi
+
+source tools/set_path.sh
+
+python tools/process_ptsc_pairings.py --file $INPUT_FILE


### PR DESCRIPTION
that can be used with pairing_assigner to perform re-pairing.

Adding optional override_site flag to pairing_assigner; the default behavior will be not to alter the pairing of any participant which is already paired with a site (e.g. because they have already completed PM&B).