### PR TITLE
Support the ETL export url path

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -35,7 +35,10 @@ def log_api_request(model_obj=None):
         except ValueError:
             log.resource = request.data
     parts = request.url.split('/')
-    log.version = int(parts[4][1:]) if len(parts) > 4 else 0
+    try:
+        log.version = int(parts[4][1:]) if len(parts) > 4 else 0
+    except ValueError:
+        log.version = 0  # unknown, for urls that don't use the /rdr/v1/ format.
 
     request.logged = True
 


### PR DESCRIPTION
Apparently there are some APIs that use the base_api class, but don't have the "/rdr/v1/" prefix in the url path.