### PR TITLE
[DA-1338] Setting biobank_order_identifier.system based on user

### DIFF
--- a/rdr_service/api_util.py
+++ b/rdr_service/api_util.py
@@ -18,10 +18,10 @@ RDR_AND_PTC = [RDR, PTC]
 PTC_AND_HEALTHPRO = [PTC, HEALTHPRO]
 PTC_HEALTHPRO_AWARDEE = [PTC, HEALTHPRO, AWARDEE]
 ALL_ROLES = [PTC, HEALTHPRO, STOREFRONT, EXPORTER]
-VIBRENT_FHIR_URL = "http://joinallofus.org/fhir/"
-VIBRENT_BARCODE_URL = VIBRENT_FHIR_URL + "barcode"
-VIBRENT_ORDER_URL = VIBRENT_FHIR_URL + "order-type"
-VIBRENT_FULFILLMENT_URL = VIBRENT_FHIR_URL + "fulfillment-status"
+DV_FHIR_URL = "http://joinallofus.org/fhir/"
+DV_BARCODE_URL = DV_FHIR_URL + "barcode"
+DV_ORDER_URL = DV_FHIR_URL + "order-type"
+DV_FULFILLMENT_URL = DV_FHIR_URL + "fulfillment-status"
 
 
 def parse_date(date_str, date_format=None, date_only=False):

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -64,6 +64,9 @@ EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION = "ehr_status_bigquery_view_organization"
 HPO_REPORT_CONFIG_MIXIN_PATH = "hpo_report_config_mixin_path"
 LOCALHOST_DEFAULT_BUCKET_NAME = 'local_bucket'
 
+# For testing different account names locally
+LOCAL_AUTH_USER = "example@example.com"
+
 # Allow requests which are never permitted in production. These include fake
 # timestamps for reuqests, unauthenticated requests to create fake data, etc.
 ALLOW_NONPROD_REQUESTS = "allow_nonprod_requests"

--- a/rdr_service/model/biobank_dv_order.py
+++ b/rdr_service/model/biobank_dv_order.py
@@ -10,7 +10,12 @@ class BiobankDVOrder(Base):
   Direct Volunteer kit order shipment record
   """
 
-    _VIBRENT_ID_SYSTEM = "http://vibrenthealth.com"
+    _DV_ID_SYSTEM = {
+        'vibrent-drc-prod': "http://vibrenthealth.com",
+        'careevolution': "http://carevolution.be",
+        'example': "system-test"
+    }
+
     __tablename__ = "biobank_dv_order"
 
     # Primary Key

--- a/rdr_service/model/bq_base.py
+++ b/rdr_service/model/bq_base.py
@@ -595,4 +595,5 @@ class BQRecord(object):
         return json.dumps(self.to_dict(full_schema), default=json_serial)
 
     def get(self, attr: str, default: any = None):
-        return getattr(self, attr, default)
+        result = getattr(self, attr, default)
+        return result if result else default

--- a/rdr_service/services/gcp_db_daemon.py
+++ b/rdr_service/services/gcp_db_daemon.py
@@ -58,6 +58,11 @@ def run():
                 if self._args.enable_replica:
                     _logger.info("    pmi-drc-api-test:       replica    -> tcp: 127.0.0.1:9945")
 
+            if self._args.enable_care_evo is True:
+                _logger.info('    all-of-us-rdr-careevo-test:       primary    -> tcp: 127.0.0.1:9950')
+                if self._args.enable_replica:
+                    _logger.info('    all-of-us-rdr-careevo-test:       replica    -> tcp: 127.0.0.1:9955')
+
         def get_instances(self):
             """
       Build all instances we are going to connect to
@@ -88,6 +93,11 @@ def run():
                 instances += gcp_format_sql_instance("pmi-drc-api-test", 9940) + ","
                 if self._args.enable_replica:
                     instances += gcp_format_sql_instance("pmi-drc-api-test", 9945, True) + ","
+
+            if self._args.enable_care_evo is True:
+                instances += gcp_format_sql_instance('all-of-us-rdr-careevo-test', 9950) + ','
+                if self._args.enable_replica:
+                    instances += gcp_format_sql_instance('all-of-us-rdr-careevo-test', 9955, True) + ','
 
             # remove trailing comma
             instances = instances[:-1]
@@ -159,6 +169,10 @@ def run():
     parser.add_argument(
         "--enable-test", help=_("Add proxy to pmi-drc-api-test"), default=False, action="store_true"
     )  # noqa
