### PR TITLE
Fix for [DA-820] Use correct phone number value from spreadsheet

### DIFF
--- a/rdr_client/check_ppi_data.py
+++ b/rdr_client/check_ppi_data.py
@@ -21,7 +21,7 @@ import urllib2
 import re
 
 from client import Client
-from code_constants import EMAIL_QUESTION_CODE as EQC, PHONE_NUMBER_QUESTION_CODE as PNQC
+from code_constants import EMAIL_QUESTION_CODE as EQC, LOGIN_PHONE_NUMBER_QUESTION_CODE as PNQC
 from main_util import get_parser, configure_logging
 
 


### PR DESCRIPTION
The check_ppi_data.py script should use ConsentPII_VerifiedPrimaryPhoneNumber value for for matching phone numbers given on the command line.