### PR TITLE
[DA-1623] Creating date range intersection utility class

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -334,3 +334,94 @@ def datetime_as_naive_utc(value):
 def is_care_evo_and_not_prod():
     return GAE_PROJECT != "all-of-us-rdr-prod" and get_account_origin_id() == "careevolution"
 
+
+class DateRange:
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+
+class DateCollection:
+    def __init__(self):
+        self.ranges = []
+        self.latest_active_range = None
+
+    def add_stop(self, date_time):
+        if self.latest_active_range:
+            self.latest_active_range.end = date_time
+            self.latest_active_range = None
+
+    def add_start(self, date_time):
+        active_range = DateRange(date_time, None)
+        self.latest_active_range = active_range
+        self.ranges.append(active_range)
+
+    def _add_range(self, date_range):
+        self.ranges.append(date_range)
+
+    def get_intersection(self, other_collection):
+        # Ranges are in order for each of the lists
+        # Each range represents an active range, so find the date ranges where both are active
+        intersection = DateCollection()
+
+        if self.ranges and other_collection.ranges:
+            self_ranges = iter(self.ranges)
+            other_ranges = iter(other_collection.ranges)
+
+            active_self = next(self_ranges, None)
+            active_other = next(other_ranges, None)
+
+            # Look at self and other, if self starts and ends before other then maybe the next self overlaps other
+            #  if self starts before other and ends after: add other to intersection (the next other might overlap)
+            #  if self starts before and ends within other: add start of other and end of self (next self might overlap)
+            #  if self starts within and ends after: add start of self and end of other (next other might overlap)
+            #  if self starts after and ends after: then move to next other
+            #  if self is entirely within other, then add self and see if next self overlaps
+
+            while active_self is not None and active_other is not None:
+                new_range = None
+                need_next_self = need_next_other = False
+                if active_self.end is None and active_other.end is None:
+                    new_range = DateRange(max(active_self.start, active_other.start), active_other.end)
+                    # Getting the next of either should end the loop since the ranges should be in order
+                    need_next_other = True
+                elif active_self.end is None:
+                    if active_self.start < active_other.end:
+                        new_range = DateRange(max(active_self.start, active_other.start), active_other.end)
+                    need_next_other = True
+                elif active_other.end is None:
+                    if active_other.start < active_self.end:
+                        new_range = DateRange(max(active_self.start, active_other.start), active_self.end)
+                    need_next_self = True
+                elif active_self.end <= active_other.start:
+                    need_next_self = True
+                elif active_other.end <= active_self.start:
+                    need_next_other = True
+                elif active_self.start <= active_other.start and\
+                        active_self.end >= active_other.end:
+                    new_range = DateRange(active_other.start, active_other.end)
+                    need_next_other = True
+                elif active_self.start <= active_other.start:
+                    # Current self range starts before and ends within the other range
+                    new_range = DateRange(active_other.start, active_self.end)
+                    need_next_self = True
+                elif active_self.start >= active_other.start and\
+                        active_self.end >= active_other.end:
+                    # Current self range starts within and ends after the other range
+                    new_range = DateRange(active_self.start, active_other.end)
+                    need_next_other = True
+                else:  # Current self range starts and ends within the other
+                    new_range = DateRange(active_self.start, active_self.end)
+                    need_next_self = True
+
+                if new_range is not None:
+                    intersection._add_range(new_range)
+                if need_next_self:
+                    active_self = next(self_ranges, None)
+                if need_next_other:
+                    active_other = next(other_ranges, None)
+
+        return intersection
+
+    def any(self):
+        return len(self.ranges) > 0

--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -342,6 +342,9 @@ class DateRange:
 
 
 class DateCollection:
+    """
+    Start and stop dates must be added in order for the intersection calculations to work.
+    """
     def __init__(self):
         self.ranges = []
         self.latest_active_range = None

