### PR TITLE
[DA-652] Change ETL to run against a clone of the RDR main instance.

### DIFF
--- a/rdr_client/export_tables.py
+++ b/rdr_client/export_tables.py
@@ -6,7 +6,8 @@
 #
 # Usage: ./run_client.sh --project <PROJECT> --account <ACCOUNT> \
 # --service_account exporter@<PROJECT>.iam.gserviceaccount.com export_tables.py \
-# --database rdr --tables code,participant --directory test_directory [--db_connection_string <DB_CONNECTION_STRING>]
+# --database rdr --tables code,participant --directory test_directory
+# [--db_connection_string <DB_CONNECTION_STRING>]
 #
 # "directory" indicates a directory inside the GCS bucket to write the files to
 #
@@ -46,5 +47,6 @@ if __name__ == '__main__':
                       required=True)
   parser.add_argument('--deidentify', help='Whether to deidentify the exports',
                       action='store_true')
-  parser.add_argument('--db_connection_string', help='Database connecton string for the instance to read data from')
+  parser.add_argument('--db_connection_string',
+                      help='Database connecton string for the instance to read data from')
   export_tables(Client(parser=parser, base_path='offline'))

--- a/rdr_client/export_tables.py
+++ b/rdr_client/export_tables.py
@@ -7,15 +7,15 @@
 # Usage: ./run_client.sh --project <PROJECT> --account <ACCOUNT> \
 # --service_account exporter@<PROJECT>.iam.gserviceaccount.com export_tables.py \
 # --database rdr --tables code,participant --directory test_directory
-# [--db_connection_string <DB_CONNECTION_STRING>]
+# [--instance_name <INSTANCE_NAME>]
 #
 # "directory" indicates a directory inside the GCS bucket to write the files to
 #
 # If "rdr" is chosen for the database, the data will be written to <ENVIRONMENT>-rdr-export;
 # If "cdm" or "voc" are chosen, the data will be written to <ENVIRONMENT>-cdm.
-# If specified, "db_connection_string" must be a connection string to a
-# database instance that the RDR has access to. (This is used for exporting
-# ETL results from clones of the main RDR instance.)
+# If specified, "instance_name" must be the name of a database instance that
+# the RDR has access to with the same credentials as the main instance.
+# (This is used for exporting ETL results from clones of the main RDR instance.)
 
 import logging
 
@@ -31,8 +31,8 @@ def export_tables(client):
                   'directory': client.args.directory,
                   'deidentify': client.args.deidentify
   }
-  if client.args.db_connection_string:
-    request_body['db_connection_string'] = client.args.db_connection_string
+  if client.args.instance_name:
+    request_body['instance_name'] = client.args.instance_name
   response = client.request_json('ExportTables', 'POST', request_body)
   logging.info('Data is being exported to: %s' % response['destination'])
 
@@ -47,6 +47,5 @@ if __name__ == '__main__':
                       required=True)
   parser.add_argument('--deidentify', help='Whether to deidentify the exports',
                       action='store_true')
-  parser.add_argument('--db_connection_string',
-                      help='Database connecton string for the instance to read data from')
+  parser.add_argument('--instance_name', help='Name of the instance to read data from; defaults to rdrmaindb')
   export_tables(Client(parser=parser, base_path='offline'))

--- a/rdr_client/export_tables.py
+++ b/rdr_client/export_tables.py
@@ -6,12 +6,15 @@
 #
 # Usage: ./run_client.sh --project <PROJECT> --account <ACCOUNT> \
 # --service_account exporter@<PROJECT>.iam.gserviceaccount.com export_tables.py \
-# --database rdr --tables code,participant --directory test_directory
+# --database rdr --tables code,participant --directory test_directory [--db_connection_string <DB_CONNECTION_STRING>]
 #
 # "directory" indicates a directory inside the GCS bucket to write the files to
 #
 # If "rdr" is chosen for the database, the data will be written to <ENVIRONMENT>-rdr-export;
 # If "cdm" or "voc" are chosen, the data will be written to <ENVIRONMENT>-cdm.
