### PR TITLE
tune_metrics_v2_cron_job

### DIFF
--- a/rest-api/dao/metrics_cache_dao.py
+++ b/rest-api/dao/metrics_cache_dao.py
@@ -37,16 +37,8 @@ class MetricsCacheJobStatusDao(UpdatableDao):
       index_name_list = list(set(index_name_list))
 
       for index_name in index_name_list:
-        if index_name not in ['PRIMARY', 'participant_summary_hpo']:
+        if index_name != 'PRIMARY':
           session.execute('ALTER TABLE  metrics_tmp_participant DROP INDEX  {}'.format(index_name))
-
-      session.execute('CREATE INDEX idx_sign_up_time ON metrics_tmp_participant (sign_up_time)')
-      session.execute('CREATE INDEX idx_consent_time ON metrics_tmp_participant '
-                      '(consent_for_study_enrollment_time)')
-      session.execute('CREATE INDEX idx_member_time ON metrics_tmp_participant '
-                      '(enrollment_status_member_time)')
-      session.execute('CREATE INDEX idx_sample_time ON metrics_tmp_participant '
-                      '(enrollment_status_core_stored_sample_time)')
 
       session.execute('ALTER TABLE metrics_tmp_participant MODIFY first_name VARCHAR(255)')
       session.execute('ALTER TABLE metrics_tmp_participant MODIFY last_name VARCHAR(255)')
@@ -79,6 +71,16 @@ class MetricsCacheJobStatusDao(UpdatableDao):
       """
       params = {'test_hpo_id': self.test_hpo_id, 'test_email_pattern': self.test_email_pattern,
                 'not_withdraw': int(WithdrawalStatus.NOT_WITHDRAWN)}
+
+      session.execute('CREATE INDEX idx_hpo_id ON metrics_tmp_participant (hpo_id)')
+      session.execute('CREATE INDEX idx_sign_up_time ON metrics_tmp_participant (sign_up_time)')
+      session.execute('CREATE INDEX idx_consent_time ON metrics_tmp_participant '
+                      '(consent_for_study_enrollment_time)')
+      session.execute('CREATE INDEX idx_member_time ON metrics_tmp_participant '
+                      '(enrollment_status_member_time)')
+      session.execute('CREATE INDEX idx_sample_time ON metrics_tmp_participant '
+                      '(enrollment_status_core_stored_sample_time)')
+
       session.execute(sql, params)
 
   def set_to_complete(self, obj):

--- a/rest-api/dao/participant_counts_over_time_service.py
+++ b/rest-api/dao/participant_counts_over_time_service.py
@@ -21,8 +21,12 @@ class ParticipantCountsOverTimeService(BaseDao):
     self.test_hpo_id = HPODao().get_by_name(TEST_HPO_NAME).hpoId
     self.test_email_pattern = TEST_EMAIL_PATTERN
 
-  def refresh_metrics_cache_data(self):
+  def init_tmp_table(self):
+    dao = MetricsCacheJobStatusDao()
+    dao.init_tmp_table()
+    logging.info('Init tmp table for metrics cron job.')
 
+  def refresh_metrics_cache_data(self):
     self.refresh_data_for_metrics_cache(MetricsEnrollmentStatusCacheDao())
     logging.info('Refresh MetricsEnrollmentStatusCache done.')
     self.refresh_data_for_metrics_cache(MetricsGenderCacheDao(MetricsCacheType.METRICS_V2_API))

--- a/rest-api/offline/participant_counts_over_time.py
+++ b/rest-api/offline/participant_counts_over_time.py
@@ -4,4 +4,5 @@ from dao.participant_counts_over_time_service import ParticipantCountsOverTimeSe
 def calculate_participant_metrics():
   # call metrics functions
   service = ParticipantCountsOverTimeService()
+  service.init_tmp_table()
   service.refresh_metrics_cache_data()

--- a/rest-api/test/unit_test/api_test/participant_counts_over_time_api_test.py
+++ b/rest-api/test/unit_test/api_test/participant_counts_over_time_api_test.py
@@ -1127,6 +1127,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     results = dao.get_latest_version_from_cache('2018-01-01', '2018-01-08')
 
@@ -1169,6 +1170,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao(version=MetricsAPIVersion.V2)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     results = dao.get_latest_version_from_cache('2018-01-01', '2018-01-08')
 
@@ -1198,13 +1200,13 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     p2 = Participant(participantId=2, biobankId=5)
     self._insert(p2, 'Bob', 'Builder', 'AZ_TUCSON', time_int=self.time2)
-
     p3 = Participant(participantId=3, biobankId=6)
     self._insert(p3, 'Chad', 'Caterpillar', 'AZ_TUCSON', time_int=self.time1, time_study=self.time1,
                  time_mem=self.time3, time_fp_stored=self.time4)
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     results = dao.get_latest_version_from_cache('2018-01-01', '2018-01-08')
     self.assertIn({'date': '2018-01-01', 'metrics': {'consented': 0, 'core': 0, 'registered': 3}},
@@ -1233,6 +1235,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -1286,6 +1289,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -1351,6 +1355,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -1403,6 +1408,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -1466,6 +1472,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsGenderCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     results = dao.get_latest_version_from_cache('2017-12-31', '2018-01-08')
 
@@ -1522,6 +1529,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     self._insert(p_ghost, 'Ghost', 'G', 'AZ_TUCSON', time_int=self.time1, gender_identity=5)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao(MetricsCacheType.METRICS_V2_API))
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao(
       MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
@@ -1573,6 +1581,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     self._insert(p_ghost, 'Ghost', 'G', 'AZ_TUCSON', time_int=self.time1, gender_identity=5)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao())
 
     qs = """
