### PR TITLE
Only point DB service connections to primary db.

### DIFF
--- a/rest-api/services/gcp_config.py
+++ b/rest-api/services/gcp_config.py
@@ -17,10 +17,10 @@ GCP_PROJECTS = [
 GCP_INSTANCES = {
   'all-of-us-rdr-prod': 'all-of-us-rdr-prod:us-central1:rdrmaindb',
   'all-of-us-rdr-stable': 'all-of-us-rdr-stable:us-central1:rdrmaindb',
-  'all-of-us-rdr-staging': 'all-of-us-rdr-staging:us-central1:rdrbackupdb',
+  'all-of-us-rdr-staging': 'all-of-us-rdr-staging:us-central1:rdrmaindb',
   'all-of-us-rdr-sandbox': 'all-of-us-rdr-sandbox:us-central1:rdrmaindb',
   'pmi-drc-api-test': 'pmi-drc-api-test:us-central1:rdrmaindb',
-  'pmi-drc-api-test-repl': 'pmi-drc-api-test:us-central1:rdrbackupdb',
+  'pmi-drc-api-test-repl': 'pmi-drc-api-test:us-central1:rdrmaindb',
 }
 
 


### PR DESCRIPTION
This changes the DB services script to point at the Primary DB instead of the Backup DB for the Test and Staging environments.