### PR TITLE
Hotfix for ROC-512 and DA-1590

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -77,9 +77,10 @@ CONSENT_GROR_YES_CODE = "CheckDNA_Yes"
 CONSENT_GROR_NO_CODE = "CheckDNA_No"
 CONSENT_GROR_NOT_SURE = "CheckDNA_NotSure"
 
-# Consent COPE Answer Codes
+# Consent COPE Answer Codes.  (Deferred = expressed interest in taking the survey later)
 CONSENT_COPE_YES_CODE = "COPE_A_44"
 CONSENT_COPE_NO_CODE = "COPE_A_13"
+CONSENT_COPE_DEFERRED_CODE = "COPE_A_231"
 
 # Module names for questionnaires / consent forms
 CONSENT_FOR_GENOMICS_ROR_MODULE = "GROR"

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -34,6 +34,7 @@ from rdr_service.code_constants import (
     GROR_CONSENT_QUESTION_CODE,
     CONSENT_COPE_YES_CODE,
     CONSENT_COPE_NO_CODE,
+    CONSENT_COPE_DEFERRED_CODE,
     COPE_CONSENT_QUESTION_CODE)
 from rdr_service.config_api import is_config_admin
 from rdr_service.dao.base_dao import BaseDao
@@ -337,7 +338,7 @@ class QuestionnaireResponseDao(BaseDao):
                             answer_value = code_dao.get(answer.valueCodeId).value
                             if answer_value == CONSENT_COPE_YES_CODE:
                                 submission_status = QuestionnaireStatus.SUBMITTED
-                            elif answer_value == CONSENT_COPE_NO_CODE:
+                            elif answer_value in [CONSENT_COPE_NO_CODE, CONSENT_COPE_DEFERRED_CODE]:
                                 submission_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT
                             else:
                                 submission_status = QuestionnaireStatus.SUBMITTED_INVALID

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -4,7 +4,7 @@ import http.client
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.utils import from_client_participant_id
 from rdr_service.clock import FakeClock
-from rdr_service.code_constants import PPI_SYSTEM, RACE_WHITE_CODE
+from rdr_service.code_constants import PPI_SYSTEM, RACE_WHITE_CODE, PMI_SKIP_CODE
 from rdr_service.concepts import Concept
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
@@ -16,7 +16,7 @@ from rdr_service.participant_enums import (
     TEST_HPO_NAME,
     WithdrawalStatus,
 )
-from tests.helpers.unittest_base import BaseTestCase
+from tests.helpers.unittest_base import BaseTestCase, QUESTIONNAIRE_NONE_ANSWER
 from tests.test_data import load_biobank_order_json
 
 TIME_1 = datetime.datetime(2018, 1, 1)
@@ -360,7 +360,10 @@ class ParticipantApiTest(BaseTestCase):
         if street_address is not None:
             string_answers.append(("streetAddress", street_address))
         if street_address2 is not None:
-            string_answers.append(("streetAddress2", street_address2))
+            if street_address2 == PMI_SKIP_CODE:
+                _add_code_answer(code_answers, "streetAddress2", street_address2)
+            else:
+                string_answers.append(("streetAddress2", street_address2))
         qr = self.make_questionnaire_response_json(
             participant_id,
             questionnaire_id,
@@ -372,14 +375,14 @@ class ParticipantApiTest(BaseTestCase):
         with FakeClock(time):
             self.send_post("Participant/%s/QuestionnaireResponse" % participant_id, qr)
 
-    def test_switch_to_test_account(self):
+    def _setup_initial_participant_data(self):
         with FakeClock(TIME_1):
-            participant_1 = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
+            participant = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
         questionnaire_id = self.create_questionnaire("questionnaire3.json")
-        participant_id_1 = participant_1["participantId"]
-        self.send_consent(participant_id_1)
+        participant_id = participant["participantId"]
+        self.send_consent(participant_id)
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -403,18 +406,23 @@ class ParticipantApiTest(BaseTestCase):
             "signature.pdf",
         )
 
