### PR TITLE
v1-50-v5 HOTFIX: EHR Metrics API and Update cron job fixes

### DIFF
--- a/rest-api/cloud_utils/bigquery.py
+++ b/rest-api/cloud_utils/bigquery.py
@@ -154,8 +154,10 @@ class BigQueryJob(object):
   @staticmethod
   def _parse_timestamp(value):
     try:
+      if not value:
+        return None
       date = datetime.datetime.strptime(
-        re.sub(r'\bT\b', '', value),
+        re.sub(r'\bT\b', '', str(value)),
         '%Y-%m-%d %H:%M:%S.%f %Z'
       )
       if date.tzinfo is None:
@@ -164,7 +166,7 @@ class BigQueryJob(object):
     except ValueError:
       try:
         return datetime.datetime.utcfromtimestamp(float(value)).replace(tzinfo=pytz.UTC)
-      except ValueError:
+      except (ValueError, TypeError):
         raise ValueError("Could not parse {} as TIMESTAMP".format(value))
 
   @classmethod

--- a/rest-api/offline/update_ehr_status.py
+++ b/rest-api/offline/update_ehr_status.py
@@ -104,8 +104,13 @@ def update_organizations_from_job(job):
   for page in job:
     for row in page:
       org = organization_dao.get_by_external_id(row.org_id)
-      receipt_dao.get_or_create(
-        insert_if_created=True,
-        organizationId=org.organizationId,
-        receiptTime=datetime_as_naive_utc(row.person_upload_time)
-      )
+      if org:
+        try:
+          receipt_time = datetime_as_naive_utc(row.person_upload_time)
+        except TypeError:
+          continue
+        receipt_dao.get_or_create(
+          insert_if_created=True,
+          organizationId=org.organizationId,
+          receiptTime=receipt_time
+        )

--- a/rest-api/test/unit_test/cloud_utils_test/bigquery_test.py
+++ b/rest-api/test/unit_test/cloud_utils_test/bigquery_test.py
@@ -88,6 +88,9 @@ class BigQueryJobTransformationTest(unittest.TestCase):
       u'rows': [
         {u'f': [{u'v': u'2019-05-25 04:22:16.052 UTC'}]},
         {u'f': [{u'v': u'1.475735115E9'}]},
+        {u'f': [{u'v': 1.475735115E9}]},
+        {u'f': [{u'v': None}]},
+        {u'f': [{u'v': u''}]},
       ],
       u'schema': {
         u'fields': [
@@ -102,3 +105,24 @@ class BigQueryJobTransformationTest(unittest.TestCase):
     rows = cloud_utils.bigquery.BigQueryJob.get_rows_from_response(response)
     self.assertEqual(rows[0].timestamp, datetime.datetime(2019, 5, 25, 4, 22, 16, 52000, pytz.UTC))
     self.assertEqual(rows[1].timestamp, datetime.datetime(2016, 10, 6, 6, 25, 15, 0, pytz.UTC))
+    self.assertEqual(rows[2].timestamp, datetime.datetime(2016, 10, 6, 6, 25, 15, 0, pytz.UTC))
+    self.assertEqual(rows[3].timestamp, None)
+    self.assertEqual(rows[4].timestamp, None)
+
+    response = {
+      u'rows': [
+        {u'f': [{u'v': dict(foo='bar')}]},
+        {u'f': [{u'v': u'An invalid datestring'}]},
+      ],
+      u'schema': {
+        u'fields': [
+          {
+            u'mode': u'NULLABLE',
+            u'name': u'timestamp',
+            u'type': u'TIMESTAMP',
+          }
+        ]
+      }
+    }
+    with self.assertRaises(ValueError):
+      cloud_utils.bigquery.BigQueryJob.get_rows_from_response(response)


### PR DESCRIPTION
This changeset does two things:

1. improve robustness when parsing data from biquery (handle new edge cases)
2. adjust filter logic for two queries to make the counts identical