### PR TITLE
[DA-1549] Genomic Outreach API; GEM Report States

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -1,9 +1,9 @@
 from werkzeug.exceptions import NotFound, BadRequest
 
 from rdr_service.api.base_api import BaseApi
-from rdr_service.api_util import GEM
+from rdr_service.api_util import GEM, RDR_AND_PTC
 from rdr_service.app_util import auth_required
-from rdr_service.dao.genomics_dao import GenomicPiiDao
+from rdr_service.dao.genomics_dao import GenomicPiiDao, GenomicOutreachDao
 
 
 class GenomicPiiApi(BaseApi):
@@ -29,3 +29,20 @@ class GenomicPiiApi(BaseApi):
             return self._make_response(proto_payload)
 
         raise BadRequest
+
+
+class GenomicOutreachApi(BaseApi):
+    def __init__(self):
+        super(GenomicOutreachApi, self).__init__(GenomicOutreachDao())
+
+    @auth_required(RDR_AND_PTC)
+    def get(self, mode=None):
+        if mode not in ('GEM', 'RHP'):
+            raise BadRequest("GenomicOutreach Mode required to be \"GEM\" or \"RHP\".")
+
+        if mode == "GEM":
+            report_states_result = self.dao.date_lookup(mode)
+
+            return self._make_response(report_states_result)
+
+        return BadRequest

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -846,6 +846,8 @@ class GenomicOutreachDao(BaseDao):
         pass
 
     def to_client_json(self, result):
+        if result:
+            pass
         return {"message": "pass"}
 
     def participant_lookup(self, pid):

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -429,12 +429,14 @@ class GenomicSetMemberDao(UpdatableDao):
                     GenomicWorkflowState.A2
                 )) &
                 (
-                    (ParticipantSummary.consentForGenomicsROR != QuestionnaireStatus.SUBMITTED) |
-                    (ParticipantSummary.consentForStudyEnrollment != QuestionnaireStatus.SUBMITTED)
-                ) &
-                (
-                    (ParticipantSummary.consentForGenomicsRORAuthored > _date) |
-                    (ParticipantSummary.consentForStudyEnrollmentAuthored > _date)
+                    (
+                        (ParticipantSummary.consentForGenomicsROR != QuestionnaireStatus.SUBMITTED) &
+                        (ParticipantSummary.consentForGenomicsRORAuthored > _date)
+                    ) |
+                    (
+                        (ParticipantSummary.consentForStudyEnrollment != QuestionnaireStatus.SUBMITTED) &
+                        (ParticipantSummary.consentForStudyEnrollmentAuthored > _date)
+                    )
                 )
             ).all()
         return members
@@ -456,12 +458,14 @@ class GenomicSetMemberDao(UpdatableDao):
                     GenomicWorkflowState.GEM_RPT_DELETED,
                 )) &
                 (
-                    (ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED) |
-                    (ParticipantSummary.consentForStudyEnrollment == QuestionnaireStatus.SUBMITTED)
-                ) &
-                (
-                    (ParticipantSummary.consentForGenomicsRORAuthored > _date) |
-                    (ParticipantSummary.consentForStudyEnrollmentAuthored > _date)
+                    (
+                        (ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED) &
+                        (ParticipantSummary.consentForGenomicsRORAuthored > _date)
+                    ) |
+                    (
+                        (ParticipantSummary.consentForStudyEnrollment == QuestionnaireStatus.SUBMITTED) &
+                        (ParticipantSummary.consentForStudyEnrollmentAuthored > _date)
+                    )
                 )
             ).all()
         return members

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -12,8 +12,6 @@ from rdr_service.config import (
     getSetting,
     getSettingList,
     GENOME_TYPE_ARRAY,
-    GENOME_TYPE_WGS,
-    GENOME_TYPE_CVL,
 )
 from rdr_service.participant_enums import (
     GenomicSubProcessResult,

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -10,7 +10,11 @@ from rdr_service import clock
 from rdr_service.config import (
     GENOMIC_GC_METRICS_BUCKET_NAME,
     getSetting,
-    getSettingList)
+    getSettingList,
+    GENOME_TYPE_ARRAY,
+    GENOME_TYPE_WGS,
+    GENOME_TYPE_CVL,
+)
 from rdr_service.participant_enums import (
     GenomicSubProcessResult,
     GenomicSubProcessStatus)
@@ -230,6 +234,18 @@ class GenomicJobController:
             self.job_result = self._aggregate_run_results()
         except RuntimeError:
             self.job_result = GenomicSubProcessResult.ERROR
