### PR TITLE
[DA-1373] Put one-off BQ tasks in own queue

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -160,7 +160,8 @@ class BaseApi(Resource):
                 bq_participant_summary_update_task(participant_id)
             else:
                 params = {'p_id': participant_id}
-                task = GCPCloudTask('bq_rebuild_one_participant_task', payload=params, in_seconds=5)
+                task = GCPCloudTask('bq_rebuild_one_participant_task',
+                                    queue='bigquery-tasks', payload=params, in_seconds=5)
                 task.execute()
 
         log_api_request(result)
@@ -317,7 +318,8 @@ class UpdatableApi(BaseApi):
                 bq_participant_summary_update_task(participant_id)
             else:
                 params = {'p_id': participant_id}
-                task = GCPCloudTask('bq_rebuild_one_participant_task', payload=params, in_seconds=5)
+                task = GCPCloudTask('bq_rebuild_one_participant_task',
+                                    queue='bigquery-tasks', payload=params, in_seconds=5)
                 task.execute()
 
         log_api_request(m)

--- a/rdr_service/api/import_codebook_api.py
+++ b/rdr_service/api/import_codebook_api.py
@@ -71,7 +71,7 @@ def import_codebook():
     if GAE_PROJECT == 'localhost':
         rebuild_bq_codebook_task()
     else:
-        task = GCPCloudTask('bq_rebuild_codebook_task')
+        task = GCPCloudTask('bq_rebuild_codebook_task', queue='bigquery-tasks')
         task.execute()
 
     return _log_and_return_json(response)

--- a/rdr_service/api/questionnaire_response_api.py
+++ b/rdr_service/api/questionnaire_response_api.py
@@ -34,7 +34,8 @@ class QuestionnaireResponseApi(BaseApi):
                 bq_questionnaire_update_task(p_id, qr_id)
             else:
                 params = {'p_id': p_id, 'qr_id': qr_id}
-                task = GCPCloudTask('bq_rebuild_questionnaire_task', payload=params, in_seconds=5)
+                task = GCPCloudTask('bq_rebuild_questionnaire_task',
+                                    queue='bigquery-tasks', payload=params, in_seconds=5)
                 task.execute()
 
         return resp

--- a/rdr_service/queue.yaml
+++ b/rdr_service/queue.yaml
@@ -27,3 +27,9 @@ queue:
   max_concurrent_requests: 2
   retry_parameters:
     task_retry_limit: 4
+
+- name: bigquery-tasks
+  rate: 50/s
+  max_concurrent_requests: 10
+  retry_parameters:
+    task_retry_limit: 5


### PR DESCRIPTION
Improve SQL performance by replacing use of `sp_get_questionnaire_answers` stored proc with more efficient queries. 