### PR TITLE
[DA-623] Insure questionnaire response answer link ids are valid for questionnaire.

### DIFF
--- a/rest-api/dao/questionnaire_response_dao.py
+++ b/rest-api/dao/questionnaire_response_dao.py
@@ -91,28 +91,24 @@ class QuestionnaireResponseDao(BaseDao):
     :param resource: A group section of the response json.
     :param link_ids: List of link ids to validate against.
     """
-    # look for child group sections and call ourselves
+    # note: resource can be either a dict or a list.
+    # if this is a dict and 'group' is found, always call ourselves.
     if 'group' in resource:
       self._validate_link_ids_from_resource_json_group(resource['group'], link_ids)
 
-    if type(resource) is list:
+    if 'question' not in resource and type(resource) is list:
       for item in resource:
         self._validate_link_ids_from_resource_json_group(item, link_ids)
 
-    # look for question section:
+    # once we have a question section, iterate through list of answers.
     if 'question' in resource:
+      for section in resource['question']:
 
-      # if question is a list, then loop through the list
-      if type(resource['question']) is list:
-        self._validate_link_ids_from_resource_json_group(resource['question'], link_ids)
-
-      # if question is not a list, check linkId directly
-      for question in resource['question']:
-        # Do not raise exception when link id is 'ignoreThis' for unit testing.
-        if 'linkId' in question and question['linkId'].lower() != 'ignorethis' \
-              and question['linkId'] not in link_ids:
+        # Do not raise exception when link id is 'ignoreThis' for unit tests.
+        if 'linkId' in section and section['linkId'].lower() != 'ignorethis' \
+              and section['linkId'] not in link_ids:
           raise BadRequest(
-            'Questionnaire response contains invalid link ID %s.' % question['linkId'])
+            'Questionnaire response contains invalid link ID %s.' % resource['linkId'])
 
   def insert_with_session(self, session, questionnaire_response):
 

--- a/rest-api/dao/questionnaire_response_dao.py
+++ b/rest-api/dao/questionnaire_response_dao.py
@@ -86,7 +86,8 @@ class QuestionnaireResponseDao(BaseDao):
   def _validate_link_ids_from_resource_json_group(self, resource, link_ids):
     """
     Look for question sections and validate the linkid in each answer. If there is a response
-    answer link id that does not exist in the questionnaire, then raise an exception.
+    answer link id that does not exist in the questionnaire, then log a message. In
+    the future this may be changed to raising an exception.
     This is a recursive function because answer groups can be nested.
     :param resource: A group section of the response json.
     :param link_ids: List of link ids to validate against.
@@ -104,11 +105,11 @@ class QuestionnaireResponseDao(BaseDao):
     if 'question' in resource:
       for section in resource['question']:
 
-        # Do not raise exception when link id is 'ignoreThis' for unit tests.
+        # Do not log warning or raise exception when link id is 'ignoreThis' for unit tests.
         if 'linkId' in section and section['linkId'].lower() != 'ignorethis' \
               and section['linkId'] not in link_ids:
-          raise BadRequest(
-            'Questionnaire response contains invalid link ID %s.' % section['linkId'])
+          logging.error('Questionnaire response contains invalid link ID %s.' % section['linkId'])
+
 
   def insert_with_session(self, session, questionnaire_response):
 

--- a/rest-api/dao/questionnaire_response_dao.py
+++ b/rest-api/dao/questionnaire_response_dao.py
@@ -85,8 +85,9 @@ class QuestionnaireResponseDao(BaseDao):
 
   def _validate_link_ids_from_resource_json_group(self, resource, link_ids):
     """
-    Look for question sections and validate the linkid in each answer.
-    This is a recursive function because groups can be nested.
+    Look for question sections and validate the linkid in each answer. If there is a response
+    answer link id that does not exist in the questionnaire, then raise an exception.
+    This is a recursive function because answer groups can be nested.
     :param resource: A group section of the response json.
     :param link_ids: List of link ids to validate against.
     """

--- a/rest-api/dao/questionnaire_response_dao.py
+++ b/rest-api/dao/questionnaire_response_dao.py
@@ -108,7 +108,7 @@ class QuestionnaireResponseDao(BaseDao):
         if 'linkId' in section and section['linkId'].lower() != 'ignorethis' \
               and section['linkId'] not in link_ids:
           raise BadRequest(
-            'Questionnaire response contains invalid link ID %s.' % resource['linkId'])
+            'Questionnaire response contains invalid link ID %s.' % section['linkId'])
 
   def insert_with_session(self, session, questionnaire_response):
 

