### PR TITLE
[DA-1593] Enable selected Genomic pipeline jobs on PROD

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -1,9 +1,5 @@
 cron:
 - description: Genomic new participant workflow (Cohort 3) from Biobank Samples
-- description: Genomic GC Manifest Workflow
-- description: Genomic Data Manifest Workflow (ingestion and reconciliation of data)
-- description: Genomic GEM A1 and A2 Workflow
-- description: Genomic GEM A3 (Delete Report) Manifest Workflow
 - description: Sync site bucket consent files
   url: /offline/SyncConsentFiles
   schedule: 1 of month 00:00


### PR DESCRIPTION
This removes the Genomics pipeline job override definitions in cron_prod.yaml to enable the default definitions found in [cron_default.yaml](https://github.com/all-of-us/raw-data-repository/blob/devel/rdr_service/cron_default.yaml)

The Genomic New Participant workflow job is intended to remain disabled
