### PR TITLE
[DA-1359] Updated logging, exceptions formatting for Python 3.

### DIFF
--- a/rdr_service/api/awardee_api.py
+++ b/rdr_service/api/awardee_api.py
@@ -16,7 +16,7 @@ class AwardeeApi(BaseApi):
         if a_id:
             hpo = self.dao.get_by_name(a_id)
             if not hpo:
-                raise NotFound("Awardee with ID %s not found" % a_id)
+                raise NotFound(f"Awardee with ID {a_id} not found")
             return self._make_response(self.dao.get_with_children(hpo.hpoId))
         return super(AwardeeApi, self)._query(id_field="id")
 

--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -119,12 +119,11 @@ class BaseApi(Resource):
             return self.list(participant_id)
         obj = self.dao.get_with_children(id_) if self._get_returns_children else self.dao.get(id_)
         if not obj:
-            raise NotFound("%s with ID %s not found" % (self.dao.model_type.__name__, id_))
+            raise NotFound(f"{self.dao.model_type.__name__} with ID {id_} not found")
         if participant_id:
             if participant_id != obj.participantId:
                 raise NotFound(
-                    "%s with ID %s is not for participant with ID %s"
-                    % (self.dao.model_type.__name__, id_, participant_id)
+                    f"{self.dao.model_type.__name__} with ID {id_} is not for participant with ID {participant_id}"
                 )
         log_api_request(obj)
         return self._make_response(obj)
