### PR TITLE
[DA-1117] Fix exception error on duplicate questionnaire submissions

### DIFF
--- a/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
+++ b/rest-api/test/unit_test/api_test/questionnaire_response_api_test.py
@@ -1,6 +1,8 @@
 import datetime
 import httplib
 import json
+import pytz
+from dateutil.parser import parse
 
 from code_constants import PPI_EXTRA_SYSTEM
 from clock import FakeClock
@@ -27,6 +29,37 @@ def _questionnaire_response_url(participant_id):
 
 
 class QuestionnaireResponseApiTest(FlaskTestBase):
+
+  def test_duplicate_consent_submission(self):
+    """
+    Submit duplicate study enrollment questionnaires, so we can make sure
+    a duplicate submission doesn't error out and the authored timestamp is
+    updated.
+    """
+    participant_id = self.create_participant()
+    authored = datetime.datetime(2019, 3, 16, 1, 39, 33, tzinfo=pytz.utc)
+    created = datetime.datetime(2019, 3, 16, 1, 51, 22)
+    with FakeClock(created):
+      self.send_consent(participant_id, authored=authored)
+
+    summary = self.send_get('Participant/{0}/Summary'.format(participant_id))
+    self.assertEqual(parse(summary['consentForStudyEnrollmentTime']),
+                     created.replace(tzinfo=None))
+    self.assertEqual(parse(summary['consentForStudyEnrollmentAuthored']),
+                     authored.replace(tzinfo=None))
+
+    # submit consent questionnaire again with new timestamps.
+    authored = datetime.datetime(2019, 3, 17, 1, 24, 16, tzinfo=pytz.utc)
+    with FakeClock(datetime.datetime(2019, 3, 17, 1, 25, 58)):
+      self.send_consent(participant_id, authored=authored)
+
+    summary = self.send_get('Participant/{0}/Summary'.format(participant_id))
+    # created should remain the same as the first submission.
+    self.assertEqual(parse(summary['consentForStudyEnrollmentTime']),
+                     created.replace(tzinfo=None))
+    self.assertEqual(parse(summary['consentForStudyEnrollmentAuthored']),
+                     authored.replace(tzinfo=None))
+
 
   def test_insert_raises_400_for_excessively_long_valueString(self):
     participant_id = self.create_participant()

--- a/rest-api/test/unit_test/unit_test_util.py
+++ b/rest-api/test/unit_test/unit_test_util.py
@@ -646,7 +646,7 @@ class FlaskTestBase(NdbTestBase):
     response = self.send_post('Participant', {})
     return response['participantId']
 
-  def send_consent(self, participant_id, email=None, language=None, code_values=None):
+  def send_consent(self, participant_id, email=None, language=None, code_values=None, authored=None):
     if not self._consent_questionnaire_id:
       self._consent_questionnaire_id = self.create_questionnaire('study_consent.json')
     self.first_name = self.fake.first_name()
@@ -662,7 +662,8 @@ class FlaskTestBase(NdbTestBase):
                                                          ("email", email),
                                                          ("streetAddress", self.streetAddress),
                                                          ("streetAddress2", self.streetAddress2)],
-                                         language=language, code_answers=code_values)
+                                         language=language, code_answers=code_values,
+                                         authored=authored)
     self.send_post(questionnaire_response_url(participant_id), qr_json)
 
   def create_questionnaire(self, filename):
@@ -733,7 +734,7 @@ def sort_lists(obj):
 
 def make_questionnaire_response_json(participant_id, questionnaire_id, code_answers=None,
                                 string_answers=None, date_answers=None, uri_answers=None,
-                                     language=None):
+                                     language=None, authored=None):
   results = []
   if code_answers:
     for answer in code_answers:
@@ -782,6 +783,8 @@ def make_questionnaire_response_json(participant_id, questionnaire_id, code_answ
                        "valueCode": "{}".format(language)}
                     ]
       })
+  if authored is not None:
+    response_json.update({"authored": authored.isoformat()})
   return response_json
 
 def questionnaire_response_url(participant_id):


### PR DESCRIPTION
This fixes the datetime exception error when comparing authored dates, where one date has tzinfo and the other does not.