### PR TITLE
update deploy process with Cron YAML builder

### DIFF
--- a/rest-api/cron_default.yaml
+++ b/rest-api/cron_default.yaml
@@ -39,13 +39,3 @@ cron:
   schedule: every day 00:10
   timezone: America/New_York
   target: offline
-- description: Sync site bucket consent files
-  url: /offline/SyncConsentFiles
-  schedule: 1 of month 00:00
-  timezone: America/New_York
-  target: offline
-- description: Update EHR Status from curation data
-  url: /offline/UpdateEhrStatus
-  schedule: every day 00:00
-  timezone: America/New_York
-  target: offline

--- a/rest-api/cron_prod.yaml
+++ b/rest-api/cron_prod.yaml
@@ -1,0 +1,11 @@
+cron:
+- description: Sync site bucket consent files
+  url: /offline/SyncConsentFiles
+  schedule: 1 of month 00:00
+  timezone: America/New_York
+  target: offline
+- description: Update EHR Status from curation data
+  url: /offline/UpdateEhrStatus
+  schedule: every day 00:00
+  timezone: America/New_York
+  target: offline

--- a/rest-api/cron_sandbox.yaml
+++ b/rest-api/cron_sandbox.yaml
@@ -1,6 +1,10 @@
 # Daily metrics are omitted for sandbox due to large synthetic dataset.
 # See https://groups.google.com/forum/#!msg/pmi-drc-alerts/ifY__zLf5k8/TlCMREA4CwAJ
 cron:
+- description: Daily metrics
+- description: Monthly reconciliation report
+- description: Participant count metrics
+- description: Flag ghost participants
 - description: Daily public metrics
   url: /offline/PublicMetricsRecalculate
   schedule: every day 05:00

--- a/rest-api/requirements.txt
+++ b/rest-api/requirements.txt
@@ -21,6 +21,7 @@ alembic>=0.8.10
 dictalchemy>=0.1.2.7
 MySQL-python>=1.2.5
 protorpc>=0.12.0
+PyYAML==5.1
 parameterized>=0.6.1
 google-auth-httplib2
 googlemaps>=2.5.1

--- a/rest-api/tools/build_cron_yaml.py
+++ b/rest-api/tools/build_cron_yaml.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+"""
+Compile the cron YAML file for a project.
+
+see `_compile_job_list` comments for details on merging process.
+"""
+
+import argparse
+import collections
+import os
+import sys
+
+import yaml
+try:
+  from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+  from yaml import Loader, Dumper
+
+if sys.version > '3':
+  imap = map
+else:
+  from itertools import imap
+
+
+BASE_CRON_NAME = 'default'
+PROJECT_NAME_MAPPING = {
+  'all-of-us-rdr-prod': 'prod',
+  'all-of-us-rdr-stable': 'stable',
+  'all-of-us-rdr-staging': 'staging',
+  'all-of-us-rdr-dryrun': 'dryrun',
+  'pmi-drc-api-test': 'test',
+  'all-of-us-rdr-sandbox': 'sandbox',
+}
+
+CRON_SEARCH_LOCATION = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def _get_cron_names_for_project_name(project_name):
+  """
+  Make a list of crons to merge for the given project name.
+  """
+  name = PROJECT_NAME_MAPPING.get(project_name)
+  return filter(bool, [BASE_CRON_NAME, name])
+
+
+def _lazy_chain(iterators):
+  """
+  Iterate the items from each iterator in turn.
+
+  Different than itertools chain because it can take an iterator of iterators instead of needing
+  each iterator argument defined at call time.
+  """
+  for iterator in iterators:
+    for value in iterator:
+      yield value
+
+
+def _get_cron_filename_from_name(name):
+  """
+  Resolve a `name` to a cron yaml file location
+  """
+  return os.path.join(CRON_SEARCH_LOCATION, 'cron_{}.yaml'.format(name))
+
+
+def _load_yaml_file_by_name(name):
+  filename = _get_cron_filename_from_name(name)
+  if filename and os.path.isfile(filename):
+    with open(filename, 'r') as handle:
+      return yaml.load(handle, Loader=Loader)
+
+
+def _compile_job_list(job_iterator):
+  """
+  Make one unified list of jobs from a job iterator.
+  Identify jobs by their `description` or index in the `job_iterator`.
+  Keep the last one in the `job_iterator` for each job identifier.
+  Remove jobs missing the required fields.
+  """
+  jobs_dict = collections.OrderedDict()
+  for i, job in enumerate(job_iterator):
+    job_id = job.get('description', i)
+    if 'url' in job and 'schedule' in job:
+      jobs_dict[job_id] = job
+    elif job_id in jobs_dict:
+      del jobs_dict[job_id]
+  return jobs_dict.values()
+
+
+def build_cron_yaml(project_name, outstream):
+  """
+  Compile the cron YAML file for the given project name.
+  Write to the `outstream`
+  """
+  yaml_names = _get_cron_names_for_project_name(project_name)
+  config_job_list_iterator = [
+    config.get('cron')
+    for config
+    in imap(_load_yaml_file_by_name, yaml_names)
+    if config
+  ]
+  job_iterator = _lazy_chain(config_job_list_iterator)
+  compiled_jobs_list = _compile_job_list(job_iterator)
+  yaml.dump({
+    'cron': compiled_jobs_list
+  }, outstream, Dumper=Dumper)
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--project', required=True)
+  parser.add_argument('--outfile', '-o', type=argparse.FileType('w'), default='-',
+                      help='Default: stdout')
+  args = parser.parse_args()
+  build_cron_yaml(args.project, args.outfile)

--- a/rest-api/tools/deploy_app.sh
+++ b/rest-api/tools/deploy_app.sh
@@ -145,12 +145,7 @@ then
   declare -a tmp_files
 
   # Deploy cron/queue in all cases.
-  CRON_YAML=cron_default.yaml
-  if [ "${PROJECT}" = "all-of-us-rdr-sandbox" ]
-  then
-    CRON_YAML=cron_sandbox.yaml
-  fi
-  cp "${CRON_YAML}" cron.yaml
+  tools/build_cron_yaml.py --project ${PROJECT} > cron.yaml
   yamls+=( cron.yaml queue.yaml )
   tmp_files+=( cron.yaml )
   before_comment="Updating cron/queue configuration in ${PROJECT}."


### PR DESCRIPTION
This change adds a cron.yaml builder script with inheritance and the ability to override/remove inherited cron jobs.

This is needed so we can have mostly shared cron definitions with a few exceptions.

---

## The old system
- if project name is `all-of-us-rdr-sandbox`
    - use `cron_sandbox.yaml`
- else
   - use `cron_default.yaml`

## This system
1. Build list of cron files to combine
    - start with `cron_default.yaml`
    - add `cron_<project_shortname>.yaml` if exists
2. Iterate each job from files in order
    - identify jobs by `description` (cannot be overridden or removed if missing `description`)
    - add new jobs
    - overwrite existing jobs
    - remove existing job if new job is missing either `url` or `schedule` (the required fields)
3. Serialize compiled job list as `cron.yaml`