-        ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
+        return participant_id, questionnaire_id
+
+    def test_switch_to_test_account(self):
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
+
+        ps_1 = self.send_get("Participant/%s/Summary" % participant_id)
         self.assertEqual("215-222-2222", ps_1["loginPhoneNumber"])
         self.assertEqual("PITT", ps_1["hpoId"])
 
-        p_1 = self.send_get("Participant/%s" % participant_id_1)
+        p_1 = self.send_get("Participant/%s" % participant_id)
         self.assertEqual("PITT", p_1["hpoId"])
         self.assertEqual(TIME_1.strftime("%Y" "-" "%m" "-" "%d" "T" "%X"), p_1["lastModified"])
         self.assertEqual('W/"1"', p_1["meta"]["versionId"])
 
         # change login phone number to 444-222-2222
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -439,52 +447,24 @@ class ParticipantApiTest(BaseTestCase):
             TIME_2,
         )
 
-        ps_1_with_test_login_phone_number = self.send_get("Participant/%s/Summary" % participant_id_1)
+        ps_1_with_test_login_phone_number = self.send_get("Participant/%s/Summary" % participant_id)
 
         self.assertEqual("444-222-2222", ps_1_with_test_login_phone_number["loginPhoneNumber"])
         self.assertEqual("TEST", ps_1_with_test_login_phone_number["hpoId"])
         self.assertEqual("1234 Main Street", ps_1_with_test_login_phone_number["streetAddress"])
         self.assertEqual("APT C", ps_1_with_test_login_phone_number["streetAddress2"])
 
-        p_1 = self.send_get("Participant/%s" % participant_id_1)
+        p_1 = self.send_get("Participant/%s" % participant_id)
         self.assertEqual("TEST", p_1["hpoId"])
         self.assertEqual(TIME_2.strftime("%Y" "-" "%m" "-" "%d" "T" "%X"), p_1["lastModified"])
         self.assertEqual('W/"2"', p_1["meta"]["versionId"])
 
     def test_street_address_two_clears_on_address_update(self):
-        with FakeClock(TIME_1):
-            participant_1 = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
-        questionnaire_id = self.create_questionnaire("questionnaire3.json")
-        participant_id_1 = participant_1["participantId"]
-        self.send_consent(participant_id_1)
-        self.submit_questionnaire_response(
-            participant_id_1,
-            questionnaire_id,
-            RACE_WHITE_CODE,
-            "male",
-            "Bob",
-            "Q",
-            "Jones",
-            "78751",
-            "PIIState_VA",
-            "1234 Main Street",
-            "APT C",
-            "Austin",
-            "male_sex",
-            "215-222-2222",
-            "straight",
-            "512-555-5555",
-            "email_code",
-            "en",
-            "highschool",
-            "lotsofmoney",
-            datetime.date(1978, 10, 9),
-            "signature.pdf",
-        )
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
 
         # Change street address to only have one line
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -509,44 +489,15 @@ class ParticipantApiTest(BaseTestCase):
             TIME_2,
         )
 
-        participant_summary = self.send_get("Participant/%s/Summary" % participant_id_1)
+        participant_summary = self.send_get("Participant/%s/Summary" % participant_id)
         self.assertEqual("", participant_summary["streetAddress2"])
 
