### PR TITLE
[DA-1398] New Reconcilation Report: Missing Salivary

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -470,7 +470,7 @@ _ORDER_JOINS = """
     ON biobank_order.amended_site_id = amended_site.site_id
     LEFT OUTER JOIN
       site cancelled_site
-    ON biobank_order.cancelled_site_id = cancelled_site.site_id   
+    ON biobank_order.cancelled_site_id = cancelled_site.site_id
 """
 
 _STORED_SAMPLE_JOIN_CRITERIA = """
@@ -692,7 +692,7 @@ _RECONCILIATION_REPORT_SQL = (
     FROM
       biobank_stored_sample
       LEFT OUTER JOIN
-        participant ON biobank_stored_sample.biobank_id = participant.biobank_id      
+        participant ON biobank_stored_sample.biobank_id = participant.biobank_id
     WHERE biobank_stored_sample.confirmed IS NOT NULL AND NOT EXISTS (
       SELECT 0 FROM """
     + _ORDER_JOINS

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -338,7 +338,7 @@ def _get_report_paths(report_datetime, report_type="daily"):
 
 def _query_and_write_reports(exporter, now, report_type, path_received,
                              path_missing, path_modified,
-                             path_withdrawals, path_salivary_missing):
+                             path_withdrawals, path_salivary_missing=None):
     """Runs the reconciliation MySQL queries and writes result rows to the given CSV writers.
 
   Note that due to syntax differences, the query runs on MySQL only (not SQLite in unit tests).
@@ -412,15 +412,16 @@ def _query_and_write_reports(exporter, now, report_type, path_received,
     )
 
     # Generate the missing salivary report, within last n days (10 1/20)
-    exporter.run_export(
-        path_salivary_missing,
-        _SALIVARY_MISSING_REPORT_SQL,
-        {
-            "biobank_id_prefix": get_biobank_id_prefix(),
-            "n_days_interval": 10,
-        },
-        backup=True,
-    )
+    if report_type != "monthly" and path_salivary_missing is not None:
+        exporter.run_export(
+            path_salivary_missing,
+            _SALIVARY_MISSING_REPORT_SQL,
+            {
+                "biobank_id_prefix": get_biobank_id_prefix(),
+                "n_days_interval": 10,
+            },
+            backup=True,
+        )
 
 
 # Indexes from the SQL query below; used in predicates.

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -275,7 +275,7 @@ class BiobankSamplesPipelineTest(BaseTestCase):
         dt = datetime.datetime(2016, 12, 22, 18, 30, 45)
         expected_prefix = "reconciliation/report_2016-12-22"
         paths = biobank_samples_pipeline._get_report_paths(dt)
-        self.assertEqual(len(paths), 4)
+        self.assertEqual(len(paths), 5)
         for path in paths:
             self.assertTrue(
                 path.startswith(expected_prefix), "Report path %r must start with %r." % (expected_prefix, path)

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -232,6 +232,7 @@ class MySqlReconciliationTest(BaseTestCase):
                                  f"PresentDVIdentifier{participant_obj.participantId}",
                                  clock.CLOCK.now().replace(microsecond=0),
                                  mayo_create_time)
+            #self.sample_dao.
 
         return dv_dao.insert(dv_order_obj)
 
@@ -594,7 +595,6 @@ class MySqlReconciliationTest(BaseTestCase):
         self._create_dv_order(p_missing_inside_timeframe, missing=False)
 
         p_present_salivary = self._insert_participant(race_codes=[RACE_WHITE_CODE])
-        # print(f'present bbid: {p_present_salivary.biobankId}')
         self._create_dv_order(p_present_salivary, missing=False, received=True)
 
         received, missing, modified, withdrawals = "rx.csv", "missing.csv", "modified.csv", "withdrawals.csv"
@@ -821,7 +821,7 @@ class MySqlReconciliationTest(BaseTestCase):
 
         # Test that the salivary received order is in received
         exporter.assertHasRow(
-            missing_salivary,
+            received,
             {
                 "biobank_id": to_client_biobank_id(p_present_salivary.biobankId)
             }

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -225,6 +225,7 @@ class MySqlReconciliationTest(BaseTestCase):
             biobankOrderId=order.biobankOrderId,
         )
 
+        # Samples for the 'received' dv order test
         if not missing and received:
             self._insert_samples(participant_obj,
                                  [BIOBANK_TESTS[12]],
@@ -232,7 +233,6 @@ class MySqlReconciliationTest(BaseTestCase):
                                  f"PresentDVIdentifier{participant_obj.participantId}",
                                  clock.CLOCK.now().replace(microsecond=0),
                                  mayo_create_time)
-            #self.sample_dao.
 
         return dv_dao.insert(dv_order_obj)
 
@@ -810,7 +810,7 @@ class MySqlReconciliationTest(BaseTestCase):
             },
         )
 
-        # Test the salivary_missing report
+        # Test the missing DV order is in salivary_missing report
         exporter.assertRowCount(missing_salivary, 1)
         exporter.assertHasRow(
             missing_salivary,
@@ -819,7 +819,7 @@ class MySqlReconciliationTest(BaseTestCase):
             }
         )
 
-        # Test that the salivary received order is in received
+        # Test that the DV received order is in the received report
         exporter.assertHasRow(
             received,
             {

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -11,6 +11,8 @@ from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderIdentifier, BiobankOrderedSample
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
+from rdr_service.model.biobank_dv_order import BiobankDVOrder
+from rdr_service.dao.dv_order_dao import DvOrderDao
 from rdr_service.model.code import CodeType
 from rdr_service.model.config_utils import to_client_biobank_id
 from rdr_service.model.participant import Participant
@@ -203,6 +205,35 @@ class MySqlReconciliationTest(BaseTestCase):
             _add_code_answer(code_answers, "race", answer)
         qr = self.make_questionnaire_response_json(participant_id, self._questionnaire_id, code_answers=code_answers)
         self.send_post("Participant/%s/QuestionnaireResponse" % participant_id, qr)
+
+    def _create_dv_order(self, participant_obj, missing=False, received=False):
+        dt = 11 if missing else 2
+        mayo_create_time = clock.CLOCK.now().replace(microsecond=0) - datetime.timedelta(days=dt)
+
+        # since not using Mayolink API for test, need a biobank order
+        order = self._insert_order(
+            participant_obj,
+            f'DVOrderMissing{participant_obj.participantId}',
+            [BIOBANK_TESTS[13]],
+            mayo_create_time
+        )
+
+        dv_dao = DvOrderDao()
+        dv_order_obj = BiobankDVOrder(
+            participantId=participant_obj.participantId,
+            version=1,
+            biobankOrderId=order.biobankOrderId,
+        )
+
+        if not missing and received:
+            self._insert_samples(participant_obj,
+                                 [BIOBANK_TESTS[12]],
+                                 [f"PresentDVSample{participant_obj.participantId}"],
+                                 f"PresentDVIdentifier{participant_obj.participantId}",
+                                 clock.CLOCK.now().replace(microsecond=0),
+                                 mayo_create_time)
+
+        return dv_dao.insert(dv_order_obj)
 
     def test_reconciliation_query(self):
         self.setup_codes([RACE_QUESTION_CODE], CodeType.QUESTION)
@@ -555,17 +586,30 @@ class MySqlReconciliationTest(BaseTestCase):
                     within_24_hours + datetime.timedelta(hours=repetition - 1),
                 )
 
+        # Participants to test the salivary missing report
+        p_missing_salivary = self._insert_participant(race_codes=[RACE_WHITE_CODE])
+        self._create_dv_order(p_missing_salivary, missing=True)
+
+        p_missing_inside_timeframe = self._insert_participant(race_codes=[RACE_WHITE_CODE])
+        self._create_dv_order(p_missing_inside_timeframe, missing=False)
+
+        p_present_salivary = self._insert_participant(race_codes=[RACE_WHITE_CODE])
+        # print(f'present bbid: {p_present_salivary.biobankId}')
+        self._create_dv_order(p_present_salivary, missing=False, received=True)
+
         received, missing, modified, withdrawals = "rx.csv", "missing.csv", "modified.csv", "withdrawals.csv"
+        missing_salivary = "missing_salivary.csv"
         exporter = InMemorySqlExporter(self)
         biobank_samples_pipeline._query_and_write_reports(
-            exporter, file_time, "daily", received, missing, modified, withdrawals
+            exporter, file_time, "daily", received, missing, modified, withdrawals, missing_salivary
         )
 
-        exporter.assertFilesEqual((received, missing, modified, withdrawals))
+        exporter.assertFilesEqual((received, missing, modified, withdrawals, missing_salivary))
 
         # sent-and-received: 4 on-time, 2 late, none of the missing/extra/repeated ones;
-        # not includes orders/samples from more than 10 days ago
-        exporter.assertRowCount(received, 10)
+        # not includes orders/samples from more than 10 days ago;
+        # Includes 1 Salivary order
+        exporter.assertRowCount(received, 11)
         exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES)
         row = exporter.assertHasRow(
             received,
@@ -764,6 +808,23 @@ class MySqlReconciliationTest(BaseTestCase):
                 "withdrawal_time": database_utils.format_datetime(within_24_hours),
                 "is_native_american": "Y",
             },
+        )
+
+        # Test the salivary_missing report
+        exporter.assertRowCount(missing_salivary, 1)
+        exporter.assertHasRow(
+            missing_salivary,
+            {
+                "biobank_id": to_client_biobank_id(p_missing_salivary.biobankId)
+            }
+        )
+
+        # Test that the salivary received order is in received
+        exporter.assertHasRow(
+            missing_salivary,
+            {
+                "biobank_id": to_client_biobank_id(p_present_salivary.biobankId)
+            }
         )
 
     def test_monthly_reconciliation_report(self):


### PR DESCRIPTION
This PR adds a new report to the Biobank Samples Pipeline: Missing Salivary Report. The code and test cases support the following requirements:

- DV orders not received at the Biobank after 10 days of being shipped will be in this report. 
- DV orders should not be in the regular "missing" report.
- DV orders that are "received" should be in the "received" report.
