### PR TITLE
Fixing bad question codes response for GROR.

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -277,6 +277,7 @@ class QuestionnaireResponseDao(BaseDao):
         race_code_ids = []
         gender_code_ids = []
         ehr_consent = False
+        gror_consent = None
         dvehr_consent = QuestionnaireStatus.SUBMITTED_NO_CONSENT
         # Set summary fields for answers that have questions with codes found in QUESTION_CODE_TO_FIELD
         for answer in questionnaire_response.answers:
@@ -353,6 +354,11 @@ class QuestionnaireResponseDao(BaseDao):
                     elif code.value == CONSENT_FOR_DVEHR_MODULE:
                         new_status = dvehr_consent
                     elif code.value == CONSENT_FOR_GENOMICS_ROR_MODULE:
+                        if gror_consent is None:
+                            raise BadRequest(
+                                "GROR Consent answer is required to match code {}."
+                                    .format([CONSENT_GROR_YES_CODE, CONSENT_GROR_NO_CODE, CONSENT_GROR_NOT_SURE])
+                            )
                         new_status = gror_consent
                     elif code.value == CONSENT_FOR_STUDY_ENROLLMENT_MODULE:
                         participant_summary.semanticVersionForPrimaryConsent = \

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -446,6 +446,18 @@ class QuestionnaireResponseApiTest(BaseTestCase):
         self.assertEqual(summary['consentForGenomicsRORTime'], TIME_2.isoformat())
         self.assertEqual(summary['consentForGenomicsRORAuthored'], '2019-12-12T09:30:44')
 
+        # Test Bad Code Value Sent returns 400
+        with open(data_path("consent_for_genomic_ror_bad_request.json")) as f:
+            resource = json.load(f)
+
+        resource["subject"]["reference"] = f'Patient/{participant_id}'
+        resource["questionnaire"]["reference"] = f'Questionnaire/{questionnaire_id}'
+
+        with FakeClock(TIME_2):
+            self.send_post(_questionnaire_response_url(participant_id),
+                           resource,
+                           expected_status=http.client.BAD_REQUEST)
+
     def test_consent_with_extension_language(self):
         with FakeClock(TIME_1):
             participant_id = self.create_participant()

--- a/tests/test-data/consent_for_genomic_ror_bad_request.json
+++ b/tests/test-data/consent_for_genomic_ror_bad_request.json
@@ -1,0 +1,39 @@
+{
+  "authored": "2019-12-12T09:30:44+00:00",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+      "valueCode": "en"
+    }
+  ],
+  "group": {
+    "linkId": "root_group",
+    "question": [
+      {
+        "answer": [
+          {
+            "valueCoding": {
+              "code": "ResultsConsent_No",
+              "display": "No, I do not want to learn about any DNA results.",
+              "system": "http://terminology.pmi-ops.org/CodeSystem/ppi"
+            }
+          }
+        ],
+        "linkId": "genomic_consent",
+        "text": "GROR"
+      }
+    ],
+    "title": "Genomics Return of Results Consent"
+  },
+  "identifier": {
+    "value": "xxxxxxxxxxxx"
+  },
+  "questionnaire": {
+    "reference": "Questionnaire/xxx"
+  },
+  "resourceType": "QuestionnaireResponse",
+  "status": "completed",
+  "subject": {
+    "reference": "Patient/P1234567"
+  }
+}


### PR DESCRIPTION
This PR adds a bad request response to the `QuestionnaireResponse` API for GROR consents that don't include a valid code value for an answer.