### PR TITLE
[ROC-512] Clear street address 2 from summary when missing answer

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -36,6 +36,7 @@ from rdr_service.code_constants import (
     CONSENT_COPE_NO_CODE,
     CONSENT_COPE_DEFERRED_CODE,
     COPE_CONSENT_QUESTION_CODE,
+    STREET_ADDRESS_QUESTION_CODE,
     STREET_ADDRESS2_QUESTION_CODE)
 from rdr_service.config_api import is_config_admin
 from rdr_service.dao.base_dao import BaseDao
@@ -285,6 +286,7 @@ class QuestionnaireResponseDao(BaseDao):
         ehr_consent = False
         gror_consent = None
         dvehr_consent = QuestionnaireStatus.SUBMITTED_NO_CONSENT
+        street_address_submitted = False
         street_address2_submitted = False
         # Set summary fields for answers that have questions with codes found in QUESTION_CODE_TO_FIELD
         for answer in questionnaire_response.answers:
@@ -294,6 +296,8 @@ class QuestionnaireResponseDao(BaseDao):
                 if code:
                     if code.value == GENDER_IDENTITY_QUESTION_CODE:
                         gender_code_ids.append(answer.valueCodeId)
+                    elif code.value == STREET_ADDRESS_QUESTION_CODE:
+                        street_address_submitted = answer.valueString is not None
                     elif code.value == STREET_ADDRESS2_QUESTION_CODE:
                         street_address2_submitted = answer.valueString is not None
 
@@ -359,7 +363,7 @@ class QuestionnaireResponseDao(BaseDao):
         # So when it hasn't been submitted and there is something set for streetAddress2 we want to clear it out.
         summary_has_street_line_two = participant_summary.streetAddress2 is not None\
             and participant_summary.streetAddress2 != ""
-        if not street_address2_submitted and summary_has_street_line_two:
+        if street_address_submitted and not street_address2_submitted and summary_has_street_line_two:
             something_changed = True
             participant_summary.streetAddress2 = None
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -35,7 +35,8 @@ from rdr_service.code_constants import (
     CONSENT_COPE_YES_CODE,
     CONSENT_COPE_NO_CODE,
     CONSENT_COPE_DEFERRED_CODE,
-    COPE_CONSENT_QUESTION_CODE)
+    COPE_CONSENT_QUESTION_CODE,
+    STREET_ADDRESS2_QUESTION_CODE)
 from rdr_service.config_api import is_config_admin
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.code_dao import CodeDao
@@ -284,6 +285,7 @@ class QuestionnaireResponseDao(BaseDao):
         ehr_consent = False
         gror_consent = None
         dvehr_consent = QuestionnaireStatus.SUBMITTED_NO_CONSENT
+        street_address2_submitted = False
         # Set summary fields for answers that have questions with codes found in QUESTION_CODE_TO_FIELD
         for answer in questionnaire_response.answers:
             question = question_map.get(answer.questionId)
@@ -292,6 +294,8 @@ class QuestionnaireResponseDao(BaseDao):
                 if code:
                     if code.value == GENDER_IDENTITY_QUESTION_CODE:
                         gender_code_ids.append(answer.valueCodeId)
+                    elif code.value == STREET_ADDRESS2_QUESTION_CODE:
+                        street_address2_submitted = answer.valueString is not None
 
                     summary_field = QUESTION_CODE_TO_FIELD.get(code.value)
                     if summary_field:
@@ -350,6 +354,14 @@ class QuestionnaireResponseDao(BaseDao):
 
                             # COPE Survey changes need to update number of modules complete in summary
                             module_changed = True
+
+        # If the answer for line 2 of the street address was left out then it needs to be clear on summary.
+        # So when it hasn't been submitted and there is something set for streetAddress2 we want to clear it out.
+        summary_has_street_line_two = participant_summary.streetAddress2 is not None\
+            and participant_summary.streetAddress2 != ""
+        if not street_address2_submitted and summary_has_street_line_two:
+            something_changed = True
+            participant_summary.streetAddress2 = None
 
         # If race was provided in the response in one or more answers, set the new value.
         if race_code_ids:

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -4,7 +4,7 @@ import http.client
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.utils import from_client_participant_id
 from rdr_service.clock import FakeClock
-from rdr_service.code_constants import PPI_SYSTEM, RACE_WHITE_CODE
+from rdr_service.code_constants import PPI_SYSTEM, RACE_WHITE_CODE, PMI_SKIP_CODE
 from rdr_service.concepts import Concept
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
@@ -16,7 +16,7 @@ from rdr_service.participant_enums import (
     TEST_HPO_NAME,
     WithdrawalStatus,
 )
-from tests.helpers.unittest_base import BaseTestCase
+from tests.helpers.unittest_base import BaseTestCase, QUESTIONNAIRE_NONE_ANSWER
 from tests.test_data import load_biobank_order_json
 
 TIME_1 = datetime.datetime(2018, 1, 1)
@@ -360,7 +360,10 @@ class ParticipantApiTest(BaseTestCase):
         if street_address is not None:
             string_answers.append(("streetAddress", street_address))
         if street_address2 is not None:
