### PR TITLE
[DA-1338] Set biobank_order_identifier.system based on user

### DIFF
--- a/rest-api/api_util.py
+++ b/rest-api/api_util.py
@@ -18,10 +18,10 @@ RDR_AND_PTC = [RDR, PTC]
 PTC_AND_HEALTHPRO = [PTC, HEALTHPRO]
 PTC_HEALTHPRO_AWARDEE = [PTC, HEALTHPRO, AWARDEE]
 ALL_ROLES = [PTC, HEALTHPRO, STOREFRONT, EXPORTER]
-VIBRENT_FHIR_URL = 'http://joinallofus.org/fhir/'
-VIBRENT_BARCODE_URL = VIBRENT_FHIR_URL + 'barcode'
-VIBRENT_ORDER_URL = VIBRENT_FHIR_URL + 'order-type'
-VIBRENT_FULFILLMENT_URL = VIBRENT_FHIR_URL + 'fulfillment-status'
+DV_FHIR_URL = 'http://joinallofus.org/fhir/'
+DV_BARCODE_URL = DV_FHIR_URL + 'barcode'
+DV_ORDER_URL = DV_FHIR_URL + 'order-type'
+DV_FULFILLMENT_URL = DV_FHIR_URL + 'fulfillment-status'
 HIERARCHY_CONTENT_SYSTEM_PREFIX = 'http://all-of-us.org/fhir/sites/'
 
 def parse_date(date_str, date_format=None, date_only=False):

--- a/rest-api/model/biobank_dv_order.py
+++ b/rest-api/model/biobank_dv_order.py
@@ -9,7 +9,13 @@ class BiobankDVOrder(Base):
   """
   Direct Volunteer kit order shipment record
   """
-  _VIBRENT_ID_SYSTEM = 'http://vibrenthealth.com'
+  # Considering moving _DV_ID_SYSTEM to the configs; perhaps into USER_INFO
+  _DV_ID_SYSTEM = {
+      'vibrent-drc-prod': "http://vibrenthealth.com",
+      'careevolution': "http://carevolution.be",
+      'authorized': "system-test"
+    }
+
   __tablename__ = 'biobank_dv_order'
 
   # Primary Key

--- a/rest-api/services/gcp_db_daemon.py
+++ b/rest-api/services/gcp_db_daemon.py
@@ -59,6 +59,11 @@ def run():
         if self._args.enable_replica:
           _logger.info('    pmi-drc-api-test:       replica    -> tcp: 127.0.0.1:9945')
 