--- a/rest-api/test/test-data/questionnaire_family_history.json
+++ b/rest-api/test/test-data/questionnaire_family_history.json
@@ -1,0 +1,15015 @@
+{
+  "status": "published",
+  "group": {
+    "concept": [
+      {
+        "code": "FamilyHistory",
+        "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+      }
+    ],
+    "title": "Family History",
+    "linkId": "root_group",
+    "required": true,
+    "question": [
+      {
+        "concept": [
+          {
+            "code": "FamilyHistory_FamilyMedicalHistoryAware",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FamilyMedicalHistoryAware_Alot",
+            "display": "A lot",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Mucho"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FamilyMedicalHistoryAware_Some",
+            "display": "Some",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Algo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FamilyMedicalHistoryAware_None",
+            "display": "None at all",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Nada"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6252",
+        "text": "How much do you know about illnesses or health problems for your parents, grandparents, brothers, sisters and/or children?\n\n",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1nta informaci\u00f3n sabe sobre las enfermedades o problemas de salud para los siguientes miembros de su familia: padres, abuelos, hermanos, hermanas e hijos?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherCancerCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherCancerCondition_BladderCancer",
+            "display": "Bladder cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de vejiga"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_BoneCancer",
+            "display": "Bone cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de huesos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_BloodCancer",
+            "display": "Blood or soft tissue cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de sangre o de los tejidos blandos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_BrainCancer",
+            "display": "Brain cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de cerebro"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_BreastCancer",
+            "display": "Breast cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de mama"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_CervicalCancer",
+            "display": "Cervical cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de \u00fatero (matriz)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_ColonRectalCancer",
+            "display": "Colon cancer/Rectal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de colon/C\u00e1ncer de recto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_EndocrineCancer",
+            "display": "Endocrine cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer del sistema end\u00f3crino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_EndometrialCancer",
+            "display": "Endometrial cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer endometrial"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_EsophagealCancer",
+            "display": "Esophageal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de es\u00f3fago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_EyeCancer",
+            "display": "Eye cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ojo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_HeadNeckCancer",
+            "display": "Head and neck (This includes cancers of the mouth, sinuses, nose, or throat. This does not include brain cancer.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cabeza y cuello (esto incluye c\u00e1ncer de boca, seno paranasal, nasal o de garganta. No incluye c\u00e1ncer de cerebro.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_KidneyCancer",
+            "display": "Kidney cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ri\u00f1\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_LungCancer",
+            "display": "Lung cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pulm\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_OvarianCancer",
+            "display": "Ovarian cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ovario"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_PancreaticCancer",
+            "display": "Pancreatic cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de p\u00e1ncreas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_SkinCancer",
+            "display": "Skin cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de piel"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_StomachCancer",
+            "display": "Stomach cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de est\u00f3mago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_ThyroidCancer",
+            "display": "Thyroid cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de tiroides"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCancerCondition_OtherCancer",
+            "display": "Other cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de c\u00e1ncer"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6358",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCancer_MotherFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "6359",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherCirculatoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherCirculatoryCondition_Anemia",
+            "display": "Anemia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_AorticAneurysm",
+            "display": "Aortic aneurysm",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Aneurisma a\u00f3rtico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_AtrialFibrilation",
+            "display": "Atrial fibrillation (or a-fib) or atrial flutter (or a-flutter).",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibrilaci\u00f3n auricular (o fa) o palpitaci\u00f3n auricular (o pa)."
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_CongestiveHeartFailure",
+            "display": "Congestive heart failure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Insuficiencia card\u00edaca congestiva"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_CoronaryArteryHeartDisease",
+            "display": "Coronary artery/coronary heart disease (included angina)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad coronaria/de la arterias coronarias (incluida la angina de pecho)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_HeartAttack",
+            "display": "Heart attack",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Infarto del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_HeartValveDisease",
+            "display": "Heart valve disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de las valvulas del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_HighBloodPressure",
+            "display": "High blood pressure (Hypertension)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertensi\u00f3n (Presi\u00f3n arterial alta)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_HighCholesterol",
+            "display": "High cholesterol",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colesterol alto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_PeripheralVascularDisease",
+            "display": "Peripheral vascular disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad vascular perif\u00e9rica"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_PulmonaryEmbolismThrombosis",
+            "display": "Pulmonary embolism or deep vein thrombosis (DVT)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Embolia en los pulmones o trombosis de las venas profundas (TVP)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_SickleCellDisease",
+            "display": "Sickle cell disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia de c\u00e9lulas falciformes"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_Stroke",
+            "display": "Stroke",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Accidente cerebrovascular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherCirculatoryCondition_SuddenDeath",
+            "display": "Sudden death",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Muerte s\u00fabita"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6363",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherDigestiveCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherDigestiveCondition_AcidReflux",
+            "display": "Acid reflux",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reflujo acido"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_CeliacDisease",
+            "display": "Celiac disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Celiac disease"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_ColonPolyps",
+            "display": "Colon polyps",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00f3lipos en el colon"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_CrohnsDisease",
+            "display": "Crohn's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Crohn"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_Diverticulitis",
+            "display": "Diverticulitis/Diverticulosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diveriticulosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_GallStones",
+            "display": "Gall stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos biliares (piedras en la vesicula biliar)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_IrritableBowelSyndrome",
+            "display": "Irritable bowel syndrome (IBS)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome del intestino irritable (SII)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_PepticUlcers",
+            "display": "Peptic (stomach) ulcers",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "\u00dalceras p\u00e9pticas (\u00falceras del est\u00f3mago o del intestino delgado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherDigestiveCondition_UlcerativeColitis",
+            "display": "Ulcerative colitis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colitis ulcerosa (ulceras e inflamacion del intestino)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6367",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherEndocrineCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherEndocrineCondition_Hyperthyroidism",
+            "display": "Hyperthyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherEndocrineCondition_Hypothyroidism",
+            "display": "Hypothyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipotiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherEndocrineCondition_Type1Diabetes",
+            "display": "Type 1 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherEndocrineCondition_Type2Diabetes",
+            "display": "Type 2 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherEndocrineCondition_OtherDiabetes",
+            "display": "Other/unknown diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de diabetes conocido/desconocido"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6371",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherKidneyCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherKidneyCondition_KidneyDisease",
+            "display": "Kidney disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad renal"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherKidneyCondition_KidneyStones",
+            "display": "Kidney stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos en los ri\u00f1ones (piedras en los rinones)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6375",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherRespiratoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherRespiratoryCondition_Asthma",
+            "display": "Asthma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherRespiratoryCondition_ChronicLungDisease",
+            "display": "Chronic lung disease (COPD, emphysema or bronchitis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad cr\u00f3nica de los pulmones (EPOC, enfisema o bronquitis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherRespiratoryCondition_SleepApnea",
+            "display": "Sleep apnea",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Apnea del sue\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6379",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherNervousCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherNervousCondition_Dementia",
+            "display": "Dementia (includes Alzheimer\u2019s, vascular, etc.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Demencia (incluye Alzheimer, vascular, etc.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_EpilepsySeizure",
+            "display": "Epilepsy or seizure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Epilepsia o convulsiones"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_AmyotrophicLateralSclerosis",
+            "display": "Lou Gehrig\u2019s disease (Amyotrophic lateral sclerosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Lou Gehrig (Esclerosis lateral amiotr\u00f3fica)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_MigraineHeadaches",
+            "display": "Migraine headaches",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Migra\u00f1as"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_MultipleSclerosis",
+            "display": "Multiple sclerosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis m\u00faltiple"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_MuscularDystrophy",
+            "display": "Muscular dystrophy (MD",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Distrofia muscular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_Narcolepsy",
+            "display": "Narcolepsy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Narcolepsia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_Neuropathy",
+            "display": "Neuropathy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Neuropat\u00eda"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_Parkinsons",
+            "display": "Parkinson's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Parkinson"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherNervousCondition_RestlessLegSyndrome",
+            "display": "Restless leg syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome de las piernas inquietas"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6383",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherMentalCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherMentalCondition_AlcoholUse",
+            "display": "Alcohol use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de alcohol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherMentalCondition_AnxietyPanic",
+            "display": "Anxiety reaction/panic disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno de ansiedad/trastorno de p\u00e1nico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherMentalCondition_Autism",
+            "display": "Autism spectrum disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Autismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherMentalCondition_Bipolar",
+            "display": "Bipolar disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno bipolar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherMentalCondition_Depression",
+            "display": "Depression",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Depresi\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherMentalCondition_DrugUse",
+            "display": "Drug use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de drogas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherMentalCondition_Schizophrenia",
+            "display": "Schizophrenia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esquizofrenia"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6387",
+        "text": "Mental Health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherSkeletalMuscularCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherSkeletalMuscularCondition_Fibromyalgia",
+            "display": "Fibromyalgia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromialgia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherSkeletalMuscularCondition_Gout",
+            "display": "Gout",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Gota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherSkeletalMuscularCondition_Osteoarthritis",
+            "display": "Osteoarthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoartritis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherSkeletalMuscularCondition_Osteoporosis",
+            "display": "Osteoporosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoporosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherSkeletalMuscularCondition_Pseudogout",
+            "display": "Pseudogout (CPPD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Seudogota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherSkeletalMuscularCondition_RheumatoidArthritis",
+            "display": "Rheumatoid arthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Artritis reumatoide"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherSkeletalMuscularCondition_SystemicLupus",
+            "display": "Systemic lupus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Lupus sist\u00e9mico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherSkeletalMuscularCondition_SpineMuscleBone",
+            "display": "Spine, muscle, or bone disorders (non-cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Problemas de los musculos y huesos de la columna vertebral (no c\u00e1ncer)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6391",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherVisionCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherVisionCondition_Cataracts",
+            "display": "Cataracts",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cataratas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherVisionCondition_Glaucoma",
+            "display": "Glaucoma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Glaucoma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherVisionCondition_MacularDegeneration",
+            "display": "Macular degeneration",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Degeneraci\u00f3n macular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherVisionCondition_HearingLoss",
+            "display": "Severe hearing loss or partial deafness in one or both ears",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00e9rdida grave de la audici\u00f3n o sordera parcial en uno o ambos o\u00eddos"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6395",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherOtherHealthCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MotherOtherHealthCondition_Allergies",
+            "display": "Allergies",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alergias"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_Endometriosis",
+            "display": "Endometriosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Endometriosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_Fibroids",
+            "display": "Fibroids",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_Obesity",
+            "display": "Obesity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Obesidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_PolycysticOvarianSyndrome",
+            "display": "Polycystic ovarian syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "PCOS (s\u00edndrome de ovario poliqu\u00edstico)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_ReactionToAnesthesia",
+            "display": "Reactions to anesthesia (such as hyperthermia)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reacciones a la anestesia (como hipertermia)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_SkinCondition",
+            "display": "Skin condition (e.g., eczema, psoriasis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de la piel (por ejemplo, eczema, psoriasis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MotherOtherHealthCondition_OtherCondition",
+            "display": "Other",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6399",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCondition_MotherFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "34756",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_MotherNoSelection",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PMI_None",
+            "display": "None of the above ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "Don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "Prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no contestar"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "35067",
+        "text": "Pick your answers from the following choices",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherCancerCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherCancerCondition_BladderCancer",
+            "display": "Bladder cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de vejiga"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_BoneCancer",
+            "display": "Bone cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de huesos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_BloodCancer",
+            "display": "Blood or soft tissue cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de sangre o de los tejidos blandos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_BrainCancer",
+            "display": "Brain cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de cerebro"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_BreastCancer",
+            "display": "Breast cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de mama"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_ColonRectalCancer",
+            "display": "Colon cancer/Rectal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de colon/C\u00e1ncer de recto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_EndocrineCancer",
+            "display": "Endocrine cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer del sistema end\u00f3crino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_EsophagealCancer",
+            "display": "Esophageal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de es\u00f3fago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_EyeCancer",
+            "display": "Eye cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ojo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_HeadNeckCancer",
+            "display": "Head and neck (This includes cancers of the mouth, sinuses, nose, or throat. This does not include brain cancer.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cabeza y cuello (esto incluye c\u00e1ncer de boca, seno paranasal, nasal o de garganta. No incluye c\u00e1ncer de cerebro.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_KidneyCancer",
+            "display": "Kidney cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ri\u00f1\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_LungCancer",
+            "display": "Lung cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pulm\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_PancreaticCancer",
+            "display": "Pancreatic cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de p\u00e1ncreas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_ProstateCancer",
+            "display": "Prostate cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pr\u00f3stata"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_SkinCancer",
+            "display": "Skin cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de piel"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_StomachCancer",
+            "display": "Stomach cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de est\u00f3mago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_ThyroidCancer",
+            "display": "Thyroid cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de tiroides"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCancerCondition_OtherCancer",
+            "display": "Other cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de c\u00e1ncer"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6407",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCancer_FatherFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "6408",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherCirculatoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherCirculatoryCondition_Anemia",
+            "display": "Anemia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_AorticAneurysm",
+            "display": "Aortic aneurysm",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Aneurisma a\u00f3rtico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_AtrialFibrilation",
+            "display": "Atrial fibrillation (or a-fib) or atrial flutter (or a-flutter). ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibrilaci\u00f3n auricular (o fa) o palpitaci\u00f3n auricular (o pa)."
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_CongestiveHeartFailure",
+            "display": "Congestive heart failure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Insuficiencia card\u00edaca congestiva"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_CoronaryArteryHeartDisease",
+            "display": "Coronary artery/coronary heart disease (included angina)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad coronaria/de la arterias coronarias (incluida la angina de pecho)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_HeartAttack",
+            "display": "Heart attack",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Infarto del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_HeartValveDisease",
+            "display": "Heart valve disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de las valvulas del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_HighBloodPressure",
+            "display": "High blood pressure (Hypertension)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertensi\u00f3n (presi\u00f3n arterial alta)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_HighCholesterol",
+            "display": "High cholesterol",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colesterol alto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_PeripheralVascularDisease",
+            "display": "Peripheral vascular disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad vascular perif\u00e9rica"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_PulmonaryEmbolismThrombosis",
+            "display": "Pulmonary embolism or deep vein thrombosis (DVT)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Embolia en los pulmones o trombosis de las venas profundas (TVP)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_SickleCellDisease",
+            "display": "Sickle cell disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia de c\u00e9lulas falciformes"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_Stroke",
+            "display": "Stroke",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Accidente cerebrovascular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherCirculatoryCondition_SuddenDeath",
+            "display": "Sudden death",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Muerte s\u00fabita"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6412",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherDigestiveCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherDigestiveCondition_AcidReflux",
+            "display": "Acid reflux",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reflujo acido"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_CeliacDisease",
+            "display": "Celiac disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Celiac disease"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_ColonPolyps",
+            "display": "Colon polyps",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00f3lipos en el colon"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_CrohnsDisease",
+            "display": "Crohn's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Crohn"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_Diverticulitis",
+            "display": "Diverticulitis/Diverticulosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diveriticulosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_GallStones",
+            "display": "Gall stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos biliares (piedras en la vesicula biliar)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_IrritableBowelSyndrome",
+            "display": "Irritable bowel syndrome (IBS)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome del intestino irritable (SII)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_PepticUlcers",
+            "display": "Peptic (stomach) ulcers",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "\u00dalceras p\u00e9pticas (\u00falceras del est\u00f3mago o del intestino delgado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherDigestiveCondition_UlcerativeColitis",
+            "display": "Ulcerative colitis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colitis ulcerosa (ulceras e inflamacion del intestino)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6416",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherEndocrineCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherEndocrineCondition_Hyperthyroidism",
+            "display": "Hyperthyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherEndocrineCondition_Hypothyroidism",
+            "display": "Hypothyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipotiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherEndocrineCondition_Type1Diabetes",
+            "display": "Type 1 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherEndocrineCondition_Type2Diabetes",
+            "display": "Type 2 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherEndocrineCondition_OtherDiabetes",
+            "display": "Other/unknown diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de diabetes de causa conocida o desconocida"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6420",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherKidneyCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherKidneyCondition_KidneyDisease",
+            "display": "Kidney disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad renal"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherKidneyCondition_KidneyStones",
+            "display": "Kidney stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos en los ri\u00f1ones (piedras en los rinones)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6424",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherRespiratoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherRespiratoryCondition_Asthma",
+            "display": "Asthma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherRespiratoryCondition_ChronicLungDisease",
+            "display": "Chronic lung disease (COPD, emphysema or bronchitis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad cr\u00f3nica de los pulmones (EPOC, enfisema o bronquitis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherRespiratoryCondition_SleepApnea",
+            "display": "Sleep apnea",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Apnea del sue\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6428",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherNervousCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherNervousCondition_Dementia",
+            "display": "Dementia (includes Alzheimer\u2019s, vascular, etc.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Demencia (incluye Alzheimer, vascular, etc.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_EpilepsySeizure",
+            "display": "Epilepsy or seizure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Epilepsia o convulsiones"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_AmyotrophicLateralSclerosis",
+            "display": "Lou Gehrig\u2019s disease (Amyotrophic lateral sclerosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Lou Gehrig (Esclerosis lateral amiotr\u00f3fica)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_MigraineHeadaches",
+            "display": "Migraine headaches",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Migra\u00f1as"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_MultipleSclerosis",
+            "display": "Multiple sclerosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis m\u00faltiple"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_MuscularDystrophy",
+            "display": "Muscular dystrophy (MD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Distrofia muscular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_Narcolepsy",
+            "display": "Narcolepsy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Narcolepsia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_Neuropathy",
+            "display": "Neuropathy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Neuropat\u00eda"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_Parkinsons",
+            "display": "Parkinson's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Parkinson"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherNervousCondition_RestlessLegsSyndrome",
+            "display": "Restless leg syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome de las piernas inquietas"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6432",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherMentalCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherMentalCondition_AlcoholUse",
+            "display": "Alcohol use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de alcohol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherMentalCondition_AnxietyPanic",
+            "display": "Anxiety reaction/panic disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno de ansiedad/trastorno de p\u00e1nico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherMentalCondition_Autism",
+            "display": "Autism spectrum disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Autismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherMentalCondition_Bipolar",
+            "display": "Bipolar disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno bipolar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherMentalCondition_Depression",
+            "display": "Depression",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Depresi\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherMentalCondition_DrugUse",
+            "display": "Drug use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de drogas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherMentalCondition_Schizophrenia",
+            "display": "Schizophrenia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esquizofrenia"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6436",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherSkeletalMuscularCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherSkeletalMuscularCondition_Fibromyalgia",
+            "display": "Fibromyalgia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromialgia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherSkeletalMuscularCondition_Gout",
+            "display": "Gout",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Gota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherSkeletalMuscularCondition_Osteoarthritis",
+            "display": "Osteoarthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoartritis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherSkeletalMuscularCondition_Osteoporosis",
+            "display": "Osteoporosis ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoporosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherSkeletalMuscularCondition_Pseudogout",
+            "display": "Pseudogout (CPPD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Seudogota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherSkeletalMuscularCondition_RheumatoidArthritis",
+            "display": "Rheumatoid arthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Artritis reumatoide"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherSkeletalMuscularCondition_SystemicLupus",
+            "display": "Systemic lupus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Lupus sist\u00e9mico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherSkeletalMuscularCondition_SpineMuscleBone",
+            "display": "Spine, muscle, or bone disorders (non-cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Problemas de los musculos y huesos de la columna vertebral"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6440",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherVisionCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherVisionCondition_Cataracts",
+            "display": "Cataracts",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cataratas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherVisionCondition_Glaucoma",
+            "display": "Glaucoma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Glaucoma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherVisionCondition_MacularDegeneration",
+            "display": "Macular degeneration",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Degeneraci\u00f3n macular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherVisionCondition_HearingLoss",
+            "display": "Severe hearing loss or partial deafness in one or both ears",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00e9rdida grave de la audici\u00f3n o sordera parcial en uno o ambos o\u00eddos"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6444",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherOtherHealthCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "FatherOtherHealthCondition_Allergies",
+            "display": "Allergies",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alergias"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherOtherHealthCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherOtherHealthCondition_Obesity",
+            "display": "Obesity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Obesidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherOtherHealthCondition_ReactionsToAnesthesia",
+            "display": "Reactions to anesthesia (such as hyperthermia)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reacciones a la anestesia (como hipertermia)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherOtherHealthCondition_SkinCondition",
+            "display": "Skin condition (e.g., eczema, psoriasis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de la piel (por ejemplo, eczema, psoriasis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "FatherOtherHealthCondition_OtherCondition",
+            "display": "Other",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6448",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCondition_FatherFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "34757",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_FatherNoSelection",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PMI_None",
+            "display": "None of the above ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "Don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "Prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no contestar"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "35068",
+        "text": "Pick your answers from the following choices",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingCancerCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingCancerCondition_BladderCancer",
+            "display": "Bladder cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de vejiga"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_BoneCancer",
+            "display": "Bone cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de huesos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_BloodCancer",
+            "display": "Blood or soft tissue cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de sangre o de los tejidos blandos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_BrainCancer",
+            "display": "Brain cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de cerebro"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_BreastCancer",
+            "display": "Breast cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de mama"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_CervicalCancer",
+            "display": "Cervical cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de \u00fatero (matriz)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_ColonRectalCancer",
+            "display": "Colon cancer/Rectal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de colon/C\u00e1ncer de recto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_EndocrineCancer",
+            "display": "Endocrine cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer del sistema end\u00f3crino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_EndometrialCancer",
+            "display": "Endometrial cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer endometrial"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_EsophagealCancer",
+            "display": "Esophageal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de es\u00f3fago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_EyeCancer",
+            "display": "Eye cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ojo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_HeadNeckCancer",
+            "display": "Head and neck (This includes cancers of the mouth, sinuses, nose, or throat. This does not include brain cancer.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cabeza y cuello (esto incluye c\u00e1ncer de boca, seno paranasal, nasal o de garganta. No incluye c\u00e1ncer de cerebro.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_KidneyCancer",
+            "display": "Kidney cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ri\u00f1\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_LungCancer",
+            "display": "Lung cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pulm\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_OvarianCancer",
+            "display": "Ovarian cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ovario"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_PancreaticCancer",
+            "display": "Pancreatic cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de p\u00e1ncreas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_ProstateCancer",
+            "display": "Prostate cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pr\u00f3stata"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_SkinCancer",
+            "display": "Skin cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de piel"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_StomachCancer",
+            "display": "Stomach cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de est\u00f3mago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_ThyroidCancer",
+            "display": "Thyroid cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de tiroides"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCancerCondition_OtherCancer",
+            "display": "Other cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de c\u00e1ncer"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6456",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCancer_SiblingFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "6457",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingCirculatoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingCirculatoryCondition_Anemia",
+            "display": "Anemia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_AorticAneurysm",
+            "display": "Aortic aneurysm",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Aneurisma a\u00f3rtico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_AtrialFibrilation",
+            "display": "Atrial fibrillation (or a-fib) or atrial flutter (or a-flutter).",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibrilaci\u00f3n auricular (o fa) o palpitaci\u00f3n auricular (o pa)."
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_CongestiveHeartFailure",
+            "display": "Congestive heart failure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Insuficiencia card\u00edaca congestiva"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_CoronaryArteryHeartDisease",
+            "display": "Coronary artery/coronary heart disease (included angina)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad coronaria/de la arterias coronarias (incluida la angina de pecho)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_HeartAttack",
+            "display": "Heart attack",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Infarto del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_HeartValveDisease",
+            "display": "Heart valve disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de las valvulas del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_HighBloodPressure",
+            "display": "High blood pressure (Hypertension)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertensi\u00f3n (presi\u00f3n arterial alta)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_HighCholesterol",
+            "display": "High cholesterol",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colesterol alto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_PeripheralVascularDisease",
+            "display": "Peripheral vascular disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad vascular perif\u00e9rica"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_PulmonaryEmbolismThrombosis",
+            "display": "Pulmonary embolism or deep vein thrombosis (DVT)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Embolia en los pulmones o trombosis de las venas profundas (TVP)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_SickleCellDisease",
+            "display": "Sickle cell disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia de c\u00e9lulas falciformes"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_Stroke",
+            "display": "Stroke",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Accidente cerebrovascular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingCirculatoryCondition_SuddenDeath",
+            "display": "Sudden death",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Muerte s\u00fabita"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6461",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingDigestiveCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingDigestiveCondition_AcidReflux",
+            "display": "Acid reflux",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reflujo acido"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_CeliacDisease",
+            "display": "Celiac disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Celiac disease"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_ColonPolyps",
+            "display": "Colon polyps",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00f3lipos en el colon"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_CrohnsDisease",
+            "display": "Crohn's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Crohn"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_Diverticulitis",
+            "display": "Diverticulitis/Diverticulosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diveriticulosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_GallStones",
+            "display": "Gall stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos biliares (piedras en la vesicula biliar)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_IrritableBowelSyndrome",
+            "display": "Irritable bowel syndrome (IBS)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome del intestino irritable (SII)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_PepticUlcers",
+            "display": "Peptic (stomach) ulcers",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "\u00dalceras p\u00e9pticas (\u00falceras del est\u00f3mago o del intestino delgado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingDigestiveCondition_UlcerativeColitis",
+            "display": "Ulcerative colitis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colitis ulcerosa (ulceras e inflamacion del intestino)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6465",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingEndocrineCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingEndocrineCondition_Hyperthyroidism",
+            "display": "Hyperthyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingEndocrineCondition_Hypothyroidism",
+            "display": "Hypothyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipotiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingEndocrineCondition_Type1Diabetes",
+            "display": "Type 1 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingEndocrineCondition_Type2Diabetes",
+            "display": "Type 2 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingEndocrineCondition_OtherDiabetes",
+            "display": "Other/unknown diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de diabetes de causa conocida o desconocida"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6469",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingKidneyCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingKidneyCondition_KidneyDisease",
+            "display": "Kidney disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad renal"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingKidneyCondition_KidneyStones",
+            "display": "Kidney stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos en los ri\u00f1ones (piedras en los rinones)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6473",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingRespiratoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingRespiratoryCondition_Asthma",
+            "display": "Asthma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingRespiratoryCondition_ChronicLungDisease",
+            "display": "Chronic lung disease (COPD, emphysema or bronchitis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad cr\u00f3nica de los pulmones (EPOC, enfisema o bronquitis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingRespiratoryCondition_SleepApnea",
+            "display": "Sleep apnea",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Apnea del sue\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6477",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingNervousCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingNervousCondition_Dementia",
+            "display": "Dementia (includes Alzheimer's, vascular, etc.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Demencia (incluye Alzheimer, vascular, etc.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_EpilepsySeizure",
+            "display": "Epilepsy or seizure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Epilepsia o convulsiones"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_AmyotrophicLateralSclerosis",
+            "display": "Lou Gehrig\u2019s disease (Amyotrophic lateral sclerosis) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis lateral amiotr\u00f3fica (Enfermedad de Lou Gehrig)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_MigraineHeadaches",
+            "display": "Migraine headaches",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Migra\u00f1as"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_MultipleSclerosis",
+            "display": "Multiple sclerosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis m\u00faltiple"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_MuscularDystrophy",
+            "display": "Muscular dystrophy (MD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Distrofia muscular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_Narcolepsy",
+            "display": "Narcolepsy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Narcolepsia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_Neuropathy",
+            "display": "Neuropathy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Neuropat\u00eda"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_Parkinsons",
+            "display": "Parkinson's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Parkinson"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingNervousCondition_RestlessLegsSyndrome",
+            "display": "Restless leg syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome de las piernas inquietas"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6481",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingMentalCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingMentalCondition_AlcoholUse",
+            "display": "Alcohol use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de alcohol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingMentalCondition_AnxietyPanic",
+            "display": "Anxiety reaction/panic disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno de ansiedad/trastorno de p\u00e1nico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingMentalCondition_Autism",
+            "display": "Autism spectrum disorder ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Autismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingMentalCondition_Bipolar",
+            "display": "Bipolar disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno bipolar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingMentalCondition_Depression",
+            "display": "Depression",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Depresi\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingMentalCondition_DrugUse",
+            "display": "Drug use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de drogas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingMentalCondition_Schizophrenia",
+            "display": "Schizophrenia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esquizofrenia"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6485",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingSkeletalMuscularCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingSkeletalMuscularCondition_Fibromyalgia",
+            "display": "Fibromyalgia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromialgia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingSkeletalMuscularCondition_Gout",
+            "display": "Gout",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Gota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingSkeletalMuscularCondition_Osteoarthritis",
+            "display": "Osteoarthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoartritis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingSkeletalMuscularCondition_Osteoporosis",
+            "display": "Osteoporosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoporosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingSkeletalMuscularCondition_Pseudogout",
+            "display": "Pseudogout (CPPD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Seudogota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingSkeletalMuscularCondition_RheumatoidArthritis",
+            "display": "Rheumatoid arthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Artritis reumatoide"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingSkeletalMuscularCondition_SystemicLupus",
+            "display": "Systemic lupus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Lupus sist\u00e9mico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingSkeletalMuscularCondition_SpineMuscleBone",
+            "display": "Spine, muscle, or bone disorders (non-cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Problemas de los musculos y huesos de la columna vertebral"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6489",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingVisionCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingVisionCondition_Cataracts",
+            "display": "Cataracts",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cataratas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingVisionCondition_Glaucoma",
+            "display": "Glaucoma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Glaucoma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingVisionCondition_MacularDegeneration",
+            "display": "Macular degeneration",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Degeneraci\u00f3n macular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingVisionCondition_HearingLoss",
+            "display": "Severe hearing loss or partial deafness in one or both ears",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00e9rdida grave de la audici\u00f3n o sordera parcial en uno o ambos o\u00eddos"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6493",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingOtherHealthCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SiblingOtherHealthCondition_Allergies",
+            "display": "Allergies",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alergias"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_Endometriosis",
+            "display": "Endometriosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Endometriosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_Fibroids",
+            "display": "Fibroids",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_Obesity",
+            "display": "Obesity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Obesidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_PolycysticOvarianSyndrome",
+            "display": "Polycystic ovarian syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "PCOS (s\u00edndrome de ovario poliqu\u00edstico)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_ReactionsToAnesthesia",
+            "display": "Reactions to anesthesia (such as hyperthermia)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reacciones a la anestesia (como hipertermia)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_SkinCondition",
+            "display": "Skin condition (e.g., eczema, psoriasis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de la piel (por ejemplo, eczema, psoriasis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingOtherHealthCondition_OtherCondition",
+            "display": "Other",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6497",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCondition_SiblingFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "34758",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SiblingNoSelection",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PMI_None",
+            "display": "None of the above ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "Don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "Prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no contestar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SiblingHealthCondition_NoBloodRelatedSiblings",
+            "display": "I do not have any brothers or sisters related by blood.",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No tengo otros hermanos o hermanas con lazo sangu\u00edneo"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "35069",
+        "text": "Pick your answers from the following choices",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterCancerCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterCancerCondition_BladderCancer",
+            "display": "Bladder cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de vejiga"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_BoneCancer",
+            "display": "Bone cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de huesos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_BloodCancer",
+            "display": "Blood or soft tissue cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de sangre o de los tejidos blandos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_BrainCancer",
+            "display": "Brain cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de cerebro"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_BreastCancer",
+            "display": "Breast cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de mama"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_CervicalCancer",
+            "display": "Cervical cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de \u00fatero (matriz)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_ColonRectalCancer",
+            "display": "Colon cancer/Rectal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de colon/C\u00e1ncer de recto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_EndocrineCancer",
+            "display": "Endocrine cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer del sistema end\u00f3crino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_EndometrialCancer",
+            "display": "Endometrial cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer endometrial"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_EsophagealCancer",
+            "display": "Esophageal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de es\u00f3fago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_EyeCancer",
+            "display": "Eye cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ojo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_HeadNeckCancer",
+            "display": "Head and neck (This includes cancers of the mouth, sinuses, nose, or throat. This does not include brain cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cabeza y cuello (esto incluye c\u00e1ncer de boca, seno paranasal, nasal o de garganta. No incluye c\u00e1ncer de cerebro)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_KidneyCancer",
+            "display": "Kidney cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ri\u00f1\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_LungCancer",
+            "display": "Lung cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pulm\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_OvarianCancer",
+            "display": "Ovarian cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ovario"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_PancreaticCancer",
+            "display": "Pancreatic cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de p\u00e1ncreas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_SkinCancer",
+            "display": "Skin cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de piel"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_StomachCancer",
+            "display": "Stomach cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de est\u00f3mago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_ThyroidCancer",
+            "display": "Thyroid cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de tiroides"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCancerCondition_OtherCancer",
+            "display": "Other cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de c\u00e1ncer"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6505",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCancer_DaughterFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "6506",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterCirculatoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterCirculatoryCondition_Anemia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Anemia"
+          },
+          {
+            "code": "DaughterCirculatoryCondition_AorticAneurysm",
+            "display": "Aortic aneurysm",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Aneurisma a\u00f3rtico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_AtrialFibrilation",
+            "display": "Atrial fibrillation (or a-fib) or atrial flutter (or a-flutter). ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibrilaci\u00f3n auricular (o fa) o palpitaci\u00f3n auricular (o pa)."
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_CongestiveHeartFailure",
+            "display": "Congestive heart failure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Insuficiencia card\u00edaca congestiva"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_CoronaryArteryHeartDisease",
+            "display": "Coronary artery/coronary heart disease (included angina)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad coronaria/de la arterias coronarias (incluida la angina de pecho)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_HeartAttack",
+            "display": "Heart attack",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Infarto del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_HeartValveDisease",
+            "display": "Heart valve disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de las valvulas del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_HighBloodPressure",
+            "display": "High blood pressure (Hypertension)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertensi\u00f3n (presi\u00f3n arterial alta)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_HighCholesterol",
+            "display": "High cholesterol",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colesterol alto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_PeripheralVascularDisease",
+            "display": "Peripheral vascular disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad vascular perif\u00e9rica"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_PulmonaryEmbolismThrombosis",
+            "display": "Pulmonary embolism or deep vein thrombosis (DVT)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Embolia en los pulmones o trombosis de las venas profundas (TVP)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_SickleCellDisease",
+            "display": "Sickle cell disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia de c\u00e9lulas falciformes"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_Stroke",
+            "display": "Stroke",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Accidente cerebrovascular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterCirculatoryCondition_SuddenDeath",
+            "display": "Sudden death",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Muerte s\u00fabita"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6510",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterDigestiveCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterDigestiveCondition_AcidReflux",
+            "display": "Acid reflux",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reflujo acido"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_CeliacDisease",
+            "display": "Celiac disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Celiac disease"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_ColonPolyps",
+            "display": "Colon polyps",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00f3lipos en el colon"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_CrohnsDisease",
+            "display": "Crohn's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Crohn"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_Diverticulitis",
+            "display": "Diverticulitis/Diverticulosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diveriticulosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_GallStones",
+            "display": "Gall stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos biliares (piedras en la vesicula biliar)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_IrritableBowelSyndrome",
+            "display": "Irritable bowel syndrome (IBS)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome del intestino irritable (SII)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_PepticUlcers",
+            "display": "Peptic (stomach) ulcers",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "\u00dalceras p\u00e9pticas (\u00falceras del est\u00f3mago o del intestino delgado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterDigestiveCondition_UlcerativeColitis",
+            "display": "Ulcerative colitis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colitis ulcerosa (ulceras e inflamacion del intestino)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6514",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterEndocrineCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterEndocrineCondition_Hyperthyroidism",
+            "display": "Hyperthyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterEndocrineCondition_Hypothyroidism",
+            "display": "Hypothyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipotiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterEndocrineCondition_Type1Diabetes",
+            "display": "Type 1 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterEndocrineCondition_Type2Diabetes",
+            "display": "Type 2 diabetes ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterEndocrineCondition_OtherDiabetes",
+            "display": "Other/unknown diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de diabetes de causa conocida o desconocida"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6518",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterKidneyCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterKidneyCondition_KidneyDisease",
+            "display": "Kidney disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad renal"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterKidneyCondition_KidneyStones",
+            "display": "Kidney stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos en los ri\u00f1ones (piedras en los rinones)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6522",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterRespiratoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterRespiratoryCondition_Asthma",
+            "display": "Asthma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterRespiratoryCondition_ChronicLungDisease",
+            "display": "Chronic lung disease (COPD, emphysema or bronchitis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad cr\u00f3nica de los pulmones (EPOC, enfisema o bronquitis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterRespiratoryCondition_SleepApnea",
+            "display": "Sleep apnea",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Apnea del sue\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6526",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterNervousCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterNervousCondition_Dementia",
+            "display": "Dementia (includes Alzheimer's, vascular, etc.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Demencia (incluye Alzheimer, vascular, etc.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_EpilepsySeizure",
+            "display": "Epilepsy or seizure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Epilepsia o convulsiones"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_AmyotrophicLateralSclerosis",
+            "display": "Lou Gehrig\u2019s disease (Amyotrophic lateral sclerosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis lateral amiotr\u00f3fica (Enfermedad de Lou Gehrig)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_MigraineHeadaches",
+            "display": "Migraine headaches",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Migra\u00f1as"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_MultipleSclerosis",
+            "display": "Multiple sclerosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis m\u00faltiple"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_MuscularDystrophy",
+            "display": "Muscular dystrophy (MD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Distrofia muscular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_Narcolepsy",
+            "display": "Narcolepsy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Narcolepsia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_Neuropathy",
+            "display": "Neuropathy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Neuropat\u00eda"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_Parkinsons",
+            "display": "Parkinson's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Parkinson"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterNervousCondition_RestlessLegsSyndrome",
+            "display": "Restless leg syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome de las piernas inquietas"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6530",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterMentalCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterMentalCondition_AlcoholUse",
+            "display": "Alcohol use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de alcohol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterMentalCondition_AnxietyPanic",
+            "display": "Anxiety reaction/panic disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno de ansiedad/trastorno de p\u00e1nico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterMentalCondition_Autism",
+            "display": "Autism spectrum disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Autismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterMentalCondition_Bipolar",
+            "display": "Bipolar disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno bipolar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterMentalCondition_Depression",
+            "display": "Depression",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Depresi\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterMentalCondition_DrugUse",
+            "display": "Drug use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de drogas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterMentalCondition_Schizophrenia",
+            "display": "Schizophrenia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esquizofrenia"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6534",
+        "text": "Mental Health or substance use of conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterSkeletalMuscularCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterSkeletalMuscularCondition_Fibromyalgia",
+            "display": "Fibromyalgia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromialgia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterSkeletalMuscularCondition_Gout",
+            "display": "Gout",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Gota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterSkeletalMuscularCondition_Osteoarthritis",
+            "display": "Osteoarthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoartritis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterSkeletalMuscularCondition_Osteoporosis",
+            "display": "Osteoporosis ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoporosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterSkeletalMuscularCondition_Pseudogout",
+            "display": "Pseudogout (CPPD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Seudogota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterSkeletalMuscularCondition_RheumatoidArthritis",
+            "display": "Rheumatoid arthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Artritis reumatoide"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterSkeletalMuscularCondition_SystemicLupus",
+            "display": "Systemic lupus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Lupus sist\u00e9mico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterSkeletalMuscularCondition_SpineMuscleBone",
+            "display": "Spine, muscle, or bone disorders (non-cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Problemas de los musculos y huesos de la columna vertebral (no c\u00e1ncer)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6538",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterVisionCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterVisionCondition_Cataracts",
+            "display": "Cataracts",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cataratas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterVisionCondition_Glaucoma",
+            "display": "Glaucoma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Glaucoma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterVisionCondition_MacularDegeneration",
+            "display": "Macular degeneration",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Degeneraci\u00f3n macular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterVisionCondition_HearingLoss",
+            "display": "Severe hearing loss or partial deafness in one or both ears",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00e9rdida grave de la audici\u00f3n o sordera parcial en uno o ambos o\u00eddos"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6542",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterOtherHealthCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "DaughterOtherHealthCondition_Allergies",
+            "display": "Allergies ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alergias"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_Endometriosis",
+            "display": "Endometriosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Endometriosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_Fibroids",
+            "display": "Fibroids",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_Obesity",
+            "display": "Obesity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Obesidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_PolycysticOvarianSyndrome",
+            "display": "Polycystic ovarian syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "PCOS (s\u00edndrome de ovario poliqu\u00edstico)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_ReactionsToAnesthesia",
+            "display": "Reactions to anesthesia (such as hyperthermia)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reacciones a la anestesia (como hipertermia)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_SkinCondition",
+            "display": "Skin condition (e.g., eczema, psoriasis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de la piel (por ejemplo, eczema, psoriasis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterOtherHealthCondition_OtherCondition",
+            "display": "Other",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6546",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCondition_DaughterFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "34759",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_DaughterNoSelection",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PMI_None",
+            "display": "None of the above ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "Don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "Prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no contestar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "DaughterHealthCondition_NoDaughtersRelated",
+            "display": "I do not have any daughters related by blood.",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No tengo otros hijos con lazo sangu\u00edneo."
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "35070",
+        "text": "Pick your answers from the following choices",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonCancerCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonCancerCondition_BladderCancer",
+            "display": "Bladder cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de vejiga"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_BoneCancer",
+            "display": "Bone cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de huesos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_BloodCancer",
+            "display": "Blood or soft tissue cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de sangre o de los tejidos blandos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_BrainCancer",
+            "display": "Brain cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de cerebro"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_BreastCancer",
+            "display": "Breast cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de mama"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_ColonRectalCancer",
+            "display": "Colon cancer/Rectal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de colon/C\u00e1ncer de recto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_EndocrineCancer",
+            "display": "Endocrine cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer del sistema end\u00f3crino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_EsophagealCancer",
+            "display": "Esophageal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de es\u00f3fago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_EyeCancer",
+            "display": "Eye cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ojo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_HeadNeckCancer",
+            "display": "Head and neck (This includes cancers of the mouth, sinuses, nose, or throat. This does not include brain cancer.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cabeza y cuello (esto incluye c\u00e1ncer de boca, seno paranasal, nasal o de garganta. No incluye c\u00e1ncer de cerebro.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_KidneyCancer",
+            "display": "Kidney cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ri\u00f1\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_LungCancer",
+            "display": "Lung cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pulm\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_PancreaticCancer",
+            "display": "Pancreatic cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de p\u00e1ncreas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_ProstateCancer",
+            "display": "Prostate cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pr\u00f3stata"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_SkinCancer",
+            "display": "Skin cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de piel"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_StomachCancer",
+            "display": "Stomach cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de est\u00f3mago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_ThyroidCancer",
+            "display": "Thyroid cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de tiroides"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCancerCondition_OtherCancer",
+            "display": "Other cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de c\u00e1ncer"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6554",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCancer_SonFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "6555",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonCirculatoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonCirculatoryCondition_Anemia",
+            "display": "Anemia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_AorticAneurysm",
+            "display": "Aortic aneurysm",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Aneurisma a\u00f3rtico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_AtrialFibrilation",
+            "display": "Atrial fibrillation (or a-fib) or atrial flutter (or a-flutter).",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibrilaci\u00f3n auricular (o fa) o palpitaci\u00f3n auricular (o pa)."
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_CongestiveHeartFailure",
+            "display": "Congestive heart failure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Insuficiencia card\u00edaca congestiva"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_CoronaryArteryHeartDisease",
+            "display": "Coronary artery/coronary heart disease (included angina)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad coronaria/de la arterias coronarias (incluida la angina de pecho)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_HeartAttack",
+            "display": "Heart attack",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Infarto del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_HeartValveDisease",
+            "display": "Heart valve disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de las valvulas del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_HighBloodPressure",
+            "display": "High blood pressure (hypertension)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertensi\u00f3n (presi\u00f3n arterial alta)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_HighCholesterol",
+            "display": "High cholesterol",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colesterol alto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_PeripheralVascularDisease",
+            "display": "Peripheral vascular disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad vascular perif\u00e9rica"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_PulmonaryEmbolismThrombosis",
+            "display": "Pulmonary embolism or deep vein thrombosis (DVT)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Embolia en los pulmones o trombosis de las venas profundas (TVP)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_SickleCellDisease",
+            "display": "Sickle cell disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia de c\u00e9lulas falciformes"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_Stroke",
+            "display": "Stroke",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Accidente cerebrovascular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonCirculatoryCondition_SuddenDeath",
+            "display": "Sudden death",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Muerte s\u00fabita"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6559",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonDigestiveCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonDigestiveCondition_AcidReflux",
+            "display": "Acid reflux",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reflujo acido"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_CeliacDisease",
+            "display": "Celiac disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Celiac disease"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_ColonPolyps",
+            "display": "Colon polyps",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00f3lipos en el colon"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_CrohnsDisease",
+            "display": "Crohn's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Crohn"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_Diverticulitis",
+            "display": "Diverticulitis/Diverticulosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diveriticulosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_GallStones",
+            "display": "Gall stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos biliares (piedras en la vesicula biliar)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_IrritableBowelSyndrome",
+            "display": "Irritable bowel syndrome (IBS)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome del intestino irritable (SII)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_PepticUlcers",
+            "display": "Peptic (stomach) ulcers",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "\u00dalceras p\u00e9pticas (\u00falceras del est\u00f3mago o del intestino delgado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonDigestiveCondition_UlcerativeColitis",
+            "display": "Ulcerative colitis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colitis ulcerosa (ulceras e inflamacion del intestino)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6563",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonEndocrineCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonEndocrineCondition_Hyperthyroidism",
+            "display": "Hyperthyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonEndocrineCondition_Hypothyroidism",
+            "display": "Hypothyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipotiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonEndocrineCondition_Type1Diabetes",
+            "display": "Type 1 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonEndocrineCondition_Type2Diabetes",
+            "display": "Type 2 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonEndocrineCondition_OtherDiabetes",
+            "display": "Other/unknown diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de diabetes de causa conocida o desconocida"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6567",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonKidneyCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonKidneyCondition_KidneyDisease",
+            "display": "Kidney disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad renal"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonKidneyCondition_KidneyStones",
+            "display": "Kidney stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos en los ri\u00f1ones (piedras en los rinones)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6571",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonRespiratoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonRespiratoryCondition_Asthma",
+            "display": "Asthma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonRespiratoryCondition_ChronicLungDisease",
+            "display": "Chronic lung disease (COPD, emphysema or bronchitis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad cr\u00f3nica de los pulmones (EPOC, enfisema o bronquitis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonRespiratoryCondition_SleepApnea",
+            "display": "Sleep apnea",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Apnea del sue\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6575",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonNervousCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonNervousCondition_Dementia",
+            "display": "Dementia (includes Alzheimer's, vascular, etc.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Demencia (incluye Alzheimer, vascular, etc.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_EpilepsySeizure",
+            "display": "Epilepsy or seizure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Epilepsia o convulsiones"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_AmyotrophicLateralSclerosis",
+            "display": "Lou Gehrig\u2019s disease (Amyotrophic lateral sclerosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Lou Gehrig (Esclerosis lateral amiotr\u00f3fica)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_MigraineHeadaches",
+            "display": "Migraine headaches",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Migra\u00f1as"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_MultipleSclerosis",
+            "display": "Multiple sclerosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis m\u00faltiple"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_MuscularDystrophy",
+            "display": "Muscular dystrophy (MD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Distrofia muscular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_Narcolepsy",
+            "display": "Narcolepsy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Narcolepsia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_Neuropathy",
+            "display": "Neuropathy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Neuropat\u00eda"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_Parkinsons",
+            "display": "Parkinson's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Parkinson"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonNervousCondition_RestlessLegsSyndrome",
+            "display": "Restless leg syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome de las piernas inquietas"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6579",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonMentalCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonMentalCondition_AlcoholUse",
+            "display": "Alcohol use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de alcohol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonMentalCondition_AnxietyPanic",
+            "display": "Anxiety reaction/panic disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno de ansiedad/trastorno de p\u00e1nico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonMentalCondition_Autism",
+            "display": "Autism spectrum disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Autismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonMentalCondition_Bipolar",
+            "display": "Bipolar disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno bipolar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonMentalCondition_Depression",
+            "display": "Depression",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Depresi\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonMentalCondition_DrugUse",
+            "display": "Drug use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de drogas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonMentalCondition_Schizophrenia",
+            "display": "Schizophrenia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esquizofrenia"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6583",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonSkeletalMuscularCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonSkeletalMuscularCondition_Fibromyalgia",
+            "display": "Fibromyalgia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromialgia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonSkeletalMuscularCondition_Gout",
+            "display": "Gout",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Gota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonSkeletalMuscularCondition_Osteoarthritis",
+            "display": "Osteoarthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoartritis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonSkeletalMuscularCondition_Osteoporosis",
+            "display": "Osteoporosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoporosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonSkeletalMuscularCondition_Pseudogout",
+            "display": "Pseudogout (CPPD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Seudogota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonSkeletalMuscularCondition_RheumatoidArthritis",
+            "display": "Rheumatoid arthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Artritis reumatoide"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonSkeletalMuscularCondition_SystemicLupus",
+            "display": "Systemic lupus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Lupus sist\u00e9mico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonSkeletalMuscularCondition_SpineMuscleBone",
+            "display": "Spine, muscle, or bone disorders (non-cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Problemas de los musculos y huesos de la columna vertebral (no c\u00e1ncer)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6587",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonVisionCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonVisionCondition_Cataracts",
+            "display": "Cataracts",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cataratas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonVisionCondition_Glaucoma",
+            "display": "Glaucoma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Glaucoma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonVisionCondition_MacularDegeneration",
+            "display": "Macular degeneration",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Degeneraci\u00f3n macular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonVisionCondition_HearingLoss",
+            "display": "Severe hearing loss or partial deafness in one or both ears\n",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00e9rdida grave de la audici\u00f3n o sordera parcial en uno o ambos o\u00eddos"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6591",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonOtherHealthCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SonOtherHealthCondition_Allergies",
+            "display": "Allergies ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alergias"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonOtherHealthCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonOtherHealthCondition_Obesity",
+            "display": "Obesity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Obesidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonOtherHealthCondition_ReactionsToAnesthesia",
+            "display": "Reactions to anesthesia (such as hyperthermia)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reacciones a la anestesia (como hipertermia)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonOtherHealthCondition_SkinCondition",
+            "display": "Skin condition (e.g., eczema, psoriasis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de la piel (por ejemplo, eczema, psoriasis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonOtherHealthCondition_OtherCondition",
+            "display": "Other",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6595",
+        "text": "Other Condition",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCondition_SonFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "34777",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_SonNoSelection",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PMI_None",
+            "display": "None of the above ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "Don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "Prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no contestar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SonOtherHealthCondition_NoSonsRelated",
+            "display": "I do not have any sons related by blood.",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No tengo otros hijos con lazo sangu\u00edneo."
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "35071",
+        "text": "Pick your answers from the following choices",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentCancerCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentCancerCondition_BladderCancer",
+            "display": "Bladder cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de vejiga"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_BoneCancer",
+            "display": "Bone cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de huesos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_BloodCancer",
+            "display": "Blood or soft tissue cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de sangre o de los tejidos blandos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_BrainCancer",
+            "display": "Brain cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de cerebro"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_BreastCancer",
+            "display": "Breast cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de mama"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_CervicalCancer",
+            "display": "Cervical cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de \u00fatero (matriz)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_ColonRectalCancer",
+            "display": "Colon cancer/Rectal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de colon/C\u00e1ncer de recto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_EndocrineCancer",
+            "display": "Endocrine cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer del sistema end\u00f3crino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_EndometrialCancer",
+            "display": "Endometrial cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer endometrial"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_EsophagealCancer",
+            "display": "Esophageal cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de es\u00f3fago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_EyeCancer",
+            "display": "Eye cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ojo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_HeadNeckCancer",
+            "display": "Head and neck (this includes cancers of the mouth, sinuses, nose, or throat. This does not include brain cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cabeza y cuello (esto incluye c\u00e1ncer de boca, seno paranasal, nasal o de garganta. No incluye c\u00e1ncer de cerebro)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_KidneyCancer",
+            "display": "Kidney cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ri\u00f1\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_LungCancer",
+            "display": "Lung cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pulm\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_OvarianCancer",
+            "display": "Ovarian cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de ovario"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_PancreaticCancer",
+            "display": "Pancreatic cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de p\u00e1ncreas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_ProstateCancer",
+            "display": "Prostate cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de pr\u00f3stata"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_SkinCancer",
+            "display": "Skin cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de piel"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_StomachCancer",
+            "display": "Stomach cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de est\u00f3mago"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_ThyroidCancer",
+            "display": "Thyroid cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1ncer de tiroides"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCancerCondition_OtherCancer",
+            "display": "Other cancer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de c\u00e1ncer"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6257",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCancer_GrandparentFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "6310",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentCirculatoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentCirculatoryCondition_Anemia",
+            "display": "Anemia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_AorticAneurysm",
+            "display": "Aortic aneurysm",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Aneurisma a\u00f3rtico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_AtrialFibrilation",
+            "display": "Atrial fibrillation (or a-fib) or atrial flutter (or a-flutter). ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibrilaci\u00f3n auricular (o fa) o palpitaci\u00f3n auricular (o pa)."
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_CongestiveHeartFailure",
+            "display": "Congestive heart failure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Insuficiencia card\u00edaca congestiva"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_CoronaryArteryHeartDisease",
+            "display": "Coronary artery/coronary heart disease (included angina)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad coronaria/de la arterias coronarias (incluida la angina de pecho)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_HeartAttack",
+            "display": "Heart attack",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Infarto del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_HeartValveDisease",
+            "display": "Heart valve disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de las valvulas del coraz\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_HighBloodPressure",
+            "display": "High blood pressure (Hypertension)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertensi\u00f3n (presi\u00f3n arterial alta)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_HighCholesterol",
+            "display": "High cholesterol",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colesterol alto"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_PeripheralVascularDisease",
+            "display": "Peripheral vascular disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad vascular perif\u00e9rica"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_PulmonaryEmbolismThrombosis",
+            "display": "Pulmonary embolism or deep vein thrombosis (DVT)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Embolia en los pulmones o trombosis de las venas profundas (TVP)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_SickleCellDisease",
+            "display": "Sickle cell disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Anemia de c\u00e9lulas falciformes"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_Stroke",
+            "display": "Stroke",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Accidente cerebrovascular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentCirculatoryCondition_SuddenDeath",
+            "display": "Sudden death",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Muerte s\u00fabita"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6314",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentDigestiveCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentDigestiveCondition_AcidReflux",
+            "display": "Acid reflux",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reflujo acido"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_CeliacDisease",
+            "display": "Celiac disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Celiac disease"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_ColonPolyps",
+            "display": "Colon polyps",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00f3lipos en el colon"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_CrohnsDisease",
+            "display": "Crohn's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Crohn"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_Diverticulitis",
+            "display": "Diverticulitis/Diverticulosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diveriticulosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_GallStones",
+            "display": "Gall stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos biliares (piedras en la vesicula biliar)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_IrritableBowelSyndrome",
+            "display": "Irritable bowel syndrome (IBS)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome del intestino irritable (SII)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_PepticUlcers",
+            "display": "Peptic (stomach) ulcers",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "\u00dalceras p\u00e9pticas (\u00falceras del est\u00f3mago o del intestino delgado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentDigestiveCondition_UlcerativeColitis",
+            "display": "Ulcerative colitis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colitis ulcerosa (ulceras e inflamacion del intestino)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6318",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentEndocrineCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentEndocrineCondition_Hyperthyroidism",
+            "display": "Hyperthyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipertiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentEndocrineCondition_Hypothyroidism",
+            "display": "Hypothyroidism",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hipotiroidismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentEndocrineCondition_Type1Diabetes",
+            "display": "Type 1 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentEndocrineCondition_Type2Diabetes",
+            "display": "Type 2 diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Diabetes tipo 2"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentEndocrineCondition_OtherDiabetes",
+            "display": "Other/unknown diabetes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro tipo de diabetes de causa conocida o desconocida"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6322",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentKidneyCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentKidneyCondition_KidneyDisease",
+            "display": "Kidney disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad renal"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentKidneyCondition_KidneyStones",
+            "display": "Kidney stones",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "C\u00e1lculos en los ri\u00f1ones (piedras en los rinones)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6326",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentRespiratoryCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentRespiratoryCondition_Asthma",
+            "display": "Asthma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentRespiratoryCondition_ChronicLungDisease",
+            "display": "Chronic lung disease (COPD, emphysema or bronchitis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad cr\u00f3nica de los pulmones (EPOC, enfisema o bronquitis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentRespiratoryCondition_SleepApnea",
+            "display": "Sleep apnea",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Apnea del sue\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6330",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentNervousCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentNervousCondition_Dementia",
+            "display": "Dementia (includes Alzheimer's, vascular, etc.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Demencia (incluye Alzheimer, vascular, etc.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_EpilepsySeizure",
+            "display": "Epilepsy or seizure",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Epilepsia o convulsiones"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_AmyotrophicLateralSclerosis",
+            "display": "Lou Gehrig\u2019s disease (Amyotrophic lateral sclerosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Lou Gehrig (Esclerosis lateral amiotr\u00f3fica)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_MigraineHeadaches",
+            "display": "Migraine headaches",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Migra\u00f1as"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_MultipleSclerosis",
+            "display": "Multiple sclerosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esclerosis m\u00faltiple"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_MuscularDystrophy",
+            "display": "Muscular dystrophy (MD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Distrofia muscular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_Narcolepsy",
+            "display": "Narcolepsy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Narcolepsia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_Neuropathy",
+            "display": "Neuropathy",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Neuropat\u00eda"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_Parkinsons",
+            "display": "Parkinson's disease",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de Parkinson"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentNervousCondition_RestlessLegsSyndrome",
+            "display": "Restless leg syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00edndrome de las piernas inquietas"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6334",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentMentalCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentMentalCondition_AlcoholUse",
+            "display": "Alcohol use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad relacionada con el consumo de alcohol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentMentalCondition_AnxietyPanic",
+            "display": "Anxiety reaction/panic disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno de ansiedad/trastorno de p\u00e1nico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentMentalCondition_Autism",
+            "display": "Autism spectrum disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Autismo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentMentalCondition_Bipolar",
+            "display": "Bipolar disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Trastorno bipolar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentMentalCondition_Depression",
+            "display": "Depression",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Depresi\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentMentalCondition_DrugUse",
+            "display": "Drug use disorder",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Una condici\u00f3n en la que uno necesita las drogas para funcionar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentMentalCondition_Schizophrenia",
+            "display": "Schizophrenia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Esquizofrenia"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6338",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentSkeletalMuscularCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentSkeletalMuscularCondition_Fibromyalgia",
+            "display": "Fibromyalgia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromialgia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentSkeletalMuscularCondition_Gout",
+            "display": "Gout",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Gota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentSkeletalMuscularCondition_Osteoarthritis",
+            "display": "Osteoarthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoartritis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentSkeletalMuscularCondition_Osteoporosis",
+            "display": "Osteoporosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Osteoporosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentSkeletalMuscularCondition_Pseudogout",
+            "display": "Pseudogout (CPPD)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Seudogota"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentSkeletalMuscularCondition_RheumatoidArthritis",
+            "display": "Rheumatoid arthritis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Artritis reumatoide"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentSkeletalMuscularCondition_SystemicLupus",
+            "display": "Systemic lupus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Lupus sist\u00e9mico"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentSkeletalMuscularCondition_SpineMuscleBone",
+            "display": "Spine, muscle, or bone disorders (non-cancer)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Problemas de los musculos y huesos de la columna vertebral"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6342",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentVisionCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentVisionCondition_Cataracts",
+            "display": "Cataracts",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cataratas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentVisionCondition_Glaucoma",
+            "display": "Glaucoma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Glaucoma"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentVisionCondition_MacularDegeneration",
+            "display": "Macular degeneration",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Degeneraci\u00f3n macular"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentVisionCondition_HearingLoss",
+            "display": "Severe hearing loss or partial deafness in one or both ears\n",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "P\u00e9rdida grave de la audici\u00f3n o sordera parcial en uno o ambos o\u00eddos"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6346",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentOtherHealthCondition",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GrandparentOtherHealthCondition_Allergies",
+            "display": "Allergies",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alergias"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_Endometriosis",
+            "display": "Endometriosis",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Endometriosis"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_Fibroids",
+            "display": "Fibroids",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fibromas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_LiverCondition",
+            "display": "Liver condition (e.g., cirrhosis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad hep\u00e1tica (por ejemplo, cirrosis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_Obesity",
+            "display": "Obesity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Obesidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_PolycysticOvarianSyndrome",
+            "display": "Polycystic ovarian syndrome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "PCOS (s\u00edndrome de ovario poliqu\u00edstico)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_ReactionsToAnesthesia",
+            "display": "Reactions to anesthesia (such as hyperthermia)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Reacciones a la anestesia (como hipertermia)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_SkinCondition",
+            "display": "Skin condition (e.g., eczema, psoriasis)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Enfermedad de la piel (por ejemplo, eczema, psoriasis)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GrandparentOtherHealthCondition_OtherCondition",
+            "display": "Other",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "6350",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "OtherCondition_GrandparentFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "34778",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "DiagnosedHealthCondition_GrandparentNoSelection",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PMI_None",
+            "display": "None of the above ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "Don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "Prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no contestar"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "35072",
+        "text": "Pick your answers from the following choices",
+        "repeats": false,
+        "type": "choice"
+      }
+    ],
+    "text": "This module asks about your family\u2019s medical history. Understanding these medical issues can tell us a lot about what kinds of medical issues might be related to your genetics.",
+    "repeats": false
+  },
+  "resourceType": "Questionnaire",
+  "version": "1",
+  "date": "2018-07-13T05:04:47Z",
+  "identifier": [
+    {
+      "value": "Vibrent_FORM_ID_294"
+    }
+  ],
+  "id": "655"
+}

--- a/rest-api/test/test-data/questionnaire_family_history_resp.json
+++ b/rest-api/test/test-data/questionnaire_family_history_resp.json
@@ -1,0 +1,2158 @@
+{
+  "status": "completed",
+  "id": "107251069",
+  "authored": "2018-07-23T21:21:12Z",
+  "subject": {
+    "reference": "Patient/{participant_id}"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+      "valueCode": "en"
+    }
+  ],
+  "resourceType": "QuestionnaireResponse",
+  "questionnaire": {
+    "reference": "Questionnaire/{questionnaire_id}"
+  },
+  "group": {
+    "linkId": "root_group",
+    "title": "Family History",
+    "question": [
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "FamilyMedicalHistoryAware_Alot",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "A lot"
+            }
+          }
+        ],
+        "linkId": "6252",
+        "text": "How much do you know about illnesses or health problems for your parents, grandparents, brothers, sisters and/or children?\n\n",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1nta informaci\u00f3n sabe sobre las enfermedades o problemas de salud para los siguientes miembros de su familia: padres, abuelos, hermanos, hermanas e hijos?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "MotherDigestiveCondition_Diverticulitis",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Diverticulitis/Diverticulosis"
+            }
+          }
+        ],
+        "linkId": "6367",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "MotherRespiratoryCondition_ChronicLungDisease",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Chronic lung disease (COPD, emphysema or bronchitis)"
+            }
+          }
+        ],
+        "linkId": "6379",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "MotherNervousCondition_MigraineHeadaches",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Migraine headaches"
+            }
+          }
+        ],
+        "linkId": "6383",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "MotherMentalCondition_AnxietyPanic",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Anxiety reaction/panic disorder"
+            }
+          }
+        ],
+        "linkId": "6387",
+        "text": "Mental Health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "MotherSkeletalMuscularCondition_Osteoarthritis",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Osteoarthritis"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "MotherSkeletalMuscularCondition_Osteoporosis",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Osteoporosis"
+            }
+          }
+        ],
+        "linkId": "6391",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "MotherVisionCondition_Glaucoma",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Glaucoma"
+            }
+          }
+        ],
+        "linkId": "6395",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "FatherCirculatoryCondition_HighBloodPressure",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "High blood pressure (Hypertension)"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "FatherCirculatoryCondition_HighCholesterol",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "High cholesterol"
+            }
+          }
+        ],
+        "linkId": "6412",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "SiblingNervousCondition_MigraineHeadaches",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Migraine headaches"
+            }
+          }
+        ],
+        "linkId": "6481",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "SiblingMentalCondition_AnxietyPanic",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Anxiety reaction/panic disorder"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "SiblingMentalCondition_Depression",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Depression"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "SiblingMentalCondition_DrugUse",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Drug use disorder"
+            }
+          }
+        ],
+        "linkId": "6485",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_None",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "None of the above "
+            }
+          }
+        ],
+        "linkId": "35070",
+        "text": "Pick your answers from the following choices"
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_None",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "None of the above "
+            }
+          }
+        ],
+        "linkId": "35071",
+        "text": "Pick your answers from the following choices"
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentCancerCondition_BreastCancer",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Breast cancer"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentCancerCondition_ProstateCancer",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Prostate cancer"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentCancerCondition_SkinCancer",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Skin cancer"
+            }
+          }
+        ],
+        "linkId": "6257",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentCirculatoryCondition_CongestiveHeartFailure",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Congestive heart failure"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentCirculatoryCondition_CoronaryArteryHeartDisease",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Coronary artery/coronary heart disease (included angina)"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentCirculatoryCondition_HeartAttack",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Heart attack"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentCirculatoryCondition_HighBloodPressure",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "High blood pressure (Hypertension)"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentCirculatoryCondition_HighCholesterol",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "High cholesterol"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentCirculatoryCondition_Stroke",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Stroke"
+            }
+          }
+        ],
+        "linkId": "6314",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentDigestiveCondition_Diverticulitis",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Diverticulitis/Diverticulosis"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentDigestiveCondition_PepticUlcers",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Peptic (stomach) ulcers"
+            }
+          }
+        ],
+        "linkId": "6318",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentEndocrineCondition_Hypothyroidism",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Hypothyroidism"
+            }
+          }
+        ],
+        "linkId": "6322",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentNervousCondition_Dementia",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Dementia (includes Alzheimer's, vascular, etc.)"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentNervousCondition_RestlessLegsSyndrome",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Restless leg syndrome"
+            }
+          }
+        ],
+        "linkId": "6334",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentMentalCondition_AlcoholUse",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Alcohol use disorder"
+            }
+          }
+        ],
+        "linkId": "6338",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentSkeletalMuscularCondition_Osteoarthritis",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Osteoarthritis"
+            }
+          },
+          {
+            "valueCoding": {
+              "code": "GrandparentSkeletalMuscularCondition_Osteoporosis",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Osteoporosis"
+            }
+          }
+        ],
+        "linkId": "6342",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GrandparentVisionCondition_Cataracts",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Cataracts"
+            }
+          }
+        ],
+        "linkId": "6346",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6358",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6363",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6371",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6375",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6399",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "35067",
+        "text": "Pick your answers from the following choices"
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6407",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6416",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6420",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6424",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6428",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6432",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6436",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6440",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6444",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6448",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "35068",
+        "text": "Pick your answers from the following choices"
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6456",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6461",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6465",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6469",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6473",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6477",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6489",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6493",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6497",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "35069",
+        "text": "Pick your answers from the following choices"
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6505",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6510",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6514",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6518",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6522",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6526",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6530",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6534",
+        "text": "Mental Health or substance use of conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6538",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6542",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6546",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6554",
+        "text": "Cancer",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "C\u00e1ncer"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6559",
+        "text": "Heart and blood Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del coraz\u00f3n"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6563",
+        "text": "Digestive Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades digestivas"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6567",
+        "text": "Hormone/endocrine Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del sistema end\u00f3crino/hormonales"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6571",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6575",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6579",
+        "text": "Brain and nervous System Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del cerebro y el sistema nervioso"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6583",
+        "text": "Mental health or substance use of Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades mentales y uso de sustancias"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6587",
+        "text": "Bone, joint and muscle Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los huesos, articulaculaciones y musculos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6591",
+        "text": "Hearing and eye Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los o\u00eddos y los ojos"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6595",
+        "text": "Other Condition",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6326",
+        "text": "Kidney Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades del ri\u00f1on"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6330",
+        "text": "Lung Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Enfermedades de los pulmones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "6350",
+        "text": "Other Conditions",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Otras condiciones"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "PMI_Skip",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "35072",
+        "text": "Pick your answers from the following choices"
+      }
+    ],
+    "text": "This module asks about your family\u2019s medical history. Understanding these medical issues can tell us a lot about what kinds of medical issues might be related to your genetics."
+  }
+}