@@ -190,7 +189,7 @@ class BaseApi(Resource):
       id_field: name of the field containing the ID used when constructing resource URLs for results
       participant_id: the participant ID under which to perform this query, if appropriate
     """
-        logging.info("Preparing query for %s.", self.dao.model_type)
+        logging.info(f"Preparing query for {self.dao.model_type}.")
         query = self._make_query()
         results = self.dao.query(query)
         logging.info("Query complete, bundling results.")
@@ -350,7 +349,7 @@ class UpdatableApi(BaseApi):
 
     def update_with_patch(self, id_, resource, expected_version):
         # pylint: disable=unused-argument
-        raise NotImplementedError("update_with_patch not implemented in % s " % self.__class__)
+        raise NotImplementedError(f"update_with_patch not implemented in {self.__class__}")
 
 
 def _make_etag(version):
@@ -363,8 +362,8 @@ def _parse_etag(etag):
         try:
             return int(version_str)
         except ValueError:
-            raise BadRequest("Invalid version: %s" % version_str)
-    raise BadRequest("Invalid ETag: %s" % etag)
+            raise BadRequest(f"Invalid version: {version_str}")
+    raise BadRequest(f"Invalid ETag: {etag}")
 
 
 def get_sync_results_for_request(dao, max_results):

--- a/rdr_service/api/check_ppi_data_api.py
+++ b/rdr_service/api/check_ppi_data_api.py
@@ -60,7 +60,7 @@ def check_ppi_data():
 
 def _sanity_check_codebook():
     if not CodeDao().get_code(PPI_SYSTEM, EMAIL_QUESTION_CODE):
-        raise RuntimeError("No question code found for %s; import codebook." % EMAIL_QUESTION_CODE)
+        raise RuntimeError(f"No question code found for {EMAIL_QUESTION_CODE}; import codebook.")
 
 
 class _ValidationResult(object):
@@ -89,10 +89,10 @@ def _get_validation_result(key, codes_to_answers):
             summaries = session.query(ParticipantSummary).filter(ParticipantSummary.email == key).all()
 
     if not summaries:
-        result.add_error("No ParticipantSummary found for %r." % key)
+        result.add_error(f"No ParticipantSummary found for {key}.")
         return result
     if len(summaries) > 1:
-        result.add_error("%d ParticipantSummary values found for %r." % (len(summaries), key))
+        result.add_error(f"{len(summaries)} ParticipantSummary values found for {key}.")
         return result
     participant_id = summaries[0].participantId
 
@@ -104,10 +104,10 @@ def _get_validation_result(key, codes_to_answers):
 
             question_code = code_dao.get_code(PPI_SYSTEM, code_string)
             if not question_code:
-                result.add_error("Could not find question code %r, skipping answer %r." % (code_string, answer_string))
+                result.add_error(f"Could not find question code {code_string}, skipping answer {answer_string}.")
                 continue
             if question_code.codeType != CodeType.QUESTION:
-                result.add_error("Code %r type is %s, not QUESTION; skipping." % (code_string, question_code.codeType))
+                result.add_error(f"Code {code_string} type is {question_code.codeType}, not QUESTION; skipping.")
                 continue
 
             qras = qra_dao.get_current_answers_for_concepts(session, participant_id, [question_code.codeId])
@@ -125,8 +125,8 @@ def _get_validation_result(key, codes_to_answers):
                 expected_values = set()
             if expected_values != qra_values:
                 result.add_error(
-                    "%s: Expected %s, found %s."
-                    % (question_code.value, _format_values(expected_values), _format_values(qra_values))
+                    f"{question_code.value}: Expected {_format_values(expected_values)}, \
+                    found {_format_values(qra_values)}."
                 )
     return result
 
@@ -154,11 +154,10 @@ def _get_value_for_qra(qra, question_code, code_dao, session):
         code = code_dao.get_with_session(session, qra.valueCodeId)
         if code.system != PPI_SYSTEM:
             raise ValueError(
-                "Unexpected value %r with non-PPI system %r for question %s."
-                % (code.value, code.system, question_code)
+                f"Unexpected value {code.value} with non-PPI system {code.system} for question {question_code}."
             )
         return code.value
-    raise ValueError("Answer for question %s has no value set." % question_code)
+    raise ValueError(f"Answer for question {question_code} has no value set.")
 
 
 def _boolean_to_lower(value):

--- a/rdr_service/api/data_gen_api.py
+++ b/rdr_service/api/data_gen_api.py
@@ -113,7 +113,7 @@ def generate_samples_task(fraction_missing):
             rows = biobank_order_dao.get_ordered_samples_sample(session, 1 - fraction_missing, _BATCH_SIZE)
             for biobank_id, collected_time, test in rows:
                 if collected_time is None:
-                    logging.warning("biobank_id=%s test=%s skipped (collected=%s)", biobank_id, test, collected_time)
+                    logging.warning(f"biobank_id={biobank_id} test={test} skipped (collected={collected_time})")
                     continue
                 sample_id = sample_id_start + num_rows
                 minutes_delta = random.randint(0, _MAX_MINUTES_BETWEEN_SAMPLE_COLLECTED_AND_CONFIRMED)
@@ -134,7 +134,7 @@ def generate_samples_task(fraction_missing):
                     writer.writerow(_new_row(sample_id, biobank_id, test, confirmed_time))
                     num_rows += 1
 
-    logging.info("Generated %d samples in %s.", num_rows, file_name)
+    logging.info(f"Generated {num_rows} samples in {file_name}.")
 
 
 class DataGenApi(Resource):

--- a/rdr_service/api/dv_order_api.py
+++ b/rdr_service/api/dv_order_api.py
@@ -120,7 +120,7 @@ class DvOrderApi(UpdatableApi):
             response = self.dao.send_order(resource, p_id)
             merged_resource = merge_dicts(response, resource)
             merged_resource["id"] = _id
-            logging.info("Sending salivary order to biobank for participant: %s", p_id)
+            logging.info(f"Sending salivary order to biobank for participant: {p_id}")
             self.dao.insert_biobank_order(p_id, merged_resource)
 
         response = super(DvOrderApi, self).put(
@@ -263,7 +263,7 @@ class DvOrderApi(UpdatableApi):
             response = self.dao.send_order(resource, p_id)
             merged_resource = merge_dicts(response, resource)
             merged_resource["id"] = _id
-            logging.info("Sending salivary order to biobank for participant: %s", p_id)
+            logging.info(f"Sending salivary order to biobank for participant: {p_id}")
             self.dao.insert_biobank_order(p_id, merged_resource)
 
         response = super(DvOrderApi, self).put(

--- a/rdr_service/api/metrics_api.py
+++ b/rdr_service/api/metrics_api.py
@@ -27,15 +27,16 @@ class MetricsApi(Resource):
             try:
                 start_date = datetime.datetime.strptime(start_date_str, DATE_FORMAT).date()
             except ValueError:
-                raise BadRequest("Invalid start date: %s" % start_date_str)
+                raise BadRequest(f"Invalid start date: {start_date_str}")
             try:
                 end_date = datetime.datetime.strptime(end_date_str, DATE_FORMAT).date()
             except ValueError:
-                raise BadRequest("Invalid end date: %s" % end_date_str)
+                raise BadRequest(f"Invalid end date: {end_date_str}")
             date_diff = abs((end_date - start_date).days)
             if date_diff > DAYS_LIMIT:
                 raise BadRequest(
-                    "Difference between start date and end date " "should not be greater than %s days" % DAYS_LIMIT
+                    f"Difference between start date and end date \
+                    should not be greater than {DAYS_LIMIT} days"
                 )
             buckets = dao.get_active_buckets(start_date, end_date)
             if buckets is None:

--- a/rdr_service/api/participant_counts_over_time_api.py
+++ b/rdr_service/api/participant_counts_over_time_api.py
@@ -45,7 +45,7 @@ class ParticipantCountsOverTimeApi(Resource):
         try:
             filters["stratification"] = Stratifications(params["stratification"])
         except TypeError:
-            raise BadRequest("Invalid stratification: %s" % params["stratification"])
+            raise BadRequest(f"Invalid stratification: {params['stratification']}")
 
         if filters["stratification"] in [
             Stratifications.FULL_STATE,
@@ -63,7 +63,7 @@ class ParticipantCountsOverTimeApi(Resource):
                 end_date = datetime.datetime.strptime(params["end_date"], DATE_FORMAT).date()
                 start_date = end_date
             except ValueError:
-                raise BadRequest("Invalid end date: %s" % params["end_date"])
+                raise BadRequest(f"Invalid end date: {params['end_date']}")
 
             filters["start_date"] = start_date
             filters["end_date"] = end_date
@@ -74,21 +74,21 @@ class ParticipantCountsOverTimeApi(Resource):
             try:
                 start_date = datetime.datetime.strptime(params["start_date"], DATE_FORMAT).date()
             except ValueError:
-                raise BadRequest("Invalid start date: %s" % params["start_date"])
+                raise BadRequest(f"Invalid start date: {params['start_date']}")
             try:
                 end_date = datetime.datetime.strptime(params["end_date"], DATE_FORMAT).date()
             except ValueError:
-                raise BadRequest("Invalid end date: %s" % params["end_date"])
+                raise BadRequest(f"Invalid end date: {params['end_date']}")
             date_diff = abs((end_date - start_date).days)
             if params["history"] != "TRUE" and date_diff > DAYS_LIMIT_FOR_REALTIME_DATA:
                 raise BadRequest(
-                    "Difference between start date and end date "
-                    "should not be greater than %s days" % DAYS_LIMIT_FOR_REALTIME_DATA
+                    f"Difference between start date and end date \
+                    should not be greater than {DAYS_LIMIT_FOR_REALTIME_DATA} days"
                 )
             if params["history"] == "TRUE" and date_diff > DAYS_LIMIT_FOR_HISTORY_DATA:
                 raise BadRequest(
-                    "Difference between start date and end date "
-                    "should not be greater than %s days" % DAYS_LIMIT_FOR_HISTORY_DATA
+                    f"Difference between start date and end date \
+                    should not be greater than {DAYS_LIMIT_FOR_HISTORY_DATA} days"
                 )
 
             filters["start_date"] = start_date
@@ -102,7 +102,7 @@ class ParticipantCountsOverTimeApi(Resource):
                 if awardee != "":
                     awardee_id = get_awardee_id_from_name({"awardee": awardee}, self.hpo_dao)
                     if awardee_id is None:
-                        raise BadRequest("Invalid awardee name: %s" % awardee)
+                        raise BadRequest(f"Invalid awardee name: {awardee}")
                     awardee_ids.append(awardee_id)
         filters["awardee_ids"] = awardee_ids
 
@@ -131,16 +131,16 @@ class ParticipantCountsOverTimeApi(Resource):
                 for enrollment_status in enrollment_statuses:
                     if enrollment_status != "":
                         if enrollment_status not in valid_enrollment_statuses:
-                            raise BadRequest("Invalid enrollment status: %s" % enrollment_status)
+                            raise BadRequest(f"Invalid enrollment status: {enrollment_status}")
         filters["enrollment_statuses"] = enrollment_status_strs
 
         if params["sample_time_def"] and params["sample_time_def"] not in ["STORED", "ORDERED"]:
-            raise BadRequest("Invalid value for parameter filterBy: %s" % params["sample_time_def"])
+            raise BadRequest(f"Invalid value for parameter filterBy: {params['sample_time_def']}")
         else:
             filters["sample_time_def"] = params["sample_time_def"]
 
         if params["history"] and params["history"] not in ["TRUE", "FALSE"]:
-            raise BadRequest("Invalid value for parameter history: %s" % params["history"])
+            raise BadRequest(f"Invalid value for parameter history: {params['history']}")
         else:
             filters["history"] = params["history"]
 

--- a/rdr_service/api/public_metrics_api.py
+++ b/rdr_service/api/public_metrics_api.py
@@ -95,7 +95,7 @@ class PublicMetricsApi(Resource):
             else:
                 return []
         else:
-            raise BadRequest("Invalid stratification: %s" % str(stratification))
+            raise BadRequest(f"Invalid stratification: {str(stratification)}")
 
     def validate_params(self, params):
         filters = {}
@@ -103,7 +103,7 @@ class PublicMetricsApi(Resource):
         try:
             filters["stratification"] = Stratifications(params["stratification"])
         except TypeError:
-            raise BadRequest("Invalid stratification: %s" % params["stratification"])
+            raise BadRequest(f"Invalid stratification: {params['stratification']}")
 
         if filters["stratification"] in [
             Stratifications.FULL_STATE,
@@ -121,7 +121,7 @@ class PublicMetricsApi(Resource):
                 end_date = datetime.datetime.strptime(params["end_date"], DATE_FORMAT).date()
                 start_date = end_date
             except ValueError:
-                raise BadRequest("Invalid end date: %s" % params["end_date"])
+                raise BadRequest(f"Invalid end date: {params['end_date']}")
 
             filters["start_date"] = start_date
             filters["end_date"] = end_date
@@ -132,16 +132,16 @@ class PublicMetricsApi(Resource):
             try:
                 start_date = datetime.datetime.strptime(params["start_date"], DATE_FORMAT).date()
             except ValueError:
-                raise BadRequest("Invalid start date: %s" % params["start_date"])
+                raise BadRequest(f"Invalid start date: {params['start_date']}")
             try:
                 end_date = datetime.datetime.strptime(params["end_date"], DATE_FORMAT).date()
             except ValueError:
-                raise BadRequest("Invalid end date: %s" % params["end_date"])
+                raise BadRequest(f"Invalid end date: {params['end_date']}")
             date_diff = abs((end_date - start_date).days)
             if date_diff > DAYS_LIMIT_FOR_HISTORY_DATA:
                 raise BadRequest(
-                    "Difference between start date and end date "
-                    "should not be greater than %s days" % DAYS_LIMIT_FOR_HISTORY_DATA
+                    f"Difference between start date and end date \
+                    should not be greater than {DAYS_LIMIT_FOR_HISTORY_DATA} days"
                 )
 
             filters["start_date"] = start_date
@@ -155,7 +155,7 @@ class PublicMetricsApi(Resource):
                 if awardee != "":
                     awardee_id = get_awardee_id_from_name({"awardee": awardee}, self.hpo_dao)
                     if awardee_id is None:
-                        raise BadRequest("Invalid awardee name: %s" % awardee)
+                        raise BadRequest(f"Invalid awardee name: {awardee}")
                     awardee_ids.append(awardee_id)
         filters["awardee_ids"] = awardee_ids
 
@@ -175,7 +175,7 @@ class PublicMetricsApi(Resource):
                 for enrollment_status in enrollment_statuses:
                     if enrollment_status != "":
                         if enrollment_status not in valid_enrollment_statuses:
-                            raise BadRequest("Invalid enrollment status: %s" % enrollment_status)
+                            raise BadRequest(f"Invalid enrollment status: {enrollment_status}")
         filters["enrollment_statuses"] = enrollment_status_strs
 
         return filters

--- a/rdr_service/api/questionnaire_api.py
+++ b/rdr_service/api/questionnaire_api.py
@@ -23,10 +23,10 @@ class QuestionnaireApi(UpdatableApi):
                 raise BadRequest("Either questionnaire ID or concept must be specified in request.")
             concept_code = CodeDao().get_code(PPI_SYSTEM, concept)
             if not concept_code:
-                raise BadRequest("Code not found: %s" % concept)
+                raise BadRequest(f"Code not found: {concept}")
             questionnaire = self.dao.get_latest_questionnaire_with_concept(concept_code.codeId)
             if not questionnaire:
-                raise NotFound("Could not find questionnaire with concept: %s" % concept)
+                raise NotFound(f"Could not find questionnaire with concept: {concept}")
             return self._make_response(questionnaire)
 
     @app_util.auth_required(PTC)

--- a/rdr_service/config_api.py
+++ b/rdr_service/config_api.py
@@ -21,7 +21,7 @@ with open(CONFIG_ADMIN_FILE) as config_file:
     try:
         CONFIG_ADMIN_MAP = json.load(config_file)
     except IOError:
-        logging.error("Unable to load config admin file %r.", CONFIG_ADMIN_FILE)
+        logging.error(f"Unable to load config admin file {CONFIG_ADMIN_FILE}.")
         CONFIG_ADMIN_MAP = {}
 
 
@@ -55,9 +55,9 @@ def check_config_admin():
     """Raises Unauthorized unless the caller is a config admin."""
     user_email = app_util.get_oauth_id()
     if is_config_admin(user_email):
-        logging.info("User %r ALLOWED for config endpoint" % user_email)
+        logging.info(f"User {user_email} ALLOWED for config endpoint")
         return
-    logging.info("User %r NOT ALLOWED for config endpoint" % user_email)
+    logging.info(f"User {user_email} NOT ALLOWED for config endpoint")
     raise Forbidden()
 
 

--- a/rdr_service/dao/base_dao.py
+++ b/rdr_service/dao/base_dao.py
@@ -281,7 +281,7 @@ class BaseDao(object):
             else:
                 return value
         except ValueError:
-            raise BadRequest("Invalid value for property of type %s: %r." % (property_type, value))
+            raise BadRequest(f"Invalid value for property of type {property_type}: {value}.")
 
     def _from_json_value(self, prop, value):
         property_type = get_property_type(prop)
@@ -290,7 +290,7 @@ class BaseDao(object):
 
     def query(self, query_def):
         if not self.order_by_ending:
-            raise BadRequest("Can't query on type %s -- no order by ending speciifed" % self.model_type)
+            raise BadRequest(f"Can't query on type {self.model_type} -- no order by ending speciifed")
 
         with self.session() as session:
             query, field_names = self._make_query(session, query_def)
@@ -357,7 +357,7 @@ class BaseDao(object):
             try:
                 f = getattr(self.model_type, field_filter.field_name)
             except AttributeError:
-                raise BadRequest("No field named %r found on %r." % (field_filter.field_name, self.model_type))
+                raise BadRequest(f"No field named {field_filter.field_name} found on {self.model_type}.")
             query = self._add_filter(query, field_filter, f)
         return query
 
@@ -399,9 +399,9 @@ class BaseDao(object):
         try:
             decoded_vals = json.loads(urlsafe_b64decode(pagination_token))
         except:
-            raise BadRequest("Invalid pagination token: %r." % pagination_token)
+            raise BadRequest(f"Invalid pagination token: {pagination_token}.")
         if not isinstance(decoded_vals, list) or len(decoded_vals) != len(fields):
-            raise BadRequest("Invalid pagination token: %r." % pagination_token)
+            raise BadRequest(f"Invalid pagination token: {pagination_token}.")
         for i in range(0, len(fields)):
             decoded_vals[i] = self._from_json_value(fields[i], decoded_vals[i])
         return decoded_vals
@@ -411,7 +411,7 @@ class BaseDao(object):
         try:
             f = getattr(self.model_type, order_by.field_name)
         except AttributeError:
-            raise BadRequest("No field named %r found on %r." % (order_by.field_name, self.model_type))
+            raise BadRequest(f"No field named {order_by.field_name} found on {self.model_type}.")
         field_names.append(order_by.field_name)
         fields.append(f)
         if order_by.ascending:
@@ -431,7 +431,7 @@ class BaseDao(object):
             try:
                 f = getattr(self.model_type, order_by_field)
             except AttributeError:
-                raise BadRequest("No field named %r found on %r." % (order_by_field, self.model_type))
+                raise BadRequest(f"No field named {order_by_field} found on {self.model_type}.")
             field_names.append(order_by_field)
             fields.append(f)
             query = query.order_by(f)
@@ -459,14 +459,14 @@ class BaseDao(object):
                 if result:
                     return result
         # We were unable to insert a participant (unlucky). Throw an error.
-        logging.warning("Giving up after %d insert attempts, tried %s." % (MAX_INSERT_ATTEMPTS, all_tried_ids))
-        raise ServiceUnavailable("Giving up after %d insert attempts." % MAX_INSERT_ATTEMPTS)
+        logging.warning(f"Giving up after {MAX_INSERT_ATTEMPTS} insert attempts, tried {all_tried_ids}.")
+        raise ServiceUnavailable(f"Giving up after {MAX_INSERT_ATTEMPTS} insert attempts.")
 
     def handle_integrity_error(self, tried_ids, e, obj):
         # pylint: disable=unused-argument
         # SQLite and MySQL variants of the error message, respectively.
         if "UNIQUE constraint failed" in str(e) or "Duplicate entry" in str(e):
-            logging.warning("Failed insert with %s: %s", tried_ids, str(e))
+            logging.warning(f"Failed insert with {tried_ids}: {str(e)}")
             return None
 
     def count(self):
@@ -596,10 +596,10 @@ class UpdatableDao(BaseDao):
     that it matches.
     """
         if not existing_obj:
