### PR TITLE
DA-794 fix pm status bug

### DIFF
--- a/rest-api/dao/physical_measurements_dao.py
+++ b/rest-api/dao/physical_measurements_dao.py
@@ -298,9 +298,9 @@ class PhysicalMeasurementsDao(UpdatableDao):
     participant_summary.lastModified = clock.CLOCK.now()
 
     if obj.status and obj.status == PhysicalMeasurementsStatus.CANCELLED:
-      if not self.existing_pm(session, participant):
+      if not self.has_uncancelled_pm(session, participant):
         # update corresponding participant summary physicalMeasurementsStatus
-        participant_summary.physicalMeasurementsStatus = obj.status
+        participant_summary.physicalMeasurementsStatus = PhysicalMeasurementsStatus.CANCELLED
 
     if participant_summary.physicalMeasurementsStatus != PhysicalMeasurementsStatus.CANCELLED:
       # if a PM was restored, it is complete again.
@@ -311,7 +311,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
 
     return participant_summary
 
-  def existing_pm(self, session, participant):
+  def has_uncancelled_pm(self, session, participant):
     """return True if participant has at least one physical measurement that is not cancelled"""
     query = session.query(PhysicalMeasurements.status).filter_by(
       participantId=participant.participantId).all()

--- a/rest-api/dao/physical_measurements_dao.py
+++ b/rest-api/dao/physical_measurements_dao.py
@@ -298,8 +298,9 @@ class PhysicalMeasurementsDao(UpdatableDao):
     participant_summary.lastModified = clock.CLOCK.now()
 
     if obj.status and obj.status == PhysicalMeasurementsStatus.CANCELLED:
-      # update corresponding participant summary physicalMeasurementsStatus
-      participant_summary.physicalMeasurementsStatus = obj.status
+      if not self.existing_pm(session, participant):
+        # update corresponding participant summary physicalMeasurementsStatus
+        participant_summary.physicalMeasurementsStatus = obj.status
 
     if participant_summary.physicalMeasurementsStatus != PhysicalMeasurementsStatus.CANCELLED:
       # if a PM was restored, it is complete again.
@@ -309,6 +310,17 @@ class PhysicalMeasurementsDao(UpdatableDao):
     session.merge(participant_summary)
 
     return participant_summary
+
+  def existing_pm(self, session, participant):
+    """return True if participant has at least one physical measurement that is not cancelled"""
+    query = session.query(PhysicalMeasurements.status).filter_by(
+      participantId=participant.participantId).all()
+    valid_pm = False
+    for pm in query:
+      if pm.status != PhysicalMeasurementsStatus.CANCELLED:
+        valid_pm = True
+
+    return valid_pm
 
   def insert(self, obj):
     if obj.physicalMeasurementsId:
@@ -668,6 +680,8 @@ class PhysicalMeasurementsDao(UpdatableDao):
     order_resource = json.dumps(order_resource)
     order.resource = order_resource
     return order
+
+
 
 
 

--- a/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
+++ b/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
@@ -270,8 +270,8 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
     self.assertEqual(response['reason'], 'a mistake was made.')
     self.assertEqual(response['cancelledUsername'], 'mike@pmi-ops.org')
     self.assertEqual(response['cancelledSiteId'], 1)
-    id = self.participant_id.strip('P')
-    ps = self.send_get('ParticipantSummary?participantId=%s' % id)
+    _id = self.participant_id.strip('P')
+    ps = self.send_get('ParticipantSummary?participantId=%s' % _id)
     # should be completed because of other valid PM
     self.assertEqual(ps['entry'][0]['resource']['physicalMeasurementsStatus'], 'COMPLETED')
 

--- a/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
+++ b/rest-api/test/unit_test/api_test/physical_measurements_api_test.py
@@ -256,8 +256,11 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
   def test_cancel_a_physical_measuremnet(self):
     self.send_consent(self.participant_id)
     measurement = load_measurement_json(self.participant_id)
+    measurement2 = load_measurement_json(self.participant_id)
     path = 'Participant/%s/PhysicalMeasurements' % self.participant_id
     response = self.send_post(path, measurement)
+    # send another PM
+    self.send_post(path, measurement2)
     path = path + '/' + response['id']
     cancel_info = get_restore_or_cancel_info()
     self.send_patch(path, cancel_info)
@@ -267,6 +270,10 @@ class PhysicalMeasurementsApiTest(FlaskTestBase):
     self.assertEqual(response['reason'], 'a mistake was made.')
     self.assertEqual(response['cancelledUsername'], 'mike@pmi-ops.org')
     self.assertEqual(response['cancelledSiteId'], 1)
+    id = self.participant_id.strip('P')
+    ps = self.send_get('ParticipantSummary?participantId=%s' % id)
+    # should be completed because of other valid PM
+    self.assertEqual(ps['entry'][0]['resource']['physicalMeasurementsStatus'], 'COMPLETED')
 
   def test_restore_a_physical_measuremnet(self):
     self.send_consent(self.participant_id)


### PR DESCRIPTION
add method to check for existing non-cancelled physical measurements  and only set PM.status to cancelled if it is the only measurement.