### PR TITLE
Fixed up database connection to use a dedicated unittest connection

### DIFF
--- a/rdr_service/.configs/db_config.json
+++ b/rdr_service/.configs/db_config.json
@@ -1,1 +1,9 @@
-{"db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",   "backup_db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",   "db_password": "rdr!pwd",   "db_connection_name": "",   "db_user": "rdr",   "db_name": "rdr" }
+{
+  "db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
+  "backup_db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
+  "unittest_connection_string": "mysql+mysqldb://root@127.0.0.1:9306",
+  "db_password": "rdr!pwd",
+  "db_connection_name": "",
+  "db_user": "rdr",
+  "db_name": "rdr"
+}

--- a/rdr_service/dao/database_factory.py
+++ b/rdr_service/dao/database_factory.py
@@ -6,7 +6,6 @@ from sqlalchemy.engine.url import make_url
 from rdr_service import singletons
 from rdr_service.model.database import Database
 
-DB_CONNECTION_STRING = os.getenv("DB_CONNECTION_STRING")
 # Exposed for testing.
 SCHEMA_TRANSLATE_MAP = None
 
@@ -51,15 +50,18 @@ def get_generic_database():
 
 
 def get_db_connection_string(backup=False, instance_name=None):
-    if DB_CONNECTION_STRING:
-        return DB_CONNECTION_STRING
-
     # Only import "config" on demand, as it depends on Datastore packages (and
     # GAE). When running via CLI or tests, we'll have this from the environment
     # instead (above).
     from rdr_service import config
 
-    connection_string_key = "backup_db_connection_string" if backup else "db_connection_string"
+    if os.environ.get("UNITTEST_FLAG", None):
+        connection_string_key = "unittest_connection_string"
+    elif backup:
+        connection_string_key = "backup_db_connection_string"
+    else:
+        connection_string_key = "db_connection_string"
+
     result = config.get_db_config()[connection_string_key]
     if instance_name:
         if backup:

--- a/tests/dao_tests/test_site_dao.py
+++ b/tests/dao_tests/test_site_dao.py
@@ -14,7 +14,9 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class SiteDaoTest(BaseTestCase):
+
     def setUp(self):
+        super(SiteDaoTest, self).setUp()
 
         self.site_dao = SiteDao()
         self.participant_dao = ParticipantDao()
@@ -29,9 +31,6 @@ class SiteDaoTest(BaseTestCase):
         site = Site(
             siteName="site", googleGroup="site@googlegroups.com", mayolinkClientNumber=12345, hpoId=PITT_HPO_ID
         )
-        with self.site_dao.session() as session:
-            x = session.query(Site.googleGroup).all()
-            print(x)
         created_site = self.site_dao.insert(site)
         new_site = self.site_dao.get(created_site.siteId)
         site.siteId = created_site.siteId

--- a/tests/helpers/mysql_helper.py
+++ b/tests/helpers/mysql_helper.py
@@ -53,9 +53,6 @@ def start_mysql_instance():
         if pid_is_running(pid):
             return
 
-    # Set this so the database factory knows to use the unittest connection string from the config.
-    os.environ["UNITTEST_FLAG"] = "True"
-
     if os.path.exists(BASE_PATH):
         shutil.rmtree(BASE_PATH)
     os.mkdir(BASE_PATH)

--- a/tests/helpers/mysql_helper.py
+++ b/tests/helpers/mysql_helper.py
@@ -53,6 +53,9 @@ def start_mysql_instance():
         if pid_is_running(pid):
             return
 
+    # Set this so the database factory knows to use the unittest connection string from the config.
+    os.environ["UNITTEST_FLAG"] = "True"
+
     if os.path.exists(BASE_PATH):
         shutil.rmtree(BASE_PATH)
     os.mkdir(BASE_PATH)
@@ -104,12 +107,6 @@ def _initialize_database(with_data=True, with_consent_codes=False):
     database_factory.DB_CONNECTION_STRING = "mysql+mysqldb://{0}@{1}:{2}".format(mysql_login, mysql_host, MYSQL_PORT)
     db = database_factory.get_database(db_name=None)
 
