### PR TITLE
[DA-1406] Fake participants on site creation via HoS

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -148,7 +148,6 @@ def get_account_origin_id():
     :return: Client Id
     """
     auth_email = get_oauth_id()
-    logging.info(f'Account email: {auth_email}')
     user_info = lookup_user_info(auth_email)
     client_id = user_info.get('clientId')
     from rdr_service.api_util import DEV_MAIL

--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -148,6 +148,7 @@ def get_account_origin_id():
     :return: Client Id
     """
     auth_email = get_oauth_id()
+    logging.info(f'Account email: {auth_email}')
     user_info = lookup_user_info(auth_email)
     client_id = user_info.get('clientId')
     from rdr_service.api_util import DEV_MAIL

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -21,9 +21,10 @@ from rdr_service.dao.bq_hpo_dao import bq_hpo_update_by_id
 from rdr_service.dao.bq_organization_dao import bq_organization_update_by_id
 from rdr_service.dao.bq_site_dao import bq_site_update_by_id
 from rdr_service.dao.code_dao import CodeDao
-from rdr_service.code_constants import PPI_SYSTEM
+from rdr_service.code_constants import PPI_SYSTEM, CONSENT_FOR_STUDY_ENROLLMENT_MODULE
 from dateutil.parser import parse
 from rdr_service.api_util import HIERARCHY_CONTENT_SYSTEM_PREFIX
+from rdr_service.app_util import get_auth_token
 from rdr_service.data_gen.fake_participant_generator import FakeParticipantGenerator
 from rdr_service.data_gen.in_process_client import InProcessClient
 
@@ -315,7 +316,7 @@ class OrganizationHierarchySyncDao(BaseDao):
             # Generates 20 fake participants for the site if not on Prod
             # Not called during unittests since codebook breaks
             logging.info(f'New site: {new_site.googleGroup}')
-            if self.code_dao.get_code(PPI_SYSTEM, 'ConsentPII'):
+            if self.code_dao.get_code(PPI_SYSTEM, CONSENT_FOR_STUDY_ENROLLMENT_MODULE):
                 logging.info('Generating fake participants.')
                 self._generate_fake_participants_for_site(new_site)
 

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -6,7 +6,7 @@ import rdr_service.lib_fhir.fhirclient_3_0_0.models.organization
 
 from rdr_service.lib_fhir.fhirclient_3_0_0.models.fhirabstractbase import FHIRValidationError
 from werkzeug.exceptions import BadRequest
-
+from flask import request
 from rdr_service import config
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.model.hpo import HPO
@@ -325,16 +325,10 @@ class OrganizationHierarchySyncDao(BaseDao):
     def _generate_fake_participants_for_site(self, new_site):
         if config.GAE_PROJECT in ['localhost',
                                   "all-of-us-rdr-stable",
-                                  "all-of-us-rdr-staging",
-                                  "all-of-us-rdr-sandbox",
-                                  "pmi-drc-api-test",
-                                  "all-of-us-rdr-careevo-test",
-                                  "all-of-us-rdr-ptsc-1-test",
-                                  "all-of-us-rdr-ptsc-2-test",
-                                  "all-of-us-rdr-ptsc-3-test"]:
-            n = 20
+                                  "all-of-us-rdr-sandbox"]:
+            n = 20  # number of participants
             logging.info(f'Generating {n} fake participants for {new_site.googleGroup}.')
-            fake_gen = FakeParticipantGenerator(client=InProcessClient(),
+            fake_gen = FakeParticipantGenerator(client=InProcessClient(headers=request.headers),
                                                 withdrawn_percent=0,
                                                 suspended_percent=0)
             for _ in range(n):

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -24,7 +24,6 @@ from rdr_service.dao.code_dao import CodeDao
 from rdr_service.code_constants import PPI_SYSTEM, CONSENT_FOR_STUDY_ENROLLMENT_MODULE
 from dateutil.parser import parse
 from rdr_service.api_util import HIERARCHY_CONTENT_SYSTEM_PREFIX
-from rdr_service.app_util import get_auth_token
 from rdr_service.data_gen.fake_participant_generator import FakeParticipantGenerator
 from rdr_service.data_gen.in_process_client import InProcessClient
 

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -328,7 +328,8 @@ class OrganizationHierarchySyncDao(BaseDao):
                                   "all-of-us-rdr-sandbox"]:
             n = 20  # number of participants
             logging.info(f'Generating {n} fake participants for {new_site.googleGroup}.')