--- a/rest-api/test/test-data/questionnaire_the_basics.json
+++ b/rest-api/test/test-data/questionnaire_the_basics.json
@@ -1,0 +1,6629 @@
+{
+  "status": "published",
+  "resourceType": "Questionnaire",
+  "version": "1",
+  "date": "2017-06-26T16:52:48+00:00",
+  "identifier": [
+    {
+      "value": "Vibrent_FORM_ID_284"
+    }
+  ],
+  "id": "21",
+  "group": {
+    "concept": [
+      {
+        "code": "TheBasics",
+        "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+      }
+    ],
+    "title": "the basics",
+    "linkId": "root_group",
+    "required": true,
+    "question": [
+      {
+        "concept": [
+          {
+            "code": "TheBasics_Birthplace",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "Birthplace_USA",
+            "display": "USA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Estados unidos"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_Other",
+            "display": "other",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otro pa\u00eds"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5690",
+        "text": "In what country were you born?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfEn qu\u00e9 pa\u00eds naci\u00f3?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "TheBasics_CountryBornTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5691",
+        "text": "country of origin",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "pa\u00eds de origen"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "Race_WhatRaceEthnicity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "WhatRaceEthnicity_AIAN",
+            "display": "American Indian or Alaska Native (For example: Aztec, Blackfeet Tribe, Mayan, Navajo Nation, Native Village of Barrow Inupiat Traditional Government, Nome Eskimo Community, etc.)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ind\u00edgena estadounidense o nativo de Alaska (por ejemplo: azteca, tribu pies negros, maya, Naci\u00f3n Navajo, Pueblo Nativo del Gobierno Tradicional del I\u00f1upiaq de Barrow, Comunidad Esquimal de Nome, etc.)*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhatRaceEthnicity_Asian",
+            "display": "Asian (For example: Asian Indian, Chinese, Filipino, Japanese, Korean, Vietnamese, etc.) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asi\u00e1tico (por ejemplo: Ind\u00edgena de Asia, chino, filipino, japon\u00e9s, coreano, vietnamita, etc.) *"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhatRaceEthnicity_Black",
+            "display": "Black, African American or African (For example: African American, Ethiopian, Haitian, Jamaican, Nigerian, Somali, etc.) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Negro, afroamericano o africano (por ejemplo: afroamericano, et\u00edope, haitiano, jamaiquino, nigeriano, somal\u00ed, etc.) *"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhatRaceEthnicity_Hispanic",
+            "display": "Hispanic, Latino, or Spanish (For example: Columbian, Cuban, Dominican, Mexican or Mexican American, Puerto Rican, Salvadoran, etc.) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hispano, latino o espa\u00f1ol (por ejemplo: colombiano, cubano, dominicano, mexicano o mexicano estadounidense, puertorrique\u00f1o, salvadore\u00f1o, etc.) *"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhatRaceEthnicity_MENA",
+            "display": "Middle Eastern or North African (For example: Algerian, Egyptian, Iranian, Lebanese, Moroccan, Syrian, etc.) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Medioriental o africano del norte (por ejemplo: argelino, egipcio, iran\u00ed, liban\u00e9s, marroqu\u00ed, sirio, etc.) *"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhatRaceEthnicity_NHPI",
+            "display": "Native Hawaiian or other Pacific Islander (For example: Chamorro, Fijian, Marshallese, Native Hawaiian, Tongan, etc.) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hawaiano nativo u otro isle\u00f1o del Pac\u00edfico (por ejemplo: chamorro, fiyiano, marshal\u00e9s, hawaiano nativo, tongano, etc.) *"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhatRaceEthnicity_White",
+            "display": "White (For example: English, European, French, German, Irish, Italian, Polish, etc.) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Blanco (por ejemplo: ingl\u00e9s, europeo, franc\u00e9s, alem\u00e1n, irland\u00e9s, italiano, polaco, etc.) *"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhatRaceEthnicity_RaceEthnicityNoneOfThese",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "Prefer not to answer\n",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5696",
+        "text": "Which categories describe you? Select all that apply. Note, you may select more than one group.",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1les son las categor\u00edas que lo describen? Seleccione todas las opciones que correspondan. Tenga en cuenta que puede seleccionar m\u00e1s de un grupo."
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "RaceEthnicityNoneOfThese_RaceEthnicityFreeTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9825",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "AIAN_AIANSpecific",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "AIANSpecific_AmericanIndian",
+            "display": "American Indian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ind\u00edgena estadounidense"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AIANSpecific_AlaskaNative",
+            "display": "Alaska Native",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Nativo de Alaska"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AIANSpecific_CentralSouthAmericanIndian",
+            "display": "Central or South American Indian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ind\u00edgena de Am\u00e9rica Central"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AIANSpecific_AIANNoneOfTheseDescribeMe",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9788",
+        "text": "American Indian or Alaska Native",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Ind\u00edgena estadounidense"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "WhatTribeAffiliation_FreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9795",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "AIANNoneOfTheseDescribeMe_AIANFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "10788",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "Asian_AsianSpecific",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "AsianSpecific_AsianSpecificIndian",
+            "display": "Asian Indian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ind\u00edgena de Asia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Cambodian",
+            "display": "Cambodian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Camboyano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Chinese",
+            "display": "Chinese",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Chino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Filipino",
+            "display": "Filipino",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Filipino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Hmong",
+            "display": "Hmong",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hmong"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Japanese",
+            "display": "Japanese",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Japon\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Korean",
+            "display": "Korean",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Coreano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Pakistani",
+            "display": "Pakistani",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Pakistan\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_Vietnamese",
+            "display": "Vietnamese",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Vietnamita"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AsianSpecific_NoneOfTheseDescribeMe",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9803",
+        "text": "Asian ",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Asi\u00e1tico"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "NoneOfTheseDescribeMe_AsianFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9804",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "Black_BlackSpecific",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "BlackSpecific_AfricanAmerican",
+            "display": "African American",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Afroamericano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Barbadian",
+            "display": "Barbadian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Barbadense"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Caribbean",
+            "display": "Caribbean",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Caribe\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Ethiopian",
+            "display": "Ethiopian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Et\u00edope"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Ghanaian",
+            "display": "Ghanaian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ghan\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Haitian",
+            "display": "Haitian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Haitiano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Jamaican",
+            "display": "Jamaican",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Jamaiquino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Liberian",
+            "display": "Liberian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Liberiano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Nigerian",
+            "display": "Nigerian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Nigeriano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_Somali",
+            "display": "Somali",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Somal\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_SouthAfrican",
+            "display": "South African",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Sudafricano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "BlackSpecific_BlackNoneOfTheseDescribeMe",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9807",
+        "text": "Black, African American or African",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Negro, afroamericano o africano"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "BlackNoneOfTheseDescribeMe_BlackFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9808",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "Hispanic_HispanicSpecific",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "HispanicSpecific_Colombian",
+            "display": "Colombian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Colombiano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_Cuban",
+            "display": "Cuban",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Cubano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_Dominican",
+            "display": "Dominican",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Dominicano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_Ecuadorian",
+            "display": "Ecuadorian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ecuatoriano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_Honduran",
+            "display": "Honduran",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hondure\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_Mexican",
+            "display": "Mexican or Mexican American",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Mexicano o mexicano estadounidense"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_PuertoRican",
+            "display": "Puerto Rican",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Puertorrique\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_Salvadoran",
+            "display": "Salvadoran",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Salvadore\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_Spanish",
+            "display": "Spanish",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Espa\u00f1ol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HispanicSpecific_HispanicNoneOfTheseDescribeMe",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9811",
+        "text": "Hispanic, Latino, or Spanish",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Hispano, latino o espa\u00f1ol"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "HispanicNoneOfTheseDescribeMe_HispanicFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9812",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "MENA_MENASpecific",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "MENASpecific_Afghan",
+            "display": "Afghan",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Afgano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Algerian",
+            "display": "Algerian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Argelino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Egypt",
+            "display": "Egyptian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Egipcio"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Iranian",
+            "display": "Iranian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Iran\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Iraqi",
+            "display": "Iraqi",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Iraqu\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Israeli",
+            "display": "Israeli",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Israel\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Lebanese",
+            "display": "Lebanese",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Liban\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Moroccan",
+            "display": "Moroccan",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Marroqu\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Syrian",
+            "display": "Syrian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Sirio"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_Tunisian",
+            "display": "Tunisian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Tunecino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "MENASpecific_MENANoneOfTheseDescribeMe",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9815",
+        "text": "Middle Eastern or North African",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Medioriental o africano del norte"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "MENANoneOfTheseDescribeMe_MENAFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9816",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "NHPI_NHPISpecific",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "NHPISpecific_Chamorro",
+            "display": "Chamorro",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Chamorro"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_Chuukese",
+            "display": "Chuukese",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Chuukese"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_Fijian",
+            "display": "Fijian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Fiyiano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_Marshallese",
+            "display": "Marshallese",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Marshal\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_NativeHawaiian",
+            "display": "Native Hawaiian\n",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hawaiano nativo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_Palauan",
+            "display": "Palauan",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Palauano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_Samoan",
+            "display": "Samoan",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Samoano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_Tahitian",
+            "display": "Tahitian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Tahitiano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_Tongan",
+            "display": "Tongan",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Tongano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "NHPISpecific_NHPINoneOfTheseDescribeMe",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9819",
+        "text": "Native Hawaiian or other Pacific Islander",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Hawaiano nativo u otro isle\u00f1o del Pac\u00edfico"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "NHPINoneOfTheseDescribeMe_NHPIFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9820",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "White_WhiteSpecific",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "WhiteSpecific_Dutch",
+            "display": "Dutch",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Holand\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_English",
+            "display": "English",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ingl\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_European",
+            "display": "European",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Europeo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_French",
+            "display": "French",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Franc\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_German",
+            "display": "German",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alem\u00e1n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_Irish",
+            "display": "Irish",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Irland\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_Italian",
+            "display": "Italian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Italiano"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_Norwegian",
+            "display": "Norwegian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Noruego"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_Polish",
+            "display": "Polish",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Polaco"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_Scottish",
+            "display": "Scottish",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Escoc\u00e9s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_Spanish",
+            "display": "Spanish",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Espa\u00f1ol"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "WhiteSpecific_WhiteNoneOfTheseDescribeMe",
+            "display": "None of these fully describe me",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna opci\u00f3n me describe completamente (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9823",
+        "text": "White ",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Blanco"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "WhiteNoneOfTheseDescribeMe_WhiteFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9824",
+        "repeats": false,
+        "type": "text",
+        "text": "enter other race or ethnicity"
+      },
+      {
+        "concept": [
+          {
+            "code": "BiologicalSexAtBirth_SexAtBirth",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SexAtBirth_Female",
+            "display": "female",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "femenino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexAtBirth_Male",
+            "display": "male",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "masculino"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexAtBirth_Intersex",
+            "display": "intersex",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "intersexual"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexAtBirth_SexAtBirthNoneOfThese",
+            "display": "none of these describe me ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "ninguna de estas opciones me describe"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5704",
+        "text": "What was your biological sex assigned at birth?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1l es el sexo que le asignaron al nacer?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "SexAtBirthNoneOfThese_SexAtBirthTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5705",
+        "text": "other (please specify)",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "otro (por favor especifique)"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "Gender_GenderIdentity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "GenderIdentity_Man",
+            "display": "man",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hombre"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GenderIdentity_Woman",
+            "display": "woman",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Mujer"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GenderIdentity_NonBinary",
+            "display": "non-binary",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No binario"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GenderIdentity_Transgender",
+            "display": "transgender",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Transg\u00e9nero"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "GenderIdentity_AdditionalOptions",
+            "display": "none of these describe me, and I want to specify",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas opciones me describe y me gustar\u00eda considerar otras opciones"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5708",
+        "text": "What terms best express how you describe your gender identity? (Check all that apply)",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfQu\u00e9 t\u00e9rmino expresa mejor la manera en que describe su identidad sexual?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "Gender_CloserGenderDescription",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "CloserGenderDescription_TransMan",
+            "display": "transman/transgender man/FTM",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hombre transexual/Hombre transg\u00e9nero/Mujer a hombre (FTM)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CloserGenderDescription_TransWoman",
+            "display": "transwoman/transgender woman/MTF",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Mujer transexual/Mujer transg\u00e9nero/Hombre a mujer (MTF)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CloserGenderDescription_Genderqueer",
+            "display": "genderqueer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Pang\u00e9nero"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CloserGenderDescription_Genderfluid",
+            "display": "genderfluid",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "G\u00e9nero fluido"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CloserGenderDescription_GenderVariant",
+            "display": "gender variant",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "G\u00e9nero variante"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CloserGenderDescription_Unsure",
+            "display": "questioning or unsure of your gender identity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Se cuestiona o duda sobre su identidad de g\u00e9nero"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CloserGenderDescription_SpecifiedGender",
+            "display": "none of these describe me, and I want to specify",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Ninguna de estas opciones me describe y me gustar\u00eda especificar (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9360",
+        "text": "Are any of these a closer description to your gender identity? (Check all that apply)",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfAlguna de estas opciones se acerca m\u00e1s a la descripci\u00f3n de su identidad sexual?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "SpecifiedGender_SpecifiedGenderTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9361",
+        "text": "other (please specify)",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "otro (por favor especifique)"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "TheBasics_SexualOrientation",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SexualOrientation_Gay",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "gay"
+          },
+          {
+            "code": "SexualOrientation_Lesbian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "lesbian"
+          },
+          {
+            "code": "SexualOrientation_Straight",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Straight; that is, not gay or lesbian, etc"
+          },
+          {
+            "code": "SexualOrientation_Bisexual",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "bisexual"
+          },
+          {
+            "code": "SexualOrientation_None",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "none of these describe me, and I\u2019d like to see additional options  "
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "prefer not to answer"
+          }
+        ],
+        "linkId": "5712",
+        "text": "Which of the following best represents how you think of yourself?",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "GenderIdentity_SexualityCloserDescription",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SexualityCloserDescription_Queer",
+            "display": "queer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Homosexual"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_PolyOmniSapioPansexual",
+            "display": "polysexual, omnisexual, sapiosexual or pansexual",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Polisexual, omnisexual, sapiosexual o pansexual"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_Asexual",
+            "display": "asexual",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Asexual"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_TwoSpirit",
+            "display": "two-spirit",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Dos esp\u00edritus"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_NotFiguredOut",
+            "display": "have not figured out or are in the process of figuring out your sexuality",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No ha definido o est\u00e1 en proceso de definir su sexualidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_MostlyStraight",
+            "display": "mostly straight, but sometimes attracted to people of your own sex",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Principalmente heterosexual, pero a veces siente atracci\u00f3n por personas de su mismo sexo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_NoSexuality",
+            "display": "do not think of yourself as having sexuality",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No cree tener sexualidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_NoLabels",
+            "display": "do not use labels to identify yourself",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No usa etiquetas para identificarse"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_DontKnow",
+            "display": "don\u2019t know the answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "no lo s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "SexualityCloserDescription_SomethingElse",
+            "display": "no, I mean something else ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No, me percibo de otra manera (respuesta libre opcional)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5715",
+        "text": "Are any of these a closer description of how you think of yourself?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfAlguna de las siguientes opciones se acerca m\u00e1s a c\u00f3mo se percibe?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "SomethingElse_SexualitySomethingElseTextBox",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5716",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "por favor especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "EducationLevel_HighestGrade",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "HighestGrade_NeverAttended",
+            "display": "never attended school or only attended kindergarten",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "nunca fue a la escuela o solo fue al k\u00ednder"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HighestGrade_OneThroughFour",
+            "display": "grades 1 through 4 (primary)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "1.\u00b0  a 6.\u00b0 grado (escuela primaria)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HighestGrade_FiveThroughEight",
+            "display": "grades 5 through 8 (middle school)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "7. \u00b0 a 9. \u00b0 grado (estudios secundarios)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HighestGrade_NineThroughEleven",
+            "display": "grades 9 through 11 (Some high school)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "10 a 12.\u00ba grado (bachillerato)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HighestGrade_TwelveOrGED",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "grade 12 or GED (high school graduate) "
+          },
+          {
+            "code": "HighestGrade_CollegeOnetoThree",
+            "display": "1 to 3 years after high school (some college, associate\u2019s degree, or technical school) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "10 a 12.\u00ba grado (bachillerato)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HighestGrade_CollegeGraduate",
+            "display": "college 4 years or more (college graduate) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "4 a\u00f1os o m\u00e1s de universidad (graduado del universidad)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HighestGrade_AdvancedDegree",
+            "display": "advanced degree (Master\u2019s, Doctorate, etc.) ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "estudios graduados (maestr\u00eda, doctorado, etc.)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "prefiero no contestar"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5723",
+        "text": "What is the highest grade or year of school you completed?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1l es el grado o nivel de educaci\u00f3n m\u00e1s alto que ha completado?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "ActiveDuty_AvtiveDutyServeStatus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "AvtiveDutyServeStatus_Yes",
+            "display": "yes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "s\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AvtiveDutyServeStatus_No",
+            "display": "no",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "no"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5726",
+        "text": "Have you ever served on active duty in the United States Armed forces, either in the regular military or in a National Guard or military reserve unit? \n\nNote: Active duty does not include training for the Reserves or National Guard, but DOES include activation, for example, for the Persian Gulf War.",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfAlguna vez ha estado en servicio activo en las Fuerzas Armadas de los Estados Unidos, ya sea en el servicio militar regular, en la Guardia Nacional o en una unidad de reserva militar? \n\nImportante: El servicio activo no incluye el entrenamiento para las reservas o la Guardia Nacional, pero S\u00cd incluye la incorporaci\u00f3n, por ejemplo, para la Guerra del Golfo P\u00e9rsico."
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "MaritalStatus_CurrentMaritalStatus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "CurrentMaritalStatus_Married",
+            "display": "married",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "casado/a"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentMaritalStatus_Divorced",
+            "display": "divorced",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "divorciado/a"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentMaritalStatus_Widowed",
+            "display": "widowed",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "viudo/a"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentMaritalStatus_Separated",
+            "display": "separated",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "separado/a"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentMaritalStatus_NeverMarried",
+            "display": "never married",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Soltero"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentMaritalStatus_LivingWithPartner",
+            "display": "living with partner",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Vivo con mi pareja"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5729",
+        "text": "What is your current marital status?\n\n",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1l es su estado civil actual?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "LivingSituation_HowManyPeople",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5734",
+        "text": "number of people",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "cantidad de personas"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "decimal"
+      },
+      {
+        "concept": [
+          {
+            "code": "LivingSituation_PeopleUnder18",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5738",
+        "text": "number of people",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "cantidad de ni\u00f1os (number)"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "decimal"
+      },
+      {
+        "concept": [
+          {
+            "code": "Insurance_HealthInsurance",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "HealthInsurance_Yes",
+            "display": "yes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsurance_No",
+            "display": "no",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "no lo s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9762",
+        "text": "Are you covered by health insurance or some other kind of health care plan?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfEst\u00e1 cubierto por un seguro de salud o alg\u00fan otro tipo de plan de atenci\u00f3n m\u00e9dica?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "HealthInsurance_HealthInsuranceType",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "HealthInsuranceType_Private",
+            "display": "private health insurance (includes employer-based)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Seguro m\u00e9dico privado (incluye los seguros patrocinados por el empleador)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_Medicare",
+            "display": "MEDICARE",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "MEDICARE"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_MediGAP",
+            "display": "MEDI-GAP ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "MEDI-GAP"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_Medicaid",
+            "display": "MEDICAID ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "MEDICAID"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_Schip",
+            "display": "SCHIP (CHIP/Children\u2019s Health Insurance Program",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "SCHIP (CHIP/Programa de seguro m\u00e9dico para ni\u00f1os)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_Military",
+            "display": "military health care (TRICARE/VA/CHAMP-VA)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Atenci\u00f3n m\u00e9dica para militares (TRICARE/VA/CHAMP-VA)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_Indian",
+            "display": "Indian health service",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Servicio de Salud para Ind\u00edgenas Estadounidenses"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_StateSponsored",
+            "display": "state-sponsored health plan",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Plan de salud patrocinado por el estado"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_OtherGovernment",
+            "display": "other government program",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otra programa gubernamental"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_SingleService",
+            "display": "single service plan (e.g., dental, vision,  prescriptions)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Plan de servicio individual (por ejemplo, dental, oftalmolog\u00eda, medicamentos recetados)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HealthInsuranceType_NoCoverage",
+            "display": "no coverage of any type",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No tiene ning\u00fan tipo de cobertura"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "no lo s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "9766",
+        "text": "What kind of health insurance or health care coverage do you have?  Include those that pay for only one type of service  (nursing home care, accidents,  or dental care). Exclude private plans that only provide extra cash while hospitalized.  If you have more than one kind of health insurance, mark all plans that you have.",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfQu\u00e9 tipo de seguro m\u00e9dico o cobertura de atenci\u00f3n m\u00e9dica tiene? Incluya aquellos que paga por solo un tipo de servicio (atenci\u00f3n en residencias para ancianos, atenci\u00f3n en caso de accidente o atenci\u00f3n odontol\u00f3gica). Excluya los planes privados con los que solo paga un monto adicional mientras est\u00e1 hospitalizado. Si tiene m\u00e1s de un tipo de seguro m\u00e9dico, marque todos los planes que tiene.\nAqu\u00ed encontrar\u00e1 m\u00e1s informaci\u00f3n acerca de los programas Medicaid     \nhttps://www.medicaid.gov/medicaid/by-state/by-state.html"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "Employment_EmploymentStatus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "EmploymentStatus_EmployedForWages",
+            "display": "employed for wages (part-time or full-time)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "asalariado (tiempo parcial o tiempo completo)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "EmploymentStatus_SelfEmployed",
+            "display": "self-employed",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "aut\u00f3nomo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "EmploymentStatus_OutOfWorkOneOrMore",
+            "display": "out of work for 1 year or more",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "desocupado hace 1 a\u00f1o o m\u00e1s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "EmploymentStatus_OutOfWorkLessThanOne",
+            "display": "out of work for less than 1 year",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "desocupado hace menos de 1 a\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "EmploymentStatus_Homemaker",
+            "display": "a homemaker",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "dedicado a las labores del hogar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "EmploymentStatus_Student",
+            "display": "a student",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "estudiante"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "EmploymentStatus_Retired",
+            "display": "retired",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "jubilado/a"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "EmploymentStatus_UnableToWork",
+            "display": "unable to work (disabled)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "incapacitado para trabajar (discapacitado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5742",
+        "text": "What is your current employment status?  Please select 1 or more of these categories. ",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1l es su situaci\u00f3n laboral actual?  Seleccione 1 o m\u00e1s de estas categor\u00edas."
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": true,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "EmploymentWorkAddress_AddressLineOne",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5746",
+        "text": "address 1",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "direcci\u00f3n postal"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "EmploymentWorkAddress_AddressLineTwo",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5747",
+        "text": "address 2",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "direcci\u00f3n - l\u00ednea adicional (opcional)"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "EmploymentWorkAddress_City",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5748",
+        "text": "city",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "ciudad"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "EmploymentWorkAddress_State",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5749",
+        "text": "state",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "estado"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "EmploymentWorkAddress_ZipCode",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5750",
+        "text": "zip code",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "c\u00f3digo postal"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "decimal"
+      },
+      {
+        "concept": [
+          {
+            "code": "EmploymentWorkAddress_Country",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5751",
+        "text": "country",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "pa\u00eds"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "Employment_EmploymentWorkAddress",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DoesNotApplyToMe",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "does not apply to me"
+          }
+        ],
+        "linkId": "5752",
+        "text": "Pick your answers from the following choices",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "Income_AnnualIncome",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "AnnualIncome_less10k",
+            "display": "less than $10,000",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "menos que $10.000"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_10k25k",
+            "display": "$10,000- $24,999",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$10.000- $24.999"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_25k35k",
+            "display": "$25,000- $34,999",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$25.000- $34.999"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_35k50k",
+            "display": "$35,000- $49,999",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$35.000- $49.999"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_50k75k",
+            "display": "$50,000- $74,999",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$50.000- $74.999"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_75k100k",
+            "display": "$75,000-$99,999",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$75.000-$99.999$"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_100k150k",
+            "display": "$100,000- $149,999",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$100.000- $149.999"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_150k200k",
+            "display": "$150,000- $199,999",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$150.000- $199.999"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "AnnualIncome_more200k",
+            "display": "$200,000 or more",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "$200.000 o m\u00e1s"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5755",
+        "text": "One of the things we're trying to understand is how people's income may affect their use of health services. Household income includes your income plus the income of all family members in your household for the last calendar year. Include all wages and other sources of income. \n\nWhat is your annual household income from all sources?\n",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Una de las cosas que tratamos de entender es de qu\u00e9 modo los ingresos de las personas pueden afectar su uso de los servicios de salud. El ingreso familiar incluye su ingreso m\u00e1s el ingreso de todos los miembros de la familia que viven en su casa durante el \u00faltimo a\u00f1o calendario. \n\nIncluye todos los sueldos y otras fuentes de ingreso."
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "HomeOwn_CurrentHomeOwn",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "CurrentHomeOwn_Own",
+            "display": "own",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Soy propietario"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentHomeOwn_Rent",
+            "display": "rent",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alquilo"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentHomeOwn_OtherArrangement",
+            "display": "other arrangement",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Otra disposici\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_DontKnow",
+            "display": "don't know",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "no s\u00e9"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_PreferNotToAnswer",
+            "display": "prefer not to answer",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Prefiero no responder"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5758",
+        "text": "Do you own or rent the place where you live?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Es propietario de su casa o alquila?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "LivingSituation_CurrentLiving",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "CurrentLiving_CollegeCamp",
+            "display": "on a college campus",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "En el campus de la universidad"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_Friend",
+            "display": "with a friend/roommate",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Con un amigo/compa\u00f1ero de habitaci\u00f3n"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_Family",
+            "display": "with family",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Con la familia"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_MotelHotel",
+            "display": "motel/hotel",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Motel/hotel"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_TemporaryInstitute",
+            "display": "hospital, rehabilitation center, drug treatment center, or other temporary institution",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Hospital, centro de rehabilitaci\u00f3n, centro de tratamiento de drogadicci\u00f3n u otra instituci\u00f3n temporaria"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_ResidentialFacility",
+            "display": "in a group home, nursing home, or other residential facility",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "En un hogar grupal, una residencia para ancianos u otro centro residencial"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_Transitional",
+            "display": "transitional housing",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Alojamiento transitorio"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_Shelter",
+            "display": "emergency shelter or homeless shelter",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Refugio de emergencia o refugio para personas sin hogar"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "CurrentLiving_Outside",
+            "display": "anywhere outside (e.g., street, vehicle, abandoned building)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "En cualquier lugar (por ejemplo, la calle, un veh\u00edculo, un edificio abandonado)"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "PMI_Other",
+            "display": "other (please specify)",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "otro (por favor especifique)"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5761",
+        "text": "Where are you currently living?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfD\u00f3nde vive en la actualidad?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "LivingSituation_LivingSituationFreeText",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5762",
+        "text": "please specify",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "por favor especifique"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "LivingSituation_HowManyLivingYears",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "HowManyLivingYears_less1",
+            "display": "less than 1 year",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Menos de 1 a\u00f1o"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HowManyLivingYears_1to2",
+            "display": "1-2 years",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "1 a 2 a\u00f1os"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HowManyLivingYears_3to5",
+            "display": "3-5 years",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "3 a 5 a\u00f1os"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HowManyLivingYears_6to10",
+            "display": "6-10 years",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "6 a 10 a\u00f1os"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HowManyLivingYears_11to20",
+            "display": "11-20 years",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "11 a 20 a\u00f1os"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "HowManyLivingYears_more20",
+            "display": "more than 20 years",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "M\u00e1s de 20 a\u00f1os"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5765",
+        "text": "How many years have you lived at your current address?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1ntos a\u00f1os ha vivido en su direcci\u00f3n actual?"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "LivingSituation_StableHouseConcern",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "StableHouseConcern_Yes",
+            "display": "yes",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "s\u00ed"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "code": "StableHouseConcern_No",
+            "display": "no",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "no"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "linkId": "5769",
+        "text": "In the past 6 months, have you been worried or concerned about NOT having a place to live?",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "SocialSecurity_SocialSecurityNumber",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "10448",
+        "repeats": false,
+        "type": "text",
+        "text": "social security number"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneFirstName",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5789",
+        "text": "person 1 first name",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "nombre"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneMiddleInitial",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9767",
+        "text": "person 1 middle initial",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "nombre"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneLastName",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5790",
+        "text": "person 1 last name",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "apellido"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneAddressOne",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5791",
+        "text": "person 1 address 1",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "direcci\u00f3n postal"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneAddressTwo",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5792",
+        "text": "person 1 address 2",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "direcci\u00f3n - l\u00ednea adicional (opcional)"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "PersonOneAddress_PersonOneAddressCity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5793",
+        "text": "person 1 city",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "ciudad"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "PersonOneAddress_PersonOneAddressState",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PersonOneAddressState_AL",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Alabama"
+          },
+          {
+            "code": "PersonOneAddressState_AK",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Alaska"
+          },
+          {
+            "code": "PersonOneAddressState_AS",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "American Samoa"
+          },
+          {
+            "code": "PersonOneAddressState_AZ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Arizona"
+          },
+          {
+            "code": "PersonOneAddressState_AR",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Arkansas"
+          },
+          {
+            "code": "PersonOneAddressState_CA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "California"
+          },
+          {
+            "code": "PersonOneAddressState_CO",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Colorado"
+          },
+          {
+            "code": "PersonOneAddressState_CT",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Connecticut"
+          },
+          {
+            "code": "PersonOneAddressState_DC",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "District of Columbia"
+          },
+          {
+            "code": "PersonOneAddressState_DE",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Delaware"
+          },
+          {
+            "code": "PersonOneAddressState_FM",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Federated States of Micronesia"
+          },
+          {
+            "code": "PersonOneAddressState_FL",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Florida"
+          },
+          {
+            "code": "PersonOneAddressState_GA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Georgia"
+          },
+          {
+            "code": "PersonOneAddressState_GU",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Guam"
+          },
+          {
+            "code": "PersonOneAddressState_HI",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Hawaii"
+          },
+          {
+            "code": "PersonOneAddressState_ID",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Idaho"
+          },
+          {
+            "code": "PersonOneAddressState_IL",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Illinois"
+          },
+          {
+            "code": "PersonOneAddressState_IN",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Indiana"
+          },
+          {
+            "code": "PersonOneAddressState_IA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Iowa"
+          },
+          {
+            "code": "PersonOneAddressState_KS",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Kansas"
+          },
+          {
+            "code": "PersonOneAddressState_KY",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Kentucky"
+          },
+          {
+            "code": "PersonOneAddressState_LA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Louisiana"
+          },
+          {
+            "code": "PersonOneAddressState_ME",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Maine"
+          },
+          {
+            "code": "PersonOneAddressState_MH",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Marshall Islands"
+          },
+          {
+            "code": "PersonOneAddressState_MD",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Maryland"
+          },
+          {
+            "code": "PersonOneAddressState_MA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Massachusetts"
+          },
+          {
+            "code": "PersonOneAddressState_MI",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Michigan"
+          },
+          {
+            "code": "PersonOneAddressState_MN",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Minnesota"
+          },
+          {
+            "code": "PersonOneAddressState_MS",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Mississippi"
+          },
+          {
+            "code": "PersonOneAddressState_MO",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Missouri"
+          },
+          {
+            "code": "PersonOneAddressState_MT",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Montana"
+          },
+          {
+            "code": "PersonOneAddressState_NE",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Nebraska"
+          },
+          {
+            "code": "PersonOneAddressState_NV",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Nevada"
+          },
+          {
+            "code": "PersonOneAddressState_NH",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New Hampshire"
+          },
+          {
+            "code": "PersonOneAddressState_NJ",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New Jersey"
+          },
+          {
+            "code": "PersonOneAddressState_NM",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New Mexico"
+          },
+          {
+            "code": "PersonOneAddressState_NY",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New York"
+          },
+          {
+            "code": "PersonOneAddressState_NC",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "North Carolina"
+          },
+          {
+            "code": "PersonOneAddressState_MP",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "North Marianas Islands"
+          },
+          {
+            "code": "PersonOneAddressState_ND",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "North Dakota"
+          },
+          {
+            "code": "PersonOneAddressState_OH",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Ohio"
+          },
+          {
+            "code": "PersonOneAddressState_OK",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Oklahoma"
+          },
+          {
+            "code": "PersonOneAddressState_OR",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Oregon"
+          },
+          {
+            "code": "PersonOneAddressState_PW",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Palau"
+          },
+          {
+            "code": "PersonOneAddressState_PA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Pennsylvania"
+          },
+          {
+            "code": "PersonOneAddressState_PR",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Puerto Rico"
+          },
+          {
+            "code": "PersonOneAddressState_RI",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Rhode Island"
+          },
+          {
+            "code": "PersonOneAddressState_SC",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "South Carolina"
+          },
+          {
+            "code": "PersonOneAddressState_SD",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "South Dakota"
+          },
+          {
+            "code": "PersonOneAddressState_TN",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Tennessee"
+          },
+          {
+            "code": "PersonOneAddressState_TX",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Texas"
+          },
+          {
+            "code": "PersonOneAddressState_UT",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Utah"
+          },
+          {
+            "code": "PersonOneAddressState_VT",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Vermont"
+          },
+          {
+            "code": "PersonOneAddressState_VA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Virginia"
+          },
+          {
+            "code": "PersonOneAddressState_VI",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Virgin Islands"
+          },
+          {
+            "code": "PersonOneAddressState_WA",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Washington"
+          },
+          {
+            "code": "PersonOneAddressState_WV",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "West Virginia"
+          },
+          {
+            "code": "PersonOneAddressState_WI",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Wisconsin"
+          },
+          {
+            "code": "PersonOneAddressState_WY",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Wyoming"
+          }
+        ],
+        "linkId": "10409",
+        "text": "person 1 state",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "PersonOneAddress_PersonOneAddressZipCode",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "10412",
+        "repeats": false,
+        "type": "text",
+        "text": "PersonOneAddress_PersonOneAddressZipCode"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneEmail",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "5796",
+        "text": "person 1 email address",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "c\u00f3digo/ n\u00famero de tel\u00e9fono"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneTelephone",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "10413",
+        "text": "person 1 phone number",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "c\u00f3digo/ n\u00famero de tel\u00e9fono"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_PersonOneRelationship",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "PersonOneRelationship_SpousePartner",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "spouse/partner"
+          },
+          {
+            "code": "PersonOneRelationship_Friend",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "friend"
+          },
+          {
+            "code": "PersonOneRelationship_ParentGuardian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "parent/guardian"
+          },
+          {
+            "code": "PersonOneRelationship_Child",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "child"
+          },
+          {
+            "code": "PersonOneRelationship_Relative",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "relative"
+          }
+        ],
+        "linkId": "5798",
+        "text": "relationship to you",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "relaci\u00f3n con el entrevistado"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsFirstName",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9771",
+        "text": "person 2 first name",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "nombre"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsMiddleInitial",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9772",
+        "text": "person 2 middle initial",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "nombre"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsLastName",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9773",
+        "text": "person 2 last name",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "apellido"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsAddressOne",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9774",
+        "text": "person 2 address 1",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "direcci\u00f3n postal"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsAddressTwo",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9775",
+        "text": "person 2 address 2",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "direcci\u00f3n - l\u00ednea adicional (opcional)"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondContactsAddress_SecondContactCity",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9776",
+        "text": "person 2 city",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "ciudad"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondContactsAddress_SecondContactState",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SecondContactState_Alabama",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Alabama"
+          },
+          {
+            "code": "SecondContactState_Alaska",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Alaska"
+          },
+          {
+            "code": "SecondContactState_AmericanSamoa",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "American Samoa"
+          },
+          {
+            "code": "SecondContactState_Arizona",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Arizona"
+          },
+          {
+            "code": "SecondContactState_Arkansas",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Arkansas"
+          },
+          {
+            "code": "SecondContactState_California",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "California"
+          },
+          {
+            "code": "SecondContactState_Colorado",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Colorado"
+          },
+          {
+            "code": "SecondContactState_Connecticut",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Connecticut"
+          },
+          {
+            "code": "SecondContactState_DistrictofColumbia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "District of Columbia"
+          },
+          {
+            "code": "SecondContactState_Delaware",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Delaware"
+          },
+          {
+            "code": "SecondContactState_FederatedStatesofMicronesia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Federated States of Micronesia"
+          },
+          {
+            "code": "SecondContactState_Florida",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Florida"
+          },
+          {
+            "code": "SecondContactState_Georgia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Georgia"
+          },
+          {
+            "code": "SecondContactState_Guam",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Guam"
+          },
+          {
+            "code": "SecondContactState_Hawaii",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Hawaii"
+          },
+          {
+            "code": "SecondContactState_Idaho",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Idaho"
+          },
+          {
+            "code": "SecondContactState_Illinois",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Illinois"
+          },
+          {
+            "code": "SecondContactState_Indiana",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Indiana"
+          },
+          {
+            "code": "SecondContactState_Iowa",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Iowa"
+          },
+          {
+            "code": "SecondContactState_Kansas",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Kansas"
+          },
+          {
+            "code": "SecondContactState_Kentucky",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Kentucky"
+          },
+          {
+            "code": "SecondContactState_Louisiana",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Louisiana"
+          },
+          {
+            "code": "SecondContactState_Maine",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Maine"
+          },
+          {
+            "code": "SecondContactState_MarshallIslands",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Marshall Islands"
+          },
+          {
+            "code": "SecondContactState_Maryland",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Maryland"
+          },
+          {
+            "code": "SecondContactState_Massachusetts",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Massachusetts"
+          },
+          {
+            "code": "SecondContactState_Michigan",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Michigan"
+          },
+          {
+            "code": "SecondContactState_Minnesota",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Minnesota"
+          },
+          {
+            "code": "SecondContactState_Mississippi",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Mississippi"
+          },
+          {
+            "code": "SecondContactState_Missouri",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Missouri"
+          },
+          {
+            "code": "SecondContactState_Montana",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Montana"
+          },
+          {
+            "code": "SecondContactState_Nebraska",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Nebraska"
+          },
+          {
+            "code": "SecondContactState_Nevada",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Nevada"
+          },
+          {
+            "code": "SecondContactState_NewHampshire",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New Hampshire"
+          },
+          {
+            "code": "SecondContactState_NewJersey",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New Jersey"
+          },
+          {
+            "code": "SecondContactState_NewMexico",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New Mexico"
+          },
+          {
+            "code": "SecondContactState_NewYork",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "New York"
+          },
+          {
+            "code": "SecondContactState_NorthCarolina",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "North Carolina"
+          },
+          {
+            "code": "SecondContactState_NorthMarianasIslands",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "North Marianas Islands"
+          },
+          {
+            "code": "SecondContactState_NorthDakota",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "North Dakota"
+          },
+          {
+            "code": "SecondContactState_Ohio",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Ohio"
+          },
+          {
+            "code": "SecondContactState_Oklahoma",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Oklahoma"
+          },
+          {
+            "code": "SecondContactState_Oregon",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Oregon"
+          },
+          {
+            "code": "SecondContactState_Palau",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Palau"
+          },
+          {
+            "code": "SecondContactState_Pennsylvania",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Pennsylvania"
+          },
+          {
+            "code": "SecondContactState_PuertoRico",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Puerto Rico"
+          },
+          {
+            "code": "SecondContactState_RhodeIsland",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Rhode Island"
+          },
+          {
+            "code": "SecondContactState_SouthCarolina",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "South Carolina"
+          },
+          {
+            "code": "SecondContactState_SouthDakota",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "South Dakota"
+          },
+          {
+            "code": "SecondContactState_Tennessee",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Tennessee"
+          },
+          {
+            "code": "SecondContactState_Texas",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Texas"
+          },
+          {
+            "code": "SecondContactState_Utah",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Utah"
+          },
+          {
+            "code": "SecondContactState_Vermont",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Vermont"
+          },
+          {
+            "code": "SecondContactState_Virginia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Virginia"
+          },
+          {
+            "code": "SecondContactState_VirginIslands",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Virgin Islands"
+          },
+          {
+            "code": "SecondContactState_Washington",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Washington"
+          },
+          {
+            "code": "SecondContactState_WestVirginia",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "West Virginia"
+          },
+          {
+            "code": "SecondContactState_Wisconsin",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Wisconsin"
+          },
+          {
+            "code": "SecondContactState_Wyoming",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "Wyoming"
+          }
+        ],
+        "linkId": "10459",
+        "text": "person 2 state",
+        "repeats": false,
+        "type": "choice"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondContactsAddress_SecondContactZipCode",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "10414",
+        "repeats": false,
+        "type": "text",
+        "text": "SecondContactsAddress_SecondContactZipCode"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsEmail",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "9779",
+        "text": "person 2 email address",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "correo electr\u00f3nico"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsNumber",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "linkId": "10415",
+        "text": "person 2 phone number",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "c\u00f3digo/ n\u00famero de tel\u00e9fono"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "text"
+      },
+      {
+        "concept": [
+          {
+            "code": "SecondaryContactInfo_SecondContactsRelationship",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+          }
+        ],
+        "option": [
+          {
+            "code": "SecondContactsRelationship_SpousePartner",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "spouse/partner"
+          },
+          {
+            "code": "SecondContactsRelationship_Friend",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "friend"
+          },
+          {
+            "code": "SecondContactsRelationship_ParentGuardian",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "parent/guardian"
+          },
+          {
+            "code": "SecondContactsRelationship_Child",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "child"
+          },
+          {
+            "code": "SecondContactsRelationship_Relative",
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "display": "relative"
+          }
+        ],
+        "linkId": "9782",
+        "text": "relationship to you",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "relaci\u00f3n con el entrevistado"
+                }
+              ]
+            }
+          ]
+        },
+        "repeats": false,
+        "type": "choice"
+      }
+    ],
+    "text": "This set of items asks about your background, household, and contact information. The purpose is to gather some general information about you.",
+    "repeats": false
+  }
+}

