### PR TITLE
DA-1268 update appengine tool to restart instances

### DIFF
--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -821,16 +821,15 @@ def gcp_deploy_app(project, config_files: list, version: str = None, promote: bo
 
     return True
 
-def gcp_restart_instances(project=None):
+def gcp_restart_instances(self):
     """
     Restart running instances of an App Engine environment.
     :return: True if successful, else False.
     """
 
-    if not project:
-        project = gcp_get_current_project()
+    project = self.gcp_env.project if self.gcp_env.project else gcp_get_current_project()
     # First get instance ID's
-    args = f"instances list --format json --project {project}"
+    args = "instances list --format json --project {}".format(project)
     pcode, so, se = gcp_gcloud_command("app", args)
 
     if pcode != 0 or not so:
@@ -843,7 +842,7 @@ def gcp_restart_instances(project=None):
     # if we ever move to compute engine we can pass a list of instances
     se_list = []
     for k, v in names.items():
-        args = f"instances delete " + k + ' --version=' + v + ' --project={project} --service=default -q'
+        args = "instances delete " + k + ' --version=' + v + ' --project={} --service=default -q'.format(project)
         pcode, so, se = gcp_gcloud_command("app", args)
         # this method always sends to se
         se_list.append(se)

--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -821,13 +821,12 @@ def gcp_deploy_app(project, config_files: list, version: str = None, promote: bo
 
     return True
 
-def gcp_restart_instances(self):
+def gcp_restart_instances(project, service='default'):
     """
     Restart running instances of an App Engine environment.
     :return: True if successful, else False.
     """
 
-    project = self.gcp_env.project if self.gcp_env.project else gcp_get_current_project()
     # First get instance ID's
     args = "instances list --format json --project {}".format(project)
     pcode, so, se = gcp_gcloud_command("app", args)
@@ -842,7 +841,7 @@ def gcp_restart_instances(self):
     # if we ever move to compute engine we can pass a list of instances
     se_list = []
     for k, v in names.items():
-        args = "instances delete " + k + ' --version=' + v + ' --project={} --service=default -q'.format(project)
+        args = "instances delete {} --version={} --project={} --service={} -q".format(k, v, project, service)
         pcode, so, se = gcp_gcloud_command("app", args)
         # this method always sends to se
         se_list.append(se)

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -18,7 +18,7 @@ from rdr_service.services.system_utils import setup_logging, setup_i18n, git_cur
 from rdr_service.tools.tool_libs import GCPProcessContext, GCPEnvConfigObject
 from rdr_service.services.gcp_config import GCP_SERVICES, GCP_SERVICE_CONFIG_MAP, GCP_APP_CONFIG_MAP
 from rdr_service.services.gcp_utils import gcp_get_app_versions, gcp_deploy_app, gcp_app_services_split_traffic, \
-    gcp_application_default_creds_exist
+    gcp_application_default_creds_exist, gcp_restart_instances
 from rdr_service.tools.tool_libs.alembic import AlembicManagerClass
 from rdr_service.services.jira_utils import JiraTicketHandler
 
@@ -236,7 +236,7 @@ class DeployAppClass(object):
 
         # Install app config
         _logger.info(self.add_jira_comment(f"Updating config for '{self.gcp_env.project}'"))
-        app_config = AppConfigClass(self.args, self.gcp_env)
+        app_config = AppConfigClass(self.args, self.gcp_env, restart=False)
         app_config.update_app_config()
         _logger.info(self.add_jira_comment(f"Config for '{self.gcp_env.project}' updated."))
 
@@ -246,6 +246,8 @@ class DeployAppClass(object):
 
         _logger.info('Cleaning up...')
         self.clean_up_config_files(config_files)
+
+        gcp_restart_instances(self.gcp_env.project)
 
         _logger.info('Switching back to git branch/tag: {0}...'.format(self._current_git_branch))
         git_checkout_branch(self._current_git_branch)
@@ -311,6 +313,7 @@ class DeployAppClass(object):
         _logger.info('')
         _logger.info('=' * 90)
 
+
         if not self.args.quiet:
             confirm = input('\nStart deployment (Y/n)? : ')
             if confirm and confirm.lower().strip() != 'y':
@@ -318,6 +321,7 @@ class DeployAppClass(object):
                 return 1
 
         return self.deploy_app()
+
 
 
 class ListServicesClass(object):
@@ -428,13 +432,14 @@ class AppConfigClass(object):
     _config_dir = None
     _provider = None
 
-    def __init__(self, args, gcp_env: GCPEnvConfigObject):
+    def __init__(self, args, gcp_env: GCPEnvConfigObject, restart=True):
         """
         :param args: command line arguments.
         :param gcp_env: gcp environment information, see: gcp_initialize().
         """
         self.args = args
         self.gcp_env = gcp_env
+        self.restart = restart
 
         self._config_dir = os.path.join(self.args.git_project, 'rdr_service/config')
         if not os.path.exists(self._config_dir):
@@ -597,7 +602,45 @@ class AppConfigClass(object):
         else:
             self.get_app_config()
 
+        if self.restart:
+            gcp_restart_instances(self.gcp_env.project)
+
         return 0
+
+
+class RunGCPUtilCommand:
+    _config_dir = None
+    _provider = None
+
+    def __init__(self, args, gcp_env: GCPEnvConfigObject):
+        """
+        :param args: The argument to 'run_single_util' should be a function inside of gcp_utils
+        :param gcp_env: gcp environment information, see: gcp_initialize().
+        """
+        self.args = args
+        self.gcp_env = gcp_env
+
+        self._config_dir = os.path.join(self.args.git_project, 'rdr_service/config')
+        if not os.path.exists(self._config_dir):
+            raise FileNotFoundError('Unable to locate the app config directory.')
+
+        from rdr_service.config import GoogleCloudDatastoreConfigProvider
+        self._provider = GoogleCloudDatastoreConfigProvider()
+
+        if not hasattr(self.args, 'key'):
+            setattr(self.args, 'key', 'current_config')
+
+    def run(self, args):
+        function = args.run_single_util
+        try:
+            package = "rdr_service.services.gcp_utils"
+            imported = getattr(__import__(package, fromlist=[function]), function)
+            # call the function
+            return_code = imported()
+        except ImportError as err:
+            _logger.warning(err)
+
+        return return_code
 
 
 def run():
@@ -623,8 +666,7 @@ def run():
     deploy_parser.add_argument("--quiet", help="do not ask for user input", default=False, action="store_true") # noqa
     deploy_parser.add_argument("--git-target", help="git branch/tag to deploy.", default=git_current_branch())  # noqa
     deploy_parser.add_argument("--deploy-as", help="deploy as version", default=None)  #noqa
-    deploy_parser.add_argument("--services", help="comma delimited list of service names to deploy",
-                               default=None)  # noqa
+   
     deploy_parser.add_argument("--no-promote", help="do not promote version to serving state.",
                         default=False, action="store_true")  # noqa
 
@@ -650,6 +692,10 @@ def run():
     config_parser.add_argument('--update', help='update cloud app config.', default=False, action="store_true")  # noqa
     config_parser.add_argument('--to-file', help='export config to file', default='', type=str)  # noqa
     config_parser.add_argument('--from-file', help='import config from file', default='', type=str)  # noqa
+
+    config_parser = subparser.add_parser("test")
+    config_parser.add_argument('--run-single-util', help='runs single gcp util command, good for testing',
+                               default='', type=str)  # noqa
 
     args = parser.parse_args()
 
@@ -680,7 +726,12 @@ def run():
             process = AppConfigClass(args, gcp_env)
             exit_code = process.run()
 
+        elif hasattr(args, 'run_single_util'):
+            process = RunGCPUtilCommand(args, gcp_env)
+            exit_code = process.run(args)
+
         else:
+            import ipdb; ipdb.set_trace()
             _logger.info('Please select a service option to run. For help use "app-engine --help".')
             exit_code = 1
         return exit_code

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -657,9 +657,9 @@ def run():
     deploy_parser.add_argument("--quiet", help="do not ask for user input", default=False, action="store_true") # noqa
     deploy_parser.add_argument("--git-target", help="git branch/tag to deploy.", default=git_current_branch())  # noqa
     deploy_parser.add_argument("--deploy-as", help="deploy as version", default=None)  #noqa
-   
+
     deploy_parser.add_argument("--no-promote", help="do not promote version to serving state.",
-                        default=False, action="store_true")  # noqa
+                               default=False, action="store_true")  # noqa
 
     # List app engine services
     service_list_parser = subparser.add_parser("list")

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -724,7 +724,6 @@ def run():
             exit_code = process.run()
 
         else:
-            import ipdb; ipdb.set_trace()
             _logger.info('Please select a service option to run. For help use "app-engine --help".')
             exit_code = 1
         return exit_code

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -620,23 +620,14 @@ class RunGCPUtilCommand:
         self.args = args
         self.gcp_env = gcp_env
 
-        self._config_dir = os.path.join(self.args.git_project, 'rdr_service/config')
-        if not os.path.exists(self._config_dir):
-            raise FileNotFoundError('Unable to locate the app config directory.')
 
-        from rdr_service.config import GoogleCloudDatastoreConfigProvider
-        self._provider = GoogleCloudDatastoreConfigProvider()
-
-        if not hasattr(self.args, 'key'):
-            setattr(self.args, 'key', 'current_config')
-
-    def run(self, args):
-        function = args.run_single_util
+    def run(self):
+        function = self.args.run_single_util
         try:
             package = "rdr_service.services.gcp_utils"
             imported = getattr(__import__(package, fromlist=[function]), function)
             # call the function
-            return_code = imported()
+            return_code = imported(self)
         except ImportError as err:
             _logger.warning(err)
 
@@ -728,7 +719,7 @@ def run():
 
         elif hasattr(args, 'run_single_util'):
             process = RunGCPUtilCommand(args, gcp_env)
-            exit_code = process.run(args)
+            exit_code = process.run()
 
         else:
             import ipdb; ipdb.set_trace()

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -657,6 +657,8 @@ def run():
     deploy_parser.add_argument("--quiet", help="do not ask for user input", default=False, action="store_true") # noqa
     deploy_parser.add_argument("--git-target", help="git branch/tag to deploy.", default=git_current_branch())  # noqa
     deploy_parser.add_argument("--deploy-as", help="deploy as version", default=None)  #noqa
+    deploy_parser.add_argument("--services", help="comma delimited list of service names to deploy",
+                               default=None)  # noqa
 
     deploy_parser.add_argument("--no-promote", help="do not promote version to serving state.",
                                default=False, action="store_true")  # noqa


### PR DESCRIPTION
This update adds the restart instances functionality when deploying or when updating configs.
Since deploy also updates configs, I've passed in a new flag to prevent deployment from restarting instances when it calls the config update. Also added a function in app engine manager to allow calling a single gcp_util function (mostly for testing).