### PR TITLE
Fix auto population for 'created' and 'modified' columns in new tables.

### DIFF
--- a/rest-api/genomic/genomic_set_file_handler.py
+++ b/rest-api/genomic/genomic_set_file_handler.py
@@ -173,7 +173,6 @@ def _insert_genomic_set_from_row(row, csv_filename, timestamp):
   Returns:
     A new GenomicSet.
   """
-  now = clock.CLOCK.now()
   genomic_set_name = row[CsvColumns.GENOMIC_SET_NAME],
 
   set_dao = GenomicSetDao()
@@ -185,8 +184,6 @@ def _insert_genomic_set_from_row(row, csv_filename, timestamp):
     genomicSetFileTime=timestamp,
     genomicSetStatus=GenomicSetStatus.UNSET,
     genomicSetVersion=genomic_set_version,
-    created=now,
-    modified=now
   )
 
   genomic_set = GenomicSet(**kwargs)
@@ -202,12 +199,8 @@ def _create_genomic_set_member_from_row(genomic_set_id, row):
   Returns:
     A new GenomicSetMember.
   """
-  now = clock.CLOCK.now()
-
   kwargs = dict(
     genomicSetId=genomic_set_id,
-    created=now,
-    modified=now,
     validationStatus=GenomicValidationStatus.UNSET,
     participantId=row[CsvColumns.PID],
     sexAtBirth=row[CsvColumns.SEX_AT_BIRTH],

--- a/rest-api/model/base.py
+++ b/rest-api/model/base.py
@@ -1,6 +1,6 @@
 """Defines the declarative base. Import this and extend from Base for all rdr
 tables. Extend MetricsBase for all metrics tables."""
-
+import clock
 from sqlalchemy import MetaData
 from sqlalchemy.ext.declarative import declarative_base
 from dictalchemy import DictableModel
@@ -22,6 +22,18 @@ Base = declarative_base(cls=DictableModel)
 # MetricsBase is the parent for all models in the "metrics" DB. These are
 # collected separately for DB migration purposes.
 MetricsBase = declarative_base(cls=DictableModel, metadata=MetaData(schema='metrics'))
+
+# pylint: disable=unused-argument
+def model_insert_listener(mapper, connection, target):
+  """ On insert auto set `created` and `modified` column values """
+  now = clock.CLOCK.now()
+  target.created = now
+  target.modified = now
+
+# pylint: disable=unused-argument
+def model_update_listener(mapper, connection, target):
+  """ On update auto set `modified` column value """
+  target.modified = clock.CLOCK.now()
 
 def get_column_name(model_type, field_name):
   return getattr(model_type, field_name).property.columns[0].name

--- a/rest-api/model/biobank_dv_order.py
+++ b/rest-api/model/biobank_dv_order.py
@@ -1,8 +1,8 @@
-from model.base import Base
+from model.base import Base, model_insert_listener, model_update_listener
 from model.utils import UTCDateTime6, Enum
 from participant_enums import OrderShipmentStatus, OrderShipmentTrackingStatus
 from sqlalchemy import Column, DateTime, Integer, String, ForeignKey, UniqueConstraint, Text,\
-  BigInteger
+  BigInteger, event
 
 
 class BiobankDVOrder(Base):
@@ -106,3 +106,6 @@ class BiobankDVOrder(Base):
   __table_args__ = (
     UniqueConstraint('participant_id', 'order_id', name='uidx_partic_id_order_id'),
   )
+
+event.listen(BiobankDVOrder, 'before_insert', model_insert_listener)
+event.listen(BiobankDVOrder, 'before_update', model_update_listener)

--- a/rest-api/model/genomics.py
+++ b/rest-api/model/genomics.py
@@ -1,7 +1,7 @@
-from model.base import Base
+from model.base import Base, model_insert_listener, model_update_listener
 from model.utils import Enum
 from protorpc import messages
-from sqlalchemy import Column, DateTime, Integer, String, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, DateTime, Integer, String, ForeignKey, UniqueConstraint, event
 from sqlalchemy.orm import relationship
 
 
@@ -56,6 +56,8 @@ class GenomicSet(Base):
     UniqueConstraint('genomic_set_name', 'genomic_set_version', name='uidx_genomic_name_version'),
   )
 
+event.listen(GenomicSet, 'before_insert', model_insert_listener)
+event.listen(GenomicSet, 'before_update', model_update_listener)
 
 class GenomicSetMember(Base):
   """
@@ -86,3 +88,6 @@ class GenomicSetMember(Base):
                             default=GenomicValidationStatus.UNSET)
 
   validatedTime = Column('validated_time', DateTime, nullable=True)
+
+event.listen(GenomicSetMember, 'before_insert', model_insert_listener)
+event.listen(GenomicSetMember, 'before_update', model_update_listener)

--- a/rest-api/test/unit_test/offline_test/genomic_pipeline_test.py
+++ b/rest-api/test/unit_test/offline_test/genomic_pipeline_test.py
@@ -64,7 +64,6 @@ class GenomicPipelineTest(CloudStorageSqlTestBase, NdbTestBase):
     Kwargs pass through to BiobankOrder constructor, overriding defaults.
     """
     participant_id = kwargs['participantId']
-    modified = datetime.datetime(2019, 03, 25, 15, 59, 30)
 
     for k, default_value in (
         ('biobankOrderId', u'1'),
@@ -84,7 +83,7 @@ class GenomicPipelineTest(CloudStorageSqlTestBase, NdbTestBase):
             description=u'description',
             processingRequired=True)]),
         ('dvOrders', [BiobankDVOrder(
-          participantId=participant_id, modified=modified, version=1)])):
+          participantId=participant_id, version=1)])):
       if k not in kwargs:
         kwargs[k] = default_value
 
@@ -347,8 +346,6 @@ class GenomicPipelineTest(CloudStorageSqlTestBase, NdbTestBase):
 
     set_dao = GenomicSetDao()
     genomic_set.genomicSetVersion = set_dao.get_new_version_number(genomic_set.genomicSetName)
-    genomic_set.created = now
-    genomic_set.modified = now
 
     set_dao.insert(genomic_set)
 
@@ -357,11 +354,8 @@ class GenomicPipelineTest(CloudStorageSqlTestBase, NdbTestBase):
   def _create_fake_genomic_member(self, genomic_set_id, participant_id, biobank_order_id,
                                   validation_status=GenomicValidationStatus.VALID,
                                   sex_at_birth='F', genome_type='aou_array', ny_flag='Y'):
-    now = clock.CLOCK.now()
     genomic_set_member = GenomicSetMember()
     genomic_set_member.genomicSetId = genomic_set_id
-    genomic_set_member.created = now
-    genomic_set_member.modified = now
     genomic_set_member.validationStatus = validation_status
     genomic_set_member.participantId = participant_id
     genomic_set_member.sexAtBirth = sex_at_birth


### PR DESCRIPTION
'created' and 'modified' fields for 'biobank_dv_order', 'genomic_set' and 'genomic_set_member' are now auto populated using sqlalchemy listener hooks.  There should be no need to manually set those column values.