### PR TITLE
DA-1159 make expected delivery date optional

### DIFF
--- a/rest-api/dao/dv_order_dao.py
+++ b/rest-api/dao/dv_order_dao.py
@@ -118,8 +118,10 @@ class DvOrderDao(UpdatableDao):
         url=VIBRENT_FHIR_URL + 'tracking-status').valueString
       existing_obj.shipmentCarrier = fhir_resource.extension.get(
         url=VIBRENT_FHIR_URL + 'carrier').valueString
-      existing_obj.shipmentEstArrival = parse_date(fhir_resource.extension.get(
+      if hasattr(fhir_resource['extension'], VIBRENT_FHIR_URL + 'expected-delivery-date'):
+        existing_obj.shipmentEstArrival = parse_date(fhir_resource.extension.get(
         url=VIBRENT_FHIR_URL + 'expected-delivery-date').valueDateTime)
+
       existing_obj.trackingId = fhir_resource.identifier.get(
         system=VIBRENT_FHIR_URL + 'trackingId').value
       # USPS status

--- a/rest-api/test/test-data/dv_order_api_post_supply_delivery_alt.json
+++ b/rest-api/test/test-data/dv_order_api_post_supply_delivery_alt.json
@@ -47,10 +47,6 @@
     "valueString": "IN_TRANSIT"
   },
   {
-    "url": "http://joinallofus.org/fhir/expected-delivery-date",
-    "valueDateTime": "2019-04-01T00:00:00+00:00"
-  },
-  {
     "url": "http://joinallofus.org/fhir/order-type",
     "valueString": "Salivary Order"
   },


### PR DESCRIPTION
🚨HOTFIX🚨:  Made expected delivery date optional for supply-delivery calls and removed the field from one of the test order json files to prove.