### PR TITLE
DA-758 add support for suspended participation

### DIFF
--- a/rdr_client/admin_withdrawal.py
+++ b/rdr_client/admin_withdrawal.py
@@ -5,7 +5,8 @@ param: withdrawalreason must be one of FRAUDULENT | TEST | DUPLICATE.
 param: withdrawalreasonjustification is a string explanation.
 run with run_client e.g.
 $run_client.sh --project <PROJECT> --account <ACCOUNT> [--service_account <ACCOUNT>]
-admin_withdrawal.py --withdrawal_reason <FRAUDULENT, DUPLICATE, TEST> --participants <P1000, P1001>
+admin_withdrawal.py --withdrawal_reason <FRAUDULENT [DUPLICATE | TEST] >
+--withdrawal_justification <a string without quotes is fine> --participants <P1000 [P1001]>
 """
 import logging
 import pprint

--- a/rest-api/dao/participant_summary_dao.py
+++ b/rest-api/dao/participant_summary_dao.py
@@ -14,7 +14,7 @@ from dao.organization_dao import OrganizationDao
 from dao.site_dao import SiteDao
 from model.config_utils import to_client_biobank_id
 from model.participant_summary import ParticipantSummary, WITHDRAWN_PARTICIPANT_FIELDS, \
-  WITHDRAWN_PARTICIPANT_VISIBILITY_TIME
+  WITHDRAWN_PARTICIPANT_VISIBILITY_TIME, SUSPENDED_PARTICIPANT_FIELDS
 from model.utils import to_client_participant_id, get_property_type
 from participant_enums import QuestionnaireStatus, PhysicalMeasurementsStatus, SampleStatus, \
   EnrollmentStatus, SuspensionStatus, WithdrawalStatus, get_bucketed_age
@@ -344,6 +344,11 @@ class ParticipantSummaryDao(UpdatableDao):
         (model.withdrawalTime is None or
          model.withdrawalTime < clock.CLOCK.now() - WITHDRAWN_PARTICIPANT_VISIBILITY_TIME)):
       result = {k: result.get(k) for k in WITHDRAWN_PARTICIPANT_FIELDS}
+
+    elif model.withdrawalStatus != WithdrawalStatus.NO_USE and \
+      model.suspensionStatus == SuspensionStatus.NO_CONTACT:
+      for i in SUSPENDED_PARTICIPANT_FIELDS:
+        result[i] = UNSET
 
     result['participantId'] = to_client_participant_id(model.participantId)
     biobank_id = result.get('biobankId')

--- a/rest-api/model/participant_summary.py
+++ b/rest-api/model/participant_summary.py
@@ -1,15 +1,14 @@
 import datetime
-from sqlalchemy import Column, Integer, String, Date
-from sqlalchemy import ForeignKey, Index, SmallInteger, UnicodeText
+
+from model.base import Base
+from model.utils import Enum, UTCDateTime
+from participant_enums import EnrollmentStatus, Race, SampleStatus, OrderStatus, \
+  PhysicalMeasurementsStatus, QuestionnaireStatus, WithdrawalStatus, SuspensionStatus, \
+  WithdrawalReason
+from sqlalchemy import Column, Integer, String, Date, ForeignKey, Index, SmallInteger, UnicodeText
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
 
-from model.base import Base
-from model.utils import Enum
-from model.utils import UTCDateTime
-from participant_enums import EnrollmentStatus, Race, SampleStatus, OrderStatus
-from participant_enums import PhysicalMeasurementsStatus, QuestionnaireStatus
-from participant_enums import WithdrawalStatus, SuspensionStatus, WithdrawalReason
 
 # The only fields that can be returned, queried on, or ordered by for queries for withdrawn
 # participants.
@@ -25,6 +24,11 @@ WITHDRAWN_PARTICIPANT_FIELDS = ['withdrawalStatus', 'withdrawalTime',
 # The period of time for which withdrawn participants will still be returned in results for
 # queries that don't ask for withdrawn participants.
 WITHDRAWN_PARTICIPANT_VISIBILITY_TIME = datetime.timedelta(days=2)
+
+# suspended participants don't allow contact but can still use samples. These fields
+# will not be returned when queried on suspended participant.
+SUSPENDED_PARTICIPANT_FIELDS = ['zipCode', 'city', 'streetAddress', 'phoneNumber',
+                                'loginPhoneNumber', 'email']
 
 
 class ParticipantSummary(Base):

--- a/rest-api/test/unit_test/api_test/participant_summary_api_test.py
+++ b/rest-api/test/unit_test/api_test/participant_summary_api_test.py
@@ -287,6 +287,56 @@ class ParticipantSummaryApiTest(FlaskTestBase):
       self.assertEqual(response['withdrawalReason'], 'DUPLICATE')
       self.assertEqual(response['withdrawalReasonJustification'],  "IT WAS A DUPLICATE")
 
+  def test_suspension_status_returns_right_info(self):
+    with FakeClock(TIME_1):
+      SqlTestBase.setup_codes(["PIIState_VA", "male_sex", "male", "straight", "email_code", "en",
+                               "highschool", "lotsofmoney"], code_type=CodeType.ANSWER)
+      participant = self.send_post('Participant', {"providerLink": [self.provider_link]})
+      participant_id = participant['participantId']
+      with FakeClock(TIME_1):
+        self.send_consent(participant_id)
+      questionnaire_id = self.create_questionnaire('questionnaire3.json')
+
+      # Populate some answers to the questionnaire
+      answers = {
+        'race': RACE_WHITE_CODE,
+        'genderIdentity': 'male',
+        'firstName': self.fake.first_name(),
+        'middleName': self.fake.first_name(),
+        'lastName': self.fake.last_name(),
+        'zipCode': '78751',
+        'state': 'PIIState_VA',
+        'streetAddress': '1234 Main Street',
+        'city': 'Austin',
+        'sex': 'male_sex',
+        'sexualOrientation': 'straight',
+        'phoneNumber': '512-555-5555',
+        'recontactMethod': 'email_code',
+        'language': 'en',
+        'education': 'highschool',
+        'income': 'lotsofmoney',
+        'dateOfBirth': datetime.date(1978, 10, 9),
+        'CABoRSignature': 'signature.pdf',
+        }
+
+      self.post_demographics_questionnaire(participant_id, questionnaire_id, **answers)
+
+    with FakeClock(TIME_2):
+      path = 'Participant/%s' % participant_id
+      participant['suspensionStatus'] = "NO_CONTACT"
+      self.send_put(path, participant, headers={'If-Match': 'W/"1"'})
+
+    with FakeClock(TIME_3):
+      response = self.send_get('Participant/%s/Summary' % participant_id)
+      self.assertEqual(response['email'], 'UNSET')
+      self.assertEqual(response['city'], 'UNSET')
+      self.assertEqual(response['streetAddress'], 'UNSET')
+      self.assertEqual(response['zipCode'], 'UNSET')
+      self.assertEqual(response['phoneNumber'], 'UNSET')
+      self.assertEqual(response['loginPhoneNumber'], 'UNSET')
+      self.assertEqual(response['recontactMethod'], 'NO_CONTACT')
+
+
   def test_no_justification_fails(self):
     with FakeClock(TIME_1):
       SqlTestBase.setup_codes(["PIIState_VA", "male_sex", "male", "straight", "email_code", "en",

--- a/rest-api/test/unit_test/dao_test/participant_summary_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/participant_summary_dao_test.py
@@ -2,21 +2,22 @@ import datetime
 import json
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 
-from query import Query, Operator, FieldFilter, OrderBy
-
 import config
 from dao.base_dao import json_serial
 from dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from dao.participant_dao import ParticipantDao
 from dao.participant_summary_dao import ParticipantSummaryDao
+from model.biobank_stored_sample import BiobankStoredSample
 from model.participant import Participant
 from model.participant_summary import ParticipantSummary
-from model.biobank_stored_sample import BiobankStoredSample
-from participant_enums import EnrollmentStatus, PhysicalMeasurementsStatus
-from participant_enums import SampleStatus, QuestionnaireStatus
+from participant_enums import EnrollmentStatus, PhysicalMeasurementsStatus, SampleStatus, \
+  QuestionnaireStatus
+from query import Query, Operator, FieldFilter, OrderBy
 from unit_test_util import NdbTestBase, PITT_HPO_ID
 
+
 NUM_BASELINE_PPI_MODULES = 3
+
 
 class ParticipantSummaryDaoTest(NdbTestBase):
   def setUp(self):
@@ -216,11 +217,13 @@ class ParticipantSummaryDaoTest(NdbTestBase):
     p_no_samples = self._insert(Participant(participantId=3, biobankId=33))
     p_unconfirmed = self._insert(Participant(participantId=4, biobankId=44))
     self.assertEquals(self.dao.get(p_baseline_samples.participantId).numBaselineSamplesArrived, 0)
+
     def get_p_baseline_last_modified():
       return self.dao.get(p_baseline_samples.participantId).lastModified
     p_baseline_last_modified1 = get_p_baseline_last_modified()
 
     sample_dao = BiobankStoredSampleDao()
+
     def add_sample(participant, test_code, sample_id):
       TIME = datetime.datetime(2018, 3, 2)
       sample_dao.insert(BiobankStoredSample(


### PR DESCRIPTION
Added feature to use existing suspension_status to filter out contact fields only while allowing the continued use of PM&B.