### PR TITLE
[DA-1558] Update GEM Color PII API to handle GEM or RHP suffix

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -3,18 +3,29 @@ from werkzeug.exceptions import NotFound, BadRequest
 from rdr_service.api.base_api import BaseApi
 from rdr_service.api_util import GEM
 from rdr_service.app_util import auth_required
-from rdr_service.dao.genomics_dao import GemPiiDao
+from rdr_service.dao.genomics_dao import GenomicPiiDao
 
 
-class GenomicGemPiiApi(BaseApi):
+class GenomicPiiApi(BaseApi):
     def __init__(self):
-        super(GenomicGemPiiApi, self).__init__(GemPiiDao())
+        super(GenomicPiiApi, self).__init__(GenomicPiiDao())
 
     @auth_required(GEM)
-    def get(self, p_id=None):
+    def get(self, mode=None, p_id=None):
+        if mode not in ('GEM', 'RHP'):
+            raise BadRequest("GenomicPII Mode required to be \"GEM\" or \"RHP\".")
+
         if p_id is not None:
             pii = self.dao.get_by_pid(p_id)
+
             if not pii:
                 raise NotFound(f"Participant with ID {p_id} not found")
-            return self._make_response(pii)
+
+            proto_payload = {
+                'mode': mode,
+                'data': pii
+            }
+
+            return self._make_response(proto_payload)
+
         raise BadRequest

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -721,9 +721,9 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
             return GenomicSubProcessResult.ERROR
 
 
-class GemPiiDao(BaseDao):
+class GenomicPiiDao(BaseDao):
     def __init__(self):
