### PR TITLE
modify_participant_count_cronjob_time

### DIFF
--- a/rest-api/cron_default.yaml
+++ b/rest-api/cron_default.yaml
@@ -21,7 +21,7 @@ cron:
   target: offline
 - description: Participant count metrics
   url: /offline/ParticipantCountsOverTime
-  schedule: every day 23:00
+  schedule: every day 03:30
   timezone: America/New_York
   target: offline
 - description: Flag ghost participants


### PR DESCRIPTION
We tried to move ParticipantCountsOverTime cron job to 23:00, but it's failed with deadlock error.
Move it back to 3:30.