+    # pylint: disable=E0602
+    parser.add_argument('--enable-care-evo', help=_('Add proxy to all-of-us-rdr-careevo-test'),
+                        default=False, action='store_true')  # noqa
+
     parser.add_argument("action", choices=("start", "stop", "restart"), default="")  # noqa
 
     args = parser.parse_args()

--- a/tests/api_tests/test_dv_order_api.py
+++ b/tests/api_tests/test_dv_order_api.py
@@ -8,12 +8,20 @@ from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.biobank_dv_order import BiobankDVOrder
-from rdr_service.model.biobank_order import BiobankOrderIdentifier, BiobankOrderedSample
+from rdr_service.model.biobank_order import (
+    BiobankOrderIdentifier,
+    BiobankOrderedSample,
+    BiobankOrder,
+    BiobankOrderIdentifierHistory,
+    BiobankOrderedSampleHistory,
+    BiobankOrderHistory
+)
 from rdr_service.model.code import Code, CodeType
 from rdr_service.model.participant import Participant
 from tests.test_data import load_test_data_json
 from tests.helpers.unittest_base import BaseTestCase
 
+from rdr_service import config, api_util
 
 class DvOrderApiTestBase(BaseTestCase):
     mayolink_response = None
@@ -139,6 +147,97 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
         self.assertEqual(1, len(order))
         self.assertEqual(post_response._status_code, 201)
 
