### PR TITLE
[DA-1221] Create BQ view for analytics team

### DIFF
--- a/rest-api/dao/bigquery_sync_dao.py
+++ b/rest-api/dao/bigquery_sync_dao.py
@@ -216,15 +216,15 @@ class BQParticipantSummaryGenerator(object):
       'contact_method_id': qnan.PIIContactInformation_RecontactMethod,
       'addresses': [
         {
-          'address_type': BQStreetAddressTypeEnum.RESIDENCE.name,
-          'address_type_id': BQStreetAddressTypeEnum.RESIDENCE.value,
-          'street_address_1': qnan.PIIAddress_StreetAddress,
-          'street_address_2': qnan.PIIAddress_StreetAddress2,
-          'city': qnan.StreetAddress_PIICity,
-          'state': qnan.StreetAddress_PIIState.replace('PIIState_', '').upper()
+          'addr_type': BQStreetAddressTypeEnum.RESIDENCE.name,
+          'addr_type_id': BQStreetAddressTypeEnum.RESIDENCE.value,
+          'addr_street_address_1': qnan.PIIAddress_StreetAddress,
+          'addr_street_address_2': qnan.PIIAddress_StreetAddress2,
+          'addr_city': qnan.StreetAddress_PIICity,
+          'addr_state': qnan.StreetAddress_PIIState.replace('PIIState_', '').upper()
                           if qnan.StreetAddress_PIIState else None,
-          'zip': qnan.StreetAddress_PIIZIP,
-          'country': 'us'
+          'addr_zip': qnan.StreetAddress_PIIZIP,
+          'addr_country': 'us'
         }
       ],
       'consents': [
@@ -286,13 +286,13 @@ class BQParticipantSummaryGenerator(object):
       for row in results:
         module_name = self._lookup_code_value(row.codeId, session)
         modules.append({
-          'module': module_name,
-          'baseline_module': 'true' if module_name in baseline_modules else 'false',
-          'authored': row.authored,
-          'created': row.created,
-          'language': row.language,
-          'status': BQModuleStatusEnum.SUBMITTED.name,
-          'status_id': BQModuleStatusEnum.SUBMITTED.value,
+          'mod_module': module_name,
+          'mod_baseline_module': 'true' if module_name in baseline_modules else 'false',
+          'mod_authored': row.authored,
+          'mod_created': row.created,
+          'mod_language': row.language,
+          'mod_status': BQModuleStatusEnum.SUBMITTED.name,
+          'mod_status_id': BQModuleStatusEnum.SUBMITTED.value,
         })
 
         # check if this is a module with consents.
@@ -354,6 +354,8 @@ class BQParticipantSummaryGenerator(object):
     data['education_id'] = self._lookup_code_id(qnan.EducationLevel_HighestGrade, session)
     data['income'] = qnan.Income_AnnualIncome
     data['income_id'] = self._lookup_code_id(qnan.Income_AnnualIncome, session)
+    data['sex'] = qnan.BiologicalSexAtBirth_SexAtBirth
+    data['sex_id'] = self._lookup_code_id(qnan.BiologicalSexAtBirth_SexAtBirth, session)
     data['sexual_orientation'] = qnan.TheBasics_SexualOrientation
     data['sexual_orientation_id'] = self._lookup_code_id(qnan.TheBasics_SexualOrientation, session)
 
@@ -379,14 +381,15 @@ class BQParticipantSummaryGenerator(object):
 
     for row in results:
       pm_list.append({
-        'status': str(PhysicalMeasurementsStatus(row.status) if row.status else PhysicalMeasurementsStatus.UNSET),
-        'status_id': int(PhysicalMeasurementsStatus(row.status) if row.status else PhysicalMeasurementsStatus.UNSET),
-        'created': row.created,
-        'created_site': self._lookup_site_name(row.createdSiteId, session),
-        'created_site_id': row.createdSiteId,
-        'finalized': row.finalized,
-        'finalized_site': self._lookup_site_name(row.finalizedSiteId, session),
-        'finalized_site_id': row.finalizedSiteId,
+        'pm_status': str(PhysicalMeasurementsStatus(row.status) if row.status else PhysicalMeasurementsStatus.UNSET),
+        'pm_status_id': int(PhysicalMeasurementsStatus(row.status) if row.status else
+                                PhysicalMeasurementsStatus.UNSET),
+        'pm_created': row.created,
+        'pm_created_site': self._lookup_site_name(row.createdSiteId, session),
+        'pm_created_site_id': row.createdSiteId,
+        'pm_finalized': row.finalized,
+        'pm_finalized_site': self._lookup_site_name(row.finalizedSiteId, session),
+        'pm_finalized_site_id': row.finalizedSiteId,
       })
 
     if len(pm_list) > 0:
@@ -438,42 +441,42 @@ class BQParticipantSummaryGenerator(object):
     results = [r for r in cursor]
     # loop through results and create one order record for each biobank_order_id value.
     for row in results:
-      if not filter(lambda order: order['biobank_order_id'] == row.biobank_order_id, orders):
+      if not filter(lambda order: order['bbo_biobank_order_id'] == row.biobank_order_id, orders):
         orders.append({
-          'biobank_order_id': row.biobank_order_id,
-          'created': row.created,
-          'status': str(BiobankOrderStatus(row.order_status) if row.order_status else BiobankOrderStatus.UNSET),
-          'status_id': int(BiobankOrderStatus(row.order_status) if row.order_status else BiobankOrderStatus.UNSET),
-          'dv_order': 'false' if row.dv_order == 0 else 'true',
-          'collected_site': self._lookup_site_name(row.collected_site_id, session),
-          'collected_site_id': row.collected_site_id,
-          'processed_site': self._lookup_site_name(row.processed_site_id, session),
-          'processed_site_id': row.processed_site_id,
-          'finalized_site': self._lookup_site_name(row.finalized_site_id, session),
-          'finalized_site_id': row.finalized_site_id,
+          'bbo_biobank_order_id': row.biobank_order_id,
+          'bbo_created': row.created,
+          'bbo_status': str(BiobankOrderStatus(row.order_status) if row.order_status else BiobankOrderStatus.UNSET),
+          'bbo_status_id': int(BiobankOrderStatus(row.order_status) if row.order_status else BiobankOrderStatus.UNSET),
+          'bbo_dv_order': 'false' if row.dv_order == 0 else 'true',
+          'bbo_collected_site': self._lookup_site_name(row.collected_site_id, session),
+          'bbo_collected_site_id': row.collected_site_id,
+          'bbo_processed_site': self._lookup_site_name(row.processed_site_id, session),
+          'bbo_processed_site_id': row.processed_site_id,
+          'bbo_finalized_site': self._lookup_site_name(row.finalized_site_id, session),
+          'bbo_finalized_site_id': row.finalized_site_id,
         })
     # loop through results again and add each sample to it's order.
     for row in results:
       # get the order list index for this sample record
-      idx = orders.index(filter(lambda order: order['biobank_order_id'] == row.biobank_order_id, orders)[0])
+      idx = orders.index(filter(lambda order: order['bbo_biobank_order_id'] == row.biobank_order_id, orders)[0])
       # if we haven't added any samples to this order, create an empty list.
       if 'samples' not in orders[idx]:
-        orders[idx]['samples'] = list()
+        orders[idx]['bbo_samples'] = list()
       # append the sample to the order
-      orders[idx]['samples'].append({
-        'test': row.test,
-        'baseline_test': 'true' if row.test in baseline_tests else 'false',
-        'dna_test': 'true' if row.test in dna_tests else 'false',
-        'collected': row.collected,
-        'processed': row.processed,
-        'finalized': row.finalized,
-        'bb_confirmed': row.bb_confirmed,
-        'bb_status': str(SampleStatus.RECEIVED) if row.bb_confirmed else None,
-        'bb_status_id': int(SampleStatus.RECEIVED) if row.bb_confirmed else None,
-        'bb_created': row.bb_created,
-        'bb_disposed': row.bb_disposed,
-        'bb_disposed_reason': str(SampleStatus(row.bb_status)) if row.bb_status else None,
-        'bb_disposed_reason_id': int(SampleStatus(row.bb_status)) if row.bb_status else None,
+      orders[idx]['bbo_samples'].append({
+        'bbs_test': row.test,
+        'bbs_baseline_test': 'true' if row.test in baseline_tests else 'false',
+        'bbs_dna_test': 'true' if row.test in dna_tests else 'false',
+        'bbs_collected': row.collected,
+        'bbs_processed': row.processed,
+        'bbs_finalized': row.finalized,
+        'bbs_confirmed': row.bb_confirmed,
+        'bbs_status': str(SampleStatus.RECEIVED) if row.bb_confirmed else None,
+        'bbs_status_id': int(SampleStatus.RECEIVED) if row.bb_confirmed else None,
+        'bbs_created': row.bb_created,
+        'bbs_disposed': row.bb_disposed,
+        'bbs_disposed_reason': str(SampleStatus(row.bb_status)) if row.bb_status else None,
+        'bbs_disposed_reason_id': int(SampleStatus(row.bb_status)) if row.bb_status else None,
       })
 
     if len(orders) > 0:
@@ -512,11 +515,11 @@ class BQParticipantSummaryGenerator(object):
 
     baseline_module_count = dna_sample_count = 0
     if 'modules' in summary:
-      baseline_module_count = len(filter(lambda module: module['baseline_module'] == 'true', summary['modules']))
+      baseline_module_count = len(filter(lambda module: module['mod_baseline_module'] == 'true', summary['modules']))
     if 'biobank_orders' in summary:
       for order in summary['biobank_orders']:
         if 'samples' in order:
-          dna_sample_count += len(filter(lambda sample: sample['dna_test'] == 'true', order['samples']))
+          dna_sample_count += len(filter(lambda sample: sample['bbs_dna_test'] == 'true', order['samples']))
 
     if study_consent:
       status = EnrollmentStatus.INTERESTED
@@ -551,15 +554,16 @@ class BQParticipantSummaryGenerator(object):
 
     if 'pm' in summary:
       for pm in summary['pm']:
-        if pm['status_id'] != int(PhysicalMeasurementsStatus.CANCELLED) and pm['finalized']:
-          dates.append(datetime_to_date(pm['finalized']))
+        if pm['pm_status_id'] != int(PhysicalMeasurementsStatus.CANCELLED) and pm['pm_finalized']:
+          dates.append(datetime_to_date(pm['pm_finalized']))
 
     if 'biobank_orders' in summary:
       for order in summary['biobank_orders']:
-        if order['status_id'] != int(BiobankOrderStatus.CANCELLED) and 'samples' in order:
-          for sample in order['samples']:
-            if 'finalized' in sample and sample['finalized'] and isinstance(sample['finalized'], datetime.datetime):
-              dates.append(datetime_to_date(sample['finalized']))
+        if order['bbo_status_id'] != int(BiobankOrderStatus.CANCELLED) and 'bbo_samples' in order:
+          for sample in order['bbo_samples']:
+            if 'bbs_finalized' in sample and sample['bbs_finalized'] and \
+                              isinstance(sample['bbs_finalized'], datetime.datetime):
+              dates.append(datetime_to_date(sample['bbs_finalized']))
 
     dates = list(set(dates))  # de-dup list
     data['distinct_visits'] = len(dates)

--- a/rest-api/model/__init__.py
+++ b/rest-api/model/__init__.py
@@ -5,3 +5,9 @@ BQ_SCHEMAS = [
   # (python path, class)
   ('model.bq_participant_summary', 'BQParticipantSummary'),
 ]
+
+BQ_VIEWS = [
+  # (python path, var name, view name, view desc)
+  ('model.bq_participant_summary', 'BQAnalyticsTeamParticipantSummary',
+      'v_analytics_participant_summary', 'Analytics Team Participant Summary View'),
+]

--- a/rest-api/model/bq_participant_summary.py
+++ b/rest-api/model/bq_participant_summary.py
@@ -24,29 +24,30 @@ class BQAddressSchema(BQSchema):
   Note: Do not use camelCase for property names. Property names must exactly match BQ
         field names.
   """
-  address_type = BQField('address_type', BQFieldTypeEnum.STRING, BQFieldModeEnum.REQUIRED,
+  addr_type = BQField('addr_type', BQFieldTypeEnum.STRING, BQFieldModeEnum.REQUIRED,
                         fld_enum=BQStreetAddressTypeEnum)
-  address_type_id = BQField('address_type_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED,
+  addr_type_id = BQField('addr_type_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED,
                             fld_enum=BQStreetAddressTypeEnum)
-  street_address_1 = BQField('street_address_1', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  street_address_2 = BQField('street_address_2', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  city = BQField('city', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  state = BQField('state', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  country = BQField('country', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  zip = BQField('zip', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  addr_street_address_1 = BQField('addr_street_address_1', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  addr_street_address_2 = BQField('addr_street_address_2', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  addr_city = BQField('addr_city', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  addr_state = BQField('addr_state', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  addr_country = BQField('addr_country', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  addr_zip = BQField('addr_zip', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
 
 
 class BQModuleStatusSchema(BQSchema):
   """
   Store information about modules submitted
   """
-  module = BQField('module', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  baseline_module = BQField('baseline_module', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
-  authored = BQField('authored', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  created = BQField('created', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  language = BQField('language', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  status = BQField('status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE, fld_enum=BQModuleStatusEnum)
-  status_id = BQField('status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE, fld_enum=BQModuleStatusEnum)
+  mod_module = BQField('mod_module', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  mod_baseline_module = BQField('mod_baseline_module', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
+  mod_authored = BQField('mod_authored', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  mod_created = BQField('mod_created', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  mod_language = BQField('mod_language', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  mod_status = BQField('mod_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE, fld_enum=BQModuleStatusEnum)
+  mod_status_id = BQField('mod_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
+                              fld_enum=BQModuleStatusEnum)
 
 
 class BQConsentSchema(BQSchema):
@@ -80,50 +81,50 @@ class BQPhysicalMeasurements(BQSchema):
   """
   Participant Physical Measurements
   """
-  status = BQField('status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  status_id = BQField('status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  created_site = BQField('created_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  created_site_id = BQField('created_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  finalized_site = BQField('finalized_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  finalized_site_id = BQField('finalized_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  finalized = BQField('finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  pm_status = BQField('pm_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  pm_status_id = BQField('pm_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  pm_created = BQField('pm_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  pm_created_site = BQField('pm_created_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  pm_created_site_id = BQField('pm_created_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  pm_finalized_site = BQField('pm_finalized_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  pm_finalized_site_id = BQField('pm_finalized_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  pm_finalized = BQField('pm_finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
 class BQBiobankSampleSchema(BQSchema):
   """
   Biobank sample information
   """
-  test = BQField('test', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  baseline_test = BQField('baseline_test', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
-  dna_test = BQField('dna_test', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
-  collected = BQField('collected', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  processed = BQField('processed', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  finalized = BQField('finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  bb_created = BQField('bb_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  bb_confirmed = BQField('bb_confirmed', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  bb_status = BQField('bb_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  bb_status_id = BQField('bb_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  bb_disposed = BQField('bb_disposed', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  bb_disposed_reason = BQField('bb_disposed_reason', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  bb_disposed_reason_id = BQField('bb_disposed_reason_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  bbs_test = BQField('bbs_test', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbs_baseline_test = BQField('bbs_baseline_test', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
+  bbs_dna_test = BQField('bbs_dna_test', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
+  bbs_collected = BQField('bbs_collected', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  bbs_processed = BQField('bbs_processed', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  bbs_finalized = BQField('bbs_finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  bbs_created = BQField('bbs_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  bbs_confirmed = BQField('bbs_confirmed', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  bbs_status = BQField('bbs_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbs_status_id = BQField('bbs_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  bbs_disposed = BQField('bbs_disposed', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  bbs_disposed_reason = BQField('bbs_disposed_reason', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbs_disposed_reason_id = BQField('bbs_disposed_reason_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQBiobankOrderSchema(BQSchema):
   """
   Biobank order information
   """
-  biobank_order_id = BQField('biobank_order_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-  status = BQField('status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  status_id = BQField('status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  dv_order = BQField('dv_order', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
-  collected_site = BQField('collected_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  collected_site_id = BQField('collected_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  processed_site = BQField('processed_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  processed_site_id = BQField('processed_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  finalized_site = BQField('finalized_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-  finalized_site_id = BQField('finalized_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-  samples = BQRecordField('samples', schema=BQBiobankSampleSchema)
+  bbo_biobank_order_id = BQField('bbo_biobank_order_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbo_created = BQField('bbo_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+  bbo_status = BQField('bbo_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbo_status_id = BQField('bbo_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  bbo_dv_order = BQField('bbo_dv_order', BQFieldTypeEnum.BOOLEAN, BQFieldModeEnum.NULLABLE)
+  bbo_collected_site = BQField('bbo_collected_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbo_collected_site_id = BQField('bbo_collected_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  bbo_processed_site = BQField('bbo_processed_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbo_processed_site_id = BQField('bbo_processed_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  bbo_finalized_site = BQField('bbo_finalized_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  bbo_finalized_site_id = BQField('bbo_finalized_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+  bbo_samples = BQRecordField('bbo_samples', schema=BQBiobankSampleSchema)
 
 
 class BQParticipantSummarySchema(BQSchema):
@@ -188,6 +189,8 @@ class BQParticipantSummarySchema(BQSchema):
   income = BQField('income', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
   income_id = BQField('income_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
+  sex = BQField('sex', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+  sex_id = BQField('sex_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
   sexual_orientation = BQField('sexual_orientation', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
   sexual_orientation_id = BQField('sexual_orientation_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
@@ -205,3 +208,34 @@ class BQParticipantSummary(BQTable):
   """ Participant Summary BigQuery Table """
   __tablename__ = 'participant_summary'
   __schema__ = BQParticipantSummarySchema
+
+""" Analytics Team view of the Participant Summary """
+BQAnalyticsTeamParticipantSummary = """
+SELECT 
+    genders,
+    sex,
+    sex_id,
+    sexual_orientation,
+    sexual_orientation_id,
+    education,
+    education_id,    
+    (select count(1) 
+      from `{project}`.rdr_ops_data_view.participant_summary as ps_1 
+        cross join UNNEST(biobank_orders) as orders 
+        cross join UNNEST(orders.bbo_samples) as samples
+      where ps.participant_id = ps_1.participant_id and
+        samples.bbs_baseline_test is true) as baseline_test_count,
+    (select count(1) 
+      from `{project}`.rdr_ops_data_view.participant_summary as ps_1 
+        cross join UNNEST(biobank_orders) as orders 
+        cross join UNNEST(orders.bbo_samples) as samples
+      where ps.participant_id = ps_1.participant_id and
+        samples.bbs_dna_test is true) as dna_test_count,
+    races,
+    pm,    
+    modules,
+    biobank_orders
+  FROM `{project}`.rdr_ops_data_view.participant_summary ps
+"""
+
+

--- a/rest-api/test/unit_test/dao_test/bigquery_sync_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/bigquery_sync_dao_test.py
@@ -111,7 +111,7 @@ class BigQuerySyncDaoTest(SqlTestBase):
 
     self.assertIsNotNone(ps_json)
     self.assertEqual(ps_json.sign_up_time, self.TIME_1)
-    self.assertEqual(ps_json['pm'][0]['finalized_site'], 'hpo-site-monroeville')
+    self.assertEqual(ps_json['pm'][0]['pm_finalized_site'], 'hpo-site-monroeville')
     self.assertEqual(ps_json.suspension_status, 'NOT_SUSPENDED')
     self.assertEqual(ps_json.withdrawal_status, 'NOT_WITHDRAWN')
-    self.assertEqual(ps_json['pm'][0]['status'], 'UNSET')
+    self.assertEqual(ps_json['pm'][0]['pm_status'], 'UNSET')

--- a/rest-api/tools/tool_libs/bq_migrate.py
+++ b/rest-api/tools/tool_libs/bq_migrate.py
@@ -196,6 +196,13 @@ class BQMigration(object):
 
     # Loop through table schemas
     for path, obj_name, view_name, view_desc in BQ_VIEWS:
+
+      if self.args.delete and (self.args.delete.lower() == 'all' or view_name in self.args.delete):
+        self.delete_table(view_name)
+        _logger.info('  {0:21}: {1}'.format(view_name, 'deleted'))
+        continue
+
+
       mod = importlib.import_module(path, obj_name)
       view_sql = getattr(mod, obj_name)
       if self.create_view(view_name, view_sql, view_desc):


### PR DESCRIPTION
I decided to add prefixes to all the sub-tables in the BQ particpant summary because there were too many duplicate fields names across the sub-tables which made creating a view extra difficult.  Adding prefixes alleviates the need to add aliases to the sub-table fields in table views.

**Because of this sub-table field naming change.  When this PR is merged, the following steps need to be manually done after the deploy for each environment this PR goes into.  There will be BQ sync cron job errors until these steps are completed.**

1. Run the migrate-bq tool to delete existing tables and views. 
    **`python -m tools migrate-bq --project all-of-us-rdr-XXXXX --dataset rdr_ops_data_view --delete all`**

2. Run the migrate-bq tool again to create the tables and views. 
   **`python -m tools migrate-bq --project all-of-us-rdr-XXXXX --dataset rdr_ops_data_view`**

3. Truncate the `bigquery_sync` table in mysql (root access is needed).  
    **`truncate table bigquery_sync`.**

