### PR TITLE
[ROC-527] Creating tool for pulling cope survey result counts

### DIFF
--- a/rdr_service/tools/tool_libs/cope_answers.py
+++ b/rdr_service/tools/tool_libs/cope_answers.py
@@ -1,0 +1,134 @@
+#! /bin/env python
+#
+# Find COPE survey response counts and breakdowns for each question
+#
+
+import argparse
+import json
+import logging
+import random
+import sys
+
+from rdr_service.dao import database_factory
+from rdr_service.services.gcp_utils import gcp_format_sql_instance, gcp_make_auth_header
+from rdr_service.services.system_utils import make_api_request, setup_logging, setup_i18n
+from rdr_service.tools.tool_libs import GCPProcessContext
+
+_logger = logging.getLogger("rdr_logger")
+
+# Tool_cmd and tool_desc name are required.
+# Remember to add/update bash completion in 'tool_lib/tools.bash'
+tool_cmd = "cope-answers"
+tool_desc = "create a json text file that gives total answer counts for "
+
+ANSWER_COUNT_SQL = """
+    SELECT qc.value question_code, ac.value answer_code, COUNT(DISTINCT qr.participant_id) answer_count
+    FROM questionnaire_response_answer qra
+    INNER JOIN questionnaire_response qr ON qr.questionnaire_response_id = qra.questionnaire_response_id
+    INNER JOIN questionnaire_question qq ON qq.questionnaire_question_id = qra.question_id
+    INNER JOIN code qc ON qc.code_id = qq.code_id
+    INNER JOIN code ac ON ac.code_id = qra.value_code_id
+    INNER JOIN questionnaire_history qh ON qh.questionnaire_id = qr.questionnaire_id
+        AND qh.version = qr.questionnaire_version
+    WHERE qc.value IN ('msds_11', 'msds_12', 'copect_40_xx15', 'cdc_covid_19_18', 'phq_9_4',
+                      'ipaq_1', 'ipaq_3', 'ipaq_5', 'ipaq_7', 'ucla_ls8_9')
+        AND qra.end_time IS NULL
+        AND qh.last_modified > :cope_month
+    GROUP BY qc.value, ac.value;
+"""
+
+
+class CopeAnswersClass(object):
+    def __init__(self, args, gcp_env):
+        self.args = args
+        self.gcp_env = gcp_env
+
+    def _setup_database_connection(self):
+        _logger.info("retrieving db configuration...")
+        headers = gcp_make_auth_header()
+        resp_code, resp_data = make_api_request(
+            "{0}.appspot.com".format(self.gcp_env.project), "/rdr/v1/Config/db_config", headers=headers
+        )
+        if resp_code != 200:
+            _logger.error(resp_data)
+            _logger.error("failed to retrieve config, aborting.")
+            return 1
+
+        passwd = resp_data["rdr_db_password"]
+        if not passwd:
+            _logger.error("failed to retrieve database user password from config.")
+            return 1
+
+        # connect a sql proxy to the current project
+        _logger.info("starting google sql proxy...")
+        port = random.randint(10000, 65535)
+        instances = gcp_format_sql_instance(self.gcp_env.project, port=port)
+        proxy_pid = self.gcp_env.activate_sql_proxy(instance=instances, port=port)
+        if not proxy_pid:
+            _logger.error("activating google sql proxy failed.")
+            return 1
+
+    @staticmethod
+    def _new_answer_tracker():
+        return {
+            'total_answers': 0
+        }
+
+    @staticmethod
+    def _new_question_tracker():
+        return {
+            'total_answers': 0,
+            'answers': {}
+        }
+
+    def run(self):
+        self._setup_database_connection()
+        question_totals = {}
+        with database_factory.make_server_cursor_database().session() as session:
+            answer_counts = session.execute(ANSWER_COUNT_SQL, params={'cope_month': self.args.cope_month})
+            for count in answer_counts:
+                # Get the running totals for the question and answer
+                # if they don't exist already we'll create them, but they'll need to be saved in the dictionary later
+                question_data = question_totals.get(count.question_code, self._new_question_tracker())
+                answer_data = question_data['answers'].get(count.answer_code, self._new_answer_tracker())
+
+                question_data['total_answers'] += count.answer_count
+                answer_data['total_answers'] += count.answer_count
+
+                # Set the data back on the dictionaries so that we store newly created trackers
+                question_data['answers'][count.answer_code] = answer_data
+                question_totals[count.question_code] = question_data
+
+        output_file_name = 'results.json'
+        with open(output_file_name, 'w') as file:
+            file.write(json.dumps(question_totals, indent=4))
+
+        print('SUCCESS: output written to', output_file_name)
+        return 0
+
+
+def run():
+    # Set global debug value and setup application logging.
+    setup_logging(
+        _logger, tool_cmd, "--debug" in sys.argv, "{0}.log".format(tool_cmd) if "--log-file" in sys.argv else None
+    )
+    setup_i18n()
+
+    # Setup program arguments.
+    parser = argparse.ArgumentParser(prog=tool_cmd, description=tool_desc)
+    parser.add_argument("--project", help="gcp project name", default="localhost")  # noqa
+    parser.add_argument("--account", help="pmi-ops account", default=None)  # noqa
+    parser.add_argument("--service-account", help="gcp iam service account", default=None)  # noqa
+    parser.add_argument('--cope-month', required=True, help='month of the cope survey (ex. "2020-06" for June COPE)')
+
+    args = parser.parse_args()
+
+    with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
+        process = CopeAnswersClass(args, gcp_env)
+        exit_code = process.run()
+        return exit_code
+
+
+# --- Main Program Call ---
+if __name__ == "__main__":
+    sys.exit(run())

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -352,14 +352,12 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         return questionnaire
 
     def _questionnaire(self, **kwargs):
