### PR TITLE
DA-822 refactor syncthetic data generator to accept a csv of existing participants

### DIFF
--- a/rdr_client/generate_fake_data.py
+++ b/rdr_client/generate_fake_data.py
@@ -63,11 +63,8 @@ def _read_csv_lines(filepath):
 def generate_data_from_file(client, args):
   reader = _read_csv_lines(args.create_samples_from_file)
   request_body = [reader]
-  try:
-    print('requesting pm&b for participant')
-    client.request_json('DataGen', 'PUT', request_body)
-  except:
-    pass
+  logging.info('requesting pm&b for participant')
+  client.request_json('DataGen', 'PUT', request_body)
 
 
 

--- a/rdr_client/generate_fake_data.py
+++ b/rdr_client/generate_fake_data.py
@@ -88,7 +88,8 @@ if __name__ == '__main__':
                       help='True if biobank samples should be created')
   parser.add_argument('--create_samples_from_file',
                       help='Creates PM&B for existing participants from a csv file; requires path'
-                           ' to file')
+                           ' to file. File is expected to contain a single column of ID"s with a '
+                           'leading env. identifier. i.e. P')
   rdr_client = Client(parser=parser)
   if rdr_client.args.num_participants == 0 and not rdr_client.args.create_biobank_samples and not\
     rdr_client.args.create_samples_from_file:

--- a/rdr_client/generate_fake_data.py
+++ b/rdr_client/generate_fake_data.py
@@ -6,12 +6,13 @@ Examples:
   generate_fake_data.py --num_participants 10 [--include_*]  # create 10 new participants
   generate_fake_data.py --create_biobank_samples  # store fake sampels CSV for existing participants
 """
-
+import csv
 import logging
+from time import sleep
 
 from client import Client, HttpException
 from main_util import get_parser, configure_logging
-from time import sleep
+
 
 MAX_PARTICIPANTS_PER_REQUEST = 25
 MAX_CONSECUTIVE_ERRORS = 5
@@ -52,6 +53,24 @@ def generate_fake_data(client, args):
   logging.info('Done.')
 
 
+def _read_csv_lines(filepath):
+  with open(filepath, 'r') as f:
+    reader = csv.reader(f)
+    reader.next()
+    return [line[0].strip() for line in reader]
+
+
+def generate_data_from_file(client, args):
+  reader = _read_csv_lines(args.create_samples_from_file)
+  request_body = [reader]
+  try:
+    print('requesting pm&b for participant')
+    client.request_json('DataGen', 'PUT', request_body)
+  except:
+    pass
+
+
+
 if __name__ == '__main__':
   configure_logging()
   parser = get_parser()
@@ -70,7 +89,13 @@ if __name__ == '__main__':
   parser.add_argument('--create_biobank_samples',
                       action='store_true',
                       help='True if biobank samples should be created')
+  parser.add_argument('--create_samples_from_file',
+                      help='Creates PM&B for existing participants from a csv file; requires path'
+                           ' to file')
   rdr_client = Client(parser=parser)
-  if rdr_client.args.num_participants == 0 and not rdr_client.args.create_biobank_samples:
+  if rdr_client.args.num_participants == 0 and not rdr_client.args.create_biobank_samples and not\
+    rdr_client.args.create_samples_from_file:
     parser.error('--num_participants must be nonzero unless --create_biobank_samples is true.')
+  if rdr_client.args.create_samples_from_file:
+    generate_data_from_file(rdr_client, rdr_client.args)
   generate_fake_data(rdr_client, rdr_client.args)

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -889,6 +889,9 @@ class FakeParticipantGenerator(object):
 
   def _submit_questionnaire_responses(self, participant_id, california_hpo, start_time,
                                       force_measurement=False):
+    """We may want to ignore failures in some instances. Such as when running
+    add_pm_and_biospecimens_to_participants. In this instance the existing test participant may
+    have been withdrawn and we don't want the script to fail on a large data set for that case."""
     ignore_failure = force_measurement
     if not force_measurement and random.random() <= _NO_QUESTIONNAIRES_SUBMITTED:
       return None, None, None
@@ -939,6 +942,7 @@ class FakeParticipantGenerator(object):
           body=qr_json,
           pretend_date=submission_time)
     except RuntimeError:
+      logging.warn('Questionnaire not submitted for participant %s', participant_id)
       if not ignore_failure:
         raise
 

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -129,9 +129,9 @@ class FakeParticipantGenerator(object):
     self._max_days_for_birth_date = 365 * (_MAX_PARTICIPANT_AGE - _MIN_PARTICIPANT_AGE)
     self._force_measurement = False
 
-    # 5% of participants withdraw from the study
+    # n% of participants withdraw from the study. Default is 5%
     self.withdrawn_percent = withdrawn_percent
-    # 5% of participants suspend their account
+    # n% of participants suspend their account. Default is 5%
     self.suspended_percent = suspended_percent
 
   def _days_ago(self, num_days):

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -704,7 +704,6 @@ class FakeParticipantGenerator(object):
       self._submit_status_changes(participant_id, last_request_time)
 
   def add_pm_and_biospecimens_to_participants(self, participant_id_list):
-    force_measurement = True
     for participant_id in participant_id_list:
       _, last_qr_time, the_basics_submission_time = (self._submit_questionnaire_responses
         (participant_id, False, self._now, force_measurement=True))

--- a/rest-api/data_gen/fake_participant_generator.py
+++ b/rest-api/data_gen/fake_participant_generator.py
@@ -133,7 +133,7 @@ class FakeParticipantGenerator(object):
     self.withdrawn_percent = withdrawn_percent
     # 5% of participants suspend their account
     self.suspended_percent = suspended_percent
-    
+
   def _days_ago(self, num_days):
     return self._now - datetime.timedelta(days=num_days)
 
@@ -707,8 +707,8 @@ class FakeParticipantGenerator(object):
   def add_pm_and_biospecimens_to_participants(self, participant_id_list):
     self._force_measurement = True
     for participant_id in participant_id_list:
-      consent_time, last_qr_time, the_basics_submission_time = (self._submit_questionnaire_responses(
-        participant_id, False, self._now))
+      _, last_qr_time, the_basics_submission_time = (self._submit_questionnaire_responses
+        (participant_id, False, self._now))
       if the_basics_submission_time is None:
         the_basics_submission_time = self._now
       last_request_time = last_qr_time

--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -144,7 +144,7 @@ api.add_resource(version_api.VersionApi,
 api.add_resource(DataGenApi,
                  PREFIX + 'DataGen',
                  endpoint='datagen',
-                 methods=['POST'])
+                 methods=['POST', 'PUT'])
 
 #
 # Non-resource endpoints


### PR DESCRIPTION
In order to help PTSC backfill a bunch (90k) test participants with biospecimen orders and physical measurements. We want to avoid the random percentages of withdrawn participants and random null measurements or biospecimen orders here.