### PR TITLE
Py3 BigQuery Fixes for Sync process and Import Organizations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,8 @@ workflows:
           <<: *filter_python3_branches
   deploy_to_sandbox:
     jobs:
+      - test_python3_branches:
+          <<: *only_devel
       - deploy_sandbox_py3:
           <<: *only_devel
           requires:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -31,10 +31,10 @@ cd rdr_service
 
 # Shouldn't need this anymore
 # ./tools/install_config.sh --config=config/config_dev.json --update
-./tools/setup_local_database.sh --db_user root --db_name rdr
+# ./tools/setup_local_database.sh --db_user root --db_name rdr
 
 cd $PROJ_DIR
 
 ./ci/check_licenses.sh
 
-python -m unittest discover -v -s tests
+UNITTEST_FLAG=1 python -m unittest discover -v -s tests

--- a/main.py
+++ b/main.py
@@ -8,8 +8,6 @@ import subprocess
 import sys
 import os
 
-from rdr_service.services.system_utils import setup_i18n
-
 
 # try:
 #     import googleclouddebugger
@@ -21,7 +19,6 @@ def print_service_list():
     print("Possible services are --celery, --flask, --gunicorn and --service.")
 
 if __name__ == '__main__':
-    setup_i18n()
 
     parser = argparse.ArgumentParser(prog='rdr-service', description="RDR web service")
     parser.add_argument("--debug", help="enable debug output", default=False, action="store_true")  # noqa
@@ -34,9 +31,10 @@ if __name__ == '__main__':
     parser.add_argument("--offline", help="start offline web service", default=False, action="store_true")  # noqa
 
     args = parser.parse_args()
-    env = dict(os.environ)
+
     if args.unittests:
-        env["UNITTEST_FLAG"] = "True"
+        os.environ["UNITTEST_FLAG"] = "1"
+    env = dict(os.environ)
 
     service_count = sum([args.flask, args.gunicorn, args.service, args.celery])
 

--- a/rdr_service/.configs/db_config.json
+++ b/rdr_service/.configs/db_config.json
@@ -3,7 +3,7 @@
     "backup_db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
     "unittest_db_connection_string": "mysql+mysqldb://root@127.0.0.1:9306",
     "celery_db_connection_string": "db+mysql://alembic:rdr!pwd@127.0.0.1/rdr_tasks?charset=utf8",
-    "unittest_celery_db_connection_string": "db+mysql://root:@127.0.0.1:9306/rdr_tasks?charset=utf8",
+    "unittest_celery_db_connection_string": "db+mysql://root@127.0.0.1:9306/rdr_tasks?charset=utf8",
     "celery_broker_url": "pyamqp://guest:@localhost//",
     "db_password": "rdr!pwd",
     "db_connection_name": "",

--- a/rdr_service/.configs/db_config.json
+++ b/rdr_service/.configs/db_config.json
@@ -3,6 +3,7 @@
     "backup_db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
     "unittest_db_connection_string": "mysql+mysqldb://root@127.0.0.1:9306",
     "celery_db_connection_string": "db+mysql://alembic:rdr!pwd@127.0.0.1/rdr_tasks?charset=utf8",
+    "unittest_celery_db_connection_string": "db+mysql://root:@127.0.0.1:9306/rdr_tasks?charset=utf8",
     "celery_broker_url": "pyamqp://guest:@localhost//",
     "db_password": "rdr!pwd",
     "db_connection_name": "",

--- a/rdr_service/dao/bigquery_sync_dao.py
+++ b/rdr_service/dao/bigquery_sync_dao.py
@@ -18,7 +18,7 @@ class BigQueryGenerator(object):
     Base class for generating BigQuery data JSON for storing in the bigquery_sync mysql table.
     """
 
-    def save_bqrecord(self, pk_id, bqrecord, bqtable, dao, session):
+    def save_bqrecord(self, pk_id, bqrecord, bqtable, dao, session, project_id=None):
         """
         Save the BQRecord object into the bigquery_sync table.
         :param pk_id: primary key id value from source table.
@@ -26,17 +26,25 @@ class BigQueryGenerator(object):
         :param bqtable: BQTable object.
         :param dao: BigQuerySyncDao object
         :param session: Session from a BigQuerySyncDao object
