### PR TITLE
[ROC-512] Deactivating previous street address 2

### DIFF
--- a/rdr_service/dao/questionnaire_dao.py
+++ b/rdr_service/dao/questionnaire_dao.py
@@ -7,7 +7,7 @@ from rdr_service import clock
 from rdr_service.code_constants import PPI_EXTRA_SYSTEM
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
 from rdr_service.lib_fhir.fhirclient_1_0_6.models import questionnaire
-from rdr_service.model.code import Code, CodeType
+from rdr_service.model.code import CodeType
 from rdr_service.model.questionnaire import (
     Questionnaire,
     QuestionnaireConcept,
@@ -273,15 +273,6 @@ class QuestionnaireQuestionDao(BaseDao):
         return (
             session.query(QuestionnaireQuestion).filter(QuestionnaireQuestion.questionnaireQuestionId.in_(ids)).all()
         )
-
-    def get_for_questionnaire_and_code(self, session, questionnaire_id, semantic_version, question_code):
-        return session.query(QuestionnaireQuestion).join(Code)\
-            .join(Questionnaire, Questionnaire.questionnaireId == QuestionnaireQuestion.questionnaireId)\
-            .filter(
-                Questionnaire.questionnaireId == questionnaire_id,
-                Questionnaire.semanticVersion == semantic_version,
-                Code.value == question_code
-            ).one_or_none()
 
 def _add_codes_if_missing():
     # Only import "config" on demand, as it depends on Datastore packages (and

--- a/rdr_service/dao/questionnaire_dao.py
+++ b/rdr_service/dao/questionnaire_dao.py
@@ -7,7 +7,7 @@ from rdr_service import clock
 from rdr_service.code_constants import PPI_EXTRA_SYSTEM
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
 from rdr_service.lib_fhir.fhirclient_1_0_6.models import questionnaire
-from rdr_service.model.code import CodeType
+from rdr_service.model.code import Code, CodeType
 from rdr_service.model.questionnaire import (
     Questionnaire,
     QuestionnaireConcept,
@@ -274,6 +274,14 @@ class QuestionnaireQuestionDao(BaseDao):
             session.query(QuestionnaireQuestion).filter(QuestionnaireQuestion.questionnaireQuestionId.in_(ids)).all()
         )
 
+    def get_for_questionnaire_and_code(self, session, questionnaire_id, semantic_version, question_code):
+        return session.query(QuestionnaireQuestion).join(Code)\
+            .join(Questionnaire, Questionnaire.questionnaireId == QuestionnaireQuestion.questionnaireId)\
+            .filter(
+                Questionnaire.questionnaireId == questionnaire_id,
+                Questionnaire.semanticVersion == semantic_version,
+                Code.value == question_code
+            ).one_or_none()
 
 def _add_codes_if_missing():
     # Only import "config" on demand, as it depends on Datastore packages (and

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -151,9 +151,9 @@ class QuestionnaireResponseDao(BaseDao):
     def _imply_street_address_2_from_street_address_1(code_ids):
         code_dao = CodeDao()
         street_address_1_code = code_dao.get_code(PPI_SYSTEM, STREET_ADDRESS_QUESTION_CODE)
-        if street_address_1_code.codeId in code_ids:
+        if street_address_1_code and street_address_1_code.codeId in code_ids:
             street_address_2_code = code_dao.get_code(PPI_SYSTEM, STREET_ADDRESS2_QUESTION_CODE)
-            if street_address_2_code.codeId not in code_ids:
+            if street_address_2_code and street_address_2_code.codeId not in code_ids:
                 code_ids.append(street_address_2_code.codeId)
 
     def insert_with_session(self, session, questionnaire_response):

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -8,7 +8,10 @@ from rdr_service.code_constants import PPI_SYSTEM, RACE_WHITE_CODE, PMI_SKIP_COD
 from rdr_service.concepts import Concept
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
+from rdr_service.model.code import Code
 from rdr_service.model.hpo import HPO
+from rdr_service.model.questionnaire import QuestionnaireQuestion
+from rdr_service.model.questionnaire_response import QuestionnaireResponseAnswer
 from rdr_service.participant_enums import (
     OrganizationType,
     SuspensionStatus,
@@ -524,6 +527,16 @@ class ParticipantApiTest(BaseTestCase):
 
         participant_summary = self.send_get("Participant/%s/Summary" % participant_id)
         self.assertNotIn("streetAddress2", participant_summary)
+
+        # Make sure the street address 2 answer is set inactive too
+        street_address_2_active_answer = self.session.query(QuestionnaireResponseAnswer)\
+                                             .join(QuestionnaireQuestion)\
+                                             .join(Code, Code.codeId == QuestionnaireQuestion.codeId)\
+                                             .filter(Code.value == 'PIIAddress_StreetAddress2',
+                                                     QuestionnaireResponseAnswer.endTime.is_(None))\
+                                             .one_or_none()
+        self.assertIsNone(street_address_2_active_answer)
+
 
     def test_street_address_two_clears_on_skip(self):
         participant_id, questionnaire_id = self._setup_initial_participant_data()


### PR DESCRIPTION
We're clearing line 2 of the street address when receiving an updated line 1. But the previous response for street address line 2 remains active. Previous questionnaire responses are deactivated when a new response to the same question is received. This sets the code up to deactivate previous responses for line 2 of the street address if we receive a response for line 1 or 2.

The solution I went with is to load the line 2 question if we're loading the line 1 question too. That way, later on in the code when it's loading current answers, the current answer for line 2 is loaded as well and gets an end date set on it.