-        super(GemPiiDao, self).__init__(
+        super(GenomicPiiDao, self).__init__(
             GenomicSetMember, order_by_ending=['id'])
 
     def get_id(self, obj):
@@ -733,12 +733,24 @@ class GemPiiDao(BaseDao):
         pass
 
     def to_client_json(self, result):
-        if result.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED:
-            return {
-                "biobank_id": result.biobankId,
-                "first_name": result.firstName,
-                "last_name": result.lastName,
-            }
+        if result['data'].consentForGenomicsROR == QuestionnaireStatus.SUBMITTED:
+            if result['mode'] == 'GEM':
+                return {
+                    "biobank_id": result['data'].biobankId,
+                    "first_name": result['data'].firstName,
+                    "last_name": result['data'].lastName,
+                }
+
+            elif result['mode'] == 'RHP':
+                return {
+                    "biobank_id": result['data'].biobankId,
+                    "first_name": result['data'].firstName,
+                    "last_name": result['data'].lastName,
+                    "date_of_birth": result['data'].dateOfBirth,
+                }
+            else:
+                return {"message": "Only GEM and RHP modes supported."}
+
         else:
             return {"message": "No RoR consent."}
 
@@ -753,7 +765,8 @@ class GemPiiDao(BaseDao):
                 session.query(GenomicSetMember.biobankId,
                               ParticipantSummary.firstName,
                               ParticipantSummary.lastName,
-                              ParticipantSummary.consentForGenomicsROR)
+                              ParticipantSummary.consentForGenomicsROR,
+                              ParticipantSummary.dateOfBirth,)
                 .join(
                     ParticipantSummary,
                     GenomicSetMember.participantId == ParticipantSummary.participantId,

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -28,7 +28,7 @@ from rdr_service.api.biobank_specimen_api import BiobankSpecimenApi, BiobankSpec
 from rdr_service.api.check_ppi_data_api import check_ppi_data
 from rdr_service.api.data_gen_api import DataGenApi, SpecDataGenApi
 from rdr_service.api.dv_order_api import DvOrderApi
-from rdr_service.api.genomic_api import GenomicGemPiiApi
+from rdr_service.api.genomic_api import GenomicPiiApi
 from rdr_service.api.import_codebook_api import import_codebook
 from rdr_service.api.metric_sets_api import MetricSetsApi
 from rdr_service.api.metrics_api import MetricsApi
@@ -323,9 +323,9 @@ api.add_resource(RedcapWorkbenchAuditApi,
                  endpoint='workbench.audit',
                  methods=['GET', 'POST'])
 
-api.add_resource(GenomicGemPiiApi,
-                 API_PREFIX + "GemPII/<participant_id:p_id>",
-                 endpoint='genomic.gem.pii',
+api.add_resource(GenomicPiiApi,
+                 API_PREFIX + "GenomicPII/<string:mode>/<participant_id:p_id>",
+                 endpoint='genomic.pii.gem',
                  methods=['GET'])
 
 # Configuration API for admin use.  # note: temporarily disabled until decided

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -325,7 +325,7 @@ api.add_resource(RedcapWorkbenchAuditApi,
 
 api.add_resource(GenomicPiiApi,
                  API_PREFIX + "GenomicPII/<string:mode>/<participant_id:p_id>",
-                 endpoint='genomic.pii.gem',
+                 endpoint='genomic.pii',
                  methods=['GET'])
 
 # Configuration API for admin use.  # note: temporarily disabled until decided

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -109,7 +109,7 @@ class GemApiTest(GenomicApiTestBase):
         super(GemApiTest, self).setUp()
 
     def test_get_pii_valid_pid(self):
-        p1_pii = self.send_get("GemPII/P1")
+        p1_pii = self.send_get("GenomicPII/GEM/P1")
         self.assertEqual(p1_pii['biobank_id'], '1')
         self.assertEqual(p1_pii['first_name'], 'TestFN')
         self.assertEqual(p1_pii['last_name'], 'TestLN')
@@ -118,15 +118,46 @@ class GemApiTest(GenomicApiTestBase):
         p = self._make_participant()
         self._make_summary(p, withdrawalStatus=WithdrawalStatus.NO_USE)
         self._make_set_member(p)
-        self.send_get("GemPII/P2", expected_status=404)
+        self.send_get("GenomicPII/GEM/P2", expected_status=404)
 
     def test_get_pii_no_gror_consent(self):
         p = self._make_participant()
         self._make_summary(p, consentForGenomicsROR=0)
         self._make_set_member(p)
-        p2_pii = self.send_get("GemPII/P2")
+        p2_pii = self.send_get("GenomicPII/GEM/P2")
         self.assertEqual(p2_pii['message'], "No RoR consent.")
 
     def test_get_pii_bad_request(self):
-        self.send_get("GemPII", expected_status=404)
-        self.send_get("GemPII/P8", expected_status=404)
+        self.send_get("GenomicPII/GEM/", expected_status=404)
+        self.send_get("GenomicPII/GEM/P8", expected_status=404)
+        self.send_get("GenomicPII/CVL/P2", expected_status=400)
+
+
+class RhpApiTest(GenomicApiTestBase):
+    def setUp(self):
+        super(RhpApiTest, self).setUp()
+
+    def test_get_pii_valid_pid(self):
+        p1_pii = self.send_get("GenomicPII/RHP/P1")
+        self.assertEqual(p1_pii['biobank_id'], '1')
+        self.assertEqual(p1_pii['first_name'], 'TestFN')
+        self.assertEqual(p1_pii['last_name'], 'TestLN')
+        self.assertEqual(p1_pii['date_of_birth'], '2000-01-01')
+
+    def test_get_pii_invalid_pid(self):
+        p = self._make_participant()
+        self._make_summary(p, withdrawalStatus=WithdrawalStatus.NO_USE)
+        self._make_set_member(p)
+        self.send_get("GenomicPII/RHP/P2", expected_status=404)
+
+    def test_get_pii_no_gror_consent(self):
+        p = self._make_participant()
+        self._make_summary(p, consentForGenomicsROR=0)
+        self._make_set_member(p)
+        p2_pii = self.send_get("GenomicPII/RHP/P2")
+        self.assertEqual(p2_pii['message'], "No RoR consent.")
+
+    def test_get_pii_bad_request(self):
+        self.send_get("GenomicPII/RHP/", expected_status=404)
+        self.send_get("GenomicPII/RHP/P8", expected_status=404)
+        self.send_get("GenomicPII/CVL/P2", expected_status=400)


### PR DESCRIPTION
This PR modifies the GEM PII API to be more generic to support access for both the GEM and RHP workflows. This includes renaming to the more-generic Genomic PII API where appropriate and  including URIs for "RHP" or "GEM" modes of retrieval. If the mode is RHP, DOB will also be returned.