### PR TITLE
Add a lightweight FHIR R4 object lookup utility

### DIFF
--- a/rdr_common/fhir_utils.py
+++ b/rdr_common/fhir_utils.py
@@ -1,0 +1,40 @@
+class SimpleFhirR4Reader(object):
+  """
+  A lightweight accessor for a FHIR R4 resource. Not intended to replace the fhirclient library.
+  """
+
+  def __init__(self, fhir_data_structure):
+    self._data = fhir_data_structure
+
+  def get(self, *lookup_path, **dict_lookup_keys):
+    obj = self._data
+    if dict_lookup_keys:
+      lookup_path = lookup_path + (dict_lookup_keys,)
+    for key in lookup_path:
+      obj = _lookup_obj_key(obj, key)
+    if isinstance(obj, (list, dict)):
+      return SimpleFhirR4Reader(obj)
+    return obj
+
+  def __getattr__(self, item):
+    obj = self.get(item)
+    if isinstance(obj, (list, dict)):
+      return SimpleFhirR4Reader(obj)
+    return obj
+
+
+def _lookup_obj_key(obj, key):
+  if isinstance(obj, dict):
+    return obj[key]
+  if isinstance(obj, list):
+    if isinstance(key, dict):  # dict key based lookup
+      for x in obj:
+        if _dict_has_values(x, **key):
+          return x
+
+
+def _dict_has_values(obj, **queries):
+  for key, value in queries.items():
+    if obj.get(key) != value:
+      return False
+  return True

--- a/rest-api/test/unit_test/lib_common_test/fhir_utils_test.py
+++ b/rest-api/test/unit_test/lib_common_test/fhir_utils_test.py
@@ -1,0 +1,137 @@
+import unittest
+
+from fhir_utils import SimpleFhirR4Reader
+
+
+EXAMPLE_SUPPLY_REQUEST = {
+  "authoredOn": "2019-02-12",
+  "contained": [
+    {
+      "id": "supplier-1",
+      "name": "GenoTek",
+      "resourceType": "Organization"
+    },
+    {
+      "deviceName": [
+        {
+          "name": "GenoTek DNA Kit",
+          "type": "manufacturer-name"
+        }
+      ],
+      "id": "device-1",
+      "identifier": [
+        {
+          "code": "4081",
+          "system": "SKU"
+        },
+        {
+          "code": "SNOMED CODE TBD",
+          "system": "SNOMED"
+        }
+      ],
+      "resourceType": "Device"
+    },
+    {
+      "address": [
+        {
+          "city": "FakeVille",
+          "line": [
+            "123 Fake St"
+          ],
+          "postalCode": "22155",
+          "state": "VA",
+          "type": "postal",
+          "use": "home"
+        }
+      ],
+      "id": "patient-1",
+      "identifier": [
+        {
+          "system": "participantId",
+          "value": "P748018940"
+        }
+      ],
+      "resourceType": "Patient"
+    }
+  ],
+  "deliverFrom": {
+    "reference": "#supplier-1"
+  },
+  "deliverTo": {
+    "reference": "Patient/#patient-1"
+  },
+  "extension": [
+    {
+      "url": "http://vibrenthealth.com/fhir/order-type",
+      "valueString": "Salivary Pilot"
+    },
+    {
+      "url": "http://vibrenthealth.com/fhir/fullfilment-status",
+      "valueString": "pending"
+    }
+  ],
+  "identifier": [
+    {
+      "code": "99993",
+      "system": "orderId"
+    }
+  ],
+  "itemReference": {
+    "reference": "#device-1"
+  },
+  "quantity": {
+    "value": 1
+  },
+  "requester": {
+    "reference": "Patient/#patient-1"
+  },
+  "resourceType": "SupplyRequest",
+  "status": "active",
+  "supplier": {
+    "reference": "#supplier-1"
+  },
+  "text": {
+    "div": "....",
+    "status": "generated"
+  }
+}
+
+
+class SimpleFhirR4ReaderBasicTestCase(unittest.TestCase):
+
+  def test_dict_lookup(self):
+    fhir = SimpleFhirR4Reader({'a': 'foo'})
+    self.assertEqual(fhir.get('a'), 'foo')
+
+  def test_nested_dict_lookup(self):
+    fhir = SimpleFhirR4Reader({'a': {'b': 'bar'}})
+    self.assertEqual(fhir.get('a', 'b'), 'bar')
+
+  def test_list_lookup(self):
+    fhir = SimpleFhirR4Reader([
+      {'a': 'foo', 'b': 0},
+      {'a': 'bar', 'b': 1},
+    ])
+    self.assertEqual(fhir.get(dict(a='bar'), 'b'), 1)
+
+  def test_attribute_lookup(self):
+    fhir = SimpleFhirR4Reader({
+      'foo': {
+        'bar': {
+          'baz': 123
+        }
+      }
+    })
+    self.assertEqual(fhir.foo.bar.baz, 123)
+
+
+class SimpleFhirR4ReaderSupplyRequestTestCase(unittest.TestCase):
+
+  def setUp(self):
+    self.fhir = SimpleFhirR4Reader(EXAMPLE_SUPPLY_REQUEST)
+
+  def test_lookup_patient_id(self):
+    self.assertEqual(
+      self.fhir.contained.get(resourceType='Patient').identifier.get(system='participantId').value,
+      'P748018940'
+    )


### PR DESCRIPTION
This does not intend to replace the `fhirclient` python package. We currently use `fhirclient==1.0.6` which supports version 1.0.2 of the FHIR spec. 

This utility is intended to be a stop-gap measure for accessing data in FHIR version R4 data structures without requiring a full upgrade of our current `fhirclient` usage.

_When we eventually upgrade `fhirclient`, this code will become deprecated._