### PR TITLE
Biobank Support: Updating biobank specimen migration endpoint response

### DIFF
--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -621,7 +621,10 @@ class BiobankOrderApiTest(BaseTestCase):
 
         result = self.send_put(f"Biobank/specimens", request_data=specimens)
         self.assertJsonResponseMatches(result, {
-            'summary': 'Added 2 of 2 specimen'
+            'summary': {
+                'total_received': 2,
+                'success_count': 2
+            }
         })
 
     def test_update_multiple_specimen(self):
@@ -629,7 +632,10 @@ class BiobankOrderApiTest(BaseTestCase):
         inital_test_code = specimens[0]['testcode']
         result = self.send_put(f"Biobank/specimens", request_data=specimens)
         self.assertJsonResponseMatches(result, {
-            'summary': 'Added 5 of 5 specimen'
+            'summary': {
+                'total_received': 5,
+                'success_count': 5
+            }
         })
 
         third = self.get_specimen_from_dao(rlims_id='three')
@@ -656,11 +662,21 @@ class BiobankOrderApiTest(BaseTestCase):
 
         result = self.send_put(f"Biobank/specimens", request_data=specimens)
         self.assertJsonResponseMatches(result, {
-            'summary': 'Added 1 of 4 specimen',
+            'summary': {
+                'total_received': 4,
+                'success_count': 1
+            },
             'errors': [
-                '[sabrina] Missing fields: orderID, testcode',
-                '[specimen #2] Missing fields: rlimsID, orderID',
-                '[salem] Missing fields: testcode'
+                {
+                    'rlimsID': 'sabrina',
+                    'error': 'Missing fields: orderID, testcode'
+                }, {
+                    'rlimsID': '',
+                    'error': 'Missing fields: rlimsID, orderID',
+                }, {
+                    'rlimsID': 'salem',
+                    'error': 'Missing fields: testcode'
+                }
             ]
         })
 


### PR DESCRIPTION
Lary and I talked a bit in the biobank channel and decided to make the migration endpoint's response a little easier to parse and work with. This essentially takes the summary and error strings and converts them to JSON objects. I've also added logging for the endpoint so we can see error details for individual specimen and help track down problems a little quicker.