### PR TITLE
[DA-1226] Fixes for sending to Mayolink API

### DIFF
--- a/rest-api/dao/dv_order_dao.py
+++ b/rest-api/dao/dv_order_dao.py
@@ -43,6 +43,10 @@ class DvOrderDao(UpdatableDao):
     code_dict = summary.asdict()
     format_json_code(code_dict, self.code_dao, 'genderIdentityId')
     format_json_code(code_dict, self.code_dao, 'stateId')
+    if 'genderIdentity' in code_dict and code_dict['genderIdentity']:
+      gender_val = code_dict['genderIdentity']
+    else:
+      gender_val = 'UNSET'
     # MayoLink api has strong opinions on what should be sent and the order of elements. Dont touch.
     order = {
         'order': {
@@ -54,7 +58,7 @@ class DvOrderDao(UpdatableDao):
                         'last_name': str(to_client_biobank_id(summary.biobankId)),
                         'middle_name': '',
                         'birth_date': '3/3/1933',
-                        'gender': code_dict['genderIdentity'],
+                        'gender': gender_val,
                         'address1': summary.streetAddress,
                         'address2': summary.streetAddress2,
                         'city': summary.city,
@@ -65,7 +69,7 @@ class DvOrderDao(UpdatableDao):
                         'race': summary.race,
                         'ethnic_group': None
                        },
-            'physician': {'name': None,
+            'physician': {'name': 'None',  # must be a string value, not None.
                           'phone': None,
                           'npi': None
                          },

--- a/rest-api/dao/dv_order_dao.py
+++ b/rest-api/dao/dv_order_dao.py
@@ -44,9 +44,14 @@ class DvOrderDao(UpdatableDao):
     format_json_code(code_dict, self.code_dao, 'genderIdentityId')
     format_json_code(code_dict, self.code_dao, 'stateId')
     if 'genderIdentity' in code_dict and code_dict['genderIdentity']:
-      gender_val = code_dict['genderIdentity']
+      if code_dict['genderIdentity'] == 'GenderIdentity_Woman':
+        gender_val = 'F'
+      elif code_dict['genderIdentity'] == 'GenderIdentity_Man':
+        gender_val = 'M'
+      else:
+        gender_val = 'U'
     else:
-      gender_val = 'UNSET'
+      gender_val = 'U'
     # MayoLink api has strong opinions on what should be sent and the order of elements. Dont touch.
     order = {
         'order': {


### PR DESCRIPTION
Fixes Mayolink validation errors

1. Patient gender is not included in the list
2. Physician name can't be blank