### PR TITLE
[DA-1570] Checking date limits for consent sync

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -76,12 +76,13 @@ class CopyCloudStorageObjectTaskApi(Resource):
         data = request.get_json(force=True)
         source = data.get('source', None)
         destination = data.get('destination', None)
+        date_limit = data.get('date_limit', None)
 
         if not source or not destination:
             raise NotFound('Invalid cloud storage path: Copy {0} to {1}.'.format(source, destination))
 
         logging.info('Copying cloud object.')
-        cloudstorage_copy_objects_task(source, destination)
+        cloudstorage_copy_objects_task(source, destination, date_limit=date_limit)
         logging.info('Complete.')
         return '{"success": "true"}'
 

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -186,6 +186,7 @@ def exclude_ghosts():
 @_alert_on_exceptions
 def sync_consent_files():
     sync_consent_files.do_sync_consent_files()
+    sync_consent_files.do_sync_recent_consent_files()
     return '{"success": "true"}'
 
 


### PR DESCRIPTION
This updates the cron script to work with start and end dates. Now the script works on participants that have EHR or study enrollment consent datetimes that are with the given date limits. I also copied over the behavior of the current tool that will check the updated timestamp against the start date for loaded participants.

I've added a new entry point so that when the cron runs the sync we'll sync everything from the last time it ran (the first day of the previous month).

Before closing out the ticket I'll still need to set up a way to run it manually and with different organization arguments.