### PR TITLE
[DA-1532] Implemented option to fix to signup time.

### DIFF
--- a/rdr_service/tools/tool_libs/tools.bash
+++ b/rdr_service/tools/tool_libs/tools.bash
@@ -65,7 +65,7 @@ _python()
             ;;
         fix-dup-pids)
             # These are options specific to this tool.
-            local toolopts="--csv --participant --fix-biobank-orders --fix-physical-measurements"
+            local toolopts="--csv --participant --fix-biobank-orders --fix-physical-measurements --fix-signup-time"
             COMPREPLY=( $(compgen -W "${stdopts} ${toolopts}" -- ${cur}) )
             return 0
             ;;


### PR DESCRIPTION
The new participant data replayed by PTSC will not have the original `signup_time`, so `signup_time` will need to be fixed by RDR.
This PR adds an option to the `fix-dup-pids` tool to update signup time based on a mapping of `new_pid` to original `signup_time`. 