### PR TITLE
[ROC-271] Fixing user -> system identifier mapping.

### DIFF
--- a/rdr_service/model/biobank_dv_order.py
+++ b/rdr_service/model/biobank_dv_order.py
@@ -9,9 +9,9 @@ class BiobankDVOrder(Base):
     """
   Direct Volunteer kit order shipment record
   """
-
+    # mapping a user_info.clientID (from config) to a system identifier
     _DV_ID_SYSTEM = {
-        'vibrent-drc-prod': "http://vibrenthealth.com",
+        'vibrent': "http://vibrenthealth.com",
         'careevolution': "http://carevolution.be",
         'example': "system-test"
     }


### PR DESCRIPTION
This PR fixes a bug in the way the DV order identifier is written. This changes it to be set based on the `clientID` in the config since this functionality is available. 
Additional changes were made to check this in the unit tests and to add exception handling for this issue.
