### PR TITLE
Upgrade from unsafe cryptography package

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     # CircleCI's version of pip can be out of date; make sure it's up-to-date first.
     - pip install --upgrade pip
     # Then install requirements needed to run our tools.
-    - pip install --upgrade httplib2 jira oauth2client parallel pylint
+    - pip install --upgrade httplib2 jira oauth2client parallel pylint cryptography
     - pip install -I alembic==0.9.1
 
 machine:

--- a/rest-api/requirements.txt
+++ b/rest-api/requirements.txt
@@ -22,6 +22,7 @@ dictalchemy>=0.1.2.7
 MySQL-python>=1.2.5
 protorpc>=0.12.0
 parameterized>=0.6.1
+cryptography>=2.2.3
 googlemaps>=2.5.1
 google-api-python-client==1.6.6
 backoff

--- a/rest-api/requirements.txt
+++ b/rest-api/requirements.txt
@@ -22,7 +22,6 @@ dictalchemy>=0.1.2.7
 MySQL-python>=1.2.5
 protorpc>=0.12.0
 parameterized>=0.6.1
-cryptography>=2.2.3
 googlemaps>=2.5.1
 google-api-python-client==1.6.6
 backoff


### PR DESCRIPTION
This package comes in automatically with pyOpenSSL. I couldn't figure out where that package actually comes from (it may already be installed on the OS). That particular package doesn't have a better version, so we need to explicitly upgrade this dep to avoid the vulnerability in 2.2.2.