### PR TITLE
only_enable_genomic_pipeline_on_stable

### DIFF
--- a/rest-api/cron_prod.yaml
+++ b/rest-api/cron_prod.yaml
@@ -1,4 +1,5 @@
 cron:
+- description: Genomic pipeline
 - description: Sync site bucket consent files
   url: /offline/SyncConsentFiles
   schedule: 1 of month 00:00

--- a/rest-api/cron_staging.yaml
+++ b/rest-api/cron_staging.yaml
@@ -1,0 +1,2 @@
+cron:
+- description: Genomic pipeline

--- a/rest-api/cron_test.yaml
+++ b/rest-api/cron_test.yaml
@@ -1,0 +1,2 @@
+cron:
+- description: Genomic pipeline


### PR DESCRIPTION
Genomic pipeline are testing only on stable env. Other env don't have those buckets, will throw error. Disable genomic pipeline on other envs in this PR and will enable prod when it go live.