### PR TITLE
Hotfix for minor bigquery fixes

### DIFF
--- a/rest-api/cron_prod.yaml
+++ b/rest-api/cron_prod.yaml
@@ -1,5 +1,4 @@
 cron:
-- description: BigQuery Sync
 - description: Sync site bucket consent files
   url: /offline/SyncConsentFiles
   schedule: 1 of month 00:00

--- a/rest-api/offline/bigquery_sync.py
+++ b/rest-api/offline/bigquery_sync.py
@@ -33,7 +33,7 @@ def rebuild_bigquery_handler():
   #       batches of participant ids and then we could pass a batch id in the GET request.
   """
   timestamp = datetime.utcnow()
-  batch_size = 10000
+  batch_size = 100
 
   dao = BigQuerySyncDao()
   with dao.session() as session:


### PR DESCRIPTION
Reduce batch rebuild size to 100.
Enable production cron bigquery sync job.