-            fake_gen = FakeParticipantGenerator(client=InProcessClient(headers=request.headers),
+            auth_header = request.headers.get('Authorization')
+            fake_gen = FakeParticipantGenerator(client=InProcessClient(headers=auth_header),
                                                 withdrawn_percent=0,
                                                 suspended_percent=0)
             for _ in range(n):

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -24,7 +24,6 @@ from dateutil.parser import parse
 from rdr_service.api_util import HIERARCHY_CONTENT_SYSTEM_PREFIX
 from rdr_service.data_gen.fake_participant_generator import FakeParticipantGenerator
 from rdr_service.data_gen.in_process_client import InProcessClient
-from rdr_service.rdr_client.client import Client
 
 
 class OrganizationHierarchySyncDao(BaseDao):
@@ -323,7 +322,7 @@ class OrganizationHierarchySyncDao(BaseDao):
             fake_gen = FakeParticipantGenerator(client=InProcessClient(),
                                                 withdrawn_percent=0,
                                                 suspended_percent=0)
-            for i in range(n):
+            for _ in range(n):
                 fake_gen.generate_participant(
                     include_physical_measurements=False,
                     include_biobank_orders=False,

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -323,7 +323,15 @@ class OrganizationHierarchySyncDao(BaseDao):
         bq_site_update_by_id(site_id)
 
     def _generate_fake_participants_for_site(self, new_site):
-        if config.GAE_PROJECT in ['localhost', 'all-of-us-rdr-stable']:
+        if config.GAE_PROJECT in ['localhost',
+                                  "all-of-us-rdr-stable",
+                                  "all-of-us-rdr-staging",
+                                  "all-of-us-rdr-sandbox",
+                                  "pmi-drc-api-test",
+                                  "all-of-us-rdr-careevo-test",
+                                  "all-of-us-rdr-ptsc-1-test",
+                                  "all-of-us-rdr-ptsc-2-test",
+                                  "all-of-us-rdr-ptsc-3-test"]:
             n = 20
             logging.info(f'Generating {n} fake participants for {new_site.googleGroup}.')
             fake_gen = FakeParticipantGenerator(client=InProcessClient(),

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -320,12 +320,14 @@ class OrganizationHierarchySyncDao(BaseDao):
         if config.GAE_PROJECT in ['localhost', 'all-of-us-rdr-stable']:
             n = 20
             logging.info(f'Generating {n} fake participants for {new_site.googleGroup}.')
-            fake_gen = FakeParticipantGenerator(client=InProcessClient())
+            fake_gen = FakeParticipantGenerator(client=InProcessClient(),
+                                                withdrawn_percent=0,
+                                                suspended_percent=0)
             for i in range(n):
                 fake_gen.generate_participant(
                     include_physical_measurements=False,
                     include_biobank_orders=False,
-                    hpo_obj=None,
+                    requested_hpo=None,
                     requested_site=new_site
                 )
 

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -328,7 +328,7 @@ class OrganizationHierarchySyncDao(BaseDao):
                                   "all-of-us-rdr-sandbox"]:
             n = 20  # number of participants
             logging.info(f'Generating {n} fake participants for {new_site.googleGroup}.')
-            auth_header = request.headers.get('Authorization')
+            auth_header = {'Authorization': request.headers.get('Authorization')}
             fake_gen = FakeParticipantGenerator(client=InProcessClient(headers=auth_header),
                                                 withdrawn_percent=0,
                                                 suspended_percent=0)

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -316,7 +316,7 @@ class OrganizationHierarchySyncDao(BaseDao):
             # Not called during unittests since codebook breaks
             logging.info(f'New site: {new_site.googleGroup}')
             if self.code_dao.get_code(PPI_SYSTEM, 'ConsentPII'):
-                logging.info(f'Generating fake participants.}')
+                logging.info('Generating fake participants.')
                 self._generate_fake_participants_for_site(new_site)
 
         site_id = self.site_dao.get_by_google_group(google_group).siteId

--- a/rdr_service/dao/organization_hierarchy_sync_dao.py
+++ b/rdr_service/dao/organization_hierarchy_sync_dao.py
@@ -314,7 +314,9 @@ class OrganizationHierarchySyncDao(BaseDao):
         if new_site is not None:
             # Generates 20 fake participants for the site if not on Prod
             # Not called during unittests since codebook breaks
+            logging.info(f'New site: {new_site.googleGroup}')
             if self.code_dao.get_code(PPI_SYSTEM, 'ConsentPII'):
+                logging.info(f'Generating fake participants.}')
                 self._generate_fake_participants_for_site(new_site)
 
         site_id = self.site_dao.get_by_google_group(google_group).siteId

--- a/rdr_service/data_gen/fake_participant_generator.py
+++ b/rdr_service/data_gen/fake_participant_generator.py
@@ -699,8 +699,7 @@ class FakeParticipantGenerator(object):
     def generate_participant(self, include_physical_measurements,
                              include_biobank_orders,
                              requested_hpo=None,
-                             requested_site=None,
-                             headers=None):
+                             requested_site=None):
         participant_response, creation_time, hpo = self._create_participant(requested_hpo,
                                                                             site=requested_site,
                                                                             headers=None)

--- a/rdr_service/data_gen/fake_participant_generator.py
+++ b/rdr_service/data_gen/fake_participant_generator.py
@@ -715,7 +715,8 @@ class FakeParticipantGenerator(object):
                 # Potentially include physical measurements and biobank orders if the client requested it
                 # and the participant has submitted the basics questionnaire.
                 if include_physical_measurements and the_basics_submission_time:
-                    last_measurement_time = self._submit_physical_measurements(participant_id, the_basics_submission_time)
+                    last_measurement_time = self._submit_physical_measurements(participant_id,
+                                                                               the_basics_submission_time)
                     last_request_time = max(last_request_time, last_measurement_time)
                 if include_biobank_orders and the_basics_submission_time:
                     last_biobank_time = self._submit_biobank_data(participant_id, the_basics_submission_time)

--- a/rdr_service/data_gen/fake_participant_generator.py
+++ b/rdr_service/data_gen/fake_participant_generator.py
@@ -699,9 +699,11 @@ class FakeParticipantGenerator(object):
     def generate_participant(self, include_physical_measurements,
                              include_biobank_orders,
                              requested_hpo=None,
-                             requested_site=None):
+                             requested_site=None,
+                             headers=None):
         participant_response, creation_time, hpo = self._create_participant(requested_hpo,
-                                                                            site=requested_site)
+                                                                            site=requested_site,
+                                                                            headers=None)
 
         if requested_site is None:
             participant_id = participant_response["participantId"]

