### PR TITLE
DA-982 Metrics EHR endpoint as multiple single-purpose endpoints

### DIFF
--- a/rest-api/api/metrics_ehr_api.py
+++ b/rest-api/api/metrics_ehr_api.py
@@ -15,28 +15,21 @@ import app_util
 DATE_FORMAT = '%Y-%m-%d'
 
 
-class MetricsEhrApi(Resource):
+class MetricsEhrApiBaseResource(Resource):
 
-  @app_util.auth_required(HEALTHPRO)
-  def get(self):
+  def parse_input(self):
     validators = {
       'start_date': self._parse_date,
       'end_date': self._parse_date,
       'awardee_names': self._parse_comma_separated,
       'interval': functools.partial(self._parse_choice, INTERVALS)
     }
-    valid_arguments = self._parse_input(validators, {
+    return self._parse_input(validators, {
       'start_date': request.args.get('start_date'),
       'end_date': request.args.get('end_date'),
       'awardee_names': request.args.get('awardee'),  # NOTE: non-ideal name to match existing APIs
       'interval': request.args.get('interval'),
     })
-    return MetricsEhrService().get_metrics(
-      start_date=valid_arguments['start_date'],
-      end_date=valid_arguments['end_date'],
-      interval=valid_arguments['interval'],
-      site_ids=self._get_hpo_ids_from_awardee_names(valid_arguments['awardee_names']),
-    )
 
   @staticmethod
   def _parse_input(validators, params):
@@ -87,3 +80,68 @@ class MetricsEhrApi(Resource):
       ]
     except AttributeError:
       raise BadRequest('Invalid awardees {value}'.format(value=','.join(awardee_names)))
+
+
+class MetricsEhrApi(MetricsEhrApiBaseResource):
+  """
+  A combined view of:
+  - Participant EHR Consented vs EHR Received Over Time
+  - Sites Active Over Time
+  - Site Participant Status Counts At Specific Time (end_date)
+  """
+
+  @app_util.auth_required(HEALTHPRO)
+  def get(self):
+    valid_arguments = self.parse_input()
+    return MetricsEhrService().get_metrics(
+      start_date=valid_arguments['start_date'],
+      end_date=valid_arguments['end_date'],
+      interval=valid_arguments['interval'],
+      site_ids=self._get_hpo_ids_from_awardee_names(valid_arguments['awardee_names']),
+    )
+
+
+class ParticipantEhrMetricsOverTimeApi(MetricsEhrApiBaseResource):
+  """
+  Participant EHR Consented vs EHR Received Over Time
+  """
+
+  @app_util.auth_required(HEALTHPRO)
+  def get(self):
+    valid_arguments = self.parse_input()
+    return MetricsEhrService().get_participant_ehr_metrics_over_time_data(
+      start_date=valid_arguments['start_date'],
+      end_date=valid_arguments['end_date'],
+      interval=valid_arguments['interval'],
+      hpo_ids=self._get_hpo_ids_from_awardee_names(valid_arguments['awardee_names']),
+    )
+
+
+class SitesActiveMetricsOverTimeApi(MetricsEhrApiBaseResource):
+  """
+  Sites Active Over Time
+  """
+
+  @app_util.auth_required(HEALTHPRO)
+  def get(self):
+    valid_arguments = self.parse_input()
+    return MetricsEhrService().get_sites_active_over_time_data(
+      start_date=valid_arguments['start_date'],
+      end_date=valid_arguments['end_date'],
+      interval=valid_arguments['interval'],
+      hpo_ids=self._get_hpo_ids_from_awardee_names(valid_arguments['awardee_names']),
+    )
+
+
+class SiteMetricsApi(MetricsEhrApiBaseResource):
+  """
+  Site Participant Status Counts At Specific Time (end_date)
+  """
+
+  @app_util.auth_required(HEALTHPRO)
+  def get(self):
+    valid_arguments = self.parse_input()
+    return MetricsEhrService().get_site_metrics_data(
+      end_date=valid_arguments['end_date'],
+      hpo_ids=self._get_hpo_ids_from_awardee_names(valid_arguments['awardee_names']),
+    )

--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -15,7 +15,7 @@ from api.dv_order_api import DvOrderApi
 from api.import_codebook_api import import_codebook
 from api.metric_sets_api import MetricSetsApi
 from api.metrics_api import MetricsApi
-from api.metrics_ehr_api import MetricsEhrApi
+from api import metrics_ehr_api
 from api.public_metrics_api import PublicMetricsApi
 from api.metrics_fields_api import MetricsFieldsApi
 from api.participant_api import ParticipantApi
@@ -113,9 +113,24 @@ api.add_resource(MetricSetsApi,
                  endpoint='metric_sets',
                  methods=['GET'])
 
-api.add_resource(MetricsEhrApi,
+api.add_resource(metrics_ehr_api.MetricsEhrApi,
                  PREFIX + 'MetricsEHR',
                  endpoint='metrics_ehr',
+                 methods=['GET'])
+
+api.add_resource(metrics_ehr_api.ParticipantEhrMetricsOverTimeApi,
+                 PREFIX + 'MetricsEHR/ParticipantsOverTime',
+                 endpoint='metrics_ehr.participants_over_time',
+                 methods=['GET'])
+
+api.add_resource(metrics_ehr_api.SitesActiveMetricsOverTimeApi,
+                 PREFIX + 'MetricsEHR/SitesActiveOverTime',
+                 endpoint='metrics_ehr.sites_active_over_time',
+                 methods=['GET'])
+
+api.add_resource(metrics_ehr_api.SiteMetricsApi,
+                 PREFIX + 'MetricsEHR/Sites',
+                 endpoint='metrics_ehr.sites',
                  methods=['GET'])
 
 api.add_resource(PublicMetricsApi,


### PR DESCRIPTION
This API endpoint performs 3 distinct sub-queries and merges the results into one JSON structure.
Allowing access to the results of each query as separate endpoints will allow the dashboard to load them in parallel instead of one longer request.

This maintains the current `combined` endpoint (for now.)
The `combined` logic is still used in the `PublicMetricsApi`.