### PR TITLE
Updating consent sync files for reading new config structure

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -122,47 +122,19 @@
   "mayolink_endpoint": [
     "https://test.orders.mayocliniclabs.com/orders/create.xml"
   ],
-  "consent_sync_organizations": [
-    {
-      "CAL_PMC_UCD": {
-        "bucket_name": "aou185"
-      },
-      "CAL_PMC_USC": {
-        "bucket_name": "aou298"
-      },
-      "VA_BOSTON_VAMC": {
-        "bucket_name": "aou179"
-      },
-      "VA_PALO_ALTO_VAMC": {
-        "bucket_name": "aou179"
-      },
-      "VA_ATLANTA_VAMC": {
-        "bucket_name": "aou179"
-      },
-      "VA_MINNEAPOLIS_VAMC": {
-        "bucket_name": "aou179"
-      },
-      "VA_PHOENIX_VAMC":  {
-        "bucket_name": "aou179"
-      },
-      "VA_SAN_DIEGO_VAMC": {
-        "bucket_name": "aou179"
-      },
-      "VA_HOUSTON_VAMC":  {
-        "bucket_name": "aou179"
-      },
-      "VA_LEAVENWORTH_VAMC": {
-        "bucket_name": "aou179"
-      },
-      "VA_MANHATTAN_VAMC":  {
-        "bucket_name": "aou179"
-      },
-      "VA_MILWAUKEE_VAMC": {
-        "bucket_name": "aou179"
-      },
-      "VA_EVENT":  {
-        "bucket_name": "aou179"
-      }
-    }
-  ]
+  "consent_sync_buckets": {
+    "CAL_PMC_UCD": "aou185",
+    "CAL_PMC_USC": "aou298",
+    "VA_BOSTON_VAMC": "aou179",
+    "VA_PALO_ALTO_VAMC": "aou179",
+    "VA_ATLANTA_VAMC": "aou179",
+    "VA_MINNEAPOLIS_VAMC": "aou179",
+    "VA_PHOENIX_VAMC": "aou179",
+    "VA_SAN_DIEGO_VAMC": "aou179",
+    "VA_HOUSTON_VAMC": "aou179",
+    "VA_LEAVENWORTH_VAMC": "aou179",
+    "VA_MANHATTAN_VAMC": "aou179",
+    "VA_MILWAUKEE_VAMC": "aou179",
+    "VA_EVENT": "aou179"
+  }
 }

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -45,14 +45,14 @@ def do_sync_consent_files(**kwargs):
     """
   entrypoint
   """
-    org_data_map = get_org_data_map()
-    org_ids = [org_id for org_id, org_data in org_data_map.items()]
+    org_buckets = get_org_data_map()
+    org_ids = [org_id for org_id, org_data in org_buckets.items()]
     start_date = kwargs.get('start_date')
     file_filter = kwargs.get('file_filter', 'pdf')
     for participant_data in _iter_participants_data(org_ids, **kwargs):
         kwargs = {
             "source_bucket": SOURCE_BUCKET.get(participant_data.origin_id, SOURCE_BUCKET[next(iter(SOURCE_BUCKET))]),
-            "destination_bucket": org_data_map[participant_data.org_id]['bucket_name'],
+            "destination_bucket": org_buckets[participant_data.org_id],
             "participant_id": participant_data.participant_id,
             "google_group": participant_data.google_group or DEFAULT_GOOGLE_GROUP,
         }
@@ -69,7 +69,7 @@ def do_sync_consent_files(**kwargs):
 
 
 def get_org_data_map():
-    return config.getSetting(config.CONSENT_SYNC_ORGANIZATIONS)
+    return config.getSettingJson(config.CONSENT_SYNC_ORGANIZATIONS)
 
 
 PARTICIPANT_DATA_SQL = """

--- a/rdr_service/tools/tool_libs/sync_consent.py
+++ b/rdr_service/tools/tool_libs/sync_consent.py
@@ -115,7 +115,7 @@ class SyncConsentClass(object):
     Main program process
     :return: Exit code value
     """
-        sites = get_org_data_map()
+        site_buckets = get_org_data_map()
 
         _logger.info("retrieving db configuration...")
         headers = gcp_make_auth_header()
@@ -184,12 +184,7 @@ class SyncConsentClass(object):
                     elif self.args.all_va:
                         bucket = 'aou179'
                     else:
-                        site_info = sites.get(rec[3])
-                        if not site_info:
-                            _logger.warning("\nsite info not found for [{0}].".format(rec[2]))
-                            count += 1
-                            continue
-                        bucket = site_info.get("bucket_name")
+                        bucket = site_buckets.get(rec[3], None)
                     if not bucket:
                         _logger.warning("\nno bucket name found for [{0}].".format(rec[2]))
                         count += 1