-            raise NotFound("%s with id %s does not exist" % (self.model_type.__name__, id))
+            raise NotFound(f"{self.model_type.__name__} with id {id} does not exist")
         if self.validate_version_match and existing_obj.version != obj.version:
             raise PreconditionFailed(
-                "Expected version was %s; stored version was %s" % (obj.version, existing_obj.version)
+                f"Expected version was {obj.version}; stored version was {existing_obj.version}"
             )
         self._validate_model(session, obj)
 

--- a/rdr_service/dao/biobank_order_dao.py
+++ b/rdr_service/dao/biobank_order_dao.py
@@ -112,7 +112,7 @@ class BiobankOrderDao(UpdatableDao):
     def insert_with_session(self, session, obj):
         obj.version = 1
         if obj.logPosition is not None:
-            raise BadRequest("%s.logPosition must be auto-generated." % self.model_type.__name__)
+            raise BadRequest(f"{self.model_type.__name__}.logPosition must be auto-generated.")
         obj.logPosition = LogPosition()
         if obj.biobankOrderId is None:
             raise BadRequest("Client must supply biobankOrderId.")
@@ -124,7 +124,7 @@ class BiobankOrderDao(UpdatableDao):
                 # If an existing matching order exists, just return it without trying to create it again.
                 return existing_order
             else:
-                raise Conflict("Order with ID %s already exists" % obj.biobankOrderId)
+                raise Conflict(f"Order with ID {obj.biobankOrderId} already exists")
         self._update_participant_summary(session, obj)
         inserted_obj = super(BiobankOrderDao, self).insert_with_session(session, obj)
         if inserted_obj.collectedSiteId is not None:
@@ -139,7 +139,7 @@ class BiobankOrderDao(UpdatableDao):
             raise BadRequest("participantId is required")
         participant_summary = ParticipantSummaryDao().get_with_session(session, obj.participantId)
         if not participant_summary:
-            raise BadRequest("Can't submit order for participant %s without consent" % obj.participantId)
+            raise BadRequest(f"Can't submit order for participant {obj.participantId} without consent")
         raise_if_withdrawn(participant_summary)
         for sample in obj.samples:
             self._validate_order_sample(sample)
@@ -152,12 +152,12 @@ class BiobankOrderDao(UpdatableDao):
                 .filter_by(value=identifier.value)
                 .filter(BiobankOrderIdentifier.biobankOrderId != obj.biobankOrderId)
             ):
-                raise BadRequest("Identifier %s is already in use by order %s" % (identifier, existing.biobankOrderId))
+                raise BadRequest(f"Identifier {identifier} is already in use by order {existing.biobankOrderId}")
 
     def _validate_order_sample(self, sample):
         # TODO(mwf) Make use of FHIR validation?
         if sample.test not in BIOBANK_TESTS_SET:
-            raise BadRequest("Invalid test value %r not in %s." % (sample.test, BIOBANK_TESTS_SET))
+            raise BadRequest(f"Invalid test value {sample.test} not in {BIOBANK_TESTS_SET}.")
 
     def get_with_session(self, session, obj_id, **kwargs):
         result = super(BiobankOrderDao, self).get_with_session(session, obj_id, **kwargs)
@@ -220,7 +220,7 @@ class BiobankOrderDao(UpdatableDao):
         participant_summary_dao = ParticipantSummaryDao()
         participant_summary = participant_summary_dao.get_for_update(session, obj.participantId)
         if not participant_summary:
-            raise BadRequest("Can't submit biospecimens for participant %s without consent" % obj.participantId)
+            raise BadRequest(f"Can't submit biospecimens for participant {obj.participantId} without consent")
         raise_if_withdrawn(participant_summary)
         self._set_participant_summary_fields(obj, participant_summary)
         participant_summary_dao.update_enrollment_status(participant_summary)
