### PR TITLE
[ROC-547] Update cohort assignment calculations

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -127,7 +127,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             return {'email': None, 'is_ghost_id': 0}
         qnan = BQRecord(schema=None, data=qnans)  # use only most recent response.
 
-        consent_dt = parser.parse(qnan.get('authored')).date() if qnan.get('authored') else None
+        consent_dt = parser.parse(qnan.get('authored')) if qnan.get('authored') else None
 
         data = {
             'first_name': qnan.get('PIIName_First'),

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -34,7 +34,7 @@ class BQConsentCohort(Enum):
     COHORT_3 = 3  # New Participants with consent starting from April 21, 2020 04:00:00 UTC (midnight eastern)
 
 COHORT_1_CUTOFF = datetime(2018, 4, 24, 0, 0, 0)
-COHORT_2_CUTOFF = datetime(2020, 4, 21, 0, 4, 0)
+COHORT_2_CUTOFF = datetime(2020, 4, 21, 4, 0, 0)
 
 class BQAddressSchema(BQSchema):
     """

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 from enum import Enum
 
 from rdr_service.model.bq_base import BQTable, BQSchema, BQView, BQField, BQFieldTypeEnum, BQFieldModeEnum, \
@@ -30,11 +30,11 @@ class BQConsentCohort(Enum):
     """
     UNSET = 0
     COHORT_1 = 1  # Beta participants.  Consent before April 24, 2018.
-    COHORT_2 = 2  # National Launch Participants. Consent between April 24, 2018 and April 20, 2020.
-    COHORT_3 = 3  # New Participants with consent starting from April 21, 2020.
+    COHORT_2 = 2  # National Launch Participants. Consent between April 24, 2018 and April 21, 2020 (03:59:59 UTC)
+    COHORT_3 = 3  # New Participants with consent starting from April 21, 2020 04:00:00 UTC (midnight eastern)
 
-COHORT_1_CUTOFF = date(2018, 4, 24)
-COHORT_2_CUTOFF = date(2020, 4, 20)
+COHORT_1_CUTOFF = datetime(2018, 4, 24, 0, 0, 0)
+COHORT_2_CUTOFF = datetime(2020, 4, 21, 0, 4, 0)
 
 class BQAddressSchema(BQSchema):
     """

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -39,15 +39,15 @@ TEST_HPO_ID = 19
 # Test login phone number prefix
 TEST_LOGIN_PHONE_NUMBER_PREFIX = "444"
 PARTICIPANT_COHORT_2_START_TIME = datetime(2018, 4, 24, 0, 0, 0)
-PARTICIPANT_COHORT_3_START_TIME = datetime(2020, 4, 21, 0, 0, 0)
+PARTICIPANT_COHORT_3_START_TIME = datetime(2020, 4, 21, 0, 4, 0)
 
 
 class ParticipantCohort(messages.Enum):
     """ Participant Cohort Group"""
     UNSET = 0
     COHORT_1 = 1  # Beta participants.  Consent before April 24, 2018.
-    COHORT_2 = 2  # National Launch Participants. Consent between April 24, 2018 and April 20, 2020.
-    COHORT_3 = 3  # New Participants with consent starting from April 21, 2020.
+    COHORT_2 = 2  # National Launch Participants. Consent between April 24, 2018 and April 21, 2020 (03:59:59 UTC)
+    COHORT_3 = 3  # New Participants with consent starting from April 21, 2020 04:00:00 UTC  (midnight eastern)
 
 
 # Added for DA-1622, enabling identification of Genomics pilot participants from Cohort 2

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -39,7 +39,7 @@ TEST_HPO_ID = 19
 # Test login phone number prefix
 TEST_LOGIN_PHONE_NUMBER_PREFIX = "444"
 PARTICIPANT_COHORT_2_START_TIME = datetime(2018, 4, 24, 0, 0, 0)
-PARTICIPANT_COHORT_3_START_TIME = datetime(2020, 4, 21, 0, 4, 0)
+PARTICIPANT_COHORT_3_START_TIME = datetime(2020, 4, 21, 4, 0, 0)
 
 
 class ParticipantCohort(messages.Enum):

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -128,7 +128,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             return {'email': None, 'is_ghost_id': 0}
         qnan = BQRecord(schema=None, data=qnans)  # use only most recent response.
 
-        consent_dt = parser.parse(qnan.get('authored')).date() if qnan.get('authored') else None
+        consent_dt = parser.parse(qnan.get('authored')) if qnan.get('authored') else None
         dob = qnan.get('PIIBirthInformation_BirthDate')
 
         data = {


### PR DESCRIPTION

Per HPRO, consent authored checks adjusted so cohort 3 starts at 2020-04-21T04:00:00 UTC (midnight eastern time)
A separate backfill/correction was already performed on RDR production (see ROC-544)

* Update enums / constants to use adjusted datetime value

* Fix BQ references that were using date instead of datetime when extracting consent authored value