### PR TITLE
Fix ETL scripts

### DIFF
--- a/rest-api/etl/export_etl_results.sh
+++ b/rest-api/etl/export_etl_results.sh
@@ -22,7 +22,10 @@ fi
 PROJECT_AND_ACCOUNT=
 if [ "${PROJECT}" ]
 then
-  PROJECT_AND_ACCOUNT="--project ${PROJECT} --account ${ACCOUNT} --instance_name ${INSTANCE_NAME} --service_account exporter@${PROJECT}.iam.gserviceaccount.com"
+  PROJECT_AND_ACCOUNT="--project ${PROJECT} --account ${ACCOUNT} --service_account exporter@${PROJECT}.iam.gserviceaccount.com"
+fi
+if [ -n "${INSTANCE_NAME}" ]; then
+  PROJECT_AND_ACCOUNT="${PROJECT_AND_ACCOUNT} --instance_name ${INSTANCE_NAME}"
 fi
 
 pushd ../rdr_client

--- a/rest-api/etl/export_etl_results.sh
+++ b/rest-api/etl/export_etl_results.sh
@@ -23,9 +23,9 @@ PROJECT_AND_ACCOUNT=
 if [ "${PROJECT}" ]
 then
   PROJECT_AND_ACCOUNT="--project ${PROJECT} --account ${ACCOUNT} --service_account exporter@${PROJECT}.iam.gserviceaccount.com"
-fi
-if [ -n "${INSTANCE_NAME}" ]; then
-  PROJECT_AND_ACCOUNT="${PROJECT_AND_ACCOUNT} --instance_name ${INSTANCE_NAME}"
+  if [ -n "${INSTANCE_NAME}" ]; then
+    PROJECT_AND_ACCOUNT="${PROJECT_AND_ACCOUNT} --instance_name ${INSTANCE_NAME}"
+  fi
 fi
 
 pushd ../rdr_client

--- a/rest-api/etl/run_cloud_etl.sh
+++ b/rest-api/etl/run_cloud_etl.sh
@@ -63,7 +63,7 @@ mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT}
 
 echo "Done with ETL. Exporting ETL results..."
 
-./export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} ${INSTANCE_ARGS}
+etl/export_etl_results.sh --project ${PROJECT} --account ${ACCOUNT} --directory ${INSTANCE_NAME} ${INSTANCE_ARGS}
 
 if [ -z "${NOCLONE}" ]
 then


### PR DESCRIPTION
Currently must be run from `rest-api`. Fix `--noclone` export flags.