### PR TITLE
[ROC-293] Filter obsolete records from Awardee

### DIFF
--- a/rdr_service/api/awardee_api.py
+++ b/rdr_service/api/awardee_api.py
@@ -27,4 +27,7 @@ class AwardeeApi(BaseApi):
 
     def _make_response(self, obj):
         inactive = request.args.get("_inactive")
-        return self.dao.to_client_json(obj, inactive)
+        obsolete = request.args.get("_obsolete")
+        return self.dao.to_client_json(obj,
+                                       inactive_sites=inactive,
+                                       include_obsolete=obsolete)

--- a/rdr_service/api/awardee_api.py
+++ b/rdr_service/api/awardee_api.py
@@ -5,6 +5,7 @@ from rdr_service.api.base_api import BaseApi
 from rdr_service.api_util import PTC_AND_HEALTHPRO
 from rdr_service.app_util import auth_required
 from rdr_service.dao.hpo_dao import HPODao
+from rdr_service.model.site_enums import ObsoleteStatus
 
 
 class AwardeeApi(BaseApi):
@@ -13,6 +14,7 @@ class AwardeeApi(BaseApi):
 
     @auth_required(PTC_AND_HEALTHPRO)
     def get(self, a_id=None):
+        self.dao.obsolete_filters = self._get_obsolete_filters()
         if a_id:
             hpo = self.dao.get_by_name(a_id)
             if not hpo:
@@ -27,7 +29,15 @@ class AwardeeApi(BaseApi):
 
     def _make_response(self, obj):
         inactive = request.args.get("_inactive")
-        obsolete = request.args.get("_obsolete")
         return self.dao.to_client_json(obj,
                                        inactive_sites=inactive,
-                                       include_obsolete=obsolete)
+                                       obsolete_filters=self._get_obsolete_filters())
+
+    def _get_obsolete_filters(self):
+        obsolete_param = request.args.get("_obsolete")
+        obsolete_filters = [None,
+                            ObsoleteStatus.ACTIVE,
+                            ObsoleteStatus.OBSOLETE]
+        if obsolete_param is not None and obsolete_param.lower() == 'false':
+            obsolete_filters = obsolete_filters[:-1]
+        return obsolete_filters

--- a/rdr_service/dao/hpo_dao.py
+++ b/rdr_service/dao/hpo_dao.py
@@ -1,5 +1,6 @@
 
 from sqlalchemy.orm import subqueryload
+from sqlalchemy import or_
 
 from rdr_service.code_constants import UNSET
 from rdr_service.dao.base_dao import FhirMixin, FhirProperty
@@ -8,7 +9,9 @@ from rdr_service.dao.organization_dao import OrganizationDao, _FhirOrganization
 from rdr_service.lib_fhir.fhirclient_1_0_6.models.domainresource import DomainResource
 from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
+from rdr_service.model.site_enums import ObsoleteStatus
 from rdr_service.singletons import HPO_CACHE_INDEX
+
 
 
 class _FhirAwardee(FhirMixin, DomainResource):
@@ -35,6 +38,10 @@ class HPODao(CacheAllDao):
             index_field_keys=["name"],
             order_by_ending=_ORDER_BY_ENDING,
         )
+        # Default includes obsolete HPOs
+        self.obsolete_filters = [None,
+                                 ObsoleteStatus.ACTIVE,
+                                 ObsoleteStatus.OBSOLETE]
 
     def _validate_update(self, session, obj, existing_obj):
         # HPOs aren't versioned; suppress the normal check here.
@@ -61,35 +68,35 @@ class HPODao(CacheAllDao):
     def _make_query(self, session, query_def):  # pylint: disable=unused-argument
         # For now, no filtering, ordering, or pagination is supported; fetch child organizations and
         # sites.
-        return (
-            session.query(HPO)
-            .options(subqueryload(HPO.organizations).subqueryload(Organization.sites))
-            .order_by(HPO.name),
-            _ORDER_BY_ENDING,
-        )
+        query = session.query(HPO)\
+                .options(subqueryload(HPO.organizations).subqueryload(Organization.sites)) \
+                .order_by(HPO.name)
+        if len(self.obsolete_filters) < 3:
+            query = session.query(HPO) \
+                .filter(or_(HPO.isObsolete == None, HPO.isObsolete == ObsoleteStatus.ACTIVE)) \
+                .options(subqueryload(HPO.organizations).subqueryload(Organization.sites)) \
+                .order_by(HPO.name)
+        return query, _ORDER_BY_ENDING,
 
