### PR TITLE
circleci staging deploy fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ commands:
       project-id:
         type: string
         default: bad-mojo-teacup
+      git-target:
+        type: string
+        default: bad-mojo-teacup
     steps:
       - checkout
       - run:
@@ -53,7 +56,7 @@ commands:
           command: ./ci/setup_python_env.sh
       - run:
           name: Deploy App To Test Environment
-          command: ./ci/deploy_app.sh << parameters.project-id >>
+          command: ./ci/deploy_app.sh << parameters.project-id >> << parameters.git-target >>
 
 jobs:
   job_run_unittests:
@@ -66,12 +69,14 @@ jobs:
     steps:
       - deploy-app-steps:
           project-id: pmi-drc-api-test
+          git-target: << pipeline.git.branch >>
 
   job_deploy_to_staging:
     <<: *job_defaults
     steps:
       - deploy-app-steps:
           project-id: all-of-us-rdr-staging
+          git-target: << pipeline.git.tag >>
 
 workflows:
 

--- a/ci/deploy_app.sh
+++ b/ci/deploy_app.sh
@@ -7,4 +7,4 @@ export PYTHONPATH=$PYTHONPATH:`pwd`
 export GOOGLE_APPLICATION_CREDENTIALS=/home/circleci/gcloud-credentials.key
 ./ci/activate_creds.sh ~/gcloud-credentials.key
 cd rdr_service
-python -m tools app-engine --project $1 deploy --deploy-as circleci --quiet
+python -m tools app-engine --project $1 deploy --git-target $2 --deploy-as circleci --quiet

--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -5,6 +5,9 @@ _port = 8080 # local dev/testing.
 workers = 1
 threads = 1
 
+max_requests = 1000
+max_requests_jitter = 50
+
 if os.getenv('GAE_ENV', '').startswith('standard'):
     _port = os.environ.get('PORT', 8081)
     workers = multiprocessing.cpu_count() * 2 + 1

--- a/rdr_service/services/system_utils.py
+++ b/rdr_service/services/system_utils.py
@@ -624,6 +624,20 @@ def git_current_branch():
 
     return None
 
+def git_current_tag():
+    """
+    Get the current git tag
+    :return: Git tag
+    """
+    args = ['git', 'describe', '--tags']
+    # pylint: disable=unused-variable
+    code, so, se = run_external_program(args=args)
+
+    if code == 0:
+        return so.strip()
+
+    return None
+
 def git_checkout_branch(branch):
     """
     Change current branch to the given branch.


### PR DESCRIPTION
Pass the git tag to the deploy tool from CircleCI.
Restart Gunicorn processes after 1,000 requests.  Use jitter feature to make sure all the processes don't restart at the same time.