-            string_answers.append(("streetAddress2", street_address2))
+            if street_address2 == PMI_SKIP_CODE:
+                _add_code_answer(code_answers, "streetAddress2", street_address2)
+            else:
+                string_answers.append(("streetAddress2", street_address2))
         qr = self.make_questionnaire_response_json(
             participant_id,
             questionnaire_id,
@@ -372,14 +375,14 @@ class ParticipantApiTest(BaseTestCase):
         with FakeClock(time):
             self.send_post("Participant/%s/QuestionnaireResponse" % participant_id, qr)
 
-    def test_switch_to_test_account(self):
+    def _setup_initial_participant_data(self):
         with FakeClock(TIME_1):
-            participant_1 = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
+            participant = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
         questionnaire_id = self.create_questionnaire("questionnaire3.json")
-        participant_id_1 = participant_1["participantId"]
-        self.send_consent(participant_id_1)
+        participant_id = participant["participantId"]
+        self.send_consent(participant_id)
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -403,18 +406,23 @@ class ParticipantApiTest(BaseTestCase):
             "signature.pdf",
         )
 
-        ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
+        return participant_id, questionnaire_id
+
+    def test_switch_to_test_account(self):
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
+
+        ps_1 = self.send_get("Participant/%s/Summary" % participant_id)
         self.assertEqual("215-222-2222", ps_1["loginPhoneNumber"])
         self.assertEqual("PITT", ps_1["hpoId"])
 
-        p_1 = self.send_get("Participant/%s" % participant_id_1)
+        p_1 = self.send_get("Participant/%s" % participant_id)
         self.assertEqual("PITT", p_1["hpoId"])
         self.assertEqual(TIME_1.strftime("%Y" "-" "%m" "-" "%d" "T" "%X"), p_1["lastModified"])
         self.assertEqual('W/"1"', p_1["meta"]["versionId"])
 
         # change login phone number to 444-222-2222
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -439,52 +447,24 @@ class ParticipantApiTest(BaseTestCase):
             TIME_2,
         )
 
-        ps_1_with_test_login_phone_number = self.send_get("Participant/%s/Summary" % participant_id_1)
+        ps_1_with_test_login_phone_number = self.send_get("Participant/%s/Summary" % participant_id)
 
         self.assertEqual("444-222-2222", ps_1_with_test_login_phone_number["loginPhoneNumber"])
         self.assertEqual("TEST", ps_1_with_test_login_phone_number["hpoId"])
         self.assertEqual("1234 Main Street", ps_1_with_test_login_phone_number["streetAddress"])
         self.assertEqual("APT C", ps_1_with_test_login_phone_number["streetAddress2"])
 
-        p_1 = self.send_get("Participant/%s" % participant_id_1)
+        p_1 = self.send_get("Participant/%s" % participant_id)
         self.assertEqual("TEST", p_1["hpoId"])
         self.assertEqual(TIME_2.strftime("%Y" "-" "%m" "-" "%d" "T" "%X"), p_1["lastModified"])
         self.assertEqual('W/"2"', p_1["meta"]["versionId"])
 
     def test_street_address_two_clears_on_address_update(self):
-        with FakeClock(TIME_1):
-            participant_1 = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
-        questionnaire_id = self.create_questionnaire("questionnaire3.json")
-        participant_id_1 = participant_1["participantId"]
-        self.send_consent(participant_id_1)
-        self.submit_questionnaire_response(
-            participant_id_1,
-            questionnaire_id,
-            RACE_WHITE_CODE,
-            "male",
-            "Bob",
-            "Q",
-            "Jones",
-            "78751",
-            "PIIState_VA",
-            "1234 Main Street",
-            "APT C",
-            "Austin",
-            "male_sex",
-            "215-222-2222",
-            "straight",
-            "512-555-5555",
-            "email_code",
-            "en",
-            "highschool",
-            "lotsofmoney",
-            datetime.date(1978, 10, 9),
-            "signature.pdf",
-        )
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
 
         # Change street address to only have one line
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -509,44 +489,15 @@ class ParticipantApiTest(BaseTestCase):
             TIME_2,
         )
 
-        participant_summary = self.send_get("Participant/%s/Summary" % participant_id_1)
+        participant_summary = self.send_get("Participant/%s/Summary" % participant_id)
         self.assertEqual("", participant_summary["streetAddress2"])
 
-    def test_address_string_persists_through_update(self):
-        # Make sure strings aren't cleared when an update leaves them out
-        with FakeClock(TIME_1):
-            participant_1 = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
-        questionnaire_id = self.create_questionnaire("questionnaire3.json")
-        participant_id_1 = participant_1["participantId"]
-        self.send_consent(participant_id_1)
-        self.submit_questionnaire_response(
-            participant_id_1,
-            questionnaire_id,
-            RACE_WHITE_CODE,
-            "male",
-            "Bob",
-            "Q",
-            "Jones",
-            "78751",
-            "PIIState_VA",
-            "1234 Main Street",
-            "APT C",
-            "Austin",
-            "male_sex",
-            "215-222-2222",
-            "straight",
-            "512-555-5555",
-            "email_code",
-            "en",
-            "highschool",
-            "lotsofmoney",
-            datetime.date(1978, 10, 9),
-            "signature.pdf",
-        )
+    def test_street_address_two_clears_on_no_answer(self):
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
 
