### PR TITLE
[DA-859] Refactor participant summary token sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,29 @@ Example sync:
 Pagination is provided with a token i.e.
 
     GET /ParticipantSummary?awardee=PITT&_sort=lastModified&_token=<token string>
+    
+By default when the '_sync' parameter is passed, records modified 60 seconds before the 
+last record in a batch of record will be included in the next batch of records. This 
+backfill behavior may be disabled by adding the '_backfill=false' parameter.
+
+    GET /ParticipantSummary?awardee=PITT&_sort=lastModified&_sync=true&_backfill=false
 
 It is possible to get the same participant data back in multiple sync responses.
 The recommended time between syncs is 5 minutes.
+
+#### `GET /ParticipantSummary/Modified`
+
+As an alternate method of synchronizing participant summary records, you can use this API call
+to return 'participantId' and 'lastModified' values for all records.  This allows you to see 
+which records are new and which have changed if you are storing these records in your system.
+
+    GET /ParticipantSummary/Modified
+    
+For service accounts access, the awardee parameter is required. Only records matching the
+awardee will be returned.
+
+    GET /ParticipantSummary/Modified?awardee=PITT
+
 
 See FHIR search prefixes below
 

--- a/rest-api/api/base_api.py
+++ b/rest-api/api/base_api.py
@@ -28,6 +28,20 @@ class BaseApi(Resource):
     self.dao = dao
     self._get_returns_children = get_returns_children
 
+  def _get_request_arg_bool(self, key, default=False):
+    """
+    Return boolean value for the given request parameter key.
+    :param key: key name
+    :param default: default to use when key does not exist in arguments.
+    :return: if key exists return value, otherwise return default.
+    """
+    if isinstance(default, bool) is False:
+      raise ValueError('invalid value for default parameter')
+
+    if key not in request.args:
+      return default
+    return request.args.get(key).lower() == 'true'
+
   def get(self, id_=None, participant_id=None):
     """Handle a GET request.
 

--- a/rest-api/api/participant_summary_api.py
+++ b/rest-api/api/participant_summary_api.py
@@ -3,7 +3,9 @@ from api_util import PTC_HEALTHPRO_AWARDEE, AWARDEE, DEV_MAIL
 from app_util import auth_required, get_validated_user_info
 from dao.participant_summary_dao import ParticipantSummaryDao
 from flask import request
-from werkzeug.exceptions import Forbidden, InternalServerError
+from model.participant_summary import ParticipantSummary
+from model.hpo import HPO
+from werkzeug.exceptions import Forbidden, InternalServerError, BadRequest
 
 
 class ParticipantSummaryApi(BaseApi):
@@ -39,15 +41,57 @@ class ParticipantSummaryApi(BaseApi):
 
   def _make_query(self):
     query = super(ParticipantSummaryApi, self)._make_query()
-    if self._is_last_modified_sync():
-      query.always_return_token = True
-
+    query.always_return_token = self._get_request_arg_bool('_sync')
+    query.backfill_sync = self._get_request_arg_bool('_backfill', True)
     return query
 
   def _make_bundle(self, results, id_field, participant_id):
-    if self._is_last_modified_sync():
+    if self._get_request_arg_bool('_sync'):
       return make_sync_results_for_request(self.dao, results)
     return super(ParticipantSummaryApi, self)._make_bundle(results, id_field, participant_id)
 
-  def _is_last_modified_sync(self):
-    return request.args.get('_sync') == 'true'
+
+class ParticipantSummaryModifiedApi(BaseApi):
+  """
+  API to return participant_id and last_modified fields
+  """
+  def __init__(self):
+    super(ParticipantSummaryModifiedApi, self).__init__(ParticipantSummaryDao())
+
+  def get(self):
+    """
+    Return participant_id and last_modified for all records or a subset based
+    on the awardee parameter.
+    """
+    response = list()
+    user_email, user_info = get_validated_user_info()
+    request_awardee = None
+
+    with self.dao.session() as session:
+
+      # validate parameter when passed an awardee.
+      if 'awardee' in request.args:
+        request_awardee = request.args.get('awardee')
+        hpo = session.query(HPO.hpoId).filter(HPO.name == request_awardee).first()
+        if not hpo:
+          raise BadRequest('invalid awardee')
+
+      # verify user has access to the requested awardee.
+      if AWARDEE in user_info['roles'] and user_email != DEV_MAIL:
+        try:
+          if not request_awardee or user_info['awardee'] != request_awardee:
+            raise Forbidden
+        except KeyError:
+          raise InternalServerError("config error for awardee")
+
+      query = session.query(ParticipantSummary.participantId, ParticipantSummary.lastModified)
+      query = query.order_by(ParticipantSummary.participantId)
+      if request_awardee:
+        query = query.filter(ParticipantSummary.hpoId == hpo.hpoId)
+
+      items = query.all()
+      for item in items:
+        response.append({'participantId': 'P{0}'.format(item.participantId),
+                         'lastModified': item.lastModified.isoformat()})
+
+    return response

--- a/rest-api/dao/participant_summary_dao.py
+++ b/rest-api/dao/participant_summary_dao.py
@@ -572,12 +572,11 @@ class ParticipantSummaryDao(UpdatableDao):
     seconds. Duplicate participants returned should be handled on the client side."""
     decoded_vals = super(ParticipantSummaryDao, self)._decode_token(query_def, fields)
     if query_def.order_by and (query_def.order_by.field_name == 'lastModified' and
-                                            query_def.always_return_token == True):
+         query_def.always_return_token is True and query_def.backfill_sync is True):
       decoded_vals[0] = decoded_vals[0] - datetime.timedelta(
                                           seconds=config.LAST_MODIFIED_BUFFER_SECONDS)
 
     return decoded_vals
-
 
 def _initialize_field_type_sets():
   """Using reflection, populate _DATE_FIELDS, _ENUM_FIELDS, and _CODE_FIELDS, which are

--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -17,7 +17,7 @@ from api.metrics_api import MetricsApi
 from api.metrics_fields_api import MetricsFieldsApi
 from api.participant_api import ParticipantApi
 from api.participant_counts_over_time_api import ParticipantCountsOverTimeApi
-from api.participant_summary_api import ParticipantSummaryApi
+from api.participant_summary_api import ParticipantSummaryApi, ParticipantSummaryModifiedApi
 from api.physical_measurements_api import PhysicalMeasurementsApi, sync_physical_measurements
 from api.questionnaire_api import QuestionnaireApi
 from api.questionnaire_response_api import QuestionnaireResponseApi
@@ -72,6 +72,11 @@ api.add_resource(ParticipantSummaryApi,
                  PREFIX + 'Participant/<participant_id:p_id>/Summary',
                  PREFIX + 'ParticipantSummary',
                  endpoint='participant.summary',
+                 methods=['GET'])
+
+api.add_resource(ParticipantSummaryModifiedApi,
+                 PREFIX + 'ParticipantSummary/Modified',
+                 endpoint='participant.summary.modified',
                  methods=['GET'])
 
 api.add_resource(PhysicalMeasurementsApi,


### PR DESCRIPTION
Added an API parameter to disable 60 second backfill buffer.
Added new API 'ParticipantSummary/Modified' to allow grabbing a full table snapshot of what records have changed and what records are new.