-    def to_client_json(self, model, inactive_sites, include_obsolete):
-        return HPODao._to_json(model, inactive_sites, include_obsolete)
+    def to_client_json(self, model, inactive_sites, obsolete_filters):
+        return HPODao._to_json(model, inactive_sites, obsolete_filters)
 
     @staticmethod
-    def _to_json(model, inactive_sites=False, include_obsolete=None):
+    def _to_json(model, inactive_sites=False,
+                 obsolete_filters=None):
         resource = _FhirAwardee()
         resource.id = model.name
         resource.display_name = model.displayName
-        obsolete_filters = [0, 1, None]
-        if include_obsolete is not None:
-            if include_obsolete.lower() == 'false':
-                obsolete_filters = [0, None]
-            elif include_obsolete.lower() == 'true':
-                obsolete_filters = [1]
 
         if model.organizationType:
             resource.type = str(model.organizationType)
         else:
             resource.type = UNSET
+
         resource.organizations = [
-            OrganizationDao._to_json(organization, inactive_sites)
+            OrganizationDao._to_json(organization, inactive_sites, obsolete_filters)
             for organization in model.organizations
+            if organization.isObsolete in obsolete_filters
         ]
         json = resource.as_json()
         del json["resourceType"]

--- a/rdr_service/dao/hpo_dao.py
+++ b/rdr_service/dao/hpo_dao.py
@@ -68,20 +68,28 @@ class HPODao(CacheAllDao):
             _ORDER_BY_ENDING,
         )
 
-    def to_client_json(self, model, inactive_sites):
-        return HPODao._to_json(model, inactive_sites)
+    def to_client_json(self, model, inactive_sites, include_obsolete):
+        return HPODao._to_json(model, inactive_sites, include_obsolete)
 
     @staticmethod
-    def _to_json(model, inactive_sites=False):
+    def _to_json(model, inactive_sites=False, include_obsolete=None):
         resource = _FhirAwardee()
         resource.id = model.name
         resource.display_name = model.displayName
+        obsolete_filters = [0, 1, None]
+        if include_obsolete is not None:
+            if include_obsolete.lower() == 'false':
+                obsolete_filters = [0, None]
+            elif include_obsolete.lower() == 'true':
+                obsolete_filters = [1]
+
         if model.organizationType:
             resource.type = str(model.organizationType)
         else:
             resource.type = UNSET
         resource.organizations = [
-            OrganizationDao._to_json(organization, inactive_sites) for organization in model.organizations
+            OrganizationDao._to_json(organization, inactive_sites)
+            for organization in model.organizations
         ]
         json = resource.as_json()
         del json["resourceType"]

--- a/rdr_service/dao/organization_dao.py
+++ b/rdr_service/dao/organization_dao.py
@@ -77,7 +77,7 @@ class OrganizationDao(CacheAllDao):
             return query.first()
 
     @staticmethod
-    def _to_json(model, inactive_sites):
+    def _to_json(model, inactive_sites, obsolete_filters):
         resource = _FhirOrganization()
         resource.id = model.externalId
         resource.display_name = model.displayName
@@ -88,5 +88,6 @@ class OrganizationDao(CacheAllDao):
                 SiteDao._to_json(site)
                 for site in model.sites
                 if site.siteStatus and site.siteStatus == site.siteStatus.ACTIVE
+                and site.isObsolete in obsolete_filters
             ]
         return resource

--- a/tests/api_tests/test_awardee_api.py
+++ b/tests/api_tests/test_awardee_api.py
@@ -124,8 +124,10 @@ class AwardeeApiTest(BaseTestCase):
                 isObsolete=ObsoleteStatus.OBSOLETE)
         )
         result_all = self.send_get("Awardee?_obsolete=false")
-
         self.assertEqual(3, len(result_all['entry']))
+
+        result_1_obsolete = self.send_get("Awardee/OBSOLETE_HPO?_obsolete=false")
+        self.assertEqual('OBSOLETE_HPO', result_1_obsolete['id'])
 
     def _make_expected_pitt_awardee_resource(self, inactive=False):
         sites = [

--- a/tests/helpers/mysql_helper_data.py
+++ b/tests/helpers/mysql_helper_data.py
@@ -10,6 +10,7 @@ PITT_ORG_ID = 3
 PITT_SITE_ID = 1
 AZ_HPO_ID = 4
 AZ_ORG_ID = 4
+OBSOLETE_ID = 5
 
 @contextlib.contextmanager
 def random_ids(ids):


### PR DESCRIPTION
This PR adds a filter to the awardee endpoint to exclude resulting sites, organizations, or awardees that have `isObsolete` set as `OBSOLETE`.