--- a/rest-api/test/test-data/questionnaire_the_basics_resp.json
+++ b/rest-api/test/test-data/questionnaire_the_basics_resp.json
@@ -1,0 +1,338 @@
+{
+  "status": "completed",
+  "resourceType": "QuestionnaireResponse",
+  "id": "851847069",
+  "authored": "2017-07-11T16:32:40+00:00",
+  "subject": {
+    "reference": "Patient/{participant_id}"
+  },
+  "questionnaire": {
+    "reference": "Questionnaire/{questionnaire_id}"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+      "valueCode": "en"
+    }
+  ],
+  "group": {
+    "linkId": "root_group",
+    "title": "the basics",
+    "question": [
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "Birthplace_USA",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "USA"
+            }
+          }
+        ],
+        "linkId": "5690",
+        "text": "In what country were you born?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfEn qu\u00e9 pa\u00eds naci\u00f3?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "WhiteSpecific_Polish",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "Polish"
+            }
+          }
+        ],
+        "linkId": "9823",
+        "text": "White ",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Blanco"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "GenderIdentity_NonBinary",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "non-binary"
+            }
+          }
+        ],
+        "linkId": "5708",
+        "text": "What terms best express how you describe your gender identity? (Check all that apply)",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfQu\u00e9 t\u00e9rmino expresa mejor la manera en que describe su identidad sexual?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "CloserGenderDescription_SpecifiedGender",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "none of these describe me, and I want to specify"
+            }
+          }
+        ],
+        "linkId": "9360",
+        "text": "Are any of these a closer description to your gender identity? (Check all that apply)",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfAlguna de estas opciones se acerca m\u00e1s a la descripci\u00f3n de su identidad sexual?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "AvtiveDutyServeStatus_Yes",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "yes"
+            }
+          }
+        ],
+        "linkId": "5726",
+        "text": "Have you ever served on active duty in the United States Armed forces, either in the regular military or in a National Guard or military reserve unit? \n\nNote: Active duty does not include training for the Reserves or National Guard, but DOES include activation, for example, for the Persian Gulf War.",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfAlguna vez ha estado en servicio activo en las Fuerzas Armadas de los Estados Unidos, ya sea en el servicio militar regular, en la Guardia Nacional o en una unidad de reserva militar? \n\nImportante: El servicio activo no incluye el entrenamiento para las reservas o la Guardia Nacional, pero S\u00cd incluye la incorporaci\u00f3n, por ejemplo, para la Guerra del Golfo P\u00e9rsico."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "CurrentMaritalStatus_Separated",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "separated"
+            }
+          }
+        ],
+        "linkId": "5729",
+        "text": "What is your current marital status?\n\n",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1l es su estado civil actual?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "HealthInsurance_No",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "no"
+            }
+          }
+        ],
+        "linkId": "9762",
+        "text": "Are you covered by health insurance or some other kind of health care plan?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfEst\u00e1 cubierto por un seguro de salud o alg\u00fan otro tipo de plan de atenci\u00f3n m\u00e9dica?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "EmploymentStatus_OutOfWorkOneOrMore",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "out of work for 1 year or more"
+            }
+          }
+        ],
+        "linkId": "5742",
+        "text": "What is your current employment status?  Please select 1 or more of these categories. ",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1l es su situaci\u00f3n laboral actual?  Seleccione 1 o m\u00e1s de estas categor\u00edas."
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "CurrentHomeOwn_OtherArrangement",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "other arrangement"
+            }
+          }
+        ],
+        "linkId": "5758",
+        "text": "Do you own or rent the place where you live?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "Es propietario de su casa o alquila?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "HowManyLivingYears_1to2",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "1-2 years"
+            }
+          }
+        ],
+        "linkId": "5765",
+        "text": "How many years have you lived at your current address?",
+        "_text": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/translation",
+              "extension": [
+                {
+                  "url": "lang",
+                  "valueCode": "es"
+                },
+                {
+                  "url": "content",
+                  "valueString": "\u00bfCu\u00e1ntos a\u00f1os ha vivido en su direcci\u00f3n actual?"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "StableHouseConcern_Yes",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+              "display": "yes"
+            }
+          }
+        ],
+        "linkId": "5769",
+        "text": "In the past 6 months, have you been worried or concerned about NOT having a place to live?"
+      }
+    ],
+    "text": "This set of items asks about your background, household, and contact information. The purpose is to gather some general information about you."
+  }
+}