+        :param project_id: Project ID override value.
         """
         if not dao or not session:
             raise ValueError('Invalid BigQuerySyncDao dao or session argument.')
 
-        try:
-            from rdr_service import config
-            cur_id = config.GAE_PROJECT
-            if not cur_id or cur_id == 'None':
-                cur_id = 'localhost'
-        except ImportError:
+        # see if there is a project id override value.
+        if project_id:
+            cur_id = project_id
+        else:
             cur_id = 'localhost'
+            try:
+                from rdr_service import config
+                cur_id = config.GAE_PROJECT
+                if not cur_id or cur_id == 'None':
+                    cur_id = 'localhost'
+            except ImportError:
+                pass
+            except AttributeError:
+                pass
 
         mappings = bqtable.get_project_map(cur_id)
 

--- a/rdr_service/dao/bq_hpo_dao.py
+++ b/rdr_service/dao/bq_hpo_dao.py
@@ -27,9 +27,10 @@ class BQHPOGenerator(BigQueryGenerator):
             return BQRecord(schema=BQHPOSchema, data=data, convert_to_enum=convert_to_enum)
 
 
-def bq_hpo_update():
+def bq_hpo_update(project_id=None):
     """
     Generate all new HPO records for BQ. Since there is called from a tool, this is not deferred.
+    :param project_id: Override the project_id
     """
     dao = BigQuerySyncDao()
     with dao.session() as session:
@@ -39,4 +40,4 @@ def bq_hpo_update():
         logging.info('BQ HPO table: rebuilding {0} records...'.format(len(results)))
         for row in results:
             bqr = gen.make_bqrecord(row.hpoId)
-            gen.save_bqrecord(row.hpoId, bqr, bqtable=BQHPO, dao=dao, session=session)
+            gen.save_bqrecord(row.hpoId, bqr, bqtable=BQHPO, dao=dao, session=session, project_id=project_id)

--- a/rdr_service/dao/bq_organization_dao.py
+++ b/rdr_service/dao/bq_organization_dao.py
@@ -27,9 +27,10 @@ class BQOrganizationGenerator(BigQueryGenerator):
             return BQRecord(schema=BQOrganizationSchema, data=data, convert_to_enum=convert_to_enum)
 
 
-def bq_organization_update():
+def bq_organization_update(project_id=None):
     """
     Generate all new Organization records for BQ. Since there is called from a tool, this is not deferred.
+    :param project_id: Override the project_id
     """
     dao = BigQuerySyncDao()
     with dao.session() as session:
@@ -39,4 +40,5 @@ def bq_organization_update():
 
         for row in results:
             bqr = gen.make_bqrecord(row.organizationId)
-            gen.save_bqrecord(row.organizationId, bqr, bqtable=BQOrganization, dao=dao, session=session)
+            gen.save_bqrecord(row.organizationId, bqr, bqtable=BQOrganization, dao=dao, session=session,
+                              project_id=project_id)

--- a/rdr_service/dao/bq_site_dao.py
+++ b/rdr_service/dao/bq_site_dao.py
@@ -26,9 +26,10 @@ class BQSiteGenerator(BigQueryGenerator):
             return BQRecord(schema=BQSiteSchema, data=data, convert_to_enum=convert_to_enum)
 
 
-def bq_site_update():
+def bq_site_update(project_id=None):
     """
     Generate all new Site records for BQ. Since there is called from a tool, this is not deferred.
+    :param project_id: Override the project_id
     """
     dao = BigQuerySyncDao()
     with dao.session() as session:
@@ -38,4 +39,4 @@ def bq_site_update():
 
         for row in results:
             bqr = gen.make_bqrecord(row.siteId)
-            gen.save_bqrecord(row.siteId, bqr, bqtable=BQSite, dao=dao, session=session)
+            gen.save_bqrecord(row.siteId, bqr, bqtable=BQSite, dao=dao, session=session, project_id=project_id)

--- a/rdr_service/dao/database_factory.py
+++ b/rdr_service/dao/database_factory.py
@@ -49,7 +49,18 @@ def get_generic_database() -> Database:
     )
 
 
-def get_db_connection_string(backup=False, instance_name=None):
+def get_db_connection_string(backup=False, instance_name=None) -> str:
+    """
+    Return the database connection string we should use to connect with.
+    :param backup: Use backup instance connection information.
+    :param instance_name: Connect to specific named instance.
+    :return: connection string.
+    """
+    # RDR tools define the connection string we should use in the environment var.
+    env_db_connection_string = os.getenv('DB_CONNECTION_STRING')
+    if env_db_connection_string:
+        return env_db_connection_string
+
     # Only import "config" on demand, as it depends on Datastore packages (and
     # GAE). When running via CLI or tests, we'll have this from the environment
     # instead (above).

--- a/rdr_service/dao/database_factory.py
+++ b/rdr_service/dao/database_factory.py
@@ -57,8 +57,8 @@ def get_db_connection_string(backup=False, instance_name=None) -> str:
     :return: connection string.
     """
     # RDR tools define the connection string we should use in the environment var.
