### PR TITLE
[DA-1222] Update POST/PUT methods to regenerate Json for BQ

### DIFF
--- a/rest-api/api/bigquery_participant_summary_api.py
+++ b/rest-api/api/bigquery_participant_summary_api.py
@@ -1,0 +1,47 @@
+import json
+
+from google.appengine.api import app_identity
+from werkzeug.exceptions import NotFound
+
+from api.base_api import BaseApi
+from api_util import PTC_AND_HEALTHPRO
+from app_util import auth_required, nonprod
+from cloud_utils.bigquery import BigQueryJob
+from dao.bigquery_sync_dao import BigQuerySyncDao
+from model.bigquery_sync import BigQuerySync
+
+
+class BQParticipantSummaryApi(BaseApi):
+  def __init__(self):
+    super(BQParticipantSummaryApi, self).__init__(BigQuerySyncDao())
+
+  @nonprod
+  @auth_required(PTC_AND_HEALTHPRO)
+  def get(self, p_id):
+
+    try:
+      project_id = app_identity.get_application_id()
+    except AttributeError:
+      project_id = None
+
+    if not project_id or project_id == 'None':
+      # For local testing, return the json from mysql instead of making a bigquery call.
+      with self.dao.session() as session:
+        result = session.query(BigQuerySync.resource).filter(BigQuerySync.participantId == p_id).first()
+        if result:
+          return json.loads(result[0])
+
+    else:
+      # We must validate participant id carefully as we are building a query string, not using parameters.
+      if str(p_id).isdigit() and len(str(p_id)) == 9:
+        query = 'select * from rdr_ops_data_view.participant_summary where participant_id = {0}'.format(p_id)
+        job = BigQueryJob(query, project_id=project_id, default_dataset_id='rdr_ops_data_view')
+
+        response = job.start_job()
+        if response and 'schema' in response and 'rows' in response and len(response['rows']) == 1:
+          # logging.info(resource)
+          records = BigQueryJob.get_rows(response)
+          if len(records) == 1:
+            return records[0]
+
+    raise NotFound('participant not found')

--- a/rest-api/dao/base_dao.py
+++ b/rest-api/dao/base_dao.py
@@ -630,6 +630,8 @@ def json_serial(obj):
     return obj.isoformat()
   if isinstance(obj, messages.Enum):
     return str(obj)
+  if hasattr(obj, 'name'):
+    return obj.name
   raise TypeError("Type not serializable")
 
 

--- a/rest-api/dao/bigquery_sync_dao.py
+++ b/rest-api/dao/bigquery_sync_dao.py
@@ -530,3 +530,12 @@ class BQParticipantSummaryGenerator(object):
     # Because of the complexity and need to make this right, I will create a new ticket.
     # I believe all the data needed to calculate this is in the 'summary' parameter.
     return data
+
+
+def deferred_bq_participant_summary_update(p_id):
+  """
+  Deferred task to update the Participant Summary record for the given participant.
+  :param p_id: Participant ID
+  """
+  gen = BQParticipantSummaryGenerator()
+  gen.save_participant_summary(p_id, gen.make_participant_summary(p_id))

--- a/rest-api/main.py
+++ b/rest-api/main.py
@@ -12,6 +12,7 @@ import config_api
 import version_api
 from api import metrics_ehr_api
 from api.awardee_api import AwardeeApi
+from api.bigquery_participant_summary_api import BQParticipantSummaryApi
 from api.biobank_order_api import BiobankOrderApi
 from api.check_ppi_data_api import check_ppi_data
 from api.data_gen_api import DataGenApi, SpecDataGenApi
@@ -86,6 +87,12 @@ api.add_resource(ParticipantSummaryApi,
                  PREFIX + 'Participant/<participant_id:p_id>/Summary',
                  PREFIX + 'ParticipantSummary',
                  endpoint='participant.summary',
+                 methods=['GET'])
+
+# BigQuery version of Participant Summary API
+api.add_resource(BQParticipantSummaryApi,
+                 PREFIX + 'Participant/<participant_id:p_id>/TestSummary',
+                 endpoint='bq_participant.summary',
                  methods=['GET'])
 
 api.add_resource(ParticipantSummaryModifiedApi,

--- a/rest-api/model/bq_base.py
+++ b/rest-api/model/bq_base.py
@@ -420,7 +420,7 @@ class BQRecord(object):
           raise KeyError('{0} key not in schema'.format(key))
         # TODO: Future: Validate value against schema BQField type and constraints here.
         # check for Enum32 object, if it is set the value to the enum value
-        if schema[key]['description'] and schema[key]['enum'] is True:
+        if schema and schema[key]['description'] and schema[key]['enum'] is True:
           try:
             mod_path, mod_name = schema[key]['description'].rsplit('.', 1)
             fld_enum = getattr(importlib.import_module(mod_path, mod_name), mod_name)


### PR DESCRIPTION
Codacy will fail on building a query string.  Since this does take user input, I have added validation to verify the user input is actually a numeric 9-digit value before running the BigQuery query.

I have added a testing, non-production, API for testing BigQuery queries.  
Example: https://all-of-us-rdr-sandbox.appspot.com/rdr/v1/Participant/P255612093/TestSummary
