### PR TITLE
[DA1458] Biobank specimen migration endpoint

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -1,6 +1,6 @@
 from flask import request
 
-from rdr_service.api.base_api import UpdatableApi
+from rdr_service.api.base_api import UpdatableApi, log_api_request
 from rdr_service.api_util import BIOBANK
 from rdr_service.app_util import auth_required
 from rdr_service.dao.biobank_specimen_dao import BiobankSpecimenDao
@@ -15,14 +15,55 @@ class BiobankSpecimenApi(UpdatableApi):
     def put(self, *args, **kwargs):  # pylint: disable=unused-argument
         resource = request.get_json(force=True)
 
-        for required_field in ['rlimsID', 'orderID', 'testcode', 'participantID']:
-            if required_field not in resource:
-                raise BadRequest("Missing field: %s" % required_field)
+        if 'rlims_id' in kwargs:
+            self._check_required_specimen_fields(resource)
 
-        if self.dao.exists(resource):
-            return super(BiobankSpecimenApi, self).put(kwargs['rlims_id'], skip_etag=True)
+            if self.dao.exists(resource):
+                rlims_id = kwargs['rlims_id']
+                return super(BiobankSpecimenApi, self).put(rlims_id, skip_etag=True)
+            else:
+                return super(BiobankSpecimenApi, self).post()
         else:
-            return super(BiobankSpecimenApi, self).post()
+            success_count = 0
+            total_count = 0
+            errors = []
+            with self.dao.session() as session:
+                for specimen_json in resource:
+                    if 'rlimsID' in specimen_json:
+                        descriptor = specimen_json['rlimsID']
+                    else:
+                        descriptor = f'specimen #{total_count+1}'
+
+                    try:
+                        self._check_required_specimen_fields(specimen_json)
+
+                        m = self.dao.from_client_json(specimen_json)
+                        if m.id is not None:
+                            self.dao.update_with_session(session, m)
+                        else:
+                            self.dao.insert_with_session(session, m)
+                    except BadRequest as e:
+                        errors.append(f'[{descriptor}] {e.description}')
+                    except Exception: # pylint: disable=broad-except
+                        # Handle most anything but continue with processing specimen anyway
+                        errors.append(f'[{descriptor}] Unknown error')
+                    else:
+                        success_count += 1
+                    finally:
+                        total_count += 1
+
+            log_api_request(log=request.log_record)
+            result = {'summary': f'Added {success_count} of {total_count} specimen'}
+            if errors:
+                result['errors'] = errors
+            return result
+
+    @staticmethod
+    def _check_required_specimen_fields(specimen_json):
+        missing_fields = [required_field for required_field in ['rlimsID', 'orderID', 'testcode', 'participantID']
+                          if required_field not in specimen_json]
+        if missing_fields:
+            raise BadRequest(f"Missing fields: {', '.join(missing_fields)}")
 
     def _make_response(self, obj):
         result = self.dao.to_client_json(obj)


### PR DESCRIPTION
This reuses all the code for creating/updating individual biobank specimens to iterate over a request that contains a list of them. I return a summary and list of errors with the specimen's rlmisId (if one was sent). I couldn't easily reuse the base class's put and post, so I interact directly with the DOA for processing the migration list.