### PR TITLE
Get offline cron jobs working.

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -131,7 +131,7 @@ class BaseApi(Resource):
         m = self._get_model_to_insert(resource, participant_id)
         result = self._do_insert(m)
         if participant_id:
-            task = bq_participant_summary_update_task.delay(participant_id)
+            task = bq_participant_summary_update_task.apply_async(queue='default', args=(participant_id,))
             task.forget()
         self._save_raw_request(result)
         return self._make_response(result)
@@ -281,7 +281,7 @@ class UpdatableApi(BaseApi):
         m = self._get_model_to_update(resource, id_, expected_version, participant_id)
         self._do_update(m)
         if participant_id:
-            task = bq_participant_summary_update_task.delay(participant_id)
+            task = bq_participant_summary_update_task.apply_async(queue='default', args=(participant_id,))
             task.forget()
         self._save_raw_request(m)
         return self._make_response(m)

--- a/rdr_service/api/data_gen_api.py
+++ b/rdr_service/api/data_gen_api.py
@@ -159,8 +159,8 @@ class DataGenApi(Resource):
                     include_physical_measurements, include_biobank_orders, requested_hpo
                 )
         if resource_json.get("create_biobank_samples"):
-            task = generate_samples_task.delay(
-                        resource_json.get("samples_missing_fraction", _SAMPLES_MISSING_FRACTION))
+            task = generate_samples_task.apply_async(queue='default', args=(
+                        resource_json.get("samples_missing_fraction", _SAMPLES_MISSING_FRACTION)))
             task.forget()
 
     @nonprod

--- a/rdr_service/api/import_codebook_api.py
+++ b/rdr_service/api/import_codebook_api.py
@@ -66,7 +66,7 @@ def import_codebook():
     response["active_version"] = new_codebook.version
     response["status_messages"] = ["Imported %d codes." % code_count]
 
-    task = bq_codebook_update_task.delay()
+    task = bq_codebook_update_task.apply_async(queue='default')
     task.forget()
 
     return _log_and_return_json(response)

--- a/rdr_service/api/questionnaire_response_api.py
+++ b/rdr_service/api/questionnaire_response_api.py
@@ -26,7 +26,7 @@ class QuestionnaireResponseApi(BaseApi):
     def post(self, p_id):
         resp = super(QuestionnaireResponseApi, self).post(participant_id=p_id)
         if resp and 'id' in resp:
-            task = bq_questionnaire_update_task.delay(p_id, int(resp['id']))
+            task = bq_questionnaire_update_task.apply_async(queue='default', args=(p_id, int(resp['id'])))
             task.forget()
         return resp
 

--- a/rdr_service/cloud_utils/bigquery.py
+++ b/rdr_service/cloud_utils/bigquery.py
@@ -33,7 +33,9 @@ class BigQueryJob(object):
         self.retry_count = retry_count
         self.socket_timeout = socket_timeout
         self.page_size = page_size
-        self._service = build("bigquery", "v2")
+        # https://github.com/pior/appsecrets/issues/7
+        # https://github.com/googleapis/google-api-python-client/issues/299
+        self._service = build("bigquery", "v2", cache_discovery=False)
         self._job_ref = None
         self._page_token = None
 
@@ -49,7 +51,7 @@ class BigQueryJob(object):
         else:
             return self.get_rows_from_response(self.get_job_results(page_token=self._page_token))
 
-    def __next__(self):
+    def next(self):
         return self.__next__()
 
     def _make_job_body(self):

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -354,8 +354,11 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         # loop through results again and add each sample to it's order.
         for row in results:
             # get the order list index for this sample record
-            idx = orders.index(
-                    list(filter(lambda order: order['bbo_biobank_order_id'] == row.biobank_order_id, orders))[0])
+            try:
+                idx = orders.index(
+                        list(filter(lambda order: order['bbo_biobank_order_id'] == row.biobank_order_id, orders))[0])
+            except IndexError:
+                continue
             # if we haven't added any samples to this order, create an empty list.
             if 'samples' not in orders[idx]:
                 orders[idx]['bbo_samples'] = list()