+      if self._args.enable_care_evo is True:
+        _logger.info('    all-of-us-rdr-careevo-test:       primary    -> tcp: 127.0.0.1:9950')
+        if self._args.enable_replica:
+          _logger.info('    all-of-us-rdr-careevo-test:       replica    -> tcp: 127.0.0.1:9955')
+
     def get_instances(self):
       """
       Build all instances we are going to connect to
@@ -89,6 +94,11 @@ def run():
         instances += gcp_format_sql_instance('pmi-drc-api-test', 9940) + ','
         if self._args.enable_replica:
           instances += gcp_format_sql_instance('pmi-drc-api-test', 9945, True) + ','
+
+      if self._args.enable_care_evo is True:
+        instances += gcp_format_sql_instance('all-of-us-rdr-careevo-test', 9950) + ','
+        if self._args.enable_replica:
+          instances += gcp_format_sql_instance('all-of-us-rdr-careevo-test', 9955, True) + ','
 
       # remove trailing comma
       instances = instances[:-1]
@@ -160,6 +170,10 @@ def run():
   # pylint: disable=E0602
   parser.add_argument('--enable-test', help=_('Add proxy to pmi-drc-api-test'),
                       default=False, action='store_true')  # noqa
+  # pylint: disable=E0602
+  parser.add_argument('--enable-care-evo', help=_('Add proxy to all-of-us-rdr-careevo-test'),
+                      default=False, action='store_true')  # noqa
+
   parser.add_argument('action', choices=('start', 'stop', 'restart'), default='')  # noqa
 
   args = parser.parse_args()

--- a/rest-api/test/unit_test/api_test/dv_order_api_test.py
+++ b/rest-api/test/unit_test/api_test/dv_order_api_test.py
@@ -2,7 +2,6 @@ import copy
 import httplib
 
 import mock
-import config_api
 from dao.code_dao import CodeDao
 from dao.dv_order_dao import DvOrderDao
 from dao.hpo_dao import HPODao
@@ -11,10 +10,15 @@ from dao.participant_summary_dao import ParticipantSummaryDao
 from model.biobank_dv_order import BiobankDVOrder
 from model.code import Code, CodeType
 from model.participant import Participant
-from model.biobank_order import BiobankOrderIdentifier, BiobankOrderedSample
+from model.biobank_order import (
+  BiobankOrderIdentifier,
+  BiobankOrderedSample,
+  BiobankOrder,
+  BiobankOrderIdentifierHistory,
+  BiobankOrderedSampleHistory, BiobankOrderHistory)
 from test_data import load_test_data_json
-from unit_test_util import FlaskTestBase
-
+from unit_test_util import FlaskTestBase, NdbTestBase
+import api_util
 
 class DvOrderApiTestBase(FlaskTestBase):
   mayolink_response = None
@@ -152,47 +156,101 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
     self.assertEquals(post_response._status_code, 201)
 
   def test_set_system_identifier_by_user(self):
-    # Testing how to change the AUTH_USER for the requests below
-    # self._AUTH_USER = "vibrent-drc-prod@fake-testbed-test.com"
-    # config_api.CONFIG_ADMIN_MAP["testbed-test"] = self._AUTH_USER
-    # self.set_auth_user(self._AUTH_USER)
 
     system_from_user = {
-      'vibrent-drc-prod': "http://vibrenthealth.com",
-      'careevolution': "http://carevolution.be",
-      'authorized': "test"
+      'vibrent-drc-prod@test-bed.fake': "http://vibrenthealth.com",
+      'careevolution@test-bed.fake': "http://carevolution.be",
+      'authorized@gservices.act': "system-test"
     }
 
-    post_response = self.send_post(
-      'SupplyRequest',
-      request_data=self.get_payload('dv_order_api_post_supply_request.json'),
-      expected_status=httplib.CREATED
-    )
+    # duplicate the test for each user (Vibrent and CE)
+    for user, expected_system_identifier in system_from_user.items():
+      self._switch_auth_user(user)
 
-    api_user = dict(post_response.headers)['auth_user'].split("@")[0]
+      # Make the series of API calls to create DV orders and associated Biobank records
+      post_response = self.send_post(
+        'SupplyRequest',
+        request_data=self.get_payload('dv_order_api_post_supply_request.json'),
+        expected_status=httplib.CREATED
+      )
+      location_id = post_response.location.rsplit('/', 1)[-1]
+      self.send_put(
+        'SupplyRequest/{}'.format(location_id),
+        request_data=self.get_payload('dv_order_api_put_supply_request.json'),
+      )
+      self.send_post(
+        'SupplyDelivery',
+        request_data=self._set_mayo_address(
+          self.get_payload('dv_order_api_post_supply_delivery.json')),
+        expected_status=httplib.CREATED
+      )
 
-    location_id = post_response.location.rsplit('/', 1)[-1]
-    self.send_put(
-      'SupplyRequest/{}'.format(location_id),
-      request_data=self.get_payload('dv_order_api_put_supply_request.json'),
-    )
-    self.send_post(
-      'SupplyDelivery',
-      request_data=self._set_mayo_address(
-        self.get_payload('dv_order_api_post_supply_delivery.json')),
-      expected_status=httplib.CREATED
-    )
+      # Compare the results in the DB with the system identifiers defined above
+      with self.dv_order_dao.session() as session:
+        test_order_id = self.mayolink_response['orders']['order']['number']
+        identifiers = session.query(BiobankOrderIdentifier).filter_by(
+          biobankOrderId=test_order_id
+        ).all()
+        for identifier in identifiers:
+          if identifier.system.endswith('/trackingId'):
+            self.assertEqual(identifier.system, expected_system_identifier + "/trackingId")
+          else:
+            self.assertEqual(identifier.system, expected_system_identifier)
+          session.delete(identifier)
+
+      self._intra_test_clean_up_db()
+
+    # Resetting in case downstream tests require it
+    self._switch_auth_user("authorized@gservices.act")
+
+
+  def _switch_auth_user(self, new_auth_user):
+    """Helper function to switch the auth_user's account email for testing"""
+    NdbTestBase._AUTH_USER = new_auth_user
+    NdbTestBase._CONFIG_USER_INFO = {
+      NdbTestBase._AUTH_USER: {
+        'roles': api_util.ALL_ROLES,
+      },
+    }
+
+    NdbTestBase.doSetUp(self)
+    self.set_auth_user(NdbTestBase._AUTH_USER)
+
+  def _intra_test_clean_up_db(self):
+    """DB clean-up to avoid duplicate key errors"""
+    test_order_id = self.mayolink_response['orders']['order']['number']
 
     with self.dv_order_dao.session() as session:
-      identifiers = session.query(BiobankOrderIdentifier).filter_by(
-        biobankOrderId=self.mayolink_response['orders']['order']['number']
-      ).all()
-    for identifier in identifiers:
-      if identifier.system.endswith('/trackingId'):
-        self.assertEqual(identifier.system, system_from_user[api_user] + "/trackingId")
-      else:
-        self.assertEqual(identifier.system, system_from_user[api_user])
 