+# If specified, "db_connection_string" must be a connection string to a
+# database instance that the RDR has access to. (This is used for exporting
+# ETL results from clones of the main RDR instance.)
 
 import logging
 
@@ -27,6 +30,8 @@ def export_tables(client):
                   'directory': client.args.directory,
                   'deidentify': client.args.deidentify
   }
+  if client.args.db_connection_string:
+    request_body['db_connection_string'] = client.args.db_connection_string
   response = client.request_json('ExportTables', 'POST', request_body)
   logging.info('Data is being exported to: %s' % response['destination'])
 
@@ -41,4 +46,5 @@ if __name__ == '__main__':
                       required=True)
   parser.add_argument('--deidentify', help='Whether to deidentify the exports',
                       action='store_true')
+  parser.add_argument('--db_connection_string', help='Database connecton string for the instance to read data from')
   export_tables(Client(parser=parser, base_path='offline'))

--- a/rdr_client/export_tables.py
+++ b/rdr_client/export_tables.py
@@ -47,5 +47,6 @@ if __name__ == '__main__':
                       required=True)
   parser.add_argument('--deidentify', help='Whether to deidentify the exports',
                       action='store_true')
-  parser.add_argument('--instance_name', help='Name of the instance to read data from; defaults to rdrmaindb')
+  parser.add_argument('--instance_name',
+                      help='Name of the instance to read data from; defaults to rdrmaindb')
   export_tables(Client(parser=parser, base_path='offline'))

--- a/rest-api/dao/database_factory.py
+++ b/rest-api/dao/database_factory.py
@@ -13,8 +13,8 @@ SCHEMA_TRANSLATE_MAP = None
 
 
 class _SqlDatabase(Database):
-  def __init__(self, db_name, backup=False, **kwargs):
-    url = make_url(get_db_connection_string(backup))
+  def __init__(self, db_name, backup=False, db_connection_string=None, **kwargs):
+    url = make_url(db_connection_string or get_db_connection_string(backup))
     if url.drivername != "sqlite" and not url.database:
       url.database = db_name
     super(_SqlDatabase, self).__init__(url, **kwargs)
@@ -63,7 +63,7 @@ def get_db_connection_string(backup=False):
   return config.get_db_config()['db_connection_string']
 
 