+
+    def reconcile_report_states(self, _genome_type):
+        """
+        Wrapper for the Reconciler reconcile_gem_report_states
+        and reconcile_rhp_report_states
+        :param _genome_type: array or wgs
+        """
+
+        self.reconciler = GenomicReconciler(self.job_run.id, self.job_id)
+
+        if _genome_type == GENOME_TYPE_ARRAY:
+            self.reconciler.reconcile_gem_report_states(_last_run_time=self.last_run_time)
 
     def run_gem_a2_workflow(self):
         """

--- a/rdr_service/genomic/genomic_state_handler.py
+++ b/rdr_service/genomic/genomic_state_handler.py
@@ -24,6 +24,89 @@ class AW2State(GenomicStateBase):
         elif signal == 'cvl-ready':
             return GenomicWorkflowState.CVL_READY
 
+        elif signal == 'gem-ready':
+            return GenomicWorkflowState.GEM_READY
+
+
+class GEMReadyState(GenomicStateBase):
+    """State representing the GEM_READY state"""
+    def transition_function(self, signal):
+        if signal == 'manifest-generated':
+            return GenomicWorkflowState.A1
+
+
+class A1State(GenomicStateBase):
+    """State representing the A1 manifest state"""
+    def transition_function(self, signal):
+        if signal == 'a2-gem-pass':
+            return GenomicWorkflowState.A2
+
+        if signal == 'a2-gem-fail':
+            return GenomicWorkflowState.A2F
+
+        if signal == 'unconsented':
+            return GenomicWorkflowState.GEM_RPT_PENDING_DELETE
+
+
+class A2PassState(GenomicStateBase):
+    """State representing the A2 manifest state"""
+
+    def transition_function(self, signal):
+        if signal == 'report-ready':
+            return GenomicWorkflowState.GEM_RPT_READY
+
+        if signal == 'unconsented':
+            return GenomicWorkflowState.GEM_RPT_PENDING_DELETE
+
+
+class A2FailState(GenomicStateBase):
+    """State representing the A2 manifest GEM failure state"""
+
+    def transition_function(self, signal):
+        if signal == 'report-ready':
+            return GenomicWorkflowState.GEM_RPT_READY
+
+        if signal == 'unconsented':
+            return GenomicWorkflowState.GEM_RPT_PENDING_DELETE
+
+
+class A3State(GenomicStateBase):
+    """State representing the A3 manifest; GEM Delete states"""
+
+    def transition_function(self, signal):
+        if signal == 'manifest-generated':
+            return GenomicWorkflowState.GEM_RPT_DELETED
+
+
+class GEMReportReady(GenomicStateBase):
+    """State representing the GEM Report"""
+
+    def transition_function(self, signal):
+        if signal == 'unconsented':
+            return GenomicWorkflowState.GEM_RPT_PENDING_DELETE
+
+
+class GEMReportPendingDelete(GenomicStateBase):
+    """State representing when Consent revoked, input to A3 Manifest"""
+
+    def transition_function(self, signal):
+        if signal == 'manifest-generated':
+            return GenomicWorkflowState.GEM_RPT_DELETED
+
+        if signal == 'reconsented':
+            return GenomicWorkflowState.GEM_READY
+
+
+class GEMReportDeleted(GenomicStateBase):
+    """State representing when Consent revoked, input to A3 Manifest"""
+
+    def transition_function(self, signal):
+        if signal == 'manifest-generated':
+            return GenomicWorkflowState.GEM_RPT_DELETED
+
+        if signal == 'reconsented':
+            return GenomicWorkflowState.GEM_READY
+
 
 class CVLReadyState(GenomicStateBase):
     """State representing the CVL_READY state"""
@@ -55,6 +138,14 @@ class GenomicStateHandler:
         GenomicWorkflowState.CVL_READY: CVLReadyState(),
         GenomicWorkflowState.W1: W1State(),
         GenomicWorkflowState.W2: W2State(),
+        GenomicWorkflowState.GEM_READY: GEMReadyState(),
+        GenomicWorkflowState.A1: A1State(),
+        GenomicWorkflowState.A2: A2PassState(),
+        GenomicWorkflowState.A2F: A2FailState(),
+        GenomicWorkflowState.A3: A3State(),
+        GenomicWorkflowState.GEM_RPT_READY: GEMReportReady(),
+        GenomicWorkflowState.GEM_RPT_PENDING_DELETE: GEMReportPendingDelete(),
+        GenomicWorkflowState.GEM_RPT_DELETED: GEMReportDeleted(),
     }
 
     @classmethod

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -28,7 +28,7 @@ from rdr_service.api.biobank_specimen_api import BiobankSpecimenApi, BiobankSpec
 from rdr_service.api.check_ppi_data_api import check_ppi_data
 from rdr_service.api.data_gen_api import DataGenApi, SpecDataGenApi
 from rdr_service.api.dv_order_api import DvOrderApi
-from rdr_service.api.genomic_api import GenomicPiiApi
+from rdr_service.api.genomic_api import GenomicPiiApi, GenomicOutreachApi
 from rdr_service.api.import_codebook_api import import_codebook
 from rdr_service.api.metric_sets_api import MetricSetsApi
 from rdr_service.api.metrics_api import MetricsApi
@@ -326,6 +326,11 @@ api.add_resource(RedcapWorkbenchAuditApi,
 api.add_resource(GenomicPiiApi,
                  API_PREFIX + "GenomicPII/<string:mode>/<participant_id:p_id>",
                  endpoint='genomic.pii',
+                 methods=['GET'])
+
+api.add_resource(GenomicOutreachApi,
+                 API_PREFIX + "GenomicOutreach/<string:mode>",
+                 endpoint='genomic.outreach',
                  methods=['GET'])
 
 # Configuration API for admin use.  # note: temporarily disabled until decided

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -117,6 +117,7 @@ def gem_a1_manifest_workflow():
     """
     with GenomicJobController(GenomicJob.GEM_A1_MANIFEST,
                               bucket_name=config.GENOMIC_GEM_BUCKET_NAME) as controller:
