### PR TITLE
[ROC-291] Bug fix if participant ID is zero.

### DIFF
--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -28,7 +28,7 @@ class ParticipantSummaryApi(BaseApi):
                     raise InternalServerError("Config error for awardee")
 
         # data only for user_awardee, assert that query has same awardee
-        if p_id:
+        if p_id is not None:
             if auth_awardee and user_email != DEV_MAIL:
                 raise Forbidden
             return super(ParticipantSummaryApi, self).get(p_id)

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -479,6 +479,9 @@ class ParticipantSummaryApiTest(BaseTestCase):
         response = self.send_get("ParticipantSummary")
         self.assertBundle([], response)
 
+    def test_zero_participant_id(self):
+        self.send_get("Participant/P000/Summary", expected_status=http.client.NOT_FOUND)
+
     def submit_questionnaire_response(
         self,
         participant_id,


### PR DESCRIPTION
This PR fixes a bug reported 12/11/2019 where participant summary requests with a PID of 0 were returning queries. Python evaluates `0` as `False`. The condition was updated to be more explicit by testing `if PID is not None`. This will evaluate to `True` in the case of `0`.