### PR TITLE
Mm/external id return participant

### DIFF
--- a/rest-api/api/base_api.py
+++ b/rest-api/api/base_api.py
@@ -59,7 +59,7 @@ class BaseApi(Resource):
       return self.dao.from_client_json(resource, client_id=app_util.get_oauth_id())
 
   def _do_insert(self, m):
-    self.dao.insert(m)
+    return self.dao.insert(m)
 
   def post(self, participant_id=None):
     """Handles a POST (insert) request.
@@ -69,8 +69,8 @@ class BaseApi(Resource):
     """
     resource = request.get_json(force=True)
     m = self._get_model_to_insert(resource, participant_id)
-    self._do_insert(m)
-    return self._make_response(m)
+    result = self._do_insert(m)
+    return self._make_response(result)
 
   def list(self, participant_id=None):
     """Handles a list request, as the default behavior when a GET has no id provided.

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -331,8 +331,8 @@ class BaseDao(object):
       except IntegrityError, e:
         # SQLite and MySQL variants of the error message, respectively.
         if 'UNIQUE constraint failed' in e.message or 'Duplicate entry' in e.message:
-          if 'external_id' in e.message:
-            raise Conflict('External ID already in use, error: {}'.format(e.message))
+          # if 'external_id' in e.message:
+          #   raise Conflict('External ID already in use, error: {}'.format(e.message))
           logging.warning('Failed insert with %s: %s', tried_ids, e.message)
         else:
           raise

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -340,7 +340,8 @@ class BaseDao(object):
     # pylint: disable=unused-argument
     # SQLite and MySQL variants of the error message, respectively.
     if 'UNIQUE constraint failed' in e.message or 'Duplicate entry' in e.message:
-      return logging.warning('Failed insert with %s: %s', tried_ids, e.message)
+      logging.warning('Failed insert with %s: %s', tried_ids, e.message)
+      return None
 
   def count(self):
     with self.session() as session:

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -11,8 +11,7 @@ from protorpc import messages
 from query import Operator, PropertyType, FieldFilter, Results
 from sqlalchemy import or_, and_
 from sqlalchemy.exc import IntegrityError
-from werkzeug.exceptions import BadRequest, NotFound, PreconditionFailed, ServiceUnavailable, \
-  Conflict
+from werkzeug.exceptions import BadRequest, NotFound, PreconditionFailed, ServiceUnavailable
 
 import api_util
 import dao.database_factory

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -339,6 +339,7 @@ class BaseDao(object):
     raise ServiceUnavailable('Giving up after %d insert attempts.' % MAX_INSERT_ATTEMPTS)
 
   def handle_integrity_error(self, tried_ids, e, obj):
+    # pylint: disable=unused-argument
     # SQLite and MySQL variants of the error message, respectively.
     if 'UNIQUE constraint failed' in e.message or 'Duplicate entry' in e.message:
       return logging.warning('Failed insert with %s: %s', tried_ids, e.message)

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -328,11 +328,9 @@ class BaseDao(object):
         with self.session() as session:
           return self.insert_with_session(session, obj)
       except IntegrityError as e:
-        errors = self.handle_integrity_error(tried_ids, e, obj)
-        if errors:
-          return errors
-        else:
-          continue
+        result = self.handle_integrity_error(tried_ids, e, obj)
+        if result:
+          return result
     # We were unable to insert a participant (unlucky). Throw an error.
     logging.warning(
         'Giving up after %d insert attempts, tried %s.' % (MAX_INSERT_ATTEMPTS, all_tried_ids))

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -331,8 +331,6 @@ class BaseDao(object):
       except IntegrityError, e:
         # SQLite and MySQL variants of the error message, respectively.
         if 'UNIQUE constraint failed' in e.message or 'Duplicate entry' in e.message:
-          # if 'external_id' in e.message:
-          #   raise Conflict('External ID already in use, error: {}'.format(e.message))
           logging.warning('Failed insert with %s: %s', tried_ids, e.message)
         else:
           raise

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -353,7 +353,7 @@ class ParticipantDao(UpdatableDao):
       existing_participant = self._check_if_external_id_exists(obj)
       if existing_participant:
         return existing_participant
-    return logging.warning('Failed insert with %s: %s', tried_ids, e.message)
+    return super(ParticipantDao, self).handle_integrity_error(tried_ids, e, obj)
 
 
 def _get_primary_provider_link(participant):

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -75,10 +75,7 @@ class ParticipantDao(UpdatableDao):
 
   def _check_if_external_id_exists(self, obj):
     with self.session() as session:
-      participant = session.query(Participant).filter_by(externalId=obj.externalId).first()
-      if participant:
-        return participant
-      return None
+      return session.query(Participant).filter_by(externalId=obj.externalId).first()
 
   def _update_history(self, session, obj, existing_obj):
     # Increment the version and add a new history entry.

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -39,6 +39,7 @@ class ParticipantHistoryDao(BaseDao):
     return [obj.participantId, obj.version]
 
 
+
 class ParticipantDao(UpdatableDao):
   def __init__(self):
     super(ParticipantDao, self).__init__(Participant)
@@ -70,7 +71,18 @@ class ParticipantDao(UpdatableDao):
       assert obj.biobankId
       return super(ParticipantDao, self).insert(obj)
     assert not obj.biobankId
+    if obj.externalId:
+      existing_participant = self._check_if_external_id_exists(obj)
+      if existing_participant:
+        return existing_participant
     return self._insert_with_random_id(obj, ('participantId', 'biobankId'))
+
+  def _check_if_external_id_exists(self, obj):
+    with self.session() as session:
+      participant = session.query(Participant).filter_by(externalId=obj.externalId).first()
+      if participant:
+        return participant
+      return None
 
   def _update_history(self, session, obj, existing_obj):
     # Increment the version and add a new history entry.

--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 import clock
 from api_util import format_json_enum, parse_json_enum, format_json_date, format_json_hpo, \

--- a/rest-api/test/unit_test/api_test/participant_api_test.py
+++ b/rest-api/test/unit_test/api_test/participant_api_test.py
@@ -66,7 +66,9 @@ class ParticipantApiTest(FlaskTestBase):
     get_response = self.send_get('Participant/%s' % participant_id)
     self.assertEqual(get_response['externalId'], self.participant_2['externalId'])
     self.assertEquals(response, get_response)
-    self.send_post('Participant', self.participant_2, expected_status=httplib.CONFLICT)
+    response_2 = self.send_post('Participant', self.participant_2)
+    self.assertEqual(response, response_2)
+
 
 
   def test_update_no_ifmatch_specified(self):


### PR DESCRIPTION
PTSC requested that existing participants be returned in the case where they create a new participant with the new "externalId" functionality and that externalId exists already.