### PR TITLE
[DA-1469] Return not found for participant ids out of range

### DIFF
--- a/rdr_service/api/participant_api.py
+++ b/rdr_service/api/participant_api.py
@@ -14,7 +14,7 @@ class ParticipantApi(UpdatableApi):
     @app_util.auth_required(PTC_AND_HEALTHPRO)
     def get(self, p_id):
         # Make sure participant id is in the correct range of possible values.
-        if not _MIN_ID <= p_id <= _MAX_ID:
+        if isinstance(p_id, int) and not _MIN_ID <= p_id <= _MAX_ID:
             raise NotFound(f"Participant with ID {p_id} is not found.")
         return super().get(p_id)
 

--- a/rdr_service/api/participant_api.py
+++ b/rdr_service/api/participant_api.py
@@ -1,7 +1,9 @@
 from rdr_service import app_util
+from werkzeug.exceptions import NotFound
 
 from rdr_service.api.base_api import UpdatableApi
 from rdr_service.api_util import PTC, PTC_AND_HEALTHPRO
+from rdr_service.dao.base_dao import _MIN_ID, _MAX_ID
 from rdr_service.dao.participant_dao import ParticipantDao
 
 
@@ -11,6 +13,9 @@ class ParticipantApi(UpdatableApi):
 
     @app_util.auth_required(PTC_AND_HEALTHPRO)
     def get(self, p_id):
+        # Make sure participant id is in the correct range of possible values.
+        if not _MIN_ID <= p_id <= _MAX_ID:
+            raise NotFound(f"Participant with ID {p_id} is not found.")
         return super().get(p_id)
 
     @app_util.auth_required(PTC)

--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -17,7 +17,7 @@ class ParticipantSummaryApi(BaseApi):
     @auth_required(PTC_HEALTHPRO_AWARDEE)
     def get(self, p_id=None):
         # Make sure participant id is in the correct range of possible values.
-        if not _MIN_ID <= p_id <= _MAX_ID:
+        if isinstance(p_id, int) and not _MIN_ID <= p_id <= _MAX_ID:
             raise NotFound(f"Participant with ID {p_id} is not found.")
         auth_awardee = None
         user_email, user_info = get_validated_user_info()

--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -1,9 +1,10 @@
 from flask import request
-from werkzeug.exceptions import BadRequest, Forbidden, InternalServerError
+from werkzeug.exceptions import BadRequest, Forbidden, InternalServerError, NotFound
 
 from rdr_service.api.base_api import BaseApi, make_sync_results_for_request
 from rdr_service.api_util import AWARDEE, DEV_MAIL, PTC_HEALTHPRO_AWARDEE
 from rdr_service.app_util import auth_required, get_validated_user_info
+from rdr_service.dao.base_dao import _MIN_ID, _MAX_ID
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.hpo import HPO
 from rdr_service.model.participant_summary import ParticipantSummary
@@ -15,6 +16,9 @@ class ParticipantSummaryApi(BaseApi):
 
     @auth_required(PTC_HEALTHPRO_AWARDEE)
     def get(self, p_id=None):
+        # Make sure participant id is in the correct range of possible values.
+        if not _MIN_ID <= p_id <= _MAX_ID:
+            raise NotFound(f"Participant with ID {p_id} is not found.")
         auth_awardee = None
         user_email, user_info = get_validated_user_info()
         if AWARDEE in user_info["roles"]:

--- a/rdr_service/dao/base_dao.py
+++ b/rdr_service/dao/base_dao.py
@@ -718,6 +718,12 @@ def save_raw_request_record(log: RequestsLog):
     Save the request payload and possibly link it to a table record
     :param log: RequestsLog dao object
     """
+    # Don't try to save values greater than the max value for a signed 32-bit integer.
+    if isinstance(log.participantId, int) and log.participantId > 0x7FFFFFFF:
+        log.participantId = 0
+    if isinstance(log.fpk_id, int) and log.fpk_id > 0x7FFFFFFF:
+        log.fpk_id = 0
+
     _dao = BaseDao(RequestsLog)
     with _dao.session() as session:
         session.add(log)

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -40,7 +40,7 @@ class ParticipantApiTest(BaseTestCase):
         self.order = BiobankOrderDao()
 
     def test_participant_id_out_of_range(self):
-        response = self.send_get(f"Participant/P{12345678}", expected_status=404)
+        response = self.send_get("Participant/P12345678", expected_status=404)
         self.assertEqual(None, response)
 
         response = self.send_get("Participant/P1234567890", expected_status=404)

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -39,6 +39,13 @@ class ParticipantApiTest(BaseTestCase):
         )
         self.order = BiobankOrderDao()
 
+    def test_participant_id_out_of_range(self):
+        response = self.send_get(f"Participant/P{12345678}", expected_status=404)
+        self.assertEqual(None, response)
+
+        response = self.send_get("Participant/P1234567890", expected_status=404)
+        self.assertEqual(None, response)
+
     def test_insert(self):
         response = self.send_post("Participant", self.participant)
         participant_id = response["participantId"]


### PR DESCRIPTION
Also make sure that ID values greater than 0x7FFFFFFF are not inserted into `requests_log`.