### PR TITLE
Hotfix for COPE survey month recognition and ROC-512

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytz
 from sqlalchemy.orm import subqueryload
@@ -329,7 +329,9 @@ class QuestionnaireResponseDao(BaseDao):
                         elif code_dao.get(answer.valueCodeId).value == CONSENT_GROR_NOT_SURE:
                             gror_consent = QuestionnaireStatus.SUBMITTED_NOT_SURE
                     elif code.value == COPE_CONSENT_QUESTION_CODE:
-                        month_name = questionnaire_history.lastModified.strftime('%B')
+                        # COPE survey updates can occur at the end of the previous month
+                        adjusted_last_modified = questionnaire_history.lastModified + timedelta(days=10)
+                        month_name = adjusted_last_modified.strftime('%B')
                         # Currently only have fields in participant summary for May, Jun and July
                         if month_name in ['May', 'June', 'July']:
                             answer_value = code_dao.get(answer.valueCodeId).value

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -330,7 +330,7 @@ class QuestionnaireResponseDao(BaseDao):
                             gror_consent = QuestionnaireStatus.SUBMITTED_NOT_SURE
                     elif code.value == COPE_CONSENT_QUESTION_CODE:
                         # COPE survey updates can occur at the end of the previous month
-                        adjusted_last_modified = questionnaire_history.lastModified + timedelta(days=10)
+                        adjusted_last_modified = questionnaire_history.lastModified + timedelta(days=5)
                         month_name = adjusted_last_modified.strftime('%B')
                         # Currently only have fields in participant summary for May, Jun and July
                         if month_name in ['May', 'June', 'July']:

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -590,7 +590,7 @@ class QuestionnaireResponseDao(BaseDao):
                                     qr_answer.valueDecimal = answer.valueDecimal
                                 if answer.valueInteger is not None:
                                     qr_answer.valueInteger = answer.valueInteger
-                                if answer.valueString:
+                                if answer.valueString is not None:
                                     answer_length = len(answer.valueString)
                                     max_length = QuestionnaireResponseAnswer.VALUE_STRING_MAXLEN
                                     if answer_length > max_length:

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -688,7 +688,7 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
 
         self._setup_participant()
         self._create_cope_questionnaire()  # May survey
-        self._bump_questionnaire_version(2, updated_time=datetime.datetime(2020, 6, 7))  # June survey
+        self._bump_questionnaire_version(2, updated_time=datetime.datetime(2020, 5, 23))  # update for June survey
 
         self._submit_cope_consent(self.cope_consent_yes, questionnaire_version=2, cope_consent_question_id=8)
 

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -688,7 +688,7 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
 
         self._setup_participant()
         self._create_cope_questionnaire()  # May survey
-        self._bump_questionnaire_version(2, updated_time=datetime.datetime(2020, 5, 23))  # update for June survey
+        self._bump_questionnaire_version(2, updated_time=datetime.datetime(2020, 5, 28))  # update for June survey
 
         self._submit_cope_consent(self.cope_consent_yes, questionnaire_version=2, cope_consent_question_id=8)
 


### PR DESCRIPTION
These changes are for two things I'd like to get into a hotfix.

First I was looking for the lastModified time of a COPE survey to be in the same month as what we should mark it as. I hadn't considered testing surveys in the final days of the previous month (testing June COPE in the final days of May). This shifts the time window of how I recognize the survey's month by adding a few days to the modified time before checking what the resulting month is.

The second fix is an issue that came up that seems appropriate to get a fix out for when I'm already going through the hotfix process anyway. When a participant updates their address from something like:
1234 Main St.
Apt 8

to a new address of just:
27 Oak Ave.

the questionnaire response code was viewing empty strings as a non-response and not updating the second line of the address. So the resulting address after the update would appear to be:
27 Oak Ave.
Apt 8

https://precisionmedicineinitiative.atlassian.net/jira/software/projects/ROC/boards/58?selectedIssue=ROC-512