-        # Change street address to only have one line
+        # We could see a submission to the street address line 2 without an answer included with it
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -555,8 +506,8 @@ class ParticipantApiTest(BaseTestCase):
             "Jones",
             "78751",
             "PIIState_VA",
-            None,
-            None,
+            "44 Hickory Lane",
+            QUESTIONNAIRE_NONE_ANSWER,
             "Austin",
             "male_sex",
             "444-222-2222",
@@ -571,9 +522,41 @@ class ParticipantApiTest(BaseTestCase):
             TIME_2,
         )
 
-        participant_summary = self.send_get("Participant/%s/Summary" % participant_id_1)
-        self.assertEqual("1234 Main Street", participant_summary["streetAddress"])
-        self.assertEqual("APT C", participant_summary["streetAddress2"])
+        participant_summary = self.send_get("Participant/%s/Summary" % participant_id)
+        self.assertNotIn("streetAddress2", participant_summary)
+
+    def test_street_address_two_clears_on_skip(self):
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
+
+        # We could see a submission to the street address line 2 without an answer included with it
+        self.submit_questionnaire_response(
+            participant_id,
+            questionnaire_id,
+            RACE_WHITE_CODE,
+            "male",
+            "Bob",
+            "Q",
+            "Jones",
+            "78751",
+            "PIIState_VA",
+            "44 Hickory Lane",
+            PMI_SKIP_CODE,
+            "Austin",
+            "male_sex",
+            "444-222-2222",
+            "straight",
+            "512-555-5555",
+            "email_code",
+            "en",
+            "highschool",
+            "lotsofmoney",
+            datetime.date(1978, 10, 9),
+            "signature.pdf",
+            TIME_2,
+        )
+
+        participant_summary = self.send_get("Participant/%s/Summary" % participant_id)
+        self.assertNotIn("streetAddress2", participant_summary)
 
 
 def _add_code_answer(code_answers, link_id, code):

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -82,7 +82,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
         "education",
         "income",
     )
-    string_link_ids = ("firstName", "middleName", "lastName", "streetAddress", "city", "phoneNumber", "zipCode")
+    string_link_ids = ("firstName", "middleName", "lastName", "streetAddress",
+                       "streetAddress2", "city", "phoneNumber", "zipCode")
 
     def setUp(self):
         super().setUp()

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -38,6 +38,9 @@ from rdr_service.storage import LocalFilesystemStorageProvider
 from tests.helpers.mysql_helper import reset_mysql_instance
 from tests.test_data import data_path
 
+QUESTIONNAIRE_NONE_ANSWER = 'no_answer_given'
+
+
 
 class CodebookTestMixin:
 
@@ -87,15 +90,23 @@ class QuestionnaireTestMixin:
                         "answer": [{"valueCoding": {"code": answer[1].code, "system": answer[1].system}}],
                     }
                 )
+
+        def add_question_result(question_data, answer_value, answer_structure):
+            result = {"linkId": question_data}
+            if answer_value != QUESTIONNAIRE_NONE_ANSWER:
+                result["answer"] = [answer_structure]
+            results.append(result)
+
         if string_answers:
             for answer in string_answers:
-                results.append({"linkId": answer[0], "answer": [{"valueString": answer[1]}]})
+                add_question_result(answer[0], answer[1], {"valueString": answer[1]})
         if date_answers:
             for answer in date_answers:
-                results.append({"linkId": answer[0], "answer": [{"valueDate": "%s" % answer[1].isoformat()}]})
+                add_question_result(answer[0], answer[1], {"valueDate": "%s" % answer[1].isoformat()})
         if uri_answers:
             for answer in uri_answers:
-                results.append({"linkId": answer[0], "answer": [{"valueUri": answer[1]}]})
+                results.append({"linkId": answer[0], "answer": []})
+                add_question_result(answer[0], answer[1], {"valueUri": answer[1]})
 
         response_json = {
             "resourceType": "QuestionnaireResponse",


### PR DESCRIPTION
This is a second attempt at this. Originally I thought we were getting empty strings as part of the response when a participant was trying to clear out the line two of their address. Instead I'm seeing two possibilities in the database. In some instances the response leaves out the 'answer' portion of the response to the street address line 2 question. In other cases the answer can be a skip code.

To account for the possibility of the answer being left out I set up a flag that defaults to not having found a street address 2 answer. If that is still false after looking through all the answers then I make sure that the street address 2 on the participant summary is cleared. If the answer is a skip code then the valueString of the answer will still be None, so setting the flag to the valueString being not equal to None accounts for that.

We should only should clear line 2 if we've received an updated line 1. So I set up another flag to watch for that and I only clear at the end if line 1 was updated but we don't see a line 2.

I've removed a test I had in place for checking that submitting no answer for an address should persist the one we have. There's another unit test that covers that in a cleaner way.