### PR TITLE
fix httplib2 error. Now requires authentication header.

### DIFF
--- a/rdr_client/client.py
+++ b/rdr_client/client.py
@@ -7,7 +7,6 @@ import logging
 import pprint
 
 from oauth2client.service_account import ServiceAccountCredentials
-from httplib2 import MalformedHeader
 
 
 SCOPE = 'https://www.googleapis.com/auth/userinfo.email'

--- a/rest-api/test/client_test/requests_test.py
+++ b/rest-api/test/client_test/requests_test.py
@@ -13,7 +13,7 @@ class RequestsTest(BaseClientTest):
         body='{}',
         authenticated=False,
         check_status=False)
-    self.assertEquals(response.status, httplib.UNAUTHORIZED)
+    self.assertEquals(response.status, httplib.BAD_REQUEST)
 
   def test_header_values(self):
     response, _ = self.client.request('Participant', method='POST', body='{}')

--- a/rest-api/test/client_test/requests_test.py
+++ b/rest-api/test/client_test/requests_test.py
@@ -13,7 +13,7 @@ class RequestsTest(BaseClientTest):
         body='{}',
         authenticated=False,
         check_status=False)
-    self.assertEquals(response.status, httplib.BAD_REQUEST)
+    self.assertEquals(response.status, httplib.UNAUTHORIZED)
 
   def test_header_values(self):
     response, _ = self.client.request('Participant', method='POST', body='{}')


### PR DESCRIPTION
After some research I've discovered httplib2 now requires an authentication header, else returns Malformed Header. This is technically correct as per the HTTP spec, though not all libraries require it. This PR uses the `add_credentials` function of httplib2 returning the original expected behavior. What I'm not sure of is, does this have implications for the RDR on the whole. Though I believe appengine uses urllib2 for the app, which does not require auth headers.