-def make_server_cursor_database(backup=False):
+def make_server_cursor_database(backup=False, db_connection_string=None):
   """
   Returns a database object that uses a server-side cursor when talking to the database.
   Useful in cases where you're reading a very large amount of data.
@@ -74,4 +74,5 @@ def make_server_cursor_database(backup=False):
   else:
     if backup:
       return _BackupSqlDatabase('rdr', connect_args={'cursorclass': SSCursor})
-    return _SqlDatabase('rdr', connect_args={'cursorclass': SSCursor})
+    return _SqlDatabase('rdr', db_connection_string=db_connection_string,
+                        connect_args={'cursorclass': SSCursor})

--- a/rest-api/etl/export_etl_results.sh
+++ b/rest-api/etl/export_etl_results.sh
@@ -2,12 +2,13 @@
 
 # Exports ETL results to GCS.
 
-USAGE="etl/export_etl_results.sh [--project <PROJECT> --account <ACCOUNT>] --directory <DIRECTORY>"
+USAGE="etl/export_etl_results.sh [--project <PROJECT> --account <ACCOUNT> --db_connection_string <DB_CONNECTION_STRING>] --directory <DIRECTORY>"
 while true; do
   case "$1" in
     --account) ACCOUNT=$2; shift 2;;
     --project) PROJECT=$2; shift 2;;
     --directory) DIRECTORY=$2; shift 2;;
+    --db_connection_string) DB_CONNECTION_STRING=$2; shift 2;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -21,7 +22,7 @@ fi
 PROJECT_AND_ACCOUNT=
 if [ "${PROJECT}" ]
 then
-  PROJECT_AND_ACCOUNT="--project ${PROJECT} --account ${ACCOUNT} --service_account exporter@${PROJECT}.iam.gserviceaccount.com"
+  PROJECT_AND_ACCOUNT="--project ${PROJECT} --account ${ACCOUNT} --db_connection_string ${DB_CONNECTION_STRING} --service_account exporter@${PROJECT}.iam.gserviceaccount.com"
 fi
 
 pushd ../rdr_client

--- a/rest-api/etl/export_etl_results.sh
+++ b/rest-api/etl/export_etl_results.sh
@@ -2,13 +2,13 @@
 
 # Exports ETL results to GCS.
 
-USAGE="etl/export_etl_results.sh [--project <PROJECT> --account <ACCOUNT> --db_connection_string <DB_CONNECTION_STRING>] --directory <DIRECTORY>"
+USAGE="etl/export_etl_results.sh [--project <PROJECT> --account <ACCOUNT> --instance_name <INSTANCE_NAME>] --directory <DIRECTORY>"
 while true; do
   case "$1" in
     --account) ACCOUNT=$2; shift 2;;
     --project) PROJECT=$2; shift 2;;
     --directory) DIRECTORY=$2; shift 2;;
-    --db_connection_string) DB_CONNECTION_STRING=$2; shift 2;;
+    --instance_name) INSTANCE_NAME=$2; shift 2;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -22,7 +22,7 @@ fi
 PROJECT_AND_ACCOUNT=
 if [ "${PROJECT}" ]
 then
-  PROJECT_AND_ACCOUNT="--project ${PROJECT} --account ${ACCOUNT} --db_connection_string ${DB_CONNECTION_STRING} --service_account exporter@${PROJECT}.iam.gserviceaccount.com"
+  PROJECT_AND_ACCOUNT="--project ${PROJECT} --account ${ACCOUNT} --instance_name ${INSTANCE_NAME} --service_account exporter@${PROJECT}.iam.gserviceaccount.com"
 fi
 
 pushd ../rdr_client

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -50,6 +50,8 @@ then
   }
   trap delete_instance EXIT
   INSTANCE_ARGS="--instance_name ${INSTANCE_NAME}"
+else
+  get_instance_connection_name
 fi
 
 run_cloud_sql_proxy

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -30,7 +30,7 @@ DATE_WITH_TIME=`date "+%Y%m%d-%H%M%S"`
 INSTANCE_NAME=rdr-etl${DATE_WITH_TIME}
 
 INSTANCE_ARGS=""
-if [ -z "${NOCLONE}"]
+if [ -z "${NOCLONE}" ]
 then
   set -e
   echo "Creating clone instance ${INSTANCE_NAME}..."
@@ -63,7 +63,7 @@ echo "Done with ETL. Exporting ETL results..."
 
 ./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} ${INSTANCE_ARGS}
 
-if [ -z "${NOCLONE}"]
+if [ -z "${NOCLONE}" ]
 then
   SLEEP_TIME=3600
   # TODO: do some kind of polling of task queue to determine when table export has completed.

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -25,9 +25,42 @@ CREDS_ACCOUNT=${ACCOUNT}
 
 source tools/auth_setup.sh
 
+set -e
+DATE_WITH_TIME=`date "+%Y%m%d-%H%M%S"`
+# Note: this will fail if the instance already exists or was deleted recently. You'll need to
+# manually delete the instance and wait a while if that happens.
+INSTANCE_NAME=rdr-etl${DATE_WITH_TIME}
+echo "Creating clone instance ${INSTANCE_NAME}..."
+gcloud sql instances clone rdrmaindb ${INSTANCE_NAME}
+
+# Get the main instance DB info
+get_instance_connection_name
+# Override INSTANCE_CONNECTION_NAME to use the new instance
+INSTANCE_CONNECTION_NAME=${PROJECT}:us-central1:${INSTANCE_NAME}
+
 run_cloud_sql_proxy
 set_db_connection_string
 
+function delete_instance {
+  set +e
+  echo "Deleting instance ${INSTANCE_NAME} (cleanup)..."
+  gcloud sql instances delete ${INSTANCE_NAME}
+  set -e
+  finish
+}
+
+trap delete_instance EXIT
+
+
+echo "Running ETL..."
+
 mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT} < etl/etl.sql
 
-echo "Done."
+echo "Done with ETL. Exporting ETL results..."
+
+./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME}
+
+SLEEP_TIME=3600
+# TODO: do some kind of polling of task queue to determine when table export has completed.
+echo "Waiting ${SLEEP_TIME} seconds for export to complete."
+sleep ${SLEEP_TIME}

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -1,10 +1,11 @@
 # Runs the ETL SQL on a Cloud database.
 
-USAGE="tools/run_cloud_etl.sh --project <PROJECT> --account <ACCOUNT>"
+USAGE="tools/run_cloud_etl.sh --project <PROJECT> --account <ACCOUNT> [--noclone]"
 while true; do
   case "$1" in
     --account) ACCOUNT=$2; shift 2;;
     --project) PROJECT=$2; shift 2;;
+    --noclone) NOCLONE="Y"; shift 1;;
     -- ) shift; break ;;
     * ) break ;;
   esac
@@ -25,32 +26,34 @@ CREDS_ACCOUNT=${ACCOUNT}
 
 source tools/auth_setup.sh
 
-set -e
 DATE_WITH_TIME=`date "+%Y%m%d-%H%M%S"`
-# Note: this will fail if the instance already exists or was deleted recently. You'll need to
-# manually delete the instance and wait a while if that happens.
 INSTANCE_NAME=rdr-etl${DATE_WITH_TIME}
-echo "Creating clone instance ${INSTANCE_NAME}..."
-gcloud sql instances clone rdrmaindb ${INSTANCE_NAME}
 
-# Get the main instance DB info
-get_instance_connection_name
-# Override INSTANCE_CONNECTION_NAME to use the new instance
-INSTANCE_CONNECTION_NAME=${PROJECT}:us-central1:${INSTANCE_NAME}
+INSTANCE_ARGS=""
+if [ -z "${NOCLONE}"]
+then
+  set -e
+  echo "Creating clone instance ${INSTANCE_NAME}..."
+  gcloud sql instances clone rdrmaindb ${INSTANCE_NAME}
+
+  # Get the main instance DB info
+  get_instance_connection_name
+  # Override INSTANCE_CONNECTION_NAME to use the new instance
+  INSTANCE_CONNECTION_NAME=${PROJECT}:us-central1:${INSTANCE_NAME}
+
+  function delete_instance {
+    set +e
+    echo "Deleting instance ${INSTANCE_NAME} (cleanup)..."
+    gcloud sql instances delete ${INSTANCE_NAME} --quiet
+    set -e
+    finish
+  }
+  trap delete_instance EXIT
+  INSTANCE_ARGS="--instance_name ${INSTANCE_NAME}"
+fi
 
 run_cloud_sql_proxy
 set_db_connection_string
-
-function delete_instance {
-  set +e
-  echo "Deleting instance ${INSTANCE_NAME} (cleanup)..."
-  gcloud sql instances delete ${INSTANCE_NAME} --quiet
-  set -e
-  finish
-}
-
-trap delete_instance EXIT
-
 
 echo "Running ETL..."
 
@@ -58,9 +61,13 @@ mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT}
 
 echo "Done with ETL. Exporting ETL results..."
 
-./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} --instance_name ${INSTANCE_NAME}
+./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} ${INSTANCE_ARGS}
 
-SLEEP_TIME=3600
-# TODO: do some kind of polling of task queue to determine when table export has completed.
-echo "Waiting ${SLEEP_TIME} seconds for export to complete."
-sleep ${SLEEP_TIME}
+if [ -z "${NOCLONE}"]
+then
+  SLEEP_TIME=3600
+  # TODO: do some kind of polling of task queue to determine when table export has completed.
+  echo "Waiting ${SLEEP_TIME} seconds for export to complete."
+  sleep ${SLEEP_TIME}
+  echo "Sleep done. Instance ${INSTANCE_NAME} will now be deleted."
+fi

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -67,7 +67,7 @@ echo "Done with ETL. Exporting ETL results..."
 
 if [ -z "${NOCLONE}" ]
 then
-  SLEEP_TIME=3600
+  SLEEP_TIME=600
   # TODO: do some kind of polling of task queue to determine when table export has completed.
   echo "Waiting ${SLEEP_TIME} seconds for export to complete."
   sleep ${SLEEP_TIME}

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -58,7 +58,7 @@ mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT}
 
 echo "Done with ETL. Exporting ETL results..."
 
-./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} --db_connection_string ${INSTANCE_CONNECTION_NAME}
+./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} --instance_name ${INSTANCE_NAME}
 
 SLEEP_TIME=3600
 # TODO: do some kind of polling of task queue to determine when table export has completed.

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -44,7 +44,7 @@ set_db_connection_string
 function delete_instance {
   set +e
   echo "Deleting instance ${INSTANCE_NAME} (cleanup)..."
-  gcloud sql instances delete ${INSTANCE_NAME}
+  gcloud sql instances delete ${INSTANCE_NAME} --quiet
   set -e
   finish
 }
@@ -58,7 +58,7 @@ mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT}
 
 echo "Done with ETL. Exporting ETL results..."
 
-./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME}
+./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} --db_connection_string ${INSTANCE_CONNECTION_NAME}
 
 SLEEP_TIME=3600
 # TODO: do some kind of polling of task queue to determine when table export has completed.

--- a/rest-api/offline/main.py
+++ b/rest-api/offline/main.py
@@ -110,7 +110,7 @@ def export_tables():
   resource_json = json.loads(resource)
   database = resource_json.get('database')
   tables = resource_json.get('tables')
-  db_connection_string = resource_json.get('db_connection_string')
+  instance_name = resource_json.get('instance_name')
   if not database:
     raise BadRequest("database is required")
   if not tables or type(tables) is not list:
@@ -123,7 +123,7 @@ def export_tables():
   deidentify = resource_json.get('deidentify') is True
 
   return json.dumps(TableExporter.export_tables(database, tables, directory, deidentify,
-                                                db_connection_string))
+                                                instance_name))
 
 @app_util.auth_required_cron
 @_alert_on_exceptions

--- a/rest-api/offline/main.py
+++ b/rest-api/offline/main.py
@@ -110,6 +110,7 @@ def export_tables():
   resource_json = json.loads(resource)
   database = resource_json.get('database')
   tables = resource_json.get('tables')
+  db_connection_string = resource_json.get('db_connection_string')
   if not database:
     raise BadRequest("database is required")
   if not tables or type(tables) is not list:
@@ -121,7 +122,8 @@ def export_tables():
   # Ensure this has a boolean value to avoid downstream issues.
   deidentify = resource_json.get('deidentify') is True
 
-  return json.dumps(TableExporter.export_tables(database, tables, directory, deidentify))
+  return json.dumps(TableExporter.export_tables(database, tables, directory, deidentify,
+                                                db_connection_string))
 
 @app_util.auth_required_cron
 @_alert_on_exceptions

--- a/rest-api/offline/sql_exporter.py
+++ b/rest-api/offline/sql_exporter.py
@@ -48,12 +48,15 @@ class SqlExporter(object):
     self._bucket_name = bucket_name
     self._use_unicode = use_unicode
 
-  def run_export(self, file_name, sql, query_params=None, backup=False, transformf=None):
+  def run_export(self, file_name, sql, query_params=None, backup=False, transformf=None,
+    db_connection_string=None):
     with self.open_writer(file_name) as writer:
-      self.run_export_with_writer(writer, sql, query_params, backup=backup, transformf=transformf)
+      self.run_export_with_writer(writer, sql, query_params, backup=backup, transformf=transformf,
+                                  db_connection_string=db_connection_string)
 
-  def run_export_with_writer(self, writer, sql, query_params, backup=False, transformf=None):
-    with database_factory.make_server_cursor_database(backup).session() as session:
+  def run_export_with_writer(self, writer, sql, query_params, backup=False, transformf=None,
+    db_connection_string=None):
+    with database_factory.make_server_cursor_database(backup, db_connection_string).session() as session:
       self.run_export_with_session(writer, session, sql,
                                    query_params=query_params, transformf=transformf)
 

--- a/rest-api/offline/sql_exporter.py
+++ b/rest-api/offline/sql_exporter.py
@@ -49,15 +49,15 @@ class SqlExporter(object):
     self._use_unicode = use_unicode
 
   def run_export(self, file_name, sql, query_params=None, backup=False, transformf=None,
-    db_connection_string=None):
+    instance_name=None):
     with self.open_writer(file_name) as writer:
       self.run_export_with_writer(writer, sql, query_params, backup=backup, transformf=transformf,
-                                  db_connection_string=db_connection_string)
+                                  instance_name=instance_name)
 
   def run_export_with_writer(self, writer, sql, query_params, backup=False, transformf=None,
-    db_connection_string=None):
+                             instance_name=None):
     with database_factory.make_server_cursor_database(backup,
-                                                      db_connection_string).session() as session:
+                                                      instance_name).session() as session:
       self.run_export_with_session(writer, session, sql,
                                    query_params=query_params, transformf=transformf)
 

--- a/rest-api/offline/sql_exporter.py
+++ b/rest-api/offline/sql_exporter.py
@@ -56,7 +56,8 @@ class SqlExporter(object):
 
   def run_export_with_writer(self, writer, sql, query_params, backup=False, transformf=None,
     db_connection_string=None):
-    with database_factory.make_server_cursor_database(backup, db_connection_string).session() as session:
+    with database_factory.make_server_cursor_database(backup,
+                                                      db_connection_string).session() as session:
       self.run_export_with_session(writer, session, sql,
                                    query_params=query_params, transformf=transformf)
 

--- a/rest-api/offline/table_exporter.py
+++ b/rest-api/offline/table_exporter.py
@@ -52,7 +52,8 @@ class TableExporter(object):
     return abs(struct.unpack('>q', b)[0])
 
   @classmethod
-  def _export_csv(cls, bucket_name, database, directory, deidentify_salt, table_name, db_connection_string):
+  def _export_csv(cls, bucket_name, database, directory, deidentify_salt, table_name,
+                  db_connection_string):
     assert _TABLE_PATTERN.match(table_name)
     assert _TABLE_PATTERN.match(database)
 
@@ -138,5 +139,5 @@ class TableExporter(object):
 
     for table_name in tables:
       deferred.defer(TableExporter._export_csv, bucket_name,
-                     database, directory, deidentify_salt, table_name)
+                     database, directory, deidentify_salt, table_name, db_connection_string)
     return {'destination': 'gs://%s/%s' % (bucket_name, directory)}

--- a/rest-api/offline/table_exporter.py
+++ b/rest-api/offline/table_exporter.py
@@ -53,7 +53,7 @@ class TableExporter(object):
 
   @classmethod
   def _export_csv(cls, bucket_name, database, directory, deidentify_salt, table_name,
-                  db_connection_string):
+                  instance_name):
     assert _TABLE_PATTERN.match(table_name)
     assert _TABLE_PATTERN.match(database)
 
@@ -90,11 +90,11 @@ class TableExporter(object):
       sql_table = table_name
     SqlExporter(bucket_name, use_unicode=True).run_export(
         output_path, 'SELECT * FROM {}'.format(sql_table), transformf=transformf,
-        db_connection_string=db_connection_string)
+        instance_name=instance_name)
     return '%s/%s' % (bucket_name, output_path)
 
   @staticmethod
-  def export_tables(database, tables, directory, deidentify, db_connection_string=None):
+  def export_tables(database, tables, directory, deidentify, instance_name=None):
     """
     Export the given tables from the given DB; deidentifying if requested.
 
