### PR TITLE
[DA-1632] Add Sample ID to AW2 Manifest

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -202,7 +202,8 @@ class GenomicFileIngester:
                 return validation_result
 
             if self.job_id in [GenomicJob.AW1_MANIFEST, GenomicJob.AW1F_MANIFEST]:
-                return self._ingest_gc_manifest(data_to_ingest)
+                gc_site_id = self._get_site_from_aw1()
+                return self._ingest_gc_manifest(data_to_ingest, gc_site_id)
 
             if self.job_id == GenomicJob.METRICS_INGESTION:
                 return self._process_gc_metrics_data_for_insert(data_to_ingest)
@@ -232,10 +233,11 @@ class GenomicFileIngester:
         except RuntimeError:
             return GenomicSubProcessResult.ERROR
 
-    def _ingest_gc_manifest(self, data):
+    def _ingest_gc_manifest(self, data, _site):
         """
         Updates the GenomicSetMember with GC Manifest data
         :param data:
+        :param _site: gc_site ID
         :return: result code
         """
         gc_manifest_column_mappings = {
@@ -269,6 +271,9 @@ class GenomicFileIngester:
                 collection_tube_id = row_copy['collectiontubeid']
                 genome_type = row_copy['testname']
                 member = self.member_dao.get_member_from_collection_tube(collection_tube_id, genome_type)
+
+                member.gcSiteId = _site
+
                 if member is None:
                     logging.warning(f'Invalid collection tube ID: {collection_tube_id}'
                                     f' or genome_type: {genome_type}')
@@ -406,6 +411,13 @@ class GenomicFileIngester:
 
         except (RuntimeError, KeyError):
             return GenomicSubProcessResult.ERROR
+
+    def _get_site_from_aw1(self):
+        """
+        Returns the Genomic Center's site ID from the AW1 filename
+        :return: GC site ID string
+        """
+        return self.file_obj.fileName.split('/')[-1].split("_")[0].lower()
 
 
 class GenomicFileValidator:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -367,7 +367,7 @@ class GenomicFileIngester:
                                  for key in row],
                                 row.values()))
             row_copy['file_id'] = self.file_obj.id
-            sample_id = row_copy['biobankidsampleid'].split('_')[-1]
+            sample_id = row_copy['sampleid']
             genome_type = self.file_validator.genome_type
             member = self.member_dao.get_member_from_sample_id(int(sample_id), genome_type)
             if member is not None:
@@ -439,6 +439,7 @@ class GenomicFileValidator:
         self.GC_METRICS_SCHEMAS = {
             'seq': (
                 "biobankid",
+                "sampleid",
                 "biobankidsampleid",
                 "limsid",
                 "meancoverage",
@@ -452,6 +453,7 @@ class GenomicFileValidator:
             ),
             'gen': (
                 "biobankid",
+                "sampleid",
                 "biobankidsampleid",
                 "limsid",
                 "chipwellbarcode",

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1113,6 +1113,7 @@ class GenomicPipelineTest(BaseTestCase):
         for member in self.member_dao.get_all():
             if member.id in [1, 2]:
                 self.assertEqual(1, member.reconcileGCManifestJobRunId)
+                self.assertEqual('rdr', member.gcSiteId)
                 # Package ID represents that BB sample was reconciled to GC Manifest
                 self.assertEqual("PKG-1908-218051", member.packageId)
                 self.assertEqual("SU-0026388097", member.gcManifestBoxStorageUnitId)

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -224,6 +224,7 @@ class GenomicPipelineTest(BaseTestCase):
         # Test Genomic State updated
         member = self.member_dao.get(1)
         self.assertEqual(GenomicWorkflowState.AW2, member.genomicWorkflowState)
+        self.assertEqual('1001', member.sampleId)
 
         # Test successful run result
         run_obj = self.job_run_dao.get(1)

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,3 +1,3 @@
-Biobank ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Consent for RoR,Withdrawn_status,site_id,Notes
-T1,T1_1001,10001,10001_R01C01,0.996,True,0.00654,Pass,,,JH,This sample passed
-T2,T2_1002,10002,10002_R01C02,0.996,True,0.00654,Pass,,,JH,This sample passed
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Consent for RoR,Withdrawn_status,site_id,Notes
+T1,1001,T1_1991,10001,10001_R01C01,0.996,True,0.00654,Pass,,,JH,This sample passed
+T2,1002,T2_1992,10002,10002_R01C02,0.996,True,0.00654,Pass,,,JH,This sample passed

--- a/tests/test-data/RDR_AoU_SEQ_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_SEQ_TestDataManifest.csv
@@ -1,2 +1,2 @@
-Biobank ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,Contamination,Sex Concordance,Sex Ploidy,Aligned Q20 Bases,Processing Status,Notes
-T2,2_1002,10002,2,2,3,True,XY,4,Pass,This sample passed
+Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,Contamination,Sex Concordance,Sex Ploidy,Aligned Q20 Bases,Processing Status,Notes
+T2,1002,2_1992,10002,2,2,3,True,XY,4,Pass,This sample passed


### PR DESCRIPTION
This PR ingests the Sample ID from the AW2 manifest. This field was recently added to the manifest by request from the GCs. Additionally, this PR also writes the GC identifier on the genomic set member based on the AW1 manifest filename. This is required for downstream analytics.