### PR TITLE
Reducing the number of connections opened when running biobank api tests

### DIFF
--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -182,9 +182,9 @@ class BiobankSpecimenDao(BiobankDaoBase):
         with self.session() as session:
             return session.query(BiobankSpecimen).filter(BiobankSpecimen.rlimsId == resource['rlimsID']).count() > 0
 
-    def get_with_rlims_id(self, rlims_id):
-        with self.session() as session:
-            return session.query(BiobankSpecimen).filter(BiobankSpecimen.rlimsId == rlims_id).one()
+    @staticmethod
+    def get_with_rlims_id(rlims_id, session):
+        return session.query(BiobankSpecimen).filter(BiobankSpecimen.rlimsId == rlims_id).one()
 
     @staticmethod
     def get_id_with_session(obj, session):
@@ -313,9 +313,9 @@ class BiobankAliquotDao(BiobankDaoBase):
 
         return result
 
-    def get_with_rlims_id(self, rlims_id):
-        with self.session() as session:
-            return session.query(BiobankAliquot).filter(BiobankAliquot.rlimsId == rlims_id).one()
+    @staticmethod
+    def get_with_rlims_id(rlims_id, session):
+        return session.query(BiobankAliquot).filter(BiobankAliquot.rlimsId == rlims_id).one()
 
     @staticmethod
     def get_id_with_session(obj, session):

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -19,15 +19,19 @@ TIME_2 = datetime.datetime(2020, 4, 2)
 class BiobankOrderApiTest(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.participant = Participant(participantId=123, biobankId=555)
-        self.participant_dao = ParticipantDao()
-        self.participant_dao.insert(self.participant)
-        self.summary_dao = ParticipantSummaryDao()
         self.dao = BiobankSpecimenDao()
-        self.bo_dao = BiobankOrderDao()
+        with self.dao.session() as session:
+            self.participant = Participant(participantId=123, biobankId=555)
+            self.participant_dao = ParticipantDao()
+            self.participant_dao.insert_with_session(session, self.participant)
+            self.summary_dao = ParticipantSummaryDao()
+            self.bo_dao = BiobankOrderDao()
 
-        ParticipantSummaryDao().insert(self.participant_summary(self.participant))
-        self.bio_order = self.bo_dao.insert(self._make_biobank_order(participantId=self.participant.participantId))
+            ParticipantSummaryDao().insert_with_session(session, self.participant_summary(self.participant))
+            self.bio_order = self.bo_dao.insert_with_session(session,
+                                                             self._make_biobank_order(
+                                                                 participantId=self.participant.participantId
+                                                             ))
 
     def _make_biobank_order(self, **kwargs):
         """Makes a new BiobankOrder (same values every time) with valid/complete defaults.


### PR DESCRIPTION
The CI servers seem to be hanging on some of my unit tests again. I'm reducing the number of database connections I open in the API code and in my unittest setup. This seems to help it after a couple of runs. I'll keep an eye on it moving forward.