### PR TITLE
[DA-1220] make ehr update data sources configurable

### DIFF
--- a/rest-api/config.py
+++ b/rest-api/config.py
@@ -39,8 +39,8 @@ GHOST_ID_BUCKET = 'ghost_id_bucket'
 MAYOLINK_CREDS = 'mayolink_creds'
 MAYOLINK_ENDPOINT = 'mayolink_endpoint'
 CONFIG_BUCKET = 'all-of-us-rdr-sequestered-config-test'
-CURATION_BIGQUERY_PROJECT = 'curation_bigquery_project'
-CURATION_BUCKET_NAME = 'curation_bucket_name'
+EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT = 'ehr_status_bigquery_view_participant'
+EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION = 'ehr_status_bigquery_view_organization'
 HPO_REPORT_CONFIG_MIXIN_PATH = 'hpo_report_config_mixin_path'
 
 # Allow requests which are never permitted in production. These include fake

--- a/rest-api/config/base_config.json
+++ b/rest-api/config/base_config.json
@@ -47,5 +47,7 @@
   ],
   "days_to_delete_keys": [
     3
-  ]
+  ],
+  "ehr_status_bigquery_view_participant": [],
+  "ehr_status_bigquery_view_organization": []
 }

--- a/rest-api/config/config_dev.json
+++ b/rest-api/config/config_dev.json
@@ -33,11 +33,5 @@
     "10"
   ],
   "mayolink_creds": ["rdr-mayolink-creds-test.json"],
-  "mayolink_endpoint": ["https://test.orders.mayocliniclabs.com/orders/create.xml"],
-  "curation_bigquery_project": [
-    "all-of-us-rdr-sandbox"
-  ],
-  "curation_bucket_name": [
-    "aou-rdr-sandbox-mock-data"
-  ]
+  "mayolink_endpoint": ["https://test.orders.mayocliniclabs.com/orders/create.xml"]
 }

--- a/rest-api/config/config_prod.json
+++ b/rest-api/config/config_prod.json
@@ -31,11 +31,11 @@
   "ghost_id_bucket": [
     "all-of-us-rdr-prod-ghost-accounts"
   ],
-  "curation_bigquery_project": [
-    "aou-res-curation-prod"
+  "ehr_status_bigquery_view_participant": [
+    "aou-res-curation-prod.operations_analytics.ehr_upload_pids"
   ],
-  "curation_bucket_name": [
-    "drc-curation-internal"
+  "ehr_status_bigquery_view_organization": [
+    "aou-res-curation-prod.operations_analytics.table_counts_with_upload_timestamp_for_hpo_sites_v2"
   ],
   "hpo_report_config_mixin_path": [
     "/all-of-us-rdr-sequestered-config-test/hpo-report-config-mixin.json"

--- a/rest-api/config/config_sandbox.json
+++ b/rest-api/config/config_sandbox.json
@@ -25,8 +25,5 @@
   ],
   "metrics_shards": [
     "10"
-  ],
-  "curation_bucket_name": [
-    "aou-rdr-sandbox-mock-data"
   ]
 }

--- a/rest-api/config/config_stable.json
+++ b/rest-api/config/config_stable.json
@@ -169,9 +169,6 @@
   "metrics_shards": [
     "10"
   ],
-  "curation_bucket_name": [
-    "aou-rdr-sandbox-mock-data"
-  ],
   "hpo_report_config_mixin_path": [
     "/all-of-us-rdr-sequestered-config-test/hpo-report-config-mixin--stable.json"
   ],

--- a/rest-api/config/config_staging.json
+++ b/rest-api/config/config_staging.json
@@ -63,9 +63,6 @@
     "redlock-read-only-stable@all-of-us-ops-data-api-stable.iam.gserviceaccount.com",
     "circle-deploy@all-of-us-rdr-staging.iam.gserviceaccount.com"
   ],
-  "curation_bucket_name": [
-    "aou-rdr-sandbox-mock-data"
-  ],
   "mayolink_creds": ["rdr-mayolink-creds-test.json"],
   "mayolink_endpoint": ["https://test.orders.mayocliniclabs.com/orders/create.xml"]
 }

--- a/rest-api/config/config_test.json
+++ b/rest-api/config/config_test.json
@@ -55,9 +55,6 @@
   "service_accounts_with_long_lived_keys":[
     "circle-deploy@all-of-us-rdr-staging.iam.gserviceaccount.com"
   ],
-  "curation_bucket_name": [
-    "aou-rdr-sandbox-mock-data"
-  ],
   "mayolink_creds": ["rdr-mayolink-creds-test.json"],
   "mayolink_endpoint": ["https://test.orders.mayocliniclabs.com/orders/create.xml"]
 }

