### PR TITLE
[ROC-16] updated production and staging DB replica name

### DIFF
--- a/rest-api/services/gcp_config.py
+++ b/rest-api/services/gcp_config.py
@@ -24,9 +24,9 @@ GCP_INSTANCES = {
 }
 
 GCP_REPLICA_INSTANCES = {
-  'all-of-us-rdr-prod': 'all-of-us-rdr-prod:us-central1:rdrbackupdb',
+  'all-of-us-rdr-prod': 'all-of-us-rdr-prod:us-central1:rdrbackupdb-a',
   'all-of-us-rdr-stable': 'all-of-us-rdr-stable:us-central1:rdrbackupdb',
-  'all-of-us-rdr-staging': 'all-of-us-rdr-staging:us-central1:rdrbackupdb1',
+  'all-of-us-rdr-staging': 'all-of-us-rdr-staging:us-central1:rdrbackupdb',
   'all-of-us-rdr-sandbox': 'all-of-us-rdr-sandbox:us-central1:rdrmaindb',
   'pmi-drc-api-test': 'pmi-drc-api-test:us-central1:rdrbackupdb',
 }


### PR DESCRIPTION
The production backup replica DB instance went bad, running disk space up to 3.3 TB vs 118 GB for the primary instance.  Created new replica named `rdrbackupdb-a` and deleted old backup replica.

During this, I created a new Staging backup replica instance named `rdrbackupdb` to match original naming convention and deleted `rdrbackupdb1` instance.