--- a/tests/test_date_app_util.py
+++ b/tests/test_date_app_util.py
@@ -1,0 +1,309 @@
+from datetime import datetime
+
+from rdr_service.app_util import DateCollection
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class DateCollectionTest(BaseTestCase):
+    @staticmethod
+    def _build_simple_intersection(start_of_first, end_of_first, start_of_second, end_of_second):
+        first = DateCollection()
+        first.add_start(start_of_first)
+        if end_of_first is not None:
+            first.add_stop(end_of_first)
+
+        second = DateCollection()
+        second.add_start(start_of_second)
+        if end_of_second is not None:
+            second.add_stop(end_of_second)
+
+        return first.get_intersection(second), start_of_first, end_of_first, start_of_second, end_of_second
+
+    def test_simple_collection(self):
+        # Test first starts before and ends in second
+        intersection, _, end_of_first, start_of_second, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 7, 4),
+                                            start_of_second=datetime(2020, 7, 2),
+                                            end_of_second=datetime(2020, 7, 10))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_second, date_range.start)
+        self.assertEqual(end_of_first, date_range.end)
+
+        # Test second starts before and ends in first
+        intersection, start_of_first, _, _, end_of_second =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2019, 11, 2),
+                                            end_of_second=datetime(2020, 7, 10))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertEqual(end_of_second, date_range.end)
+
+        # Test second starts and ends after first
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2020, 10, 2),
+                                            end_of_second=datetime(2020, 11, 10))
+
+        self.assertFalse(intersection.any())
+
+        # Test first starts and ends after second
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2019, 10, 2),
+                                            end_of_second=datetime(2019, 11, 10))
+
+        self.assertFalse(intersection.any())
+
+        # Test first in second
+        intersection, start_of_first, end_of_first, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2019, 11, 2),
+                                            end_of_second=datetime(2021, 7, 10))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertEqual(end_of_first, date_range.end)
+
+        # Test second in first
+        intersection, _, _, start_of_second, end_of_second =\
+            self._build_simple_intersection(start_of_first=datetime(2018, 6, 24),
+                                            end_of_first=datetime(2024, 8, 4),
+                                            start_of_second=datetime(2019, 11, 2),
+                                            end_of_second=datetime(2021, 7, 10))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_second, date_range.start)
+        self.assertEqual(end_of_second, date_range.end)
+
+        # Test first starts with second and ends first
+        intersection, start_of_first, end_of_first, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2020, 6, 24),
+                                            end_of_second=datetime(2020, 9, 10))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertEqual(end_of_first, date_range.end)
+
+        # Test first starts with second and ends after
+        intersection, start_of_first, _, _, end_of_second =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2020, 6, 24),
+                                            end_of_second=datetime(2020, 7, 10))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertEqual(end_of_second, date_range.end)
+
+        # Test first starts before and ends with second
+        intersection, _, _, start_of_second, end_of_second =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 24),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2020, 7, 24),
+                                            end_of_second=datetime(2020, 8, 4))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_second, date_range.start)
+        self.assertEqual(end_of_second, date_range.end)
+
+        # Test first starts after and ends with second
+        intersection, start_of_first, _, _, end_of_second =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 7, 29),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2020, 7, 24),
+                                            end_of_second=datetime(2020, 8, 4))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertEqual(end_of_second, date_range.end)
+
+        # Test first ends at start of second
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 7, 29),
+                                            end_of_first=datetime(2020, 8, 4),
+                                            start_of_second=datetime(2020, 8, 4),
+                                            end_of_second=datetime(2020, 8, 14))
+
+        self.assertFalse(intersection.any())
+
+        # Test second ends at start of first
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 8, 14),
+                                            end_of_first=datetime(2021, 8, 4),
+                                            start_of_second=datetime(2020, 8, 4),
+                                            end_of_second=datetime(2020, 8, 14))
+
+        self.assertFalse(intersection.any())
+
+    def test_ongoing_ranges(self):
+        # Test first starts in second but doesn't end
+        intersection, start_of_first, _, _, end_of_second =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 7, 29),
+                                            end_of_first=None,
+                                            start_of_second=datetime(2020, 7, 24),
+                                            end_of_second=datetime(2020, 8, 4))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertEqual(end_of_second, date_range.end)
+
+        # Test first starts before second but doesn't end
+        intersection, _, _, start_of_second, end_of_second =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 7, 29),
+                                            end_of_first=None,
+                                            start_of_second=datetime(2020, 8, 24),
+                                            end_of_second=datetime(2020, 8, 4))
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_second, date_range.start)
+        self.assertEqual(end_of_second, date_range.end)
+
+        # Test second starts in first but doesn't end
+        intersection, _, end_of_first, start_of_second, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 6, 29),
+                                            end_of_first=datetime(2020, 8, 24),
+                                            start_of_second=datetime(2020, 7, 24),
+                                            end_of_second=None)
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_second, date_range.start)
+        self.assertEqual(end_of_first, date_range.end)
+
+        # Test second starts before first but doesn't end
+        intersection, start_of_first, end_of_first, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 7, 29),
+                                            end_of_first=datetime(2020, 8, 24),
+                                            start_of_second=datetime(2019, 8, 24),
+                                            end_of_second=None)
+
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertEqual(end_of_first, date_range.end)
+
+        # Test second starts after first and doesn't end
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 7, 29),
+                                            end_of_first=datetime(2020, 8, 24),
+                                            start_of_second=datetime(2020, 9, 24),
+                                            end_of_second=None)
+        self.assertFalse(intersection.any())
+
+        # Test first starts after second and doesn't end
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 7, 29),
+                                            end_of_first=None,
+                                            start_of_second=datetime(2020, 3, 24),
+                                            end_of_second=datetime(2020, 4, 24))
+        self.assertFalse(intersection.any())
+
+        # Test first starts with the end of second and doesn't end
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 4, 24),
+                                            end_of_first=None,
+                                            start_of_second=datetime(2020, 3, 24),
+                                            end_of_second=datetime(2020, 4, 24))
+        self.assertFalse(intersection.any())
+
+        # Test second starts with the end of first and doesn't end
+        intersection, _, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2019, 4, 24),
+                                            end_of_first=datetime(2020, 3, 24),
+                                            start_of_second=datetime(2020, 3, 24),
+                                            end_of_second=None)
+        self.assertFalse(intersection.any())
+
+        # Test second starts first and neither end
+        intersection, start_of_first, _, _, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2020, 4, 24),
+                                            end_of_first=None,
+                                            start_of_second=datetime(2020, 3, 24),
+                                            end_of_second=None)
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_first, date_range.start)
+        self.assertIsNone(date_range.end)
+
+        # Test first starts first and neither end
+        intersection, _, _, start_of_second, _ =\
+            self._build_simple_intersection(start_of_first=datetime(2019, 4, 24),
+                                            end_of_first=None,
+                                            start_of_second=datetime(2020, 3, 24),
+                                            end_of_second=None)
+        self.assertEqual(1, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(start_of_second, date_range.start)
+        self.assertIsNone(date_range.end)
+
+    def test_complex_intersections(self):
+        first = DateCollection()
+        first.add_start(datetime(2020, 3, 1))
+        first.add_stop(datetime(2020, 3, 10))
+        first.add_start(datetime(2020, 3, 25))
+        first.add_stop(datetime(2020, 4, 21))
+        first.add_start(datetime(2020, 4, 22))
+        first.add_stop(datetime(2020, 5, 3))
+        first.add_start(datetime(2020, 6, 22))
+
+        second = DateCollection()
+        second.add_start(datetime(2020, 3, 15))
+        second.add_stop(datetime(2020, 3, 25))
+        second.add_start(datetime(2020, 3, 29))
+        second.add_stop(datetime(2020, 4, 7))
+        second.add_start(datetime(2020, 4, 12))
+        second.add_stop(datetime(2020, 4, 16))
+        second.add_start(datetime(2020, 4, 18))
+        second.add_stop(datetime(2020, 5, 10))
+        second.add_start(datetime(2020, 5, 18))
+        second.add_stop(datetime(2020, 6, 10))
+        second.add_start(datetime(2020, 7, 10))
+        second.add_stop(datetime(2020, 7, 15))
+        second.add_start(datetime(2020, 7, 20))
+
+        # first ranges:
+        #   3/1__3/10       3/25_______________________________4/21  4/22__5/3                6/22______...
+        # second ranges:
+        #             3/15__3/25  3/29__4/7  4/12__4/16  4/18_________________5/10  5/18__6/10    7/10__7/15  7/20___...
+        # expected result:
+        #                         3/29__4/7  4/12__4/16  4/18__4/21  4/22__5/3                    7/10__7/15  7/20___...
+
+        intersection = first.get_intersection(second)
+        self.assertEqual(6, len(intersection.ranges))
+        date_range = intersection.ranges[0]
+        self.assertEqual(datetime(2020, 3, 29), date_range.start)
+        self.assertEqual(datetime(2020, 4, 7), date_range.end)
+        date_range = intersection.ranges[1]
+        self.assertEqual(datetime(2020, 4, 12), date_range.start)
+        self.assertEqual(datetime(2020, 4, 16), date_range.end)
+        date_range = intersection.ranges[2]
+        self.assertEqual(datetime(2020, 4, 18), date_range.start)
+        self.assertEqual(datetime(2020, 4, 21), date_range.end)
+        date_range = intersection.ranges[3]
+        self.assertEqual(datetime(2020, 4, 22), date_range.start)
+        self.assertEqual(datetime(2020, 5, 3), date_range.end)
+        date_range = intersection.ranges[4]
+        self.assertEqual(datetime(2020, 7, 10), date_range.start)
+        self.assertEqual(datetime(2020, 7, 15), date_range.end)
+        date_range = intersection.ranges[5]
+        self.assertEqual(datetime(2020, 7, 20), date_range.start)
+        self.assertIsNone(date_range.end)


### PR DESCRIPTION
These changes are to help with changing how we find enrollment status. BigQuery calculates the participant's enrollment status by looking at the current state of their data. To make sure they stay keep the Core enrollment status if they've ever had it, the BigQuery calculation needs to determine if they've ever had it. This creates a new class to help with that calculation.

The DateCollection class receives start and stop dates in order to set up date ranges that signify when the consents are active. My plan is to track all the date ranges that a particular criteria (ehr consent, consent for study, physical measurements, ...) and get the intersection of them all to find where a participant had everything they needed to be a Core participant.