### PR TITLE
Enable supervisor/celery/gunicorn to run on AppEngine 2

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,14 @@
+# Configuration for main API service. Should be kept in sync with test.yaml.
+# This file is concatenated at the beginning of app_(non)?prod.yaml (instead of
+# using an "includes" since "includes" only imports some directives).
+
+env_variables:
+  RDR_CONFIG_PROVIDER: "rdr_service.config.GoogleCloudDatastoreConfigProvider"
+  RDR_STORAGE_PROVIDER: "rdr_service.storage.GoogleCloudStorageProvider"
+
+runtime: python37
+entrypoint: python3 main.py --service
+# app_base.yaml is concatenated to the beginning of this file for deployment.
+
+instance_class: F4
+

--- a/main.py
+++ b/main.py
@@ -10,11 +10,11 @@ import os
 from rdr_service.services.system_utils import setup_i18n
 from rdr_service.main import app
 
-try:
-    import googleclouddebugger
-    googleclouddebugger.enable()
-except ImportError:
-    pass
+# try:
+#     import googleclouddebugger
+#     googleclouddebugger.enable()
+# except ImportError:
+#     pass
 
 if __name__ == '__main__':
     setup_i18n()

--- a/rdr_service/app_base.yaml
+++ b/rdr_service/app_base.yaml
@@ -4,6 +4,7 @@
 
 env_variables:
   RDR_CONFIG_PROVIDER: "rdr_service.config.GoogleCloudDatastoreConfigProvider"
+  RDR_STORAGE_PROVIDER: "rdr_service.storage.GoogleCloudStorageProvider"
 
 runtime: python37
 endpoint: python3 main.py --service

--- a/rdr_service/app_base.yaml
+++ b/rdr_service/app_base.yaml
@@ -6,3 +6,4 @@ env_variables:
   RDR_CONFIG_PROVIDER: "rdr_service.config.GoogleCloudDatastoreConfigProvider"
 
 runtime: python37
+endpoint: python3 main.py --service

--- a/rdr_service/celery_test.py
+++ b/rdr_service/celery_test.py
@@ -1,0 +1,5 @@
+from rdr_service.services.flask import celery
+
+@celery.task()
+def add(x, y):
+    return x + y

--- a/rdr_service/data_gen/fake_participant_generator.py
+++ b/rdr_service/data_gen/fake_participant_generator.py
@@ -216,12 +216,12 @@ class FakeParticipantGenerator(object):
                 logging.warning("Question for code %s missing; import questionnaires", code_value)
 
     def _read_all_lines(self, filename):
-        with open("app_data/%s" % filename) as f:
+        with open("rdr_service/app_data/%s" % filename) as f:
             reader = csv.reader(f)
             return [line[0].strip() for line in reader]
 
     def _read_json(self, filename):
-        with open("app_data/%s" % filename) as f:
+        with open("rdr_service/app_data/%s" % filename) as f:
             return json.load(f)
 
     def _read_csv_from_gcs(self, bucket_name, file_name):
@@ -229,12 +229,12 @@ class FakeParticipantGenerator(object):
             return list(csv.DictReader(infile))
 
     def _read_csv_from_file(self, file_name):
-        with open("app_data/%s" % file_name, mode="r") as infile:
+        with open("rdr_service/app_data/%s" % file_name, mode="r") as infile:
             return list(csv.DictReader(infile))
 
     def _setup_data(self):
         self._zip_code_to_state = {}
-        with open("app_data/zipcodes.txt") as zipcodes:
+        with open("rdr_service/app_data/zipcodes.txt") as zipcodes:
             reader = csv.reader(zipcodes)
             for zipcode, state in reader:
                 self._zip_code_to_state[zipcode] = state

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -35,6 +35,7 @@ from rdr_service.api.questionnaire_api import QuestionnaireApi
 from rdr_service.api.questionnaire_response_api import ParticipantQuestionnaireAnswers, QuestionnaireResponseApi
 from rdr_service.config import get_config, get_db_config
 from rdr_service.services.flask import app, API_PREFIX
+from rdr_service.services.system_utils import run_external_program
 
 
 def _warmup():
@@ -43,6 +44,17 @@ def _warmup():
     get_db_config()
     return '{ "success": "true" }'
 
