### PR TITLE
Modified biobankStatus to source from Mayolink's API

### DIFF
--- a/rdr_service/model/biobank_dv_order.py
+++ b/rdr_service/model/biobank_dv_order.py
@@ -100,6 +100,7 @@ class BiobankDVOrder(Base):
         "biobank_order_id", String(80), ForeignKey("biobank_order.biobank_order_id"), unique=True, nullable=True
     )
 
+    # biobank_status is the response from Mayo Clinic API
     biobankStatus = Column("biobank_status", String(30), nullable=True)
     biobankReceived = Column("biobank_received", UTCDateTime6, nullable=True)
     biobankRequisition = Column("biobank_requisition", Text, nullable=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,6 @@ google-cloud-core==1.0.3  # via google-cloud-bigquery, google-cloud-datastore, g
 google-cloud-datastore==1.9.0
 google-cloud-firestore==1.4.0
 google-cloud-storage==1.18.0
-google-python-cloud-debugger==2.13
 google-resumable-media==0.3.2  # via google-cloud-bigquery, google-cloud-storage
 googleapis-common-protos==1.6.0  # via google-api-core
 googlemaps==3.0.2

--- a/tests/api_tests/test_dv_order_api.py
+++ b/tests/api_tests/test_dv_order_api.py
@@ -119,7 +119,7 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
             self.assertEqual(i.id, int(1))
             self.assertEqual(i.order_id, int(999999))
             self.assertEqual(i.biobankOrderId, "WEB1ABCD1234")
-            self.assertEqual(i.biobankStatus, "Delivered")
+            self.assertEqual(i.biobankStatus, "Queued")
             self.assertEqual(i.biobankTrackingId, "PAT-123-456")
 
         with self.dv_order_dao.session() as session:

--- a/tests/dao_tests/test_dv_order_dao.py
+++ b/tests/dao_tests/test_dv_order_dao.py
@@ -24,7 +24,6 @@ from tests.helpers.unittest_base import BaseTestCase
 
 from collections import namedtuple
 
-
 class DvOrderDaoTestBase(BaseTestCase):
     def setUp(self):
         super().setUp()
@@ -46,7 +45,7 @@ class DvOrderDaoTestBase(BaseTestCase):
         self.mayolink_response = {
             "orders": {
                 "order": {
-                    "status": "finished",
+                    "status": "Queued",
                     "reference_number": "barcode",
                     "received": "2019-04-05 12:00:00",
                     "number": "12345",
@@ -65,7 +64,7 @@ class DvOrderDaoTestBase(BaseTestCase):
         payload = self.send_post("SupplyRequest", request_data=self.post_request, expected_status=http.client.CREATED)
         request_response = json.loads(payload.response[0])
         location = payload.location.rsplit("/", 1)[-1]
-        put_response = self.send_put("SupplyRequest/{}".format(location), request_data=self.put_request)
+        self.send_put("SupplyRequest/{}".format(location), request_data=self.put_request)
         payload = self.send_post(
             "SupplyDelivery", request_data=self.post_delivery, expected_status=http.client.CREATED
         )
@@ -78,8 +77,6 @@ class DvOrderDaoTestBase(BaseTestCase):
         self.assertEqual(put_response["version"], 4)
         self.assertEqual(put_response["meta"]["versionId"].strip("W/"), '"4"')
         self.assertEqual(put_response["barcode"], "SABR90160121INA")
-        # self.assertEqual(put_response["biobankOrderId"], "12345")
-        self.assertEqual(put_response["biobankStatus"], "Delivered")
         self.assertEqual(put_response["order_id"], 999999)
 
     def test_enumerate_shipping_status(self):


### PR DESCRIPTION
Added `biobankStatus` to API test. Removed from DAO test. Writing 'status' field from Mayolink's response to `biobankStatus`.