-    def test_address_string_persists_through_update(self):
-        # Make sure strings aren't cleared when an update leaves them out
-        with FakeClock(TIME_1):
-            participant_1 = self.send_post("Participant", {"providerLink": [self.provider_link_2]})
-        questionnaire_id = self.create_questionnaire("questionnaire3.json")
-        participant_id_1 = participant_1["participantId"]
-        self.send_consent(participant_id_1)
-        self.submit_questionnaire_response(
-            participant_id_1,
-            questionnaire_id,
-            RACE_WHITE_CODE,
-            "male",
-            "Bob",
-            "Q",
-            "Jones",
-            "78751",
-            "PIIState_VA",
-            "1234 Main Street",
-            "APT C",
-            "Austin",
-            "male_sex",
-            "215-222-2222",
-            "straight",
-            "512-555-5555",
-            "email_code",
-            "en",
-            "highschool",
-            "lotsofmoney",
-            datetime.date(1978, 10, 9),
-            "signature.pdf",
-        )
+    def test_street_address_two_clears_on_no_answer(self):
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
 
-        # Change street address to only have one line
+        # We could see a submission to the street address line 2 without an answer included with it
         self.submit_questionnaire_response(
-            participant_id_1,
+            participant_id,
             questionnaire_id,
             RACE_WHITE_CODE,
             "male",
@@ -555,8 +506,8 @@ class ParticipantApiTest(BaseTestCase):
             "Jones",
             "78751",
             "PIIState_VA",
-            None,
-            None,
+            "44 Hickory Lane",
+            QUESTIONNAIRE_NONE_ANSWER,
             "Austin",
             "male_sex",
             "444-222-2222",
@@ -571,9 +522,41 @@ class ParticipantApiTest(BaseTestCase):
             TIME_2,
         )
 
-        participant_summary = self.send_get("Participant/%s/Summary" % participant_id_1)
-        self.assertEqual("1234 Main Street", participant_summary["streetAddress"])
-        self.assertEqual("APT C", participant_summary["streetAddress2"])
+        participant_summary = self.send_get("Participant/%s/Summary" % participant_id)
+        self.assertNotIn("streetAddress2", participant_summary)
+
+    def test_street_address_two_clears_on_skip(self):
+        participant_id, questionnaire_id = self._setup_initial_participant_data()
+
+        # We could see a submission to the street address line 2 without an answer included with it
+        self.submit_questionnaire_response(
+            participant_id,
+            questionnaire_id,
+            RACE_WHITE_CODE,
+            "male",
+            "Bob",
+            "Q",
+            "Jones",
+            "78751",
+            "PIIState_VA",
+            "44 Hickory Lane",
+            PMI_SKIP_CODE,
+            "Austin",
+            "male_sex",
+            "444-222-2222",
+            "straight",
+            "512-555-5555",
+            "email_code",
+            "en",
+            "highschool",
+            "lotsofmoney",
+            datetime.date(1978, 10, 9),
+            "signature.pdf",
+            TIME_2,
+        )
+
+        participant_summary = self.send_get("Participant/%s/Summary" % participant_id)
+        self.assertNotIn("streetAddress2", participant_summary)
 
 
 def _add_code_answer(code_answers, link_id, code):

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -82,7 +82,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
         "education",
         "income",
     )
-    string_link_ids = ("firstName", "middleName", "lastName", "streetAddress", "city", "phoneNumber", "zipCode")
+    string_link_ids = ("firstName", "middleName", "lastName", "streetAddress",
+                       "streetAddress2", "city", "phoneNumber", "zipCode")
 
     def setUp(self):
         super().setUp()

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -8,7 +8,7 @@ from rdr_service import config
 from rdr_service.api_util import open_cloud_file
 from rdr_service.clock import FakeClock
 from rdr_service.code_constants import GENDER_IDENTITY_QUESTION_CODE, PMI_SKIP_CODE, PPI_SYSTEM, THE_BASICS_PPI_MODULE,\
-    CONSENT_COPE_YES_CODE, CONSENT_COPE_NO_CODE
+    CONSENT_COPE_YES_CODE, CONSENT_COPE_NO_CODE, CONSENT_COPE_DEFERRED_CODE
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
@@ -93,6 +93,8 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
                                      codeType=CodeType.ANSWER)
         self.cope_consent_no = Code(codeId=10, system=PPI_SYSTEM, value=CONSENT_COPE_NO_CODE, mapped=True,
                                      codeType=CodeType.ANSWER)