--- a/rest-api/offline/update_ehr_status.py
+++ b/rest-api/offline/update_ehr_status.py
@@ -2,6 +2,7 @@ import logging
 
 import clock
 import cloud_utils.bigquery
+import config
 from app_util import datetime_as_naive_utc
 from dao.ehr_dao import EhrReceiptDao
 from dao.organization_dao import OrganizationDao
@@ -20,13 +21,21 @@ def update_ehr_status():
 
 
 def make_update_participant_summaries_job():
-  query = 'SELECT * FROM `aou-res-curation-prod.operations_analytics.ehr_upload_pids`'
-  return cloud_utils.bigquery.BigQueryJob(
-    query,
-    project_id='all-of-us-rdr-sandbox',
-    default_dataset_id='operations_analytics',
-    page_size=1000
-  )
+  config_param = config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT
+  try:
+    bigquery_view = config.getSetting(config_param, None)
+  except config.InvalidConfigException as e:
+    LOG.warn("Config lookup exception for {}: {}".format(config_param, e))
+    bigquery_view = None
+  if bigquery_view:
+    query = 'SELECT person_id FROM `{}`'.format(bigquery_view)
+    return cloud_utils.bigquery.BigQueryJob(
+      query,
+      default_dataset_id='operations_analytics',
+      page_size=1000
+    )
+  else:
+    return None
 
 
 def update_particiant_summaries():
@@ -36,44 +45,54 @@ def update_particiant_summaries():
   Loads results in batches and commits updates to database per batch.
   """
   job = make_update_participant_summaries_job()
-  summary_dao = ParticipantSummaryDao()
-  now = clock.CLOCK.now()
-  for i, page in enumerate(job):
-    LOG.info("Processing page {} of results...".format(i))
-    parameter_sets = [
-      {
-        'pid': row.person_id,
-        'receipt_time': now,
-      }
-      for row in page
-    ]
-    query_result = summary_dao.bulk_update_ehr_status(parameter_sets)
-    LOG.info("Affected {} rows.".format(query_result.rowcount))
+  if job is not None:
+    summary_dao = ParticipantSummaryDao()
+    now = clock.CLOCK.now()
+    for i, page in enumerate(job):
+      LOG.info("Processing page {} of results...".format(i))
+      parameter_sets = [
+        {
+          'pid': row.person_id,
+          'receipt_time': now,
+        }
+        for row in page
+      ]
+      query_result = summary_dao.bulk_update_ehr_status(parameter_sets)
+      LOG.info("Affected {} rows.".format(query_result.rowcount))
+  else:
+    LOG.warn("Skipping update_participant_summaries because of invalid config")
 
 
 def make_update_organizations_job():
-  query = (
-    'SELECT org_id, person_upload_time '
-    'FROM `aou-res-curation-prod.operations_analytics'
-    '.table_counts_with_upload_timestamp_for_hpo_sites_v2`'
-  )
-  return cloud_utils.bigquery.BigQueryJob(
-    query,
-    project_id='all-of-us-rdr-sandbox',
-    default_dataset_id='operations_analytics',
-    page_size=1000
-  )
+  config_param = config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION
+  try:
+    bigquery_view = config.getSetting(config_param, None)
+  except config.InvalidConfigException as e:
+    LOG.warn("Config lookup exception for {}: {}".format(config_param, e))
+    bigquery_view = None
+  if bigquery_view:
+    query = 'SELECT org_id, person_upload_time FROM `{}`'.format(bigquery_view)
+    return cloud_utils.bigquery.BigQueryJob(
+      query,
+      default_dataset_id='operations_analytics',
+      page_size=1000
+    )
+  else:
+    return None
 
 
 def update_organizations():
   job = make_update_organizations_job()
-  organization_dao = OrganizationDao()
-  receipt_dao = EhrReceiptDao()
-  for page in job:
-    for row in page:
-      org = organization_dao.get_by_external_id(row.org_id)
-      receipt_dao.get_or_create(
-        insert_if_created=True,
-        organizationId=org.organizationId,
-        receiptTime=datetime_as_naive_utc(row.person_upload_time)
-      )
+  if job is not None:
+    organization_dao = OrganizationDao()
+    receipt_dao = EhrReceiptDao()
+    for page in job:
+      for row in page:
+        org = organization_dao.get_by_external_id(row.org_id)
+        receipt_dao.get_or_create(
+          insert_if_created=True,
+          organizationId=org.organizationId,
+          receiptTime=datetime_as_naive_utc(row.person_upload_time)
+        )
+  else:
+    LOG.warn("Skipping update_organizations because of invalid config")


### PR DESCRIPTION
The existing bigquery table names were hard-coded. A view needed to change immediately after the initial release so this work allows changing the data view sources via the configuration.