@@ -312,14 +312,14 @@ class BiobankOrderDao(UpdatableDao):
         username = None
         if handling_info.site:
             if handling_info.site.system != SITE_ID_SYSTEM:
-                raise BadRequest("Invalid site system: %s" % handling_info.site.system)
+                raise BadRequest(f"Invalid site system: {handling_info.site.system}")
             site = SiteDao().get_by_google_group(handling_info.site.value)
             if not site:
-                raise BadRequest("Unrecognized site: %s" % handling_info.site.value)
+                raise BadRequest(f"Unrecognized site: {handling_info.site.value}")
             site_id = site.siteId
         if handling_info.author:
             if handling_info.author.system != HEALTHPRO_USERNAME_SYSTEM:
-                raise BadRequest("Invalid author system: %s" % handling_info.author.system)
+                raise BadRequest(f"Invalid author system: {handling_info.author.system}")
             username = handling_info.author.value
         return username, site_id
 
@@ -342,7 +342,7 @@ class BiobankOrderDao(UpdatableDao):
     def from_client_json(self, resource_json, id_=None, expected_version=None, participant_id=None, client_id=None):
         resource = _FhirBiobankOrder(resource_json)
         if not resource.created.date:  # FHIR warns but does not error on bad date values.
-            raise BadRequest("Invalid created date %r." % resource.created.origval)
+            raise BadRequest(f"Invalid created date {resource.created.origval}.")
 
         order = BiobankOrder(participantId=participant_id, created=resource.created.date.replace(tzinfo=None))
 
@@ -361,8 +361,8 @@ class BiobankOrderDao(UpdatableDao):
             order.finalizedNote = resource.notes.finalized
         if resource.subject != self._participant_id_to_subject(participant_id):
             raise BadRequest(
-                "Participant ID %d from path and %r in request do not match, should be %r."
-                % (participant_id, resource.subject, self._participant_id_to_subject(participant_id))
+                f"Participant ID {participant_id} from path and {resource.subject} \
+                in request do not match, should be {self._participant_id_to_subject(participant_id)}."
             )
         self._add_identifiers_and_main_id(order, resource)
         self._add_samples(order, resource)
@@ -389,13 +389,13 @@ class BiobankOrderDao(UpdatableDao):
                 order.biobankOrderId = i.value
                 found_main_id = True
         if not found_main_id:
-            raise BadRequest("No identifier for system %r, required for primary key." % BiobankOrder._MAIN_ID_SYSTEM)
+            raise BadRequest(f"No identifier for system {BiobankOrder._MAIN_ID_SYSTEM}, required for primary key.")
 
     @classmethod
     def _add_samples(cls, order, resource):
         all_tests = sorted([s.test for s in resource.samples])
         if len(set(all_tests)) != len(all_tests):