--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -2,13 +2,13 @@
 
 runtime: python37
 service: offline
-entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py rdr_service.offline.main:app
+entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 600 rdr_service.offline.main:app
 # Default AppEngine configuration (B1) has only 128 MB of RAM and 600 MhZ CPU, which makes
 # the metrics pipeline run very slowly. Bumping up to 1 GB of RAM and 2.4 GHz to speed things up.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: B4
-# We need to specify basic scaling in order to use a backend instance class.
-basic_scaling:
-  max_instances: 10
-  idle_timeout: 10m
+instance_class: F4
+## We need to specify basic scaling in order to use a backend instance class.
+#basic_scaling:
+#  max_instances: 10
+#  idle_timeout: 10m
 

--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -6,9 +6,9 @@ entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 600 rd
 # Default AppEngine configuration (B1) has only 128 MB of RAM and 600 MhZ CPU, which makes
 # the metrics pipeline run very slowly. Bumping up to 1 GB of RAM and 2.4 GHz to speed things up.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: F4
-## We need to specify basic scaling in order to use a backend instance class.
-#basic_scaling:
-#  max_instances: 10
-#  idle_timeout: 10m
+instance_class: B4
+# We need to specify basic scaling in order to use a backend instance class.
+basic_scaling:
+  max_instances: 10
+  idle_timeout: 10m
 

--- a/rdr_service/offline/base_pipeline.py
+++ b/rdr_service/offline/base_pipeline.py
@@ -4,8 +4,8 @@ import os
 
 # import pipeline
 from rdr_service.config import GAE_PROJECT
-from google.appengine.api import mail
-from google.appengine.ext import db
+# from google.appengine.api import mail
+# from google.appengine.ext import db
 
 from rdr_service import config
 
@@ -23,17 +23,18 @@ class pipeline(object):
 # TODO(DA-448) For more reliable delivery, switch to creating tickets via the JIRA API.
 def send_failure_alert(job_name, message, log_exc_info=False, extra_recipients=None):
     """Sends an alert email for a failed job."""
-    subject = "%s failed in %s" % (job_name, GAE_PROJECT)
-    # This sender needs to be authorized per-environment in Email Authorized Senders,
-    # see https://cloud.google.com/appengine/docs/standard/python/mail/.
-    sender = config.getSetting(config.INTERNAL_STATUS_MAIL_SENDER)
-    to_list = config.getSettingList(config.INTERNAL_STATUS_MAIL_RECIPIENTS)
-    if extra_recipients is not None:
-        to_list += extra_recipients
-    logging.error(
-        "%s: %s (email will be sent from %r to %r)", subject, message, sender, to_list, exc_info=log_exc_info
-    )
-    mail.send_mail(sender, to_list, subject, message)
+    pass
+    # subject = "%s failed in %s" % (job_name, GAE_PROJECT)
+    # # This sender needs to be authorized per-environment in Email Authorized Senders,
+    # # see https://cloud.google.com/appengine/docs/standard/python/mail/.
+    # sender = config.getSetting(config.INTERNAL_STATUS_MAIL_SENDER)
+    # to_list = config.getSettingList(config.INTERNAL_STATUS_MAIL_RECIPIENTS)
+    # if extra_recipients is not None:
+    #     to_list += extra_recipients
+    # logging.error(
+    #     "%s: %s (email will be sent from %r to %r)", subject, message, sender, to_list, exc_info=log_exc_info
+    # )
+    # mail.send_mail(sender, to_list, subject, message)
 
 
 # class BasePipeline(pipeline.Pipeline):