-    env_db_connection_string = os.getenv('DB_CONNECTION_STRING')
-    if env_db_connection_string:
+    env_db_connection_string = os.environ.get('DB_CONNECTION_STRING', None)
+    if not os.environ.get("UNITTEST_FLAG", None) and env_db_connection_string:
         return env_db_connection_string
 
     # Only import "config" on demand, as it depends on Datastore packages (and

--- a/rdr_service/offline/bigquery_sync.py
+++ b/rdr_service/offline/bigquery_sync.py
@@ -214,6 +214,7 @@ def sync_bigquery_handler(dryrun=False):
             errors = ''
             error_count = 0
             try:
+                # pylint: disable=unused-variable
                 max_created, max_modified = _get_remote_max_timestamps(project_id, dataset_id, table_id) \
                     if dryrun is False else (datetime.min, datetime.min)
             except BigQueryJobError:
@@ -222,8 +223,8 @@ def sync_bigquery_handler(dryrun=False):
 
             # figure out how many records need to be sync'd and divide into slices.
             total_rows = session.query(BigQuerySync.id). \
-                filter(BigQuerySync.tableId == table_id, BigQuerySync.datasetId == dataset_id,
-                       or_(BigQuerySync.created > max_created, BigQuerySync.modified > max_modified)).count()
+                filter(BigQuerySync.projectId == project_id, BigQuerySync.tableId == table_id,
+                       BigQuerySync.datasetId == dataset_id, BigQuerySync.modified > max_modified).count()
 
             if total_rows == 0:
                 logging.info('No rows to sync for {0}.{1}.'.format(dataset_id, table_id))
@@ -233,16 +234,15 @@ def sync_bigquery_handler(dryrun=False):
 
             while slice_num < slices:
                 results = session.query(BigQuerySync.id, BigQuerySync.created, BigQuerySync.modified). \
-                    filter(BigQuerySync.tableId == table_id, BigQuerySync.datasetId == dataset_id,
-                           or_(BigQuerySync.created > max_created, BigQuerySync.modified > max_modified)). \
-                    order_by(BigQuerySync.modified). \
-                    slice(slice_num * batch_size, (slice_num + 1) * batch_size). \
-                    all()
+                    filter(BigQuerySync.projectId == project_id, BigQuerySync.tableId == table_id,
+                           BigQuerySync.datasetId == dataset_id, BigQuerySync.modified > max_modified). \
+                    order_by(BigQuerySync.modified).limit(batch_size).all()
                 slice_num += 1
                 batch = list()
 
                 for row in results:
                     count += 1
+                    max_modified = row.modified
                     rec = session.query(BigQuerySync.resource).filter(BigQuerySync.id == row.id).first()
                     if isinstance(rec.resource, str):
                         rec_data = json.loads(rec.resource)

--- a/rdr_service/services/flask.py
+++ b/rdr_service/services/flask.py
@@ -18,7 +18,12 @@ app.url_map.converters["participant_id"] = ParticipantIdConverter
 app.config.setdefault("RESTFUL_JSON", {"cls": RdrJsonEncoder})
 
 # Add celery configuration information into Flask app.
