### PR TITLE
[DA-1192] use an independent session for participant summary update

### DIFF
--- a/rest-api/dao/participant_dao.py
+++ b/rest-api/dao/participant_dao.py
@@ -360,12 +360,11 @@ class ParticipantDao(UpdatableDao):
     # Update the version and add history row
     self._do_update(session, participant, participant)
 
-  def switch_to_test_account(self, session, participant_id):
+  def switch_to_test_account(self, session, participant):
     test_hpo_id = HPODao().get_by_name(TEST_HPO_NAME).hpoId
 
-    participant = self.get_for_update(session, participant_id)
     if participant is None:
-      raise BadRequest('No participant %r for HPO ID udpate.' % participant_id)
+      raise BadRequest('No participant %r for HPO ID udpate.')
 
     if participant.hpoId == test_hpo_id:
       return

--- a/rest-api/dao/questionnaire_response_dao.py
+++ b/rest-api/dao/questionnaire_response_dao.py
@@ -164,8 +164,10 @@ class QuestionnaireResponseDao(BaseDao):
     # to get the exclusive lock if another thread is updating the participant. See DA-269.
     # (We need to lock both participant and participant summary because the summary row may not
     # exist yet.)
-    self._update_participant_summary(
-        session, questionnaire_response, code_ids, questions, questionnaire_history, resource_json)
+    with self.session() as new_session:
+      self._update_participant_summary(
+        new_session, questionnaire_response, code_ids, questions, questionnaire_history,
+        resource_json)
 
     super(QuestionnaireResponseDao, self).insert_with_session(session, questionnaire_response)
     # Mark existing answers for the questions in this response given previously by this participant
@@ -360,7 +362,7 @@ class QuestionnaireResponseDao(BaseDao):
       # this is a requirement from PTSC
       if participant_summary.loginPhoneNumber is not None and \
         participant_summary.loginPhoneNumber.startswith(TEST_LOGIN_PHONE_NUMBER_PREFIX):
-        ParticipantDao().switch_to_test_account(session, participant_summary.participantId)
+        ParticipantDao().switch_to_test_account(session, participant)
 
       # update participant gender/race answers table
       if race_code_ids:


### PR DESCRIPTION
Two change:

1. In _update_participant_summary method, it will get the participant and participant_summary for updating, this will lock the table, so we need to commit the change immediately to db to reduce the lock time. In the previous logic, it shares the session with other operations, the change can only be commit after all other operations are done, that make the lock longer.
2. remove the nested get_for_update for participant.