@@ -44,9 +45,8 @@ class BasePipeline(pipeline):
 
     def finalized(self):
         """Finalizes this Pipeline after execution.
-
-    Sends an e-mail to us if a pipeline fails; otherwise just logs an info message.
-    """
+        Sends an e-mail to us if a pipeline fails; otherwise just logs an info message.
+        """
         if self.pipeline_id == self.root_pipeline_id:
             app_id = os.environ["APPLICATION_ID"]
             shard_index = app_id.find("~")
@@ -56,19 +56,22 @@ class BasePipeline(pipeline):
             base_path = "%s.appspot.com%s" % (app_id, self.base_path)
             status_link = "http://%s/status?root=%s" % (base_path, self.root_pipeline_id)
 
-            pipeline_record = db.get(self._root_pipeline_key)
             suffix = ""
-            if pipeline_record and pipeline_record.start_time:
-                duration = datetime.datetime.utcnow() - pipeline_record.start_time
-                seconds = duration.total_seconds()
-                hours = seconds // 3600
-                minutes = (seconds % 3600) // 60
-                seconds = seconds % 60
-                suffix = "after %d:%02d:%02d" % (hours, minutes, seconds)
-            if self.was_aborted:
-                self.handle_pipeline_failure()
-                send_failure_alert(
-                    pipeline_name, "%s failed %s; results are at %s" % (pipeline_name, suffix, status_link)
-                )
-            else:
-                logging.info("%s succeeded %s; results are at %s", pipeline_name, suffix, status_link)
+            logging.info("%s succeeded %s; results are at %s", pipeline_name, suffix, status_link)
+
+            # pipeline_record = db.get(self._root_pipeline_key)
+            # suffix = ""
+            # if pipeline_record and pipeline_record.start_time:
+            #     duration = datetime.datetime.utcnow() - pipeline_record.start_time
+            #     seconds = duration.total_seconds()
+            #     hours = seconds // 3600
+            #     minutes = (seconds % 3600) // 60
+            #     seconds = seconds % 60
+            #     suffix = "after %d:%02d:%02d" % (hours, minutes, seconds)
+            # if self.was_aborted:
+            #     self.handle_pipeline_failure()
+            #     send_failure_alert(
+            #         pipeline_name, "%s failed %s; results are at %s" % (pipeline_name, suffix, status_link)
+            #     )
+            # else:
+            #     logging.info("%s succeeded %s; results are at %s", pipeline_name, suffix, status_link)

--- a/rdr_service/offline/base_pipeline.py
+++ b/rdr_service/offline/base_pipeline.py
@@ -1,3 +1,5 @@
+# pylint: disable=unused-argument
+# pylint: disable=unused-import
 import datetime
 import logging
 import os

--- a/rdr_service/offline/bigquery_sync.py
+++ b/rdr_service/offline/bigquery_sync.py
@@ -103,8 +103,7 @@ def rebuild_bq_participant_task(timestamp, limit=0):
                 subquery()
             query = session.query(sq.c.participant_id.label('participantId')). \
                 filter(or_(sq.c.id == None, sq.c.modified < timestamp)).order_by(sq.c.modified)
-            if limit:
-                query = query.limit(1)
+            query = query.limit(1)
 
             # sql = dao.query_to_text(query)
             results = query.all()

--- a/rdr_service/offline/sa_key_remove.py
+++ b/rdr_service/offline/sa_key_remove.py
@@ -20,7 +20,7 @@ def delete_service_account_keys():
 
     project_name = "projects/" + app_id
     try:
-        service = discovery.build("iam", "v1")
+        service = discovery.build("iam", "v1", cache_discovery=False)
         request = service.projects().serviceAccounts().list(name=project_name)
         response = request.execute()
         accounts = response["accounts"]
@@ -31,7 +31,7 @@ def delete_service_account_keys():
                 continue
 
             serviceaccount = project_name + "/serviceAccounts/" + account["email"]
-            request = list(service.projects().serviceAccounts().keys()).list(
+            request = service.projects().serviceAccounts().keys().list(
                 name=serviceaccount, keyTypes="USER_MANAGED"
             )
             response = request.execute()
@@ -51,7 +51,7 @@ def delete_service_account_keys():
                             )
                         )
 
-                        delete_request = list(service.projects().serviceAccounts().keys()).delete(name=keyname)
+                        delete_request = service.projects().serviceAccounts().keys().delete(name=keyname)
                         delete_request.execute()
                     else:
                         logging.info("Service Account key is {} days old: {}".format(key_age_days, keyname))

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -45,9 +45,9 @@ def do_sync_consent_files():
             "participant_id": participant_data.participant_id,
             "google_group": participant_data.google_group or DEFAULT_GOOGLE_GROUP,
         }
-        task = cloudstorage_copy_objects_task.delay(
-            "/{source_bucket}/Participant/P{participant_id}/".format(**kwargs),
-            "/{destination_bucket}/Participant/{google_group}/P{participant_id}/".format(**kwargs))
+        task = cloudstorage_copy_objects_task.apply_async(queue='default', args=(
+                    "/{source_bucket}/Participant/P{participant_id}/".format(**kwargs),
+                    "/{destination_bucket}/Participant/{google_group}/P{participant_id}/".format(**kwargs)))
         task.forget()
 
 

--- a/rdr_service/services/celery_utils.py
+++ b/rdr_service/services/celery_utils.py
@@ -19,7 +19,8 @@ _celery_includes = [
     'rdr_service.dao.bq_participant_summary_dao',
     'rdr_service.api.data_gen_api',
     'rdr_service.offline.sync_consent_files',
-    'rdr_service.celery_test'
+    'rdr_service.celery_test',
+    'rdr_service.offline.bigquery_sync'
 ]
 
 def configure_celery(flask_app):

--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -7,11 +7,11 @@ if os.getenv('GAE_ENV', '').startswith('standard'):
     _port = os.environ.get('PORT', 8081)
 
 bind = "0.0.0.0:{0}".format(_port)
-workers = 1
-threads = 1
+workers = 2
+threads = 2
 timeout = 60
 log_level = "debug"
-# Do not use "gevent" for worker class, doesn't work.
+# Do not use "gevent" for worker class, doesn't work on App Engine.
 # worker_class = "gevent"
 raw_env = [
     "RDR_CONFIG_PROVIDER={0}".format(os.environ.get('RDR_CONFIG_PROVIDER', None)),

--- a/rdr_service/services/supervisor.conf
+++ b/rdr_service/services/supervisor.conf
@@ -51,7 +51,7 @@ stderr_logfile_maxbytes=0
 ; redirect_stderr=true
 
 [program:celery]
-command=celery -A rdr_service.services.flask:celery worker -n main.%%n --autoscale=2,1 --loglevel=info
+command=celery -A rdr_service.services.flask:celery worker -n main.%%n -Q default,offline --autoscale=2,1 --loglevel=info
 autostart=true
 autorestart=true
 stdout_logfile=/dev/fd/1

--- a/rdr_service/storage.py
+++ b/rdr_service/storage.py
@@ -166,7 +166,7 @@ class GoogleCloudStorageFile(ContextDecorator):
     _lines = None
     _line = 0
 
-    def __init__(self, provider, blob):
+    def __init__(self, provider=None, blob=None):
         self.provider = provider
         self.blob = blob
         self.position = 0
@@ -300,7 +300,7 @@ class GoogleCloudStorageProvider(StorageProvider):
 def get_storage_provider():
     # Set a good default and let the environment var be the override.
     if os.getenv('GAE_ENV', '').startswith('standard'):
-        default_provider = GoogleCloudStorageFile
+        default_provider = GoogleCloudStorageProvider
     else:
         default_provider = LocalFilesystemStorageProvider
     provider_class = StorageProvider.get_provider(default=default_provider)

--- a/rdr_service/version_api.py
+++ b/rdr_service/version_api.py
@@ -16,7 +16,7 @@ class VersionApi(Resource):
     def get(self):
 
         # Code for testing that Celery background tasks are working.
-        task = add.delay(2, 40)
+        task = add.apply_async(queue='offline', args=(2, 40))
         count = 30
         while not task.ready() and count > 0:
             count -= 1


### PR DESCRIPTION
This only covers the 7 cron jobs that show up on Sandbox.  The other cron jobs need testing.
This added two celery queue types, a `default` queue and an `offline` queue so running the BigQuery rebuild would not block all background tasks until it completes.