@@ -1636,6 +1645,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     self._insert(p_ghost, 'Ghost', 'G', 'AZ_TUCSON', time_int=self.time1, gender_identity=5)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao())
 
     qs = """
@@ -1715,6 +1725,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     self._insert(p_ghost, 'Ghost', 'G', 'AZ_TUCSON', time_int=self.time1, gender_identity=5)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao())
 
     qs = """
@@ -1791,6 +1802,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsAgeCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     results = dao.get_latest_version_from_cache('2017-12-31', '2018-01-08')
 
@@ -1857,6 +1869,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     self._insert(p_ghost, 'Ghost', 'G', 'AZ_TUCSON', time_int=self.time1, dob=dob3)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsAgeCacheDao())
 
     qs = """
@@ -1915,6 +1928,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     self._insert(p_ghost, 'Ghost', 'G', 'AZ_TUCSON', time_int=self.time1, dob=dob3)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsAgeCacheDao())
 
     qs = """
@@ -1977,6 +1991,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     self._insert(p_ghost, 'Ghost', 'G', 'AZ_TUCSON', time_int=self.time1, dob=dob3)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsAgeCacheDao())
 
     qs = """
@@ -2028,6 +2043,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -2064,6 +2080,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -2128,6 +2145,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRaceCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     results = dao.get_latest_version_from_cache('2017-12-31', '2018-01-08')
@@ -2224,6 +2242,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
     setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsRaceCacheDao(MetricsCacheType.METRICS_V2_API))
     service.refresh_data_for_metrics_cache(MetricsRaceCacheDao(
       MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
@@ -2311,6 +2330,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRaceCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -2417,6 +2437,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRaceCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -2507,6 +2528,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRaceCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -2586,6 +2608,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     results1 = dao.get_latest_version_from_cache('2017-12-31', 'FULL_STATE')
@@ -2869,6 +2892,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao(version=MetricsAPIVersion.V2)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     results1 = dao.get_latest_version_from_cache('2017-12-31', 'GEO_STATE')
@@ -3054,6 +3078,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     results1 = dao.get_latest_version_from_cache('2017-12-31', 'GEO_STATE')
@@ -3116,6 +3141,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs1 = """
@@ -3554,6 +3580,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs1 = """
@@ -3815,6 +3842,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -3895,6 +3923,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = """
@@ -4001,6 +4030,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs1 = """
@@ -4378,6 +4408,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs1 = """
@@ -4600,6 +4631,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     results1 = dao.get_latest_version_from_cache('2018-01-01', 'FULL_STATE')
@@ -4664,6 +4696,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLifecycleCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     results = dao.get_latest_version_from_cache('2018-01-03')
@@ -4848,6 +4881,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLifecycleCacheDao(MetricsCacheType.METRICS_V2_API, MetricsAPIVersion.V2)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     results = dao.get_latest_version_from_cache('2018-01-01')
@@ -5071,6 +5105,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
                  time_mem=self.time1, time_fp=self.time1, time_fp_stored=self.time1)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsLifecycleCacheDao(MetricsCacheType
                                                                     .METRICS_V2_API))
     service.refresh_data_for_metrics_cache(MetricsLifecycleCacheDao(MetricsCacheType
@@ -5251,6 +5286,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
                  time_mem=self.time1, time_fp=self.time1, time_fp_stored=self.time1)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsLifecycleCacheDao(MetricsCacheType
                                                                     .METRICS_V2_API))
     service.refresh_data_for_metrics_cache(MetricsLifecycleCacheDao(MetricsCacheType
@@ -5390,6 +5426,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
                  time_mem=self.time1, time_fp=self.time1, time_fp_stored=self.time1)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsLifecycleCacheDao(MetricsCacheType
                                                                     .METRICS_V2_API))
     dao = MetricsLifecycleCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