-            raise BadRequest("Duplicate test in sample list for order: %s." % (all_tests,))
+            raise BadRequest(f"Duplicate test in sample list for order: {all_tests}.")
         for s in resource.samples:
             order.samples.append(
                 BiobankOrderedSample(
@@ -526,7 +526,7 @@ class BiobankOrderDao(UpdatableDao):
     def _validate_patch_update(self, model, resource, expected_version):
         if expected_version != model.version:
             raise PreconditionFailed(
-                "Expected version was %s; stored version was %s" % (expected_version, model.version)
+                f"Expected version was {expected_version}; stored version was {model.version}"
             )
         required_cancelled_fields = ["amendedReason", "cancelledInfo", "status"]
         required_restored_fields = ["amendedReason", "restoredInfo", "status"]
@@ -538,7 +538,7 @@ class BiobankOrderDao(UpdatableDao):
                 raise BadRequest("Can not cancel an order that is already cancelled.")
             for field in required_cancelled_fields:
                 if field not in resource:
-                    raise BadRequest("%s is required for a cancelled biobank order" % field)
+                    raise BadRequest(f"{field} is required for a cancelled biobank order")
             if "site" not in resource["cancelledInfo"] or "author" not in resource["cancelledInfo"]:
                 raise BadRequest("author and site are required for cancelledInfo")
 
@@ -547,7 +547,7 @@ class BiobankOrderDao(UpdatableDao):
                 raise BadRequest("Can not restore an order that is not cancelled.")
             for field in required_restored_fields:
                 if field not in resource:
-                    raise BadRequest("%s is required for a restored biobank order" % field)
+                    raise BadRequest(f"{field} is required for a restored biobank order")
             if "site" not in resource["restoredInfo"] or "author" not in resource["restoredInfo"]:
                 raise BadRequest("author and site are required for restoredInfo")
 

--- a/rdr_service/dao/code_dao.py
+++ b/rdr_service/dao/code_dao.py
@@ -28,7 +28,7 @@ class CodeBookDao(BaseDao):
         old_latest = self.get_latest_with_session(session, obj.system)
         if old_latest:
             if old_latest.version == obj.version:
-                raise BadRequest("Codebook with system %s, version %s already exists" % (obj.system, obj.version))
+                raise BadRequest(f"Codebook with system {obj.system}, version {obj.version} already exists")
             old_latest.latest = False
             session.merge(old_latest)
         super(CodeBookDao, self).insert_with_session(session, obj)
@@ -54,7 +54,7 @@ class CodeBookDao(BaseDao):
         code_type = _CODE_TYPE_MAP.get(property_dict["concept-type"])
         if code_type is None:
             logging.warning(
-                "Unrecognized concept type: %s, value: %s; ignoring." % (property_dict["concept-type"], value)
+                f"Unrecognized concept type: {property_dict['concept-type']}, value: {value}; ignoring."
             )
             return 0
         code = Code(
@@ -88,7 +88,7 @@ class CodeBookDao(BaseDao):
         """Imports a codebook and all codes inside it. Returns (new_codebook, imported_code_count)."""
         version = codebook_json["version"]
         num_concepts = len(codebook_json["concept"])
-        logging.info("Importing %d concepts into new CodeBook version %r...", num_concepts, version)
+        logging.info(f"Importing {num_concepts} concepts into new CodeBook version {version}...")
         system = codebook_json["url"]
         codebook = CodeBook(name=codebook_json["name"], version=version, system=system)
         code_count = 0
@@ -102,9 +102,9 @@ class CodeBookDao(BaseDao):
             self.insert_with_session(session, codebook)
             session.flush()
             for i, concept in enumerate(codebook_json["concept"], start=1):
-                logging.info("Importing root concept %d of %d (%s).", i, num_concepts, concept.get("display"))
+                logging.info(f"Importing root concept {i} of {num_concepts} ({concept.get('display')}).")
                 code_count += self._import_concept(session, existing_codes, concept, system, codebook.codeBookId, None)
-        logging.info("Finished, %d codes imported.", code_count)
+        logging.info(f"Finished, {code_count} codes imported.")
         return codebook, code_count
 
 
@@ -195,7 +195,7 @@ class CodeDao(CacheAllDao):
                         continue
 
                     if not add_codes_if_missing:
-                        raise BadRequest("Couldn't find code: system = %s, value = %s" % (system, value))
+                        raise BadRequest(f"Couldn't find code: system = {system}, value = {value}")
                     # If it's not in the database, add it.
                     display, code_type, parent_id = code_map[(system, value)]
                     code = Code(
@@ -209,10 +209,8 @@ class CodeDao(CacheAllDao):
                     if self.silent:
                         # Log the traceback so that stackdriver error reporting reports on it.
                         logging.error(
-                            "Adding unmapped code: system = %s, value = %s: %s",
-                            code.system,
-                            code.value,
-                            traceback.format_exc(),
+                            f"Adding unmapped code: system = {code.system}, \
+                            value = {code.value}: {traceback.format_exc()}"
                         )
 
                     self.insert_with_session(session, code)

--- a/rdr_service/dao/dv_order_dao.py
+++ b/rdr_service/dao/dv_order_dao.py
@@ -268,7 +268,7 @@ class DvOrderDao(UpdatableDao):
                     )
             except AttributeError:
                 raise BadRequest(
-                    "No identifier for system %r, required for primary key." % BiobankDVOrder._DV_ID_SYSTEM[dv_user]
+                    f"No identifier for system {BiobankDVOrder._DV_ID_SYSTEM[dv_user]}, required for primary key."
                 )
         for i in resource.basedOn:
             try:
@@ -280,7 +280,7 @@ class DvOrderDao(UpdatableDao):
                     )
             except AttributeError:
                 raise BadRequest(
-                    "No identifier for system %r, required for primary key." % BiobankDVOrder._DV_ID_SYSTEM[dv_user]
+                    f"No identifier for system {BiobankDVOrder._DV_ID_SYSTEM[dv_user]}, required for primary key."
                 )
 
     def get_etag(self, id_, pid):

--- a/rdr_service/dao/metrics_dao.py
+++ b/rdr_service/dao/metrics_dao.py
@@ -48,7 +48,7 @@ class MetricsVersionDao(BaseDao):
             running_version = self.get_version_in_progress_with_session(session)
             if running_version:
                 if running_version.date + METRICS_LOCK_TIMEOUT <= clock.CLOCK.now():
-                    logging.warning("Metrics version %s timed out; breaking lock." % running_version.metricsVersionId)
+                    logging.warning(f"Metrics version {running_version.metricsVersionId} timed out; breaking lock.")
                     running_version.inProgress = False
                     session.merge(running_version)
                 else:

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -388,16 +388,16 @@ class OrganizationHierarchySyncDao(BaseDao):
                     longitude = location.get('lng')
                     return latitude, longitude
                 else:
-                    logging.warn('Can not find lat/long for %s', self.full_address)
+                    logging.warning(f'Can not find lat/long for {self.full_address}')
                     return None, None
             else:
-                logging.warn('Geocode results failed for %s.', self.full_address)
+                logging.warning(f'Geocode results failed for {self.full_address}.')
                 return None, None
         except ValueError as e:
-            logging.exception('Invalid geocode key: %s. ERROR: %s', self.api_key, e)
+            logging.exception(f'Invalid geocode key: {self.api_key}. ERROR: {e}')
             return None, None
         except IndexError as e:
-            logging.exception('Geocoding failure Check that address is correct. ERROR: %s', e)
+            logging.exception(f'Geocoding failure Check that address is correct. ERROR: {e}')
             return None, None
 
     def _get_time_zone(self, latitude, longitude):
@@ -406,5 +406,5 @@ class OrganizationHierarchySyncDao(BaseDao):
             time_zone_id = time_zone['timeZoneId']
             return time_zone_id
         else:
-            logging.info('can not retrieve time zone from %s', self.full_address)
+            logging.info(f'can not retrieve time zone from {self.full_address}')
             return None

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -98,8 +98,8 @@ class ParticipantDao(UpdatableDao):
         participant = self.get_for_update(session, pid)
         if participant is None:
             logging.warning(
-                "Tried to mark participant with id: [%r] as ghost but participant does not"
-                "exist. Wrong environment?" % pid
+                f"Tried to mark participant with id: [{pid}] as ghost \
+                 but participant does not exist. Wrong environment?"
             )
         else:
             participant.isGhostId = 1
@@ -138,7 +138,7 @@ class ParticipantDao(UpdatableDao):
             existing_obj.withdrawalStatus == WithdrawalStatus.NO_USE
             and obj.withdrawalStatus != WithdrawalStatus.NO_USE
         ):
-            raise Forbidden("Participant %d has withdrawn, cannot unwithdraw" % obj.participantId)
+            raise Forbidden(f"Participant {obj.participantId} has withdrawn, cannot unwithdraw")
 
     def get_for_update(self, session, obj_id):
         # Fetch the participant summary at the same time as the participant, as we are potentially
@@ -246,14 +246,14 @@ class ParticipantDao(UpdatableDao):
         if site_id != UNSET and site_id is not None:
             site = self.site_dao.get(site_id)
             if site is None:
-                raise BadRequest("Site with site id %s does not exist." % site_id)
+                raise BadRequest(f"Site with site id {site_id} does not exist.")
             organization_id = site.organizationId
             awardee_id = site.hpoId
             return site_id, organization_id, awardee_id
         elif organization_id != UNSET and organization_id is not None:
             organization = self.organization_dao.get(organization_id)
             if organization is None:
-                raise BadRequest("Organization with id %s does not exist." % organization_id)
+                raise BadRequest(f"Organization with id {organization_id} does not exist.")
             awardee_id = organization.hpoId
             return None, organization_id, awardee_id
         return None, None, awardee_id
@@ -282,7 +282,7 @@ class ParticipantDao(UpdatableDao):
         if hpo_name:
             hpo = HPODao().get_by_name(hpo_name)
             if not hpo:
-                raise BadRequest("No HPO found with name %s" % hpo_name)
+                raise BadRequest(f"No HPO found with name {hpo_name}")
             return hpo.hpoId
         else:
             return UNSET_HPO_ID
@@ -291,7 +291,7 @@ class ParticipantDao(UpdatableDao):
         """Raises BadRequest if an object has a missing or invalid participantId reference,
     or if the participant has a withdrawal status of NO_USE."""
         if obj.participantId is None:
-            raise BadRequest("%s.participantId required." % obj.__class__.__name__)
+            raise BadRequest(f"{obj.__class__.__name__}.participantId required.")
         return self.validate_participant_id(session, obj.participantId)
 
     def validate_participant_id(self, session, participant_id):
@@ -299,7 +299,7 @@ class ParticipantDao(UpdatableDao):
     or if the participant has a withdrawal status of NO_USE."""
         participant = self.get_with_session(session, participant_id)
         if participant is None:
-            raise BadRequest("Participant with ID %d is not found." % participant_id)
+            raise BadRequest(f"Participant with ID {participant_id} is not found.")
         raise_if_withdrawn(participant)
         return participant
 
@@ -379,11 +379,11 @@ class ParticipantDao(UpdatableDao):
             raise BadRequest("No site ID given for auto-pairing participant.")
         site = SiteDao().get_with_session(session, site_id)
         if site is None:
-            raise BadRequest("Invalid siteId reference %r." % site_id)
+            raise BadRequest(f"Invalid siteId reference {site_id}.")
 
         participant = self.get_for_update(session, participant_id)
         if participant is None:
-            raise BadRequest("No participant %r for HPO ID udpate." % participant_id)
+            raise BadRequest(f"No participant {participant_id} for HPO ID udpate.")
 
         if participant.siteId == site.siteId:
             return
@@ -392,7 +392,7 @@ class ParticipantDao(UpdatableDao):
         participant.siteId = site.siteId
         participant.providerLink = make_primary_provider_link_for_id(site.hpoId)
         if participant.participantSummary is None:
-            raise RuntimeError("No ParticipantSummary available for P%d." % participant_id)
+            raise RuntimeError(f"No ParticipantSummary available for P{participant_id}.")
         participant.participantSummary.hpoId = site.hpoId
         participant.lastModified = clock.CLOCK.now()
         # Update the version and add history row
@@ -402,7 +402,7 @@ class ParticipantDao(UpdatableDao):
         test_hpo_id = HPODao().get_by_name(TEST_HPO_NAME).hpoId
 
         if participant is None:
-            raise BadRequest("No participant %r for HPO ID udpate.")
+            raise BadRequest("No participant for HPO ID udpate.")
 
         if participant.hpoId == test_hpo_id:
             return
@@ -444,4 +444,4 @@ def _get_hpo_name_from_participant(participant):
 
 def raise_if_withdrawn(obj):
     if obj.withdrawalStatus == WithdrawalStatus.NO_USE:
-        raise Forbidden("Participant %d has withdrawn" % obj.participantId)
+        raise Forbidden(f"Participant {obj.participantId} has withdrawn")

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -317,7 +317,7 @@ class ParticipantSummaryDao(UpdatableDao):
     def _validate_update(self, session, obj, existing_obj):  # pylint: disable=unused-argument
         """Participant summaries don't have a version value; drop it from validation logic."""
         if not existing_obj:
-            raise NotFound("%s with id %s does not exist" % (self.model_type.__name__, id))
+            raise NotFound(f"{self.model_type.__name__} with id {id} does not exist")
 
     def _has_withdrawn_filter(self, query):
         for field_filter in query.field_filters:
@@ -339,7 +339,7 @@ class ParticipantSummaryDao(UpdatableDao):
         non_withdrawn_field = self._get_non_withdrawn_filter_field(query_def)
         if self._has_withdrawn_filter(query_def):
             if non_withdrawn_field:
-                raise BadRequest("Can't query on %s for withdrawn participants" % non_withdrawn_field)
+                raise BadRequest(f"Can't query on {non_withdrawn_field} for withdrawn participants")
             # When querying for withdrawn participants, ensure that the only fields being filtered on or
             # ordered by are in WITHDRAWN_PARTICIPANT_FIELDS.
             return super(ParticipantSummaryDao, self)._initialize_query(session, query_def)
@@ -388,21 +388,21 @@ class ParticipantSummaryDao(UpdatableDao):
         if field_name == "hpoId" or field_name == "awardee":
             hpo = self.hpo_dao.get_by_name(value)
             if not hpo:
-                raise BadRequest("No HPO found with name %s" % value)
+                raise BadRequest(f"No HPO found with name {value}")
             if field_name == "awardee":
                 field_name = "hpoId"
             return super(ParticipantSummaryDao, self).make_query_filter(field_name, hpo.hpoId)
         if field_name == "organization":
             organization = self.organization_dao.get_by_external_id(value)
             if not organization:
-                raise BadRequest("No organization found with name %s" % value)
+                raise BadRequest(f"No organization found with name {value}")
             return super(ParticipantSummaryDao, self).make_query_filter(field_name + "Id", organization.organizationId)
         if field_name in _SITE_FIELDS:
             if value == UNSET:
                 return super(ParticipantSummaryDao, self).make_query_filter(field_name + "Id", None)
             site = self.site_dao.get_by_google_group(value)
             if not site:
-                raise BadRequest("No site found with google group %s" % value)
+                raise BadRequest(f"No site found with google group {value}")
             return super(ParticipantSummaryDao, self).make_query_filter(field_name + "Id", site.siteId)
         if field_name in _CODE_FILTER_FIELDS:
             if value == UNSET:
@@ -410,7 +410,7 @@ class ParticipantSummaryDao(UpdatableDao):
             # Note: we do not at present support querying for UNMAPPED code values.
             code = self.code_dao.get_code(PPI_SYSTEM, value)
             if not code:
-                raise BadRequest("No code found: %s" % value)
+                raise BadRequest(f"No code found: {value}")
             return super(ParticipantSummaryDao, self).make_query_filter(field_name + "Id", code.codeId)
 
         if field_name == "patientStatus":
@@ -435,7 +435,7 @@ class ParticipantSummaryDao(UpdatableDao):
             )
         organization = self.organization_dao.get_by_external_id(organization_external_id)
         if not organization:
-            raise BadRequest("No organization found with name %s" % organization_external_id)
+            raise BadRequest(f"No organization found with name {organization_external_id}")
         # Note: leaving for future use if we go back to using a relationship to PatientStatus table.
         # return PatientStatusFieldFilter(field_name, Operator.EQUALS, value,
         #                                 organization=organization,
@@ -839,7 +839,7 @@ class PatientStatusFieldFilter(FieldFilter):
                 )
             return query.filter(criterion)
         else:
-            raise ValueError("Invalid operator: %r." % self.operator)
+            raise ValueError(f"Invalid operator: {self.operator}.")
 
 
 class ParticipantGenderAnswersDao(UpdatableDao):

--- a/rdr_service/dao/physical_measurements_dao.py
+++ b/rdr_service/dao/physical_measurements_dao.py
@@ -142,7 +142,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
                         )
                     except AttributeError:
                         logging.warning(
-                            "Invalid physical measurement JSON with ID %s; skipping." % pms.physicalMeasurementsId
+                            f"Invalid physical measurement JSON with ID {pms.physicalMeasurementsId}; skipping."
                         )
                         continue
                     parsed_pms.physicalMeasurementsId = pms.physicalMeasurementsId
@@ -155,7 +155,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
                             session.merge(submeasurement)
                     num_updated += 1
                 except FHIRValidationError as e:
-                    logging.error("Could not parse measurements as FHIR: %s; exception = %s" % (pms.resource, e))
+                    logging.error(f"Could not parse measurements as FHIR: {pms.resource}; exception = {e}")
         return num_updated
 
     def get_distinct_measurements(self):
@@ -168,7 +168,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
                     for measurement in parsed_pms.measurements:
                         PhysicalMeasurementsDao.handle_measurement(measurement_map, measurement)
                 except FHIRValidationError as e:
-                    logging.error("Could not parse measurements as FHIR: %s; exception = %s" % (pms.resource, e))
+                    logging.error(f"Could not parse measurements as FHIR: {pms.resource}; exception = {e}")
             return measurement_map
 
     @staticmethod
@@ -268,9 +268,8 @@ class PhysicalMeasurementsDao(UpdatableDao):
             url = extension.get("url")
             if url not in _ALL_EXTENSIONS:
                 logging.info(
-                    "Ignoring unsupported extension for PhysicalMeasurements: %r. Expected one of: %s",
-                    url,
-                    _ALL_EXTENSIONS,
+                    f"Ignoring unsupported extension for PhysicalMeasurements: {url}. \
+                    Expected one of: {_ALL_EXTENSIONS}"
                 )
                 continue
             if url == _AMENDMENT_URL:
@@ -311,10 +310,10 @@ class PhysicalMeasurementsDao(UpdatableDao):
         participant_summary_dao = ParticipantSummaryDao()
         participant = ParticipantDao().get_for_update(session, participant_id)
         if not participant:
-            raise BadRequest("Can't submit physical measurements for unknown participant %s" % participant_id)
+            raise BadRequest(f"Can't submit physical measurements for unknown participant {participant_id}")
         participant_summary = participant.participantSummary
         if not participant_summary:
-            raise BadRequest("Can't submit physical measurements for participant %s without consent" % participant_id)
+            raise BadRequest(f"Can't submit physical measurements for participant {participant_id} without consent")
         raise_if_withdrawn(participant_summary)
         participant_summary.lastModified = clock.CLOCK.now()
         is_distinct_visit = participant_summary_dao.calculate_distinct_visits(
@@ -403,22 +402,22 @@ class PhysicalMeasurementsDao(UpdatableDao):
     its ID."""
         value_ref = extension.get("valueReference")
         if value_ref is None:
-            raise BadRequest("No valueReference in extension %r." % url)
+            raise BadRequest(f"No valueReference in extension {url}.")
         ref = value_ref.get("reference")
         if ref is None:
-            raise BadRequest("No reference in extension %r." % url)
+            raise BadRequest(f"No reference in extension {url}.")
         type_name, ref_id = ref.split("/")
         if type_name != "PhysicalMeasurements":
-            raise BadRequest("Bad reference type in extension %r: %r." % (url, ref))
+            raise BadRequest(f"Bad reference type in extension {url}: {ref}.")
 
         try:
             amended_measurement_id = int(ref_id)
         except ValueError:
-            raise BadRequest("Invalid ref id: %r" % ref_id)
+            raise BadRequest(f"Invalid ref id: {ref_id}")
 
         amended_measurement = self.get_with_session(session, amended_measurement_id)
         if amended_measurement is None:
-            raise BadRequest("Amendment references unknown PhysicalMeasurement %r." % ref_id)
+            raise BadRequest(f"Amendment references unknown PhysicalMeasurement {ref_id}.")
         amended_resource_json = json.loads(amended_measurement.resource)
         amended_resource = amended_resource_json["entry"][0]["resource"]
         amended_resource["status"] = "amended"
@@ -455,7 +454,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
             measurement.finalized = self.get_date_from_pm_resource(measurement.participantId,
                                                               measurement.physicalMeasurementsId)
 
-        logging.info("%s %s physical measurement %s.", author, resource["status"], measurement.physicalMeasurementsId)
+        logging.info(f"{author} {resource['status']} physical measurement {measurement.physicalMeasurementsId}.")
         payload = self.add_root_fields_to_resource(measurement)
         super(PhysicalMeasurementsDao, self)._do_update(session, payload, payload)
         self._update_participant_summary(session, payload)
@@ -483,14 +482,14 @@ class PhysicalMeasurementsDao(UpdatableDao):
                 pm_coding = coding
             elif coding.system.startswith(_PM_SYSTEM_PREFIX):
                 if pm_coding.system.startswith(_PM_SYSTEM_PREFIX):
-                    raise BadRequest("Multiple measurement codes starting system %s" % _PM_SYSTEM_PREFIX)
+                    raise BadRequest(f"Multiple measurement codes starting system {_PM_SYSTEM_PREFIX}")
                 pm_coding = coding
         return pm_coding
 
     @staticmethod
     def from_component(observation, component):
         if not component.code or not component.code.coding:
-            logging.warning("Skipping component without coding: %s" % component.as_json())
+            logging.warning(f"Skipping component without coding: {component.as_json()}")
             return None
         value_string = None
         value_decimal = None
@@ -535,10 +534,10 @@ class PhysicalMeasurementsDao(UpdatableDao):
                 # Skip anything *without* a related observation on the second pass.
                 return None
         if not observation.effectiveDateTime:
-            logging.warning("Skipping observation without effectiveDateTime: %s" % observation.as_json())
+            logging.warning(f"Skipping observation without effectiveDateTime: {observation.as_json()}")
             return None
         if not observation.code or not observation.code.coding:
-            logging.warning("Skipping observation without coding: %s" % observation.as_json())
+            logging.warning(f"Skipping observation without coding: {observation.as_json()}")
             return None
         body_site_code_system = None
         body_site_code_value = None
@@ -579,7 +578,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
                     if qualifier:
                         qualifiers.append(qualifier)
                     else:
-                        logging.warning("Could not find qualifier %s" % related.target.reference)
+                        logging.warning(f"Could not find qualifier {related.target.reference}")
         pm_coding = PhysicalMeasurementsDao.get_preferred_coding(observation.code)
         result = Measurement(
             codeSystem=pm_coding.system,
@@ -603,19 +602,19 @@ class PhysicalMeasurementsDao(UpdatableDao):
     @staticmethod
     def get_location_site_id(location_value):
         if not location_value.startswith(_LOCATION_PREFIX):
-            logging.warn("Invalid location: %s" % location_value)
+            logging.warning(f"Invalid location: {location_value}")
             return None
         google_group = location_value[len(_LOCATION_PREFIX) :]
         site = SiteDao().get_by_google_group(google_group)
         if not site:
-            logging.warning("Unknown site: %s" % google_group)
+            logging.warning(f"Unknown site: {google_group}")
             return None
         return site.siteId
 
     @staticmethod
     def get_author_username(author_value):
         if not author_value.startswith(_AUTHOR_PREFIX):
-            logging.warn("Invalid author: %s" % author_value)
+            logging.warning(f"Invalid author: {author_value}")
             return None
         return author_value[len(_AUTHOR_PREFIX) :]
 
@@ -656,10 +655,10 @@ class PhysicalMeasurementsDao(UpdatableDao):
                                 finalized_site_id = PhysicalMeasurementsDao.get_location_site_id(value_reference)
                             elif url not in _ALL_EXTENSIONS:
                                 logging.warning(
-                                    "Unrecognized extension URL: %r (should be one of %s)", url, _ALL_EXTENSIONS
+                                    f"Unrecognized extension URL: {url} (should be one of {_ALL_EXTENSIONS})"
                                 )
                         else:
-                            logging.warning("No valueReference in extension, skipping: %r", extension)
+                            logging.warning(f"No valueReference in extension, skipping: {extension}")
                     authors = resource.get("author")
                     for author in authors:
                         author_extension = author.get("extension")
@@ -672,10 +671,8 @@ class PhysicalMeasurementsDao(UpdatableDao):
                                 created_username = PhysicalMeasurementsDao.get_author_username(reference)
                 else:
                     logging.warning(
-                        "Unrecognized resource type (expected %r or %r), skipping: %r",
-                        _OBSERVATION_RESOURCE_TYPE,
-                        _COMPOSITION_RESOURCE_TYPE,
-                        resource_type,
+                        f"Unrecognized resource type (expected {_OBSERVATION_RESOURCE_TYPE} \
+                        or {_COMPOSITION_RESOURCE_TYPE}), skipping: {resource_type}"
                     )
 
         # Take two passes over the observations; once to find all the qualifiers and observations
@@ -707,14 +704,14 @@ class PhysicalMeasurementsDao(UpdatableDao):
                 raise BadRequest("This order is already cancelled")
             for field in cancelled_required_fields:
                 if field not in resource:
-                    raise BadRequest("%s is required in cancel request." % field)
+                    raise BadRequest(f"{field} is required in cancel request.")
 
         elif resource.get("status").lower() == "restored":
             if measurement.status != PhysicalMeasurementsStatus.CANCELLED:
                 raise BadRequest("Can not restore an order that is not cancelled.")
             for field in restored_required_fields:
                 if field not in resource:
-                    raise BadRequest("%s is required in restore request." % field)
+                    raise BadRequest(f"{field} is required in restore request.")
         else:
             raise BadRequest("status is required in restore request.")
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -540,8 +540,10 @@ class QuestionnaireResponseDao(BaseDao):
                                     answer_length = len(answer.valueString)
                                     max_length = QuestionnaireResponseAnswer.VALUE_STRING_MAXLEN
                                     if answer_length > max_length:
-                                        err_msg = "String value too long (len={:d}); must be less than {:d}"
-                                        raise BadRequest(err_msg.format(answer_length, max_length))
+                                        raise BadRequest(
+                                            f"String value too long (len={answer_length}); "
+                                            f"must be less than {max_length}"
+                                        )
                                     qr_answer.valueString = answer.valueString
                                 if answer.valueDate is not None:
                                     qr_answer.valueDate = answer.valueDate.date

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -50,7 +50,7 @@ from rdr_service.participant_enums import (
 
 _QUESTIONNAIRE_PREFIX = "Questionnaire/"
 _QUESTIONNAIRE_HISTORY_SEGMENT = "/_history/"
-_QUESTIONNAIRE_REFERENCE_FORMAT = _QUESTIONNAIRE_PREFIX + "%d" + _QUESTIONNAIRE_HISTORY_SEGMENT + "%d"
+_QUESTIONNAIRE_REFERENCE_FORMAT = _QUESTIONNAIRE_PREFIX + "{}" + _QUESTIONNAIRE_HISTORY_SEGMENT + "{}"
 
 _SIGNED_CONSENT_EXTENSION = "http://terminology.pmi-ops.org/StructureDefinition/consent-form-signed-pdf"
 
@@ -131,7 +131,7 @@ class QuestionnaireResponseDao(BaseDao):
                     and section["linkId"].lower() != "ignorethis"
                     and section["linkId"] not in link_ids
                 ):
-                    logging.error("Questionnaire response contains invalid link ID %s." % section["linkId"])
+                    logging.error(f"Questionnaire response contains invalid link ID {section['linkId']}.")
 
     def insert_with_session(self, session, questionnaire_response):
 
@@ -142,8 +142,8 @@ class QuestionnaireResponseDao(BaseDao):
 
         if not questionnaire_history:
             raise BadRequest(
-                "Questionnaire with ID %s, version %s is not found"
-                % (questionnaire_response.questionnaireId, questionnaire_response.questionnaireVersion)
+                f"Questionnaire with ID {questionnaire_response.questionnaireId}, \
+                version {questionnaire_response.questionnaireVersion} is not found"
             )
 
         # Get the questions from the questionnaire history record.
@@ -151,7 +151,7 @@ class QuestionnaireResponseDao(BaseDao):
         for answer in questionnaire_response.answers:
             if answer.questionId not in q_question_ids:
                 raise BadRequest(
-                    "Questionnaire response contains question ID %s not in questionnaire." % answer.questionId
+                    f"Questionnaire response contains question ID {answer.questionId} not in questionnaire."
                 )
 
         questionnaire_response.created = clock.CLOCK.now()
@@ -205,7 +205,7 @@ class QuestionnaireResponseDao(BaseDao):
             return answer.valueString
         if field_type == FieldType.DATE:
             return answer.valueDate
-        raise BadRequest("Don't know how to map field of type %s" % field_type)
+        raise BadRequest(f"Don't know how to map field of type {field_type}")
 
     def _update_field(self, participant_summary, field_name, field_type, answer):
         value = getattr(participant_summary, field_name)
@@ -229,7 +229,7 @@ class QuestionnaireResponseDao(BaseDao):
         participant = ParticipantDao().get_for_update(session, questionnaire_response.participantId)
 
         if participant is None:
-            raise BadRequest("Participant with ID %d is not found." % questionnaire_response.participantId)
+            raise BadRequest(f"Participant with ID {questionnaire_response.participantId} is not found.")
 
         participant_summary = participant.participantSummary
 
@@ -251,7 +251,7 @@ class QuestionnaireResponseDao(BaseDao):
                 raise BadRequest("No study enrollment consent code found; import codebook.")
             if not consent_code.codeId in code_ids:
                 raise BadRequest(
-                    "Can't submit order for participant %s without consent" % questionnaire_response.participantId
+                    f"Can't submit order for participant {questionnaire_response.participantId} without consent"
                 )
             raise_if_withdrawn(participant)
             participant_summary = ParticipantDao.create_summary_for_participant(participant)
@@ -350,7 +350,7 @@ class QuestionnaireResponseDao(BaseDao):
                                 extension.get("url") == _LANGUAGE_EXTENSION
                                 and extension.get("valueCode") not in LANGUAGE_OF_CONSENT
                             ):
-                                logging.warn("consent language %s not recognized." % extension.get("valueCode"))
+                                logging.warning(f"consent language {extension.get('valueCode')} not recognized.")
                     if getattr(participant_summary, summary_field) != new_status:
                         setattr(participant_summary, summary_field, new_status)
                         setattr(participant_summary, summary_field + "Time", questionnaire_response.created)
@@ -369,13 +369,13 @@ class QuestionnaireResponseDao(BaseDao):
             email_phone = (participant_summary.email, participant_summary.loginPhoneNumber)
             if not all(first_last):
                 raise BadRequest(
-                    "First name (%s), and last name (%s) required for consenting."
-                    % tuple(["present" if part else "missing" for part in first_last])
+                    "First name ({:s}), and last name ({:s}) required for consenting."
+                    .format(*["present" if part else "missing" for part in first_last])
                 )
             if not any(email_phone):
                 raise BadRequest(
-                    "Email address (%s), or phone number (%s) required for consenting."
-                    % tuple(["present" if part else "missing" for part in email_phone])
+                    "Email address ({:s}), or phone number ({:s}) required for consenting."
+                    .format(*["present" if part else "missing" for part in email_phone])
                 )
 
             ParticipantSummaryDao().update_enrollment_status(participant_summary)
@@ -412,13 +412,12 @@ class QuestionnaireResponseDao(BaseDao):
         fhir_qr = fhir_questionnaireresponse.QuestionnaireResponse(resource_json)
         patient_id = fhir_qr.subject.reference
         if patient_id != "Patient/P{}".format(participant_id):
-            msg = "Questionnaire response subject reference does not match participant_id %r"
-            raise BadRequest(msg % participant_id)
+            msg = "Questionnaire response subject reference does not match participant_id {}"
+            raise BadRequest(msg.format(participant_id))
         questionnaire = self._get_questionnaire(fhir_qr.questionnaire, resource_json)
         if questionnaire.status == QuestionnaireDefinitionStatus.INVALID:
             raise BadRequest(
-                "Submitted questionnaire that is marked as invalid: questionnaire ID %s"
-                % questionnaire.questionnaireId
+                f"Submitted questionnaire that is marked as invalid: questionnaire ID {questionnaire.questionnaireId}"
             )
         authored = None
         if fhir_qr.authored and fhir_qr.authored.date:
@@ -458,22 +457,22 @@ class QuestionnaireResponseDao(BaseDao):
     If a questionnaire has a history element it goes into the if block here."""
         # if history...
         if not questionnaire.reference.startswith(_QUESTIONNAIRE_PREFIX):
-            raise BadRequest("Questionnaire reference %s is invalid" % questionnaire.reference)
-        questionnaire_reference = questionnaire.reference[len(_QUESTIONNAIRE_PREFIX) :]
+            raise BadRequest(f"Questionnaire reference {questionnaire.reference} is invalid")
+        questionnaire_reference = questionnaire.reference[len(_QUESTIONNAIRE_PREFIX):]
         # If the questionnaire response specifies the version of the questionnaire it's for, use it.
         if _QUESTIONNAIRE_HISTORY_SEGMENT in questionnaire_reference:
             questionnaire_ref_parts = questionnaire_reference.split(_QUESTIONNAIRE_HISTORY_SEGMENT)
             if len(questionnaire_ref_parts) != 2:
-                raise BadRequest("Questionnaire id %s is invalid" % questionnaire_reference)
+                raise BadRequest(f"Questionnaire id {questionnaire_reference} is invalid")
             try:
                 questionnaire_id = int(questionnaire_ref_parts[0])
                 version = int(questionnaire_ref_parts[1])
                 q = QuestionnaireHistoryDao().get_with_children((questionnaire_id, version))
                 if not q:
-                    raise BadRequest("Questionnaire with id %d, version %d is not found" % (questionnaire_id, version))
+                    raise BadRequest(f"Questionnaire with id {questionnaire_id}, version {version} is not found")
                 return q
             except ValueError:
-                raise BadRequest("Questionnaire id %s is invalid" % questionnaire_reference)
+                raise BadRequest(f"Questionnaire id {questionnaire_reference} is invalid")
         else:
             # if no questionnaire/history...
             try:
@@ -482,13 +481,13 @@ class QuestionnaireResponseDao(BaseDao):
 
                 q = QuestionnaireDao().get_with_children(questionnaire_id)
                 if not q:
-                    raise BadRequest("Questionnaire with id %d is not found" % questionnaire_id)
+                    raise BadRequest(f"Questionnaire with id {questionnaire_id} is not found")
                 # Mutate the questionnaire reference to include the version.
-                questionnaire_reference = _QUESTIONNAIRE_REFERENCE_FORMAT % (questionnaire_id, q.version)
+                questionnaire_reference = _QUESTIONNAIRE_REFERENCE_FORMAT.format(questionnaire_id, q.version)
                 resource_json["questionnaire"]["reference"] = questionnaire_reference
                 return q
             except ValueError:
-                raise BadRequest("Questionnaire id %s is invalid" % questionnaire_reference)
+                raise BadRequest(f"Questionnaire id {questionnaire_reference} is invalid")
 
     @classmethod
     def _extract_codes_and_answers(cls, group, q):
@@ -518,9 +517,9 @@ class QuestionnaireResponseDao(BaseDao):
                             ignore_answer = False
                             if answer.valueCoding:
                                 if not answer.valueCoding.system:
-                                    raise BadRequest("No system provided for valueCoding: %s" % question.linkId)
+                                    raise BadRequest(f"No system provided for valueCoding: {question.linkId}")
                                 if not answer.valueCoding.code:
-                                    raise BadRequest("No code provided for valueCoding: %s" % question.linkId)
+                                    raise BadRequest(f"No code provided for valueCoding: {question.linkId}")
                                 if answer.valueCoding.system == PPI_EXTRA_SYSTEM:
                                     # Ignore answers from the ppi-extra system, as they aren't used for analysis.
                                     ignore_answer = True
@@ -541,8 +540,8 @@ class QuestionnaireResponseDao(BaseDao):
                                     answer_length = len(answer.valueString)
                                     max_length = QuestionnaireResponseAnswer.VALUE_STRING_MAXLEN
                                     if answer_length > max_length:
-                                        err_msg = "String value too long (len=%d); must be less than %d"
-                                        raise BadRequest(err_msg % (answer_length, max_length))
+                                        err_msg = "String value too long (len={:d}); must be less than {:d}"
+                                        raise BadRequest(err_msg.format(answer_length, max_length))
                                     qr_answer.valueString = answer.valueString
                                 if answer.valueDate is not None:
                                     qr_answer.valueDate = answer.valueDate.date
@@ -583,7 +582,7 @@ def _add_codes_if_missing(client_id):
 def _validate_consent_pdfs(resource):
     """Checks for any consent-form-signed-pdf extensions and validates their PDFs in GCS."""
     if resource.get("resourceType") != "QuestionnaireResponse":
-        raise ValueError('Expected QuestionnaireResponse for "resourceType" in %r.' % resource)
+        raise ValueError(f'Expected QuestionnaireResponse for "resourceType" in {resource}.')
     consent_bucket = config.getSetting(config.CONSENT_PDF_BUCKET)
     for extension in resource.get("extension", []):
         if extension["url"] != _SIGNED_CONSENT_EXTENSION:
@@ -591,11 +590,11 @@ def _validate_consent_pdfs(resource):
         local_pdf_path = extension["valueString"]
         _, ext = os.path.splitext(local_pdf_path)
         if ext.lower() != ".pdf":
-            raise BadRequest("Signed PDF must end in .pdf, found %r (from %r)." % (ext, local_pdf_path))
+            raise BadRequest(f"Signed PDF must end in .pdf, found {ext} (from {local_pdf_path}).")
         # Treat the value as a bucket-relative path, allowing a leading slash or not.
         if not local_pdf_path.startswith("/"):
             local_pdf_path = "/" + local_pdf_path
-        _raise_if_gcloud_file_missing("/%s%s" % (consent_bucket, local_pdf_path))
+        _raise_if_gcloud_file_missing("/{}{}".format(consent_bucket, local_pdf_path))
 
 
 def _raise_if_gcloud_file_missing(path):
@@ -608,7 +607,7 @@ def _raise_if_gcloud_file_missing(path):
   """
     storage_provier = storage.get_storage_provider()
     if not storage_provier.exists(path):
-        raise BadRequest("Google Cloud Storage file not found in %s." % (path))
+        raise BadRequest(f"Google Cloud Storage file not found in {path}.")
 
 
 class QuestionnaireResponseAnswerDao(BaseDao):

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -83,7 +83,7 @@ def _log_request_exception(sender, exception, **extra):  # pylint: disable=unuse
         # Log everything at error. This handles 400s which, since we have few/predefined clients,
         # we want to notice (and we don't see client-side logs); Stackdriver error reporting only
         # reports error logs with stack traces. (500s are logged with stacks by Flask automatically.)
-        logging.error("%s: %s", exception, exception.description, exc_info=True)
+        logging.error(f"{exception}: {exception.description}", exc_info=True)
 
 
 got_request_exception.connect(_log_request_exception, app)


### PR DESCRIPTION
This PR updates string formatting of logged messages in the `rdr_service` directory from the Python 2 method to the Python 3 method. Google logging with Python 3 does not support the Python 2 string formatting method.