+        self.cope_consent_deferred = Code(codeId=11, system=PPI_SYSTEM, value=CONSENT_COPE_DEFERRED_CODE, mapped=True,
+                                    codeType=CodeType.ANSWER)
 
         config.override_setting(config.CONSENT_PDF_BUCKET, _FAKE_BUCKET)
 
@@ -119,6 +121,7 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
         self.code_dao.insert(self.skip_code)
         self.code_dao.insert(self.cope_consent_yes)
         self.code_dao.insert(self.cope_consent_no)
+        self.code_dao.insert(self.cope_consent_deferred)
         self.consent_code_id = self.code_dao.insert(consent_code()).codeId
         self.first_name_code_id = self.code_dao.insert(first_name_code()).codeId
         self.last_name_code_id = self.code_dao.insert(last_name_code()).codeId
@@ -694,6 +697,20 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
 
         participant_summary = self.participant_summary_dao.get(1)
         self.assertEqual(QuestionnaireStatus.SUBMITTED, participant_summary.questionnaireOnCopeJune)
+
+    def test_cope_june_survey_consent_deferred(self):
+        self.insert_codes()
+        p = Participant(participantId=1, biobankId=2)
+        self.participant_dao.insert(p)
+
+        self._setup_participant()
+        self._create_cope_questionnaire()  # May survey
+        self._bump_questionnaire_version(2, updated_time=datetime.datetime(2020, 6, 7))  # June survey
+
+        self._submit_cope_consent(self.cope_consent_deferred, questionnaire_version=2, cope_consent_question_id=8)
+
+        participant_summary = self.participant_summary_dao.get(1)
+        self.assertEqual(QuestionnaireStatus.SUBMITTED_NO_CONSENT, participant_summary.questionnaireOnCopeJune)
 
     def test_from_client_json_raises_BadRequest_for_excessively_long_value_string(self):
         self.insert_codes()

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -38,6 +38,9 @@ from rdr_service.storage import LocalFilesystemStorageProvider
 from tests.helpers.mysql_helper import reset_mysql_instance
 from tests.test_data import data_path
 
+QUESTIONNAIRE_NONE_ANSWER = 'no_answer_given'
+
+
 
 class CodebookTestMixin:
 
@@ -87,15 +90,23 @@ class QuestionnaireTestMixin:
                         "answer": [{"valueCoding": {"code": answer[1].code, "system": answer[1].system}}],
                     }
                 )
+
+        def add_question_result(question_data, answer_value, answer_structure):
+            result = {"linkId": question_data}
+            if answer_value != QUESTIONNAIRE_NONE_ANSWER:
+                result["answer"] = [answer_structure]
+            results.append(result)
+
         if string_answers:
             for answer in string_answers:
-                results.append({"linkId": answer[0], "answer": [{"valueString": answer[1]}]})
+                add_question_result(answer[0], answer[1], {"valueString": answer[1]})
         if date_answers:
             for answer in date_answers:
-                results.append({"linkId": answer[0], "answer": [{"valueDate": "%s" % answer[1].isoformat()}]})
+                add_question_result(answer[0], answer[1], {"valueDate": "%s" % answer[1].isoformat()})
         if uri_answers:
             for answer in uri_answers:
-                results.append({"linkId": answer[0], "answer": [{"valueUri": answer[1]}]})
+                results.append({"linkId": answer[0], "answer": []})
+                add_question_result(answer[0], answer[1], {"valueUri": answer[1]})
 
         response_json = {
             "resourceType": "QuestionnaireResponse",


### PR DESCRIPTION
This is to create a hotfix two separate issues: clearing street address line 2 when we receive an update for line 1, and recognizing the new COPE consent option of taking a survey later as a no consent response.

These changes exist in devel, but this is a PR to merge them against the code for 1.71.2 that is currently deployed on prod.