-    print(database_factory.DB_CONNECTION_STRING, '<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<')
-    print('\n')
-    print('\n')
-    print('\n')
-    print('\n')
-    print('\n')
     db.get_engine().execute("DROP DATABASE IF EXISTS rdr")
     db.get_engine().execute("DROP DATABASE IF EXISTS metrics")
     # Keep in sync with tools/setup_local_database.sh.

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -1,3 +1,4 @@
+import os
 import faker
 import unittest
 
@@ -21,8 +22,8 @@ class BaseTestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(BaseTestCase, self).__init__(*args, **kwargs)
-        # make sure this gets called before anything else.
-        reset_mysql_instance()
+        # Set this so the database factory knows to use the unittest connection string from the config.
+        os.environ["UNITTEST_FLAG"] = "True"
         self.fake = faker.Faker()
 
     def setUp(self) -> None:

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -1,8 +1,10 @@
+import faker
 import unittest
+
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.concepts import Concept
-from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao import questionnaire_dao, questionnaire_response_dao
+from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.participant import Participant, ParticipantHistory
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.participant_enums import (
@@ -13,11 +15,21 @@ from rdr_service.participant_enums import (
 )
 from tests.helpers.mysql_helper import reset_mysql_instance
 
+
 class BaseTestCase(unittest.TestCase):
     """ Base class for unit tests."""
 
-    def setUp(self):
+    def __init__(self, *args, **kwargs):
+        super(BaseTestCase, self).__init__(*args, **kwargs)
+        # make sure this gets called before anything else.
         reset_mysql_instance()
+        self.fake = faker.Faker()
+
+    def setUp(self) -> None:
+        super(BaseTestCase, self).setUp()
+
+        reset_mysql_instance()
+
         # Allow printing the full diff report on errors.
         self.maxDiff = None
         # Always add codes if missing when handling questionnaire responses.

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -107,3 +107,54 @@ class BaseTestCase(unittest.TestCase):
         summary.email = self.fake.email()
         return summary
 
+
+def make_questionnaire_response_json(
+    participant_id,
+    questionnaire_id,
+    code_answers=None,
+    string_answers=None,
+    date_answers=None,
+    uri_answers=None,
+    language=None,
+    authored=None,
+):
+    results = []
+    if code_answers:
+        for answer in code_answers:
+            results.append(
+                {
+                    "linkId": answer[0],
+                    "answer": [{"valueCoding": {"code": answer[1].code, "system": answer[1].system}}],
+                }
+            )
+    if string_answers:
+        for answer in string_answers:
+            results.append({"linkId": answer[0], "answer": [{"valueString": answer[1]}]})
+    if date_answers:
+        for answer in date_answers:
+            results.append({"linkId": answer[0], "answer": [{"valueDate": "%s" % answer[1].isoformat()}]})
+    if uri_answers:
+        for answer in uri_answers:
+            results.append({"linkId": answer[0], "answer": [{"valueUri": answer[1]}]})
+
+    response_json = {
+        "resourceType": "QuestionnaireResponse",
+        "status": "completed",
+        "subject": {"reference": "Patient/{}".format(participant_id)},
+        "questionnaire": {"reference": "Questionnaire/{}".format(questionnaire_id)},
+        "group": {"question": results},
+    }
+    if language is not None:
+        response_json.update(
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                        "valueCode": "{}".format(language),
+                    }
+                ]
+            }
+        )
+    if authored is not None:
+        response_json.update({"authored": authored.isoformat()})
+    return response_json

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,24 +1,15 @@
-import json
 import os
 import sys
-import unittest
 
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.model.hpo import HPO
-
-from tests.helpers.mysql_helper import reset_mysql_instance
 from tests.helpers.unittest_base import BaseTestCase
-
 
 
 class TestEnvironment(BaseTestCase):
     """
     Test our python environment
     """
-
-    def setUp(self) -> None:
-        pass
-
     def test_python_version(self):
         """ Make sure we are using Python 3.7 or higher """
         self.assertEqual(sys.version_info[0], 3)


### PR DESCRIPTION
Dropped using a connection string from the os environment, now uses a dedicated unittest connection string in the local connection config file (.configs/db_config.json).

ALSO remember to call super() for BaseTestCase.setUp().