### PR TITLE
[DA-1233] BQ - calculate distinct visits and fix sync errors

### DIFF
--- a/rest-api/model/bq_participant_summary.py
+++ b/rest-api/model/bq_participant_summary.py
@@ -76,6 +76,19 @@ class BQGenderSchema(BQSchema):
   gender_id = BQField('gender_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
+class BQPhysicalMeasurements(BQSchema):
+  """
+  Participant Physical Measurements
+  """
+  status = BQField('status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  status_id = BQField('status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  created_site = BQField('created_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  created_site_id = BQField('created_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  finalized_site = BQField('finalized_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  finalized_site_id = BQField('finalized_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  finalized = BQField('finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
 class BQBiobankSampleSchema(BQSchema):
   """
   Biobank sample information
@@ -101,6 +114,8 @@ class BQBiobankOrderSchema(BQSchema):
   """
   biobank_order_id = BQField('biobank_order_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
   created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  status = BQField('status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  status_id = BQField('status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
   dv_order = BQField('dv_order', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
   collected_site = BQField('collected_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
   collected_site_id = BQField('collected_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
@@ -176,14 +191,7 @@ class BQParticipantSummarySchema(BQSchema):
   sexual_orientation = BQField('sexual_orientation', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
   sexual_orientation_id = BQField('sexual_orientation_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
-  pm_status = BQField('pm_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  pm_status_id = BQField('pm_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  pm_created = BQField('pm_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  pm_created_site = BQField('pm_created_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  pm_created_site_id = BQField('pm_created_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  pm_finalized_site = BQField('pm_finalized_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  pm_finalized_site_id = BQField('pm_finalized_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  pm_finalized = BQField('pm_finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  pm = BQRecordField('pm', schema=BQPhysicalMeasurements)
 
   races = BQRecordField('races', schema=BQRaceSchema)
   genders = BQRecordField('genders', schema=BQGenderSchema)

--- a/rest-api/test/unit_test/cloud_utils_test/bigquery_schema_test.py
+++ b/rest-api/test/unit_test/cloud_utils_test/bigquery_schema_test.py
@@ -131,7 +131,7 @@ class BigQueryRecordTest(unittest.TestCase):
 
   def test_schema_nested_data(self):
     """ test a BQRecord object with schema and nested data """
-    record = BQRecord(schema=BQTestSchema, data=self.full_data)
+    record = BQRecord(schema=BQTestSchema, data=self.full_data, convert_to_enum=False)
     new_data = record.to_dict()
 
     self.assertEqual(self.full_data, new_data)

--- a/rest-api/test/unit_test/dao_test/bigquery_sync_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/bigquery_sync_dao_test.py
@@ -111,7 +111,7 @@ class BigQuerySyncDaoTest(SqlTestBase):
 
     self.assertIsNotNone(ps_json)
     self.assertEqual(ps_json.sign_up_time, self.TIME_1)
-    self.assertEqual(ps_json.pm_finalized_site, 'hpo-site-monroeville')
+    self.assertEqual(ps_json['pm'][0]['finalized_site'], 'hpo-site-monroeville')
     self.assertEqual(ps_json.suspension_status, 'NOT_SUSPENDED')
     self.assertEqual(ps_json.withdrawal_status, 'NOT_WITHDRAWN')
-    self.assertEqual(ps_json.pm_status, 'COMPLETED')
+    self.assertEqual(ps_json['pm'][0]['status'], 'UNSET')


### PR DESCRIPTION
This PR adds a calculation for distinct number of visits modeled after Michael's backfill sql logic.
This also fixes the problem that was causing records to fail on insert into BQ.
Lastly, changed the Physical Measurements to be a sub-table as there can be multiple PM records.