+    def test_set_system_identifier_by_user(self):
+        system_from_user = {
+            'vibrent-drc-prod@test-bed.fake': "http://vibrenthealth.com",
+            'careevolution@test-bed.fake': "http://carevolution.be",
+            'example@example.com': "system-test"
+        }
+
+        # duplicate the test for each user (Vibrent and CE)
+        for user, expected_system_identifier in system_from_user.items():
+            self._switch_auth_user(user)
+
+            # Make the series of API calls to create DV orders and associated Biobank records
+            post_response = self.send_post(
+                'SupplyRequest',
+                request_data=self.get_payload('dv_order_api_post_supply_request.json'),
+                expected_status=http.client.CREATED
+            )
+            location_id = post_response.location.rsplit('/', 1)[-1]
+            self.send_put(
+                'SupplyRequest/{}'.format(location_id),
+                request_data=self.get_payload('dv_order_api_put_supply_request.json'),
+            )
+            self.send_post(
+                'SupplyDelivery',
+                request_data=self._set_mayo_address(
+                    self.get_payload('dv_order_api_post_supply_delivery.json')),
+                expected_status=http.client.CREATED
+            )
+
+            # Compare the results in the DB with the system identifiers defined above
+            with self.dv_order_dao.session() as session:
+                test_order_id = self.mayolink_response['orders']['order']['number']
+                identifiers = session.query(BiobankOrderIdentifier).filter_by(
+                    biobankOrderId=test_order_id
+                ).all()
+                for identifier in identifiers:
+                    if identifier.system.endswith('/trackingId'):
+                        self.assertEqual(identifier.system, expected_system_identifier + "/trackingId")
+                    else:
+                        self.assertEqual(identifier.system, expected_system_identifier)
+                    session.delete(identifier)
+
+            self._intra_test_clean_up_db()
+
+        # Resetting in case downstream tests require it
+        self._switch_auth_user("example@example.com")
+
+    def _switch_auth_user(self, new_auth_user):
+        config.LOCAL_AUTH_USER = new_auth_user
+        config_user_info = {
+            new_auth_user: {
+                'roles': api_util.ALL_ROLES
+            }
+        }
+        config.override_setting("user_info", config_user_info)
+
+    def _intra_test_clean_up_db(self):
+        """DB clean-up to avoid duplicate key errors"""
+        test_order_id = self.mayolink_response['orders']['order']['number']
+
+        with self.dv_order_dao.session() as session:
+
+            identifier_history = session.query(BiobankOrderIdentifierHistory).filter_by(
+                biobankOrderId=test_order_id
+            ).all()
+            for record in identifier_history:
+                session.delete(record)
+
+            ordered_samples_history = session.query(BiobankOrderedSampleHistory).filter_by(
+                biobankOrderId=test_order_id
+            ).all()
+            for record in ordered_samples_history:
+                session.delete(record)
+
+            dv_orders = session.query(BiobankDVOrder).filter_by(
+                participantId=self.participant.participantId
+            ).all()
+            for dv_order in dv_orders:
+                session.delete(dv_order)
+
+            bb_order_history = session.query(BiobankOrderHistory).filter_by(
+                biobankOrderId=test_order_id
+            ).all()
+            for record in bb_order_history:
+                session.delete(record)
+
+            bb_orders = session.query(BiobankOrder).filter_by(
+                biobankOrderId=test_order_id
+            ).all()
+            for bb_order in bb_orders:
+                session.delete(bb_order)
 
 class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
     mayolink_response = {

--- a/tests/dao_tests/test_dv_order_dao.py
+++ b/tests/dao_tests/test_dv_order_dao.py
@@ -5,9 +5,9 @@ import mock
 from werkzeug.exceptions import ServiceUnavailable
 
 from rdr_service.api_util import (
-    VIBRENT_FHIR_URL,
-    VIBRENT_FULFILLMENT_URL,
-    VIBRENT_ORDER_URL,
+    DV_FHIR_URL,
+    DV_FULFILLMENT_URL,
+    DV_ORDER_URL,
     parse_date,
     get_code_id,
 )
@@ -87,7 +87,7 @@ class DvOrderDaoTestBase(BaseTestCase):
     def test_enumerate_tracking_status(self):
         fhir_resource = SimpleFhirR4Reader(self.post_delivery)
         status = self.dao._enumerate_order_tracking_status(
-            fhir_resource.extension.get(url=VIBRENT_FHIR_URL + "tracking-status").valueString
+            fhir_resource.extension.get(url=DV_FHIR_URL + "tracking-status").valueString
         )
         self.assertEqual(status, OrderShipmentTrackingStatus.IN_TRANSIT)
 
@@ -145,17 +145,17 @@ class DvOrderDaoTestBase(BaseTestCase):
         fhir_device = fhir_resource.contained.get(resourceType="Device")
         test_fields.update({
             'itemName': fhir_device.deviceName.get(type="manufacturer-name").name,
-            'orderType': fhir_resource.extension.get(url=VIBRENT_ORDER_URL).valueString
+            'orderType': fhir_resource.extension.get(url=DV_ORDER_URL).valueString
         })
 
         # add the fields to test for each resource type (SupplyRequest, SupplyDelivery)
         if resource_type == self.post_request:
             test_fields.update({
-                'order_id': int(fhir_resource.identifier.get(system=VIBRENT_FHIR_URL + "orderId").value),
+                'order_id': int(fhir_resource.identifier.get(system=DV_FHIR_URL + "orderId").value),
                 'supplier': fhir_resource.contained.get(resourceType="Organization").id,
-                'supplierStatus': fhir_resource.extension.get(url=VIBRENT_FULFILLMENT_URL).valueString,
+                'supplierStatus': fhir_resource.extension.get(url=DV_FULFILLMENT_URL).valueString,
                 'itemQuantity': fhir_resource.quantity.value,
-                'itemSKUCode': fhir_device.identifier.get(system=VIBRENT_FHIR_URL + "SKU").value,
+                'itemSKUCode': fhir_device.identifier.get(system=DV_FHIR_URL + "SKU").value,
             })
             # Address Handling
             fhir_address = fhir_resource.contained.get(resourceType="Patient").address[0]
@@ -164,9 +164,9 @@ class DvOrderDaoTestBase(BaseTestCase):
             test_fields.update({
                 'order_id': int(fhir_resource.basedOn[0].identifier.value),
                 'shipmentEstArrival': parse_date(fhir_resource.extension.get(
-                    url=VIBRENT_FHIR_URL + "expected-delivery-date").valueDateTime),
-                'shipmentCarrier': fhir_resource.extension.get(url=VIBRENT_FHIR_URL + "carrier").valueString,
-                'trackingId': fhir_resource.identifier.get(system=VIBRENT_FHIR_URL + "trackingId").value,
+                    url=DV_FHIR_URL + "expected-delivery-date").valueDateTime),
+                'shipmentCarrier': fhir_resource.extension.get(url=DV_FHIR_URL + "carrier").valueString,
+                'trackingId': fhir_resource.identifier.get(system=DV_FHIR_URL + "trackingId").value,
                 'shipmentLastUpdate': parse_date(fhir_resource.occurrenceDateTime),
             })
             # Address Handling


### PR DESCRIPTION
Additionally:
- Constants now named to allow for multiple Salivary DV providers (Vibrent AND Care Evolution).
- Care Evolution added to Google cloud proxy. 
- Expanded tests to allow for switching of authenticated user's email locally.
- setup_local_database.sh errors fixed (bq_base)