-_result_backend = config.get_db_config()['celery_db_connection_string']
+if not os.environ.get("UNITTEST_FLAG", None):
+    key = 'celery_db_connection_string'
+else:
+    key = 'unittest_celery_db_connection_string'
+
+_result_backend = config.get_db_config()[key]
 _broker_url = config.get_db_config()['celery_broker_url']
 
 app.config.update(

--- a/rdr_service/tools/import_organizations.py
+++ b/rdr_service/tools/import_organizations.py
@@ -649,9 +649,9 @@ def main(args):
 
     # Update Organization BigQuery records
     if not args.dry_run:
-        bq_hpo_update()
-        bq_organization_update()
-        bq_site_update()
+        bq_hpo_update(args.project)
+        bq_organization_update(args.project)
+        bq_site_update(args.project)
 
 
 if __name__ == "__main__":

--- a/rdr_service/tools/setup_local_database.sh
+++ b/rdr_service/tools/setup_local_database.sh
@@ -53,6 +53,7 @@ echo '{"db_connection_string": "'$DB_CONNECTION_STRING'", ' \
      ' "backup_db_connection_string": "'$DB_CONNECTION_STRING'", ' \
      ' "unittest_db_connection_string": "'mysql+mysqldb://root@127.0.0.1:9306'",' \
      ' "celery_db_connection_string": "'db+mysql://${ALEMBIC_DB_USER}:${RDR_PASSWORD}@127.0.0.1/rdr_tasks?charset=utf8'",' \
+     ' "unittest_celery_db_connection_string": "'db+mysql://root@127.0.0.1:9306/rdr_tasks?charset=utf8'",' \
      ' "celery_broker_url": "pyamqp://guest:@localhost//", ' \
      ' "db_password": "'$RDR_PASSWORD'", ' \
      ' "db_connection_name": "", '\

--- a/tests/helpers/mysql_helper.py
+++ b/tests/helpers/mysql_helper.py
@@ -101,7 +101,7 @@ def _initialize_database(with_data=True, with_consent_codes=False):
     :param with_consent_codes: Populate with consent codes.
     """
     # Set this so the database factory knows to use the unittest connection string from the config.
-    os.environ["UNITTEST_FLAG"] = "True"
+    os.environ["UNITTEST_FLAG"] = "1"
     mysql_host = "127.0.0.1"  # Do not use 'localhost', we want to force using an IP socket.
 
     if "CIRCLECI" in os.environ:
@@ -115,9 +115,11 @@ def _initialize_database(with_data=True, with_consent_codes=False):
 
     with engine.begin():
         engine.execute("DROP DATABASE IF EXISTS rdr")
+        engine.execute("DROP DATABASE IF EXISTS rdr_tasks")
         engine.execute("DROP DATABASE IF EXISTS metrics")
         # Keep in sync with tools/setup_local_database.sh.
         engine.execute("CREATE DATABASE rdr CHARACTER SET utf8 COLLATE utf8_general_ci")
+        engine.execute("CREATE DATABASE rdr_tasks CHARACTER SET utf8 COLLATE utf8_general_ci")
         engine.execute("CREATE DATABASE metrics CHARACTER SET utf8 COLLATE utf8_general_ci")
 
         engine.execute("USE metrics")
@@ -127,12 +129,44 @@ def _initialize_database(with_data=True, with_consent_codes=False):
         database.create_schema()
         _load_views_and_functions(engine)
 
+        # Celery will create these tables during class loading. But since we are dropping the databases
+        # later to reset, we need to create them every time we initialize the database.
+        engine.execute("USE rdr_tasks")
+        engine.execute("""
+            create table rdr_tasks.celery_taskmeta
+            (
+                id        int auto_increment primary key,
+                task_id   varchar(155) null,
+                status    varchar(50)  null,
+                result    blob         null,
+                date_done datetime     null,
+                traceback text         null,
+                constraint task_id
+                    unique (task_id)
+            );
+        """)
+
+        engine.execute("""
+            create table rdr_tasks.celery_tasksetmeta
+            (
+                id         int auto_increment primary key,
+                taskset_id varchar(155) null,
+                result     blob         null,
+                date_done  datetime     null,
+                constraint taskset_id
+                    unique (taskset_id)
+            );
+        """)
+
+
     engine.dispose()
     database = None
     singletons.reset_for_tests()
 
-    conn_str = "mysql+mysqldb://{0}@{1}:{2}/rdr?charset=utf8".format(mysql_login, mysql_host, MYSQL_PORT)
-    config.override_setting('unittest_db_connection_string', conn_str)
+    db_conn_str = "mysql+mysqldb://{0}@{1}:{2}/rdr?charset=utf8".format(mysql_login, mysql_host, MYSQL_PORT)
+    celery_conn_str = "mysql+mysqldb://{0}@{1}:{2}/rdr_tasks?charset=utf8".format(mysql_login, mysql_host, MYSQL_PORT)
+    config.override_setting('unittest_db_connection_string', db_conn_str)
+    config.override_setting('unittest_celery_db_connection_string', celery_conn_str)
 
     if with_data:
         _setup_hpos()


### PR DESCRIPTION
Fixes a minor BigQuery sync issue.
Fixes the `localhost` BigQuery sync issue after running `import_organizations.sh`.
Use the DB connection string created by the cli tools when they are run.  Otherwise we only connect to our localhost DB when running cli tools.