@@ -139,5 +139,5 @@ class TableExporter(object):
 
     for table_name in tables:
       deferred.defer(TableExporter._export_csv, bucket_name,
-                     database, directory, deidentify_salt, table_name, db_connection_string)
+                     database, directory, deidentify_salt, table_name, instance_name)
     return {'destination': 'gs://%s/%s' % (bucket_name, directory)}

--- a/rest-api/offline/table_exporter.py
+++ b/rest-api/offline/table_exporter.py
@@ -10,6 +10,7 @@ from offline.sql_exporter import SqlExporter
 from werkzeug.exceptions import BadRequest
 
 _TABLE_PATTERN = re.compile("^[A-Za-z0-9_]+$")
+_INSTANCE_PATTERN = re.compile("^[A-Za-z0-9_-]+$")
 
 # TODO(calbach): Factor this out into the datastore config.
 _DEIDENTIFY_DB_TABLE_WHITELIST = {
@@ -56,6 +57,8 @@ class TableExporter(object):
                   instance_name):
     assert _TABLE_PATTERN.match(table_name)
     assert _TABLE_PATTERN.match(database)
+    if instance_name:
+      assert _INSTANCE_PATTERN.match(instance_name)
 
     transformf = None
     if deidentify_salt:
@@ -118,6 +121,9 @@ class TableExporter(object):
       bucket_name = '%s-cdm' % app_id
     else:
       raise BadRequest("Invalid database: %s" % database)