@@ -5458,6 +5495,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLanguageCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     results = dao.get_latest_version_from_cache('2017-12-30', '2018-01-03')
 
@@ -5491,6 +5529,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLanguageCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     # test API without awardee and enrollmentStatus parameters
@@ -5581,6 +5620,7 @@ class ParticipantCountsOverTimeApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLanguageCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     results = dao.get_latest_version_from_cache('2017-12-30', '2018-01-03')
 

--- a/rest-api/test/unit_test/api_test/public_metrics_api_test.py
+++ b/rest-api/test/unit_test/api_test/public_metrics_api_test.py
@@ -248,6 +248,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = (
@@ -353,6 +354,7 @@ class PublicMetricsApiTest(FlaskTestBase):
                                       codeId=gender_code_dict['GenderIdentity_Transgender'])))
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao(MetricsCacheType.METRICS_V2_API))
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao(
       MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
@@ -527,6 +529,7 @@ class PublicMetricsApiTest(FlaskTestBase):
                                       codeId=gender_code_dict['GenderIdentity_Transgender'])))
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao(MetricsCacheType.METRICS_V2_API))
     service.refresh_data_for_metrics_cache(MetricsGenderCacheDao(
       MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
@@ -659,6 +662,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsAgeCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = (
@@ -751,6 +755,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsEnrollmentStatusCacheDao()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = (
@@ -830,6 +835,7 @@ class PublicMetricsApiTest(FlaskTestBase):
     setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsRaceCacheDao(MetricsCacheType.METRICS_V2_API))
     service.refresh_data_for_metrics_cache(
       MetricsRaceCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
@@ -995,6 +1001,7 @@ class PublicMetricsApiTest(FlaskTestBase):
     setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
 
     service = ParticipantCountsOverTimeService()
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(MetricsRaceCacheDao(MetricsCacheType.METRICS_V2_API))
     service.refresh_data_for_metrics_cache(MetricsRaceCacheDao(
       MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
@@ -1154,6 +1161,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsRegionCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs1 = (
@@ -1228,6 +1236,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLifecycleCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs1 = (
@@ -1305,6 +1314,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLanguageCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
     qs = (
           '&stratification=LANGUAGE'
@@ -1351,6 +1361,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLifecycleCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = (
@@ -1398,6 +1409,7 @@ class PublicMetricsApiTest(FlaskTestBase):
 
     service = ParticipantCountsOverTimeService()
     dao = MetricsLifecycleCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+    service.init_tmp_table()
     service.refresh_data_for_metrics_cache(dao)
 
     qs = (


### PR DESCRIPTION
The idea is to create a temp table at the very beginning to store all the participant and participant summary data.
And then run the cron job against the temp table, so it will not lock the participant and participant summary tables.