+def _start():
+
+    code, so, se = run_external_program('pip list')
+    logging.info(so)
+
+    get_config()
+    get_db_config()
+    return '{ "success": "true" }'
+
+def _stop():
+    return '{ "success": "true" }'
 
 def _log_request_exception(sender, exception, **extra):  # pylint: disable=unused-argument
     """Logs HTTPExceptions.
@@ -243,6 +255,8 @@ app.add_url_rule(API_PREFIX + 'RebuildBigQueryCore',
                  methods=['POST'])
 
 app.add_url_rule("/_ah/warmup", endpoint="warmup", view_func=_warmup, methods=["GET"])
+app.add_url_rule("/_ah/start", endpoint="start", view_func=_start, methods=["GET"])
+app.add_url_rule("/_ah/stop", endpoint="stop", view_func=_stop, methods=["GET"])
 
 app.after_request(app_util.add_headers)
 app.before_request(app_util.request_logging)

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -40,15 +40,13 @@ from rdr_service.services.system_utils import run_external_program
 
 def _warmup():
     # Load configurations into the cache.
+    # Not called in AppEngine2????
     get_config()
     get_db_config()
     return '{ "success": "true" }'
 
 def _start():
-
-    code, so, se = run_external_program('pip list')
-    logging.info(so)
-
+    # Load configurations into the cache.
     get_config()
     get_db_config()
     return '{ "success": "true" }'

--- a/rdr_service/services/celery_utils.py
+++ b/rdr_service/services/celery_utils.py
@@ -8,6 +8,8 @@
 # https://stackoverflow.com/questions/56179319/running-celery-as-a-flask-app-with-gunicorn
 # https://stackoverflow.com/questions/31999269/how-to-setup-sqlalchemy-session-in-celery-tasks-with-no-global-variable
 #
+# AMQP version issue: https://github.com/celery/py-amqp/issues/242
+#
 from celery import Celery
 
 # Every python module that has a Celery task must be included in this list.
@@ -16,7 +18,8 @@ _celery_includes = [
     'rdr_service.dao.bq_questionnaire_dao',
     'rdr_service.dao.bq_participant_summary_dao',
     'rdr_service.api.data_gen_api',
-    'rdr_service.offline.sync_consent_files'
+    'rdr_service.offline.sync_consent_files',
+    'rdr_service.celery_test'
 ]
 
 def configure_celery(flask_app):

--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -1,4 +1,4 @@
-import multiprocessing
+# import multiprocessing
 
 bind = "0.0.0.0:8081"
 workers = 1

--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -1,0 +1,8 @@
+import multiprocessing
+
+bind = "0.0.0.0:8081"
+workers = 1
+threads = 1
+
+# workers = multiprocessing.cpu_count() * 2 + 1
+# threads = multiprocessing.cpu_count() * 2 + 1

--- a/rdr_service/services/supervisor.conf
+++ b/rdr_service/services/supervisor.conf
@@ -22,7 +22,7 @@ serverurl = http://127.0.0.1:9001
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:flask_wsgi]
-command=gunicorn -b 0.0.0.0:8080 -w 3 --worker-class gevent rdr_service.wsgi
+command=gunicorn -b 0.0.0.0:%(PORT)s -w 3 --worker-class gevent rdr_service.wsgi
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1

--- a/rdr_service/services/supervisor.conf
+++ b/rdr_service/services/supervisor.conf
@@ -21,8 +21,18 @@ serverurl = http://127.0.0.1:9001
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
+; [program:pip_list]
+; command=pip list
+; autostart=true
+; autorestart=false
+; stdout_logfile=/dev/fd/1
+; stdout_logfile_maxbytes=0
+; stderr_logfile=/dev/fd/2
+; stderr_logfile_maxbytes=0
+
 [program:flask_wsgi]
-command=gunicorn -b 0.0.0.0:%(PORT)s -w 3 --worker-class gevent rdr_service.wsgi
+command=gunicorn -c rdr_service/services/gunicorn_config.py rdr_service.main:app
+;command=gunicorn -b 0.0.0.0:8081 -w 3 --worker-class gevent rdr_service.wsgi
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1
@@ -37,6 +47,6 @@ autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-; stderr_logfile=/dev/fd/2
-; stderr_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
 redirect_stderr=true

--- a/rdr_service/version_api.py
+++ b/rdr_service/version_api.py
@@ -19,7 +19,7 @@ class VersionApi(Resource):
         task = add.delay(2, 40)
         count = 30
         while not task.ready() and count > 0:
-            count =- 1
+            count -= 1
             sleep(1.0)
 
         if not task.ready():

--- a/rdr_service/version_api.py
+++ b/rdr_service/version_api.py
@@ -15,17 +15,18 @@ class VersionApi(Resource):
 
     def get(self):
 
+        # Code for testing that Celery background tasks are working.
         task = add.delay(2, 40)
         count = 30
-
         while not task.ready() and count > 0:
             count =- 1
             sleep(1.0)
 
         if not task.ready():
+            task.forget()
             print('****** Celery Add Task Failed ********')
         else:
-            print('****** Celery Add Task Succeeded, The Answer Is: {0} ********'.format(task.get()))
-
+            answer = task.get()
+            print('****** Celery Add Task Succeeded, The Answer Is: {0} ********'.format(answer))
 
         return {"version_id": GAE_VERSION_ID}

--- a/rdr_service/version_api.py
+++ b/rdr_service/version_api.py
@@ -2,9 +2,10 @@
 
 No auth is required for this endpoint because it serves nothing sensitive.
 """
+from time import sleep
 
 from rdr_service.config import GAE_VERSION_ID
-
+from rdr_service.celery_test import add
 
 from flask_restful import Resource
 
@@ -13,4 +14,18 @@ class VersionApi(Resource):
     """Api handler for retrieving version info."""
 
     def get(self):
+
+        task = add.delay(2, 40)
+        count = 30
+
+        while not task.ready() and count > 0:
+            count =- 1
+            sleep(1.0)
+
+        if not task.ready():
+            print('****** Celery Add Task Failed ********')
+        else:
+            print('****** Celery Add Task Succeeded, The Answer Is: {0} ********'.format(task.get()))
+
+
         return {"version_id": GAE_VERSION_ID}

--- a/requirements.in
+++ b/requirements.in
@@ -44,6 +44,7 @@ sqlparse
 ## Background Tasks
 celery
 librabbitmq
+amqp==2.1.1
 
 ## misc
 dnspython

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile
 #
 alembic==1.0.11
-amqp==2.5.1               # via kombu, librabbitmq
+amqp==2.1.1               # via kombu, librabbitmq
 aniso8601==7.0.0          # via flask-restful
 asn1crypto==0.24.0        # via cryptography
 astroid==2.2.5            # via pylint


### PR DESCRIPTION
Force amqp package version to 2.1.1 for now.