+        controller.reconcile_report_states(_genome_type=config.GENOME_TYPE_ARRAY)
         controller.generate_manifest(GenomicManifestTypes.GEM_A1, _genome_type=config.GENOME_TYPE_ARRAY)
 
 
@@ -126,6 +127,7 @@ def gem_a2_manifest_workflow():
     """
     with GenomicJobController(GenomicJob.GEM_A2_MANIFEST,
                               bucket_name=config.GENOMIC_GEM_BUCKET_NAME) as controller:
+        controller.reconcile_report_states(_genome_type=config.GENOME_TYPE_ARRAY)
         controller.run_gem_a2_workflow()
 
 
@@ -135,6 +137,7 @@ def gem_a3_manifest_workflow():
     """
     with GenomicJobController(GenomicJob.GEM_A3_MANIFEST,
                               bucket_name=config.GENOMIC_GEM_BUCKET_NAME) as controller:
+        controller.reconcile_report_states(_genome_type=config.GENOME_TYPE_ARRAY)
         controller.generate_manifest(GenomicManifestTypes.GEM_A3, _genome_type=config.GENOME_TYPE_ARRAY)
 
 

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -574,6 +574,17 @@ class GenomicWorkflowState(messages.Enum):
     RHP_RPT_ACCESSED = 21
     CVL_READY = 22
 
+    # GEM Reporting States
+    GEM_RPT_READY = 23
+    GEM_RPT_PENDING_DELETE = 24
+    GEM_RPT_DELETED = 25
+    GEM_RPT_ACCESSED = 26
+    GEM_READY = 27
+    A1 = 28
+    A2 = 29
+    A2F = 30
+    A3 = 31
+
 
 class GenomicSubProcessStatus(messages.Enum):
     """The status of a Genomics Sub-Process"""

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -161,3 +161,12 @@ class RhpApiTest(GenomicApiTestBase):
         self.send_get("GenomicPII/RHP/", expected_status=404)
         self.send_get("GenomicPII/RHP/P8", expected_status=404)
         self.send_get("GenomicPII/CVL/P2", expected_status=400)
+
+
+class GenomicOutreachApiTest(GenomicApiTestBase):
+    def setUp(self):
+        super(GenomicOutreachApiTest, self).setUp()
+
+    def test_get_date_lookup(self):
+        resp = self.send_get("GenomicOutreach/GEM?start_date=2020-05-28T08:00:01-05:00")
+        print(resp)

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1445,7 +1445,6 @@ class GenomicPipelineTest(BaseTestCase):
         genomic_pipeline.reconcile_metrics_vs_manifest()  # run_id = 3
         genomic_pipeline.reconcile_metrics_vs_genotyping_data()  # run_id = 4
 
-        members = self.member_dao.get_all()
         # finally run the manifest workflow
         bucket_name = config.getSetting(config.GENOMIC_GEM_BUCKET_NAME)
         a1_time = datetime.datetime(2020, 4, 1, 0, 0, 0, 0)

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,2 +1,3 @@
 Biobank ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Consent for RoR,Withdrawn_status,site_id,Notes
 T1,T1_1,10001,10001_R01C01,0.996,True,0.00654,Pass,,,JH,This sample passed
+T2,T2_2,10002,10002_R01C02,0.996,True,0.00654,Pass,,,JH,This sample passed


### PR DESCRIPTION
This PR implements the Genomic Outreach API to serve PTSC with GEM report state resources. This includes look-ups by date-range and participant_id. This PR also includes refactoring of the GEM A1, A2, and A3 manifests to use the new FSM created for the genomic system instead of relying on genomic set members' job_run_ids to determine report state.