### PR TITLE
[DA-1591] Fail cron jobs when alerting on exceptions

### DIFF
--- a/rdr_service/cron_sandbox.yaml
+++ b/rdr_service/cron_sandbox.yaml
@@ -4,11 +4,6 @@ cron:
 - description: Monthly reconciliation report
 - description: Participant count metrics (Do not manually start)
 - description: Flag ghost participants
-- description: Daily Biobank sample import and order reconciliation
-  url: /offline/BiobankSamplesImport
-  schedule: every day 03:00
-  timezone: America/New_York
-  target: offline
 - description: Rotate service account keys older than 3 days
   url: /offline/DeleteOldKeys
   schedule: every day 01:00

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -172,7 +172,7 @@ def _open_latest_samples_file(cloud_bucket_name):
     blob_name = _find_latest_samples_csv(cloud_bucket_name)
     file_name = os.path.basename(blob_name)
     path = os.path.normpath(cloud_bucket_name + '/' + blob_name)
-    logging.info("Opening latest samples CSV in %r: %r.", cloud_bucket_name, file_name)
+    logging.info(f'Opening latest samples CSV in {cloud_bucket_name}: {file_name}')
     return path, file_name
 
 

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -269,6 +269,15 @@ class BiobankSamplesPipelineTest(BaseTestCase):
             with self.assertRaises(biobank_samples_pipeline.DataError):
                 biobank_samples_pipeline._upsert_samples_from_csv(reader)
 
+    def test_wrong_csv_delimiter(self):
+        self.clear_default_storage()
+        self.create_mock_buckets(self.mock_bucket_paths)
+        # Use a valid file containing commas as separators
+        with open(test_data.data_path("biobank_samples_wrong_delimiter.csv")) as samples_file:
+            reader = csv.DictReader(samples_file, delimiter="\t")
+            with self.assertRaises(biobank_samples_pipeline.DataError):
+                biobank_samples_pipeline._upsert_samples_from_csv(reader)
+
     def test_get_reconciliation_report_paths(self):
         self.clear_default_storage()
         self.create_mock_buckets(self.mock_bucket_paths)

--- a/tests/test-data/biobank_samples_wrong_delimiter.csv
+++ b/tests/test-data/biobank_samples_wrong_delimiter.csv
@@ -1,0 +1,2 @@
+Sample Family Id","Sample Id","Sample Storage Status","Sample Type","Parent Expected Volume","Sample Quantity","Sample Container Type","Sample Family Collection Date","Sample Disposal Status","Sample Disposed Date","Parent Sample Id","Sample Confirmed Date","External Participant Id","Test Code","Sample Treatment","Sample Family Create Date","Sent Order Id"
+"SF161129-000713","16334002110","In Circulation","Whole Blood","10 mL","10 mL","Vacutainer Tube, 10m","2020/05/22 08:00:00","","","","2020/05/26 09:14:35","{biobank_id","{test}","EDTA","2020/05/26 08:42:36","KIT-1"


### PR DESCRIPTION
Ticket pertains to BiobankSamplesImport cron job failure but changes impact any offline resources with @_alert_on_exceptions decorator when raising DataError

* Update _alert_on_exceptions wrapper function to raise exceptions and trigger HTTP 500 response

* Fix logging message still using Python2 syntax

* Add biobank sample import unit test (and test-data file) for CSV files using incorrect delimiter.

* Remove redundant cron job from cron_sandbox.yaml (exists in cron_default.yaml)

[Sample logs](https://console.cloud.google.com/logs/viewer?expandAll=false&project=all-of-us-rdr-sandbox&minLogLevel=0&timestamp=2020-06-11T14%3A23%3A21.377000000Z&customFacets&limitCustomFacetWidth=true&advancedFilter=resource.type%3D%22gae_app%22%0Aresource.labels.version_id%3D%22pb-da-1591-8%22%0Aresource.labels.project_id%3D%22all-of-us-rdr-sandbox%22%0Aresource.labels.zone%3D%22local-machine%22%0Aresource.labels.module_id%3D%22app-offline%22%0Atimestamp%3D%222020-06-11T12%3A50%3A03.738390207Z%22%0AinsertId%3D%22RJNIFkjLeKztwlgK%22&dateRangeStart=2020-06-11T08%3A23%3A21.628Z&dateRangeEnd=2020-06-11T14%3A23%3A21.628Z&interval=PT6H&scrollTimestamp=2020-06-11T12%3A50%3A03.738390207Z) from sandbox showing the new cron job fail status.  

There is some redundancy in logging the error/DataError exception message first and then triggering the traceback logging from the re-raise, but the logging.error() entry is more readable