-        if 'version' not in kwargs:
-            kwargs['version'] = 1
-        if 'created' not in kwargs:
-            kwargs['created'] = datetime.now()
-        if 'lastModified' not in kwargs:
-            kwargs['lastModified'] = datetime.now()
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'test'
+        for field, default in [('version', 1),
+                               ('created', datetime.now()),
+                               ('lastModified', datetime.now()),
+                               ('resource', 'test')]:
+            if field not in kwargs:
+                kwargs[field] = default
 
         return Questionnaire(**kwargs)
 
@@ -369,14 +367,13 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         return questionnaire_history
 
     def _questionnaire_history(self, **kwargs):
-        if 'version' not in kwargs:
-            kwargs['version'] = 1
-        if 'created' not in kwargs:
-            kwargs['created'] = datetime.now()
-        if 'lastModified' not in kwargs:
-            kwargs['lastModified'] = datetime.now()
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'test'
+        for field, default in [('version', 1),
+                               ('created', datetime.now()),
+                               ('lastModified', datetime.now()),
+                               ('resource', 'test')]:
+            if field not in kwargs:
+                kwargs[field] = default
+
         if 'questionnaireId' not in kwargs:
             questionnaire = self.create_database_questionnaire()
             kwargs['questionnaireId'] = questionnaire.questionnaireId

