### PR TITLE
[ROC-334] Obsolete flag integrated with inactive=true.

### DIFF
--- a/rdr_service/dao/organization_dao.py
+++ b/rdr_service/dao/organization_dao.py
@@ -82,7 +82,10 @@ class OrganizationDao(CacheAllDao):
         resource.id = model.externalId
         resource.display_name = model.displayName
         if inactive_sites:
-            resource.sites = [SiteDao._to_json(site) for site in model.sites]
+            resource.sites = [
+                SiteDao._to_json(site) for site in model.sites
+                if site.isObsolete in obsolete_filters
+            ]
         else:
             resource.sites = [
                 SiteDao._to_json(site)


### PR DESCRIPTION
PR adds the `_obsolete=false` Awardee API parameter to the `_inactive=true` filter on sites.