### PR TITLE
Add 'google-auth-httplib2' to requirements.txt to fix delete keys cron job

### DIFF
--- a/rest-api/requirements.txt
+++ b/rest-api/requirements.txt
@@ -22,6 +22,7 @@ dictalchemy>=0.1.2.7
 MySQL-python>=1.2.5
 protorpc>=0.12.0
 parameterized>=0.6.1
+google-auth-httplib2
 googlemaps>=2.5.1
 google-api-python-client==1.6.6
 backoff


### PR DESCRIPTION
'google-auth-httplib2' is depreciated, an no longer recommended for use.  The other google packages no longer include it, so pip does not automatically install it anymore.  This pull request is to insure the package is installed to make sure the delete key cron job runs.