--- a/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
+++ b/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
@@ -368,7 +368,10 @@ class QuestionnaireResponseApiTest(FlaskTestBase):
 
   def test_invalid_questionnaire_linkid(self):
     """
-    Make sure that an invalid link id in response triggers a Bad Request status
+    DA-623 - Make sure that an invalid link id in response triggers a BadRequest status.
+    Per a PTSC group request, invalid link ids only log a message for invalid link ids.
+    In the future if questionnaires with bad link ids trigger a BadRequest, the code below
+    can be uncommented.
     """
     participant_id = self.create_participant()
     self.send_consent(participant_id)
@@ -388,7 +391,9 @@ class QuestionnaireResponseApiTest(FlaskTestBase):
                               expected_status=httplib.OK)
 
     # Alter response to set a bad link id value
-    resource['group']['question'][0]['linkId'] = 'bad-link-id'
+    # resource['group']['question'][0]['linkId'] = 'bad-link-id'
 
-    self.send_post(_questionnaire_response_url(participant_id), resource,
-                              expected_status=httplib.BAD_REQUEST)
+    # # DA-623 - Per the PTSC groups request, invalid link ids only log a message for
+    # invalid link ids.
+    # self.send_post(_questionnaire_response_url(participant_id), resource,
+    #                           expected_status=httplib.BAD_REQUEST)

