### PR TITLE
[DA-1590] Handle new (June) COPE Survey consent option

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -77,9 +77,10 @@ CONSENT_GROR_YES_CODE = "CheckDNA_Yes"
 CONSENT_GROR_NO_CODE = "CheckDNA_No"
 CONSENT_GROR_NOT_SURE = "CheckDNA_NotSure"
 
-# Consent COPE Answer Codes
+# Consent COPE Answer Codes.  (Deferred = expressed interest in taking the survey later)
 CONSENT_COPE_YES_CODE = "COPE_A_44"
 CONSENT_COPE_NO_CODE = "COPE_A_13"
+CONSENT_COPE_DEFERRED_CODE = "COPE_A_231"
 
 # Module names for questionnaires / consent forms
 CONSENT_FOR_GENOMICS_ROR_MODULE = "GROR"

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -34,6 +34,7 @@ from rdr_service.code_constants import (
     GROR_CONSENT_QUESTION_CODE,
     CONSENT_COPE_YES_CODE,
     CONSENT_COPE_NO_CODE,
+    CONSENT_COPE_DEFERRED_CODE,
     COPE_CONSENT_QUESTION_CODE)
 from rdr_service.config_api import is_config_admin
 from rdr_service.dao.base_dao import BaseDao
@@ -335,7 +336,7 @@ class QuestionnaireResponseDao(BaseDao):
                             answer_value = code_dao.get(answer.valueCodeId).value
                             if answer_value == CONSENT_COPE_YES_CODE:
                                 submission_status = QuestionnaireStatus.SUBMITTED
-                            elif answer_value == CONSENT_COPE_NO_CODE:
+                            elif answer_value in [CONSENT_COPE_NO_CODE, CONSENT_COPE_DEFERRED_CODE]:
                                 submission_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT
                             else:
                                 submission_status = QuestionnaireStatus.SUBMITTED_INVALID

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -8,7 +8,7 @@ from rdr_service import config
 from rdr_service.api_util import open_cloud_file
 from rdr_service.clock import FakeClock
 from rdr_service.code_constants import GENDER_IDENTITY_QUESTION_CODE, PMI_SKIP_CODE, PPI_SYSTEM, THE_BASICS_PPI_MODULE,\
-    CONSENT_COPE_YES_CODE, CONSENT_COPE_NO_CODE
+    CONSENT_COPE_YES_CODE, CONSENT_COPE_NO_CODE, CONSENT_COPE_DEFERRED_CODE
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
@@ -93,6 +93,8 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
                                      codeType=CodeType.ANSWER)
         self.cope_consent_no = Code(codeId=10, system=PPI_SYSTEM, value=CONSENT_COPE_NO_CODE, mapped=True,
                                      codeType=CodeType.ANSWER)
+        self.cope_consent_deferred = Code(codeId=11, system=PPI_SYSTEM, value=CONSENT_COPE_DEFERRED_CODE, mapped=True,
+                                    codeType=CodeType.ANSWER)
 
         config.override_setting(config.CONSENT_PDF_BUCKET, _FAKE_BUCKET)
 
@@ -119,6 +121,7 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
         self.code_dao.insert(self.skip_code)
         self.code_dao.insert(self.cope_consent_yes)
         self.code_dao.insert(self.cope_consent_no)
+        self.code_dao.insert(self.cope_consent_deferred)
         self.consent_code_id = self.code_dao.insert(consent_code()).codeId
         self.first_name_code_id = self.code_dao.insert(first_name_code()).codeId
         self.last_name_code_id = self.code_dao.insert(last_name_code()).codeId
@@ -694,6 +697,20 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
 
         participant_summary = self.participant_summary_dao.get(1)
         self.assertEqual(QuestionnaireStatus.SUBMITTED, participant_summary.questionnaireOnCopeJune)
+
+    def test_cope_june_survey_consent_deferred(self):
+        self.insert_codes()
+        p = Participant(participantId=1, biobankId=2)
+        self.participant_dao.insert(p)
+
+        self._setup_participant()
+        self._create_cope_questionnaire()  # May survey
+        self._bump_questionnaire_version(2, updated_time=datetime.datetime(2020, 6, 7))  # June survey
+
+        self._submit_cope_consent(self.cope_consent_deferred, questionnaire_version=2, cope_consent_question_id=8)
+
+        participant_summary = self.participant_summary_dao.get(1)
+        self.assertEqual(QuestionnaireStatus.SUBMITTED_NO_CONSENT, participant_summary.questionnaireOnCopeJune)
 
     def test_from_client_json_raises_BadRequest_for_excessively_long_value_string(self):
         self.insert_codes()


### PR DESCRIPTION
* Define the new COPE consent answer option (to defer taking the survey until later)

* Handle new consent code as SUBMITTED_NO_CONSENT

* Add unit test