--- a/rdr_service/data_gen/fake_participant_generator.py
+++ b/rdr_service/data_gen/fake_participant_generator.py
@@ -701,8 +701,7 @@ class FakeParticipantGenerator(object):
                              requested_hpo=None,
                              requested_site=None):
         participant_response, creation_time, hpo = self._create_participant(requested_hpo,
-                                                                            site=requested_site,
-                                                                            headers=None)
+                                                                            site=requested_site)
 
         if requested_site is None:
             participant_id = participant_response["participantId"]

--- a/rdr_service/data_gen/in_process_client.py
+++ b/rdr_service/data_gen/in_process_client.py
@@ -10,6 +10,10 @@ class InProcessClient(object):
 
   Used for creating fake data.
   """
+    _headers = None
+
+    def __init__(self, headers=None):
+        self._headers = headers
 
     def request_json(self, local_path, method="GET", body=None, headers=None, pretend_date=None):
         """
@@ -20,10 +24,15 @@ class InProcessClient(object):
         :param headers: the headers for the request.
         :param pretend_date: the time at which the request should appear to occur.
         """
+
+        merged_headers = {**self._headers, **headers} \
+            if self._headers and headers else self._headers \
+            if self._headers else headers
+
         with FakeClock(pretend_date):
             with app.app_context():
                 with app.test_request_context(
-                    API_PREFIX + local_path, method=method, headers=headers, data=json.dumps(body)
+                    API_PREFIX + local_path, method=method, headers=merged_headers, data=json.dumps(body)
                 ):
                     try:
                         rv = app.preprocess_request()

--- a/rdr_service/data_gen/in_process_client.py
+++ b/rdr_service/data_gen/in_process_client.py
@@ -10,8 +10,6 @@ class InProcessClient(object):
 
   Used for creating fake data.
   """
-    _headers = None
-
     def __init__(self, headers=None):
         self._headers = headers
 


### PR DESCRIPTION
This PR includes functionality that generates 20 fake participants on `localhost`, `stable`, and `sandbox` environments when a new site is inserted via the HoS API.
The fake data generator does not work with unittests since they do not have an instance of the codebook, which the fake data generator relies on. Therefore, this was tested manually on `sandbox`.