--- a/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
+++ b/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
@@ -127,9 +127,12 @@ class QuestionnaireResponseApiTest(FlaskTestBase):
     with FakeClock(TIME_1):
       participant_id = self.create_participant()
       self.send_consent(participant_id)
-    questionnaire_id = self.create_questionnaire('questionnaire_demographics.json')
-    with open(data_path('questionnaire_response_demographics.json')) as f:
+
+    questionnaire_id = self.create_questionnaire('questionnaire_the_basics.json')
+
+    with open(data_path('questionnaire_the_basics_resp.json')) as f:
       resource = json.load(f)
+
     resource['subject']['reference'] = \
       resource['subject']['reference'].format(participant_id=participant_id)
     resource['questionnaire']['reference'] = \
@@ -321,9 +324,11 @@ class QuestionnaireResponseApiTest(FlaskTestBase):
     self.assertJsonResponseMatches(expected, summary)
 
     # verify if the response is not consent, the primary language will not change
-    questionnaire_id = self.create_questionnaire('questionnaire3.json')
-    with open(data_path('questionnaire_response3.json')) as f:
+    questionnaire_id = self.create_questionnaire('questionnaire_family_history.json')
+
+    with open(data_path('questionnaire_family_history_resp.json')) as f:
       resource = json.load(f)
