### PR TITLE
[bug-fix] Explicitly ordering test-file list.

### DIFF
--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -577,7 +577,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         # test file processing queue
         files_processed = self.genomic_file_processed_dao.get_all()
-        files_processed = sorted(files_processed, key=lambda x: x.fileName, reverse=True)
+        files_processed.sort(key=lambda x: x.fileName, reverse=True)
         self.assertEqual(len(files_processed), 2)
         self._gc_files_processed_test_cases(files_processed, bucket_name)
 

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -577,6 +577,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         # test file processing queue
         files_processed = self.genomic_file_processed_dao.get_all()
+        files_processed = sorted(files_processed, key=lambda x: x.fileName, reverse=True)
         self.assertEqual(len(files_processed), 2)
         self._gc_files_processed_test_cases(files_processed, bucket_name)
 


### PR DESCRIPTION
Sorting the `files_processed` list in place to enforce ordering for testing genomic filenames.