+      identifier_history = session.query(BiobankOrderIdentifierHistory).filter_by(
+        biobankOrderId=test_order_id
+      ).all()
+      for record in identifier_history:
+        session.delete(record)
+
+      ordered_samples_history = session.query(BiobankOrderedSampleHistory).filter_by(
+        biobankOrderId=test_order_id
+      ).all()
+      for record in ordered_samples_history:
+        session.delete(record)
+
+      dv_orders = session.query(BiobankDVOrder).filter_by(
+        participantId=self.participant.participantId
+      ).all()
+      for dv_order in dv_orders:
+        session.delete(dv_order)
+
+      bb_order_history = session.query(BiobankOrderHistory).filter_by(
+        biobankOrderId=test_order_id
+      ).all()
+      for record in bb_order_history:
+        session.delete(record)
+
+      bb_orders = session.query(BiobankOrder).filter_by(
+        biobankOrderId=test_order_id
+      ).all()
+      for bb_order in bb_orders:
+        session.delete(bb_order)
 
 class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
   mayolink_response = {

--- a/rest-api/test/unit_test/dao_test/dv_order_dao_test.py
+++ b/rest-api/test/unit_test/dao_test/dv_order_dao_test.py
@@ -9,9 +9,9 @@ from dao.participant_dao import ParticipantDao
 from dao.participant_summary_dao import ParticipantSummaryDao
 from fhir_utils import SimpleFhirR4Reader
 from api_util import (
-  VIBRENT_FHIR_URL,
-  VIBRENT_FULFILLMENT_URL,
-  VIBRENT_ORDER_URL,
+  DV_FHIR_URL,
+  DV_FULFILLMENT_URL,
+  DV_ORDER_URL,
   parse_date,
   get_code_id,
 )
@@ -127,7 +127,7 @@ class DvOrderDaoTestBase(FlaskTestBase):
 
   def test_enumerate_tracking_status(self):
     fhir_resource = SimpleFhirR4Reader(self.post_delivery)
-    status = self.dao._enumerate_order_tracking_status(fhir_resource.extension.get(url=VIBRENT_FHIR_URL + 'tracking-status').valueString)
+    status = self.dao._enumerate_order_tracking_status(fhir_resource.extension.get(url=DV_FHIR_URL + 'tracking-status').valueString)
     self.assertEquals(status, OrderShipmentTrackingStatus.IN_TRANSIT)
 
   def test_from_client_json(self):
@@ -185,17 +185,17 @@ class DvOrderDaoTestBase(FlaskTestBase):
     fhir_device = fhir_resource.contained.get(resourceType="Device")
     test_fields.update({
       'itemName': fhir_device.deviceName.get(type="manufacturer-name").name,
-      'orderType': fhir_resource.extension.get(url=VIBRENT_ORDER_URL).valueString
+      'orderType': fhir_resource.extension.get(url=DV_ORDER_URL).valueString
     })
 
     # add the fields to test for each resource type (SupplyRequest, SupplyDelivery)
     if resource_type == self.post_request:
       test_fields.update({
-        'order_id': int(fhir_resource.identifier.get(system=VIBRENT_FHIR_URL + "orderId").value),
+        'order_id': int(fhir_resource.identifier.get(system=DV_FHIR_URL + "orderId").value),
         'supplier': fhir_resource.contained.get(resourceType="Organization").id,
-        'supplierStatus': fhir_resource.extension.get(url=VIBRENT_FULFILLMENT_URL).valueString,
+        'supplierStatus': fhir_resource.extension.get(url=DV_FULFILLMENT_URL).valueString,
         'itemQuantity': fhir_resource.quantity.value,
-        'itemSKUCode': fhir_device.identifier.get(system=VIBRENT_FHIR_URL + "SKU").value,
+        'itemSKUCode': fhir_device.identifier.get(system=DV_FHIR_URL + "SKU").value,
       })
       # Address Handling
       fhir_address = fhir_resource.contained.get(resourceType="Patient").address[0]
@@ -204,10 +204,10 @@ class DvOrderDaoTestBase(FlaskTestBase):
       test_fields.update({
         'order_id': int(fhir_resource.basedOn[0].identifier.value),
         'shipmentEstArrival': parse_date(fhir_resource.extension.get(
-          url=VIBRENT_FHIR_URL + "expected-delivery-date").valueDateTime),
+          url=DV_FHIR_URL + "expected-delivery-date").valueDateTime),
         'shipmentCarrier': fhir_resource.extension.get(
-          url=VIBRENT_FHIR_URL + "carrier").valueString,
-        'trackingId': fhir_resource.identifier.get(system=VIBRENT_FHIR_URL + "trackingId").value,
+          url=DV_FHIR_URL + "carrier").valueString,
+        'trackingId': fhir_resource.identifier.get(system=DV_FHIR_URL + "trackingId").value,
         'shipmentLastUpdate': parse_date(fhir_resource.occurrenceDateTime),
       })
       # Address Handling


### PR DESCRIPTION
This PR changed the source for `biobank_order_identifier.system` to be the authenticated user supplying the `SupplyDelivery` and `SupplyRequest` payloads.
The constants related to the DV order system were refactored to reflect multiple providers, currently Vibrent and Care Evolution. Because the `SupplyRequest` and `SupplyDelivery` payloads are agnostic of which provider is supplying the payload, the authenticated user making the API call was used to determine the source for `biobank_order_identifier.system`.

Additional Notes:
- The system identifier for Care Evolution was assumed to be `http://carevolution.be` based on induction: the system identifier for Vibrent is `http://vibrenthealth.com`.
- A cloud DB proxy was created for the Care Evolution test environment.