+
     resource['subject']['reference'] = \
       resource['subject']['reference'].format(participant_id=participant_id)
     resource['questionnaire']['reference'] = \
@@ -361,3 +366,29 @@ class QuestionnaireResponseApiTest(FlaskTestBase):
     self.send_post(_questionnaire_response_url(participant_id), resource,
                    expected_status=httplib.BAD_REQUEST)
 
+  def test_invalid_questionnaire_linkid(self):
+    """
+    Make sure that an invalid link id in response triggers a Bad Request status
+    """
+    participant_id = self.create_participant()
+    self.send_consent(participant_id)
+
+    questionnaire_id = self.create_questionnaire('questionnaire_family_history.json')
+
+    with open(data_path('questionnaire_family_history_resp.json')) as fd:
+      resource = json.load(fd)
+
+    # update resource json to set participant and questionnaire ids.
+    resource['subject']['reference'] = \
+      resource['subject']['reference'].format(participant_id=participant_id)
+    resource['questionnaire']['reference'] = \
+      resource['questionnaire']['reference'].format(questionnaire_id=questionnaire_id)
+
+    self.send_post(_questionnaire_response_url(participant_id), resource,
+                              expected_status=httplib.OK)
+
+    # Alter response to set a bad link id value
+    resource['group']['question'][0]['linkId'] = 'bad-link-id'
+
+    self.send_post(_questionnaire_response_url(participant_id), resource,
+                              expected_status=httplib.BAD_REQUEST)

