### PR TITLE
Minor fixes to bigquery sync

### DIFF
--- a/rest-api/cron_default.yaml
+++ b/rest-api/cron_default.yaml
@@ -52,7 +52,7 @@ cron:
 - description: BigQuery Sync
   url: /offline/BigQuerySync
   timezone: America/New_York
-  schedule: every 60 minutes
+  schedule: every 2 minutes
   target: offline
 - description: Backfill Patient Status (Manual)
   url: /offline/PatientStatusBackfill

--- a/rest-api/dao/bigquery_sync_dao.py
+++ b/rest-api/dao/bigquery_sync_dao.py
@@ -1,5 +1,3 @@
-import logging
-
 from dao.base_dao import UpsertableDao
 from model.bigquery_sync import BigQuerySync
 from model.code import Code
@@ -44,7 +42,7 @@ class BigQueryGenerator(object):
     for project_id, dataset_id, table_id in mappings:
       # If project_id is None, we shouldn't save records for this project.
       if dataset_id is None:
-        logging.warning('{0} is mapped to none in {1} project.'.format(project_id, cur_id))
+        # logging.warning('{0} is mapped to none in {1} project.'.format(project_id, cur_id))
         continue
       bqs_rec = session.query(BigQuerySync.id).\
                   filter(BigQuerySync.pk_id == pk_id, BigQuerySync.projectId == project_id,


### PR DESCRIPTION
Set bigquery sync cron job to run every 2 minutes.
Ensure we are joining with `bigquery_sync` correctly to get the list of participant ids to rebuild.
Removed an unneeded logged warning.
Changed task batch size from 100 to 300.