### PR TITLE
[Biobank Support] Setting status and clearing disposal information when expected

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -98,13 +98,13 @@ class BiobankTargetedUpdateBase(BiobankApiBase):
 
 class BiobankStatusApiMixin:
     def update_model(self, model, resource, session):
-        self.dao.read_client_status(resource, model)
+        self.dao.read_client_status(resource, model, clear_disposal_fields=True)
         self.dao.update_with_session(session, model)
 
 
 class BiobankDisposalApiMixin:
     def update_model(self, model, resource, session):
-        self.dao.read_client_disposal(resource, model)
+        self.dao.read_client_disposal(resource, model, set_status=True)
         self.dao.update_with_session(session, model)
 
 

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -38,7 +38,7 @@ class BiobankDaoBase(UpdatableDao):
         return disposal_status
 
     @staticmethod
-    def read_client_status(status_source, model):
+    def read_client_status(status_source, model, clear_disposal_fields=False):
         for status_field_name, parser in [('status', None),
                                           ('freezeThawCount', None),
                                           ('location', None),
@@ -48,13 +48,20 @@ class BiobankDaoBase(UpdatableDao):
                                           ('processingCompleteDate', BiobankDaoBase.parse_nullable_date)]:
             BiobankDaoBase.map_optional_json_field_to_object(status_source, model, status_field_name, parser=parser)
 
+        if clear_disposal_fields:
+            model.disposalDate = None
+            model.disposalReason = ''
+
     @staticmethod
-    def read_client_disposal(status_source, model):
+    def read_client_disposal(status_source, model, set_status=False):
         for disposal_client_field_name, disposal_model_field_name, parser in\
                 [('reason', 'disposalReason', None),
                  ('disposalDate', None, BiobankSpecimenDao.parse_nullable_date)]:
             BiobankDaoBase.map_optional_json_field_to_object(status_source, model, disposal_client_field_name,
                                                              disposal_model_field_name, parser=parser)
+
+        if set_status:
+            model.status = 'Disposed'
 
     @staticmethod
     def map_optional_json_field_to_object(json, obj, json_field_name, object_field_name=None, parser=None):


### PR DESCRIPTION
When we receive that a sample has been disposed, using the <rlims_id>/disposalStatus endpoint, the status (usually "In Circulation") is expected to automatically change to "Disposed". Likewise, if we receive a status update through the <rlims_id>/status endpoint then disposal information should be cleared. 