+    if instance_name:
+      if not _INSTANCE_PATTERN.match(instance_name):
+        raise BadRequest("Invalid instance name: %s" % instance_name)
     for table_name in tables:
       if not _TABLE_PATTERN.match(table_name):
         raise BadRequest("Invalid table name: %s" % table_name)

--- a/rest-api/offline/table_exporter.py
+++ b/rest-api/offline/table_exporter.py
@@ -52,7 +52,7 @@ class TableExporter(object):
     return abs(struct.unpack('>q', b)[0])
 
   @classmethod
-  def _export_csv(cls, bucket_name, database, directory, deidentify_salt, table_name):
+  def _export_csv(cls, bucket_name, database, directory, deidentify_salt, table_name, db_connection_string):
     assert _TABLE_PATTERN.match(table_name)
     assert _TABLE_PATTERN.match(database)
 
@@ -89,11 +89,11 @@ class TableExporter(object):
       sql_table = table_name
     SqlExporter(bucket_name, use_unicode=True).run_export(
         output_path, 'SELECT * FROM {}'.format(sql_table), transformf=transformf,
-        backup=True)
+        db_connection_string=db_connection_string)
     return '%s/%s' % (bucket_name, output_path)
 
   @staticmethod
-  def export_tables(database, tables, directory, deidentify):
+  def export_tables(database, tables, directory, deidentify, db_connection_string=None):
     """
     Export the given tables from the given DB; deidentifying if requested.
 

--- a/rest-api/tools/install_config.py
+++ b/rest-api/tools/install_config.py
@@ -20,10 +20,10 @@ def _log_and_write_config_lines(raw_config_lines, output_path):
   safe_config_lines = []
   for line in raw_config_lines:
     match = re.search('db_password', line)
-    #if 'db_connection_string' in line or match is not None:
-    #  safe_config_lines.append(line.split(':')[0] + ' *******')
-    #else:
-    safe_config_lines.append(line)
+    if 'db_connection_string' in line or match is not None:
+      safe_config_lines.append(line.split(':')[0] + ' *******')
+    else:
+      safe_config_lines.append(line)
   logging.info('\n'.join(safe_config_lines))
   if output_path:
     with open(output_path, 'w') as output_file:

--- a/rest-api/tools/install_config.py
+++ b/rest-api/tools/install_config.py
@@ -20,10 +20,10 @@ def _log_and_write_config_lines(raw_config_lines, output_path):
   safe_config_lines = []
   for line in raw_config_lines:
     match = re.search('db_password', line)
-    if 'db_connection_string' in line or match is not None:
-      safe_config_lines.append(line.split(':')[0] + ' *******')
-    else:
-      safe_config_lines.append(line)
+    #if 'db_connection_string' in line or match is not None:
+    #  safe_config_lines.append(line.split(':')[0] + ' *******')
+    #else:
+    safe_config_lines.append(line)
   logging.info('\n'.join(safe_config_lines))
   if output_path:
     with open(output_path, 'w') as output_file:


### PR DESCRIPTION
Changing run_cloud_etl to export ETL results after the ETL finishes.

This will 1) isolate prod from the performance impacts of running the ETL, and 2) make sure the data isn't changing while the ETL is in progress.

The current script waits for an hour after the table export and then deletes the instance when it's done... in future we should try polling the task queue or something so that we can delete it as soon as the export finishes.