--- a/rdr_service/tools/tool_libs/sync_consent.py
+++ b/rdr_service/tools/tool_libs/sync_consent.py
@@ -115,7 +115,7 @@ class SyncConsentClass(object):
     Main program process
     :return: Exit code value
     """
-        site_buckets = get_org_data_map()
+        org_buckets = get_org_data_map()
 
         _logger.info("retrieving db configuration...")
         headers = gcp_make_auth_header()
@@ -184,9 +184,9 @@ class SyncConsentClass(object):
                     elif self.args.all_va:
                         bucket = 'aou179'
                     else:
-                        bucket = site_buckets.get(rec[3], None)
+                        bucket = org_buckets.get(org_id, None)
                     if not bucket:
-                        _logger.warning("\nno bucket name found for [{0}].".format(rec[2]))
+                        _logger.warning("\nno bucket name found for [{0}].".format(site))
                         count += 1
                         continue
 

--- a/tests/cron_job_tests/test_sync_consent_files.py
+++ b/tests/cron_job_tests/test_sync_consent_files.py
@@ -30,17 +30,11 @@ class SyncConsentFilesTest(BaseTestCase):
         self.participant_dao = ParticipantDao()
         self.summary_dao = ParticipantSummaryDao()
 
-        self.org_map_data = {
-            "test_one": {
-                "hpo_id": "t_1",
-                "bucket_name": "testbucket123"
-            },
-            "test_two": {
-                "hpo_id": "t_2",
-                "bucket_name": "testbucket456"
-            }
+        self.org_buckets = {
+            "test_one": "testbucket123",
+            "test_two": "testbucket456"
         }
-        config.override_setting(config.CONSENT_SYNC_ORGANIZATIONS, [self.org_map_data])
+        config.override_setting(config.CONSENT_SYNC_ORGANIZATIONS, self.org_buckets)
 
         self.org1 = self._create_org(1, 'test_one')
         self.site1 = self._create_site(1001, "group1")
@@ -98,7 +92,7 @@ class SyncConsentFilesTest(BaseTestCase):
         self._create_participant(1, self.org1.organizationId, self.site1.siteId, consents=True)
         sync_consent_files.do_sync_consent_files()
 
-        org_bucket_name = self.org_map_data[self.org1.externalId]['bucket_name']
+        org_bucket_name = self.org_buckets[self.org1.externalId]
         mock_copy_cloud_file.assert_has_calls(
             [
                 mock.call("/{}/Participant/P1/consent.pdf".format(self.source_consent_bucket),
@@ -122,7 +116,7 @@ class SyncConsentFilesTest(BaseTestCase):
 
         sync_consent_files.do_sync_consent_files(start_date='2020-02-01', end_date='2020-03-01')
 
-        org_bucket_name = self.org_map_data[self.org1.externalId]['bucket_name']
+        org_bucket_name = self.org_buckets[self.org1.externalId]
         mock_copy_cloud_file.called_once_with(f'/{self.source_consent_bucket}/Participant/P2/consent.pdf',
                                               f'/{org_bucket_name}/Participant/{self.site1.googleGroup}/P2/consent.pdf')
         self.assertEqual(1, mock_copy_cloud_file.call_count, 'Files should be copied for one participant')
@@ -141,7 +135,7 @@ class SyncConsentFilesTest(BaseTestCase):
                                  consent_time=datetime.datetime(2020, 2, 3))
         sync_consent_files.do_sync_consent_files(start_date='2020-02-01')
 
-        org_bucket_name = self.org_map_data[self.org1.externalId]['bucket_name']
+        org_bucket_name = self.org_buckets[self.org1.externalId]
         mock_copy_cloud_file.called_once_with(f'/{self.source_consent_bucket}/Participant/P1/consent.pdf',
                                               f'/{org_bucket_name}/Participant/{self.site1.googleGroup}/P1/consent.pdf')
         self.assertEqual(1, mock_copy_cloud_file.call_count, 'One file should be copied')
@@ -165,7 +159,7 @@ class SyncConsentFilesTest(BaseTestCase):
 
         sync_consent_files.do_sync_recent_consent_files()
 
-        org_bucket_name = self.org_map_data[self.org1.externalId]['bucket_name']
+        org_bucket_name = self.org_buckets[self.org1.externalId]
         mock_copy_cloud_file.called_once_with(f'/{self.source_consent_bucket}/Participant/P2/consent.pdf',
                                               f'/{org_bucket_name}/Participant/{self.site1.googleGroup}/P2/consent.pdf')
         self.assertEqual(1, mock_copy_cloud_file.call_count, 'Files should be copied for one participant')
@@ -183,7 +177,7 @@ class SyncConsentFilesTest(BaseTestCase):
                                  consent_time=datetime.datetime(2020, 2, 3))
         sync_consent_files.do_sync_consent_files()
 
-        org_bucket_name = self.org_map_data[self.org1.externalId]['bucket_name']
+        org_bucket_name = self.org_buckets[self.org1.externalId]
         mock_copy_cloud_file.called_once_with(f'/{self.source_consent_bucket}/Participant/P1/consent.pdf',
                                               f'/{org_bucket_name}/Participant/{self.site1.googleGroup}/P1/consent.pdf')
         self.assertEqual(1, mock_copy_cloud_file.call_count, 'Only PDF files should be copied')
@@ -201,7 +195,7 @@ class SyncConsentFilesTest(BaseTestCase):
                                  consent_time=datetime.datetime(2020, 2, 3))
         sync_consent_files.do_sync_consent_files(file_filter=None)
 
-        org_bucket_name = self.org_map_data[self.org1.externalId]['bucket_name']
+        org_bucket_name = self.org_buckets[self.org1.externalId]
         mock_copy_cloud_file.assert_has_calls(
             [
                 mock.call(f'/{self.source_consent_bucket}/Participant/P1/consent.pdf',

--- a/tests/tool_tests/test_sync_consent.py
+++ b/tests/tool_tests/test_sync_consent.py
@@ -18,11 +18,9 @@ class SyncConsentTest(BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        config.override_setting(config.CONSENT_SYNC_ORGANIZATIONS, [{
-            'test_org': {
-                'bucket_name': 'test_dest_bucket'
-            }
-        }])
+        config.override_setting(config.CONSENT_SYNC_ORGANIZATIONS, {
+            'test_org': 'test_dest_bucket'
+        })
 
         site = self.create_database_site(googleGroup='test_site_google_group')
         org = self.create_database_organization(externalId='test_org')


### PR DESCRIPTION
The consent sync tool and cron script had been using a more verbose structure for mapping organizations to buckets. But that structure has been cleaned up after review. These changes are to get the both sets of code set up to properly read the new config structure.