### PR TITLE
Fixed error message typo.

### DIFF
--- a/rdr_service/dao/dv_order_dao.py
+++ b/rdr_service/dao/dv_order_dao.py
@@ -52,7 +52,7 @@ class DvOrderDao(UpdatableDao):
         fhir_resource = SimpleFhirR4Reader(resource)
         summary = ParticipantSummaryDao().get(pid)
         if not summary:
-            raise BadRequest("No summary for particpant id: {}".format(pid))
+            raise BadRequest("No summary for participant id: {}".format(pid))
         code_dict = summary.asdict()
         format_json_code(code_dict, self.code_dao, "genderIdentityId")
         format_json_code(code_dict, self.code_dao, "stateId")


### PR DESCRIPTION
Per DA-1315: # 1.) 

> possible typo: supplyDelivery error message when participant without primary consent "No summary for particpant id: 927711636".