--- a/tests/tool_tests/test_cope_answers.py
+++ b/tests/tool_tests/test_cope_answers.py
@@ -1,0 +1,139 @@
+from collections import namedtuple
+from datetime import datetime
+import json
+import mock
+import os
+from pathlib import Path
+import tempfile
+
+from rdr_service.tools.tool_libs.cope_answers import CopeAnswersClass
+from tests.helpers.unittest_base import BaseTestCase
+
+FakeFile = namedtuple('FakeFile', ['name', 'updated'])
+
+
+class CopeAnswerTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        # June COPE survey
+        self.questionnaire_history = self.create_database_questionnaire_history(
+            lastModified=datetime.strptime('2020-06-04', '%Y-%m-%d')
+        )
+
+        self.questions = {}
+        for code in ['ipaq_1', 'ipaq_3', 'ipaq_5', 'ipaq_7']:
+            question_code = self.create_database_code(value=code)
+            self.questions[code] = self.create_database_questionnaire_question(codeId=question_code.codeId)
+
+        self.answer_codes = {}
+        for code in ['a1', 'a2', 'a3']:
+            self.answer_codes[code] = self.create_database_code(value=code)
+
+    def create_response(self, questionnaire_history, answers):
+        participant = self.create_database_participant()
+
+        questionnaire_response = self.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            questionnaireId=questionnaire_history.questionnaireId,
+            questionnaireVersion=questionnaire_history.version,
+        )
+
+        for answer in answers:
+            self.create_database_questionnaire_response_answer(
+                questionnaireResponseId=questionnaire_response.questionnaireResponseId,
+                questionId=self.questions[answer['question']].questionnaireQuestionId,
+                valueCodeId=self.answer_codes[answer['answer']].codeId
+            )
+
+    @staticmethod
+    def setup_local_file_creation(mock_gcp_cp):
+        # Actually create the files locally so the zipping code will have something to work with
+        def create_local_file(source, destination, **_):
+            if destination.startswith(tempfile.gettempdir()):
+                Path(os.path.join(destination, Path(source).name)).touch()
+        mock_gcp_cp.side_effect = create_local_file
+
+    @staticmethod
+    def run_tool(cope_month='2020-06'):
+        environment = mock.MagicMock()
+        environment.project = 'unit_test'
+
+        args = mock.MagicMock(spec=['cope_month'])
+        args.cope_month = cope_month
+
+        # Patching things to keep tool from trying to call GAE and to provide test data
+        with mock.patch('rdr_service.tools.tool_libs.cope_answers.make_api_request',
+                        return_value=(200, {'rdr_db_password': 'test'})),\
+                mock.patch('rdr_service.tools.tool_libs.cope_answers.open') as mock_open:
+
+            cope_answer_tool = CopeAnswersClass(args, environment)
+            cope_answer_tool.run()
+
+            # Return data written to file as JSON
+            mock_file_write = mock_open.return_value.__enter__.return_value.write
+            if mock_file_write.mock_calls:  # make sure we don't fail if there weren't supposed to be calls
+                file_data = mock_file_write.mock_calls[0].args[0]
+                result = json.loads(file_data)
+                return result
+
+    def test_answer_counts(self):
+        self.create_response(self.questionnaire_history, [
+            {'question': 'ipaq_1', 'answer': 'a1'},
+            {'question': 'ipaq_3', 'answer': 'a1'},
+            {'question': 'ipaq_5', 'answer': 'a2'},
+            {'question': 'ipaq_7', 'answer': 'a2'}
+        ])
+        self.create_response(self.questionnaire_history, [
+            {'question': 'ipaq_1', 'answer': 'a1'},
+            {'question': 'ipaq_3', 'answer': 'a2'},
+            {'question': 'ipaq_5', 'answer': 'a2'},
+            {'question': 'ipaq_7', 'answer': 'a2'}
+        ])
+        self.create_response(self.questionnaire_history, [
+            {'question': 'ipaq_1', 'answer': 'a1'},
+            {'question': 'ipaq_3', 'answer': 'a3'},
+            {'question': 'ipaq_7', 'answer': 'a1'}
+        ])
+        result = self.run_tool()
+        self.assertEqual({
+            'ipaq_1': {'total_answers': 3,
+                       'answers': {'a1': {'total_answers': 3}}},
+            'ipaq_3': {'total_answers': 3,
+                       'answers': {'a1': {'total_answers': 1},
+                                   'a2': {'total_answers': 1},
+                                   'a3': {'total_answers': 1}}},
+            'ipaq_5': {'total_answers': 2,
+                       'answers': {'a2': {'total_answers': 2}}},
+            'ipaq_7': {'total_answers': 3,
+                       'answers': {'a1': {'total_answers': 1},
+                                   'a2': {'total_answers': 2}}}
+        }, result)
+
+    def test_count_from_specified_month(self):
+        may_questionnaire_history = self.create_database_questionnaire_history(
+            lastModified=datetime.strptime('2020-05-18', '%Y-%m-%d')
+        )
+        self.create_response(self.questionnaire_history, [
+            {'question': 'ipaq_1', 'answer': 'a1'},
+            {'question': 'ipaq_3', 'answer': 'a1'}
+        ])
+        self.create_response(self.questionnaire_history, [
+            {'question': 'ipaq_1', 'answer': 'a1'},
+            {'question': 'ipaq_3', 'answer': 'a2'},
+        ])
+
+        # Create May response that should not be counted for June results
+        self.create_response(may_questionnaire_history, [
+            {'question': 'ipaq_1', 'answer': 'a1'},
+            {'question': 'ipaq_3', 'answer': 'a3'}
+        ])
+
+        result = self.run_tool()
+        self.assertEqual({
+            'ipaq_1': {'total_answers': 2,
+                       'answers': {'a1': {'total_answers': 2}}},
+            'ipaq_3': {'total_answers': 2,
+                       'answers': {'a1': {'total_answers': 1},
+                                   'a2': {'total_answers': 1}}}
+        }, result)

--- a/tests/tool_tests/test_cope_answers.py
+++ b/tests/tool_tests/test_cope_answers.py
@@ -52,9 +52,7 @@ class CopeAnswerTest(BaseTestCase):
         args.cope_month = cope_month
 
         # Patching things to keep tool from trying to call GAE and to get result data
-        with mock.patch('rdr_service.tools.tool_libs.cope_answers.make_api_request',
-                        return_value=(200, {'rdr_db_password': 'test'})),\
-                mock.patch('rdr_service.tools.tool_libs.cope_answers.open') as mock_open:
+        with mock.patch('rdr_service.tools.tool_libs.cope_answers.open') as mock_open:
 
             cope_answer_tool = CopeAnswersClass(args, environment)
             cope_answer_tool.run()


### PR DESCRIPTION
CE is asking for answer counts for a specific set of question codes. They'd like to see the total number of answers for each of the questions and the counts for each option on that question. There's an example on the ticket of the type of output they'd like to see that could clarify what they're looking for.

I didn't follow their output very closely, but I've emailed Kyle the results of the tool and he's happy with the output structure.

We'll need to use this at the end of the month to pull the June COPE survey data, and likely again at the end of July for that month's survey.