--- a/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
+++ b/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
@@ -369,7 +369,7 @@ class QuestionnaireResponseApiTest(FlaskTestBase):
   def test_invalid_questionnaire_linkid(self):
     """
     DA-623 - Make sure that an invalid link id in response triggers a BadRequest status.
-    Per a PTSC group request, invalid link ids only log a message for invalid link ids.
+    Per a PTSC group request, only log a message for invalid link ids.
     In the future if questionnaires with bad link ids trigger a BadRequest, the code below
     can be uncommented.
     """

--- a/rest-api/test/unit_test/dao_test/questionnaire_response_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/questionnaire_response_dao_test.py
@@ -656,8 +656,17 @@ class QuestionnaireResponseDaoTest(FlaskTestBase):
         self.LN_QUESTION.linkId,
         self.EMAIL_QUESTION.linkId,
         consent_paths)
+
+    # We need to remove the unused answers in the resource so we don't trigger an unused
+    # link id exception.
+    res_len = len(resource['group']['question']) - 1
+    for idx in range(res_len, -1, -1):
+      if resource['group']['question'][idx]['linkId'].isdigit() is True:
+        del resource['group']['question'][idx]
+
     questionnaire_response = self.questionnaire_response_dao.from_client_json(
         resource, participant.participantId)
+
     return questionnaire_response
 
   @mock.patch('dao.questionnaire_response_dao._raise_if_gcloud_file_missing')


### PR DESCRIPTION
_Note: This change closes a loophole that was used by many unit tests, it is unknown if Health Pro or PTSC are knowingly or inadvertently using this loophole._ 

Before this change extra/invalid answers added to a questionnaire response were silently ignored.  With this change, every questionnaire response must use either a full set or a sub set of answer link ids found in the questionnaire. No extra or invalid answer link ids are allowed.

Many of the unit tests took advantage of this loophole to use mixed questionnaire and response json data to test for specific answers within the response.  Closing this loophole required refactoring many unit tests and creating new questionnaire and response json data to test with.