### PR TITLE
Updates for consent sync code

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -5,6 +5,11 @@ cron:
   schedule: 1 of month 00:00
   timezone: America/New_York
   target: offline
+- description: Sync VA consent files
+  url: /offline/SyncVaConsentFiles
+  schedule: 1 of month 00:30
+  timezone: America/New_York
+  target: offline
 - description: Update EHR Status from curation data
   url: /offline/UpdateEhrStatus
   schedule: every day 00:00

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -109,18 +109,29 @@ def do_sync_consent_files(zip_files=False, **kwargs):
     """
   entrypoint
   """
+    logging.info('Syncing consent files.')
     org_buckets = get_org_data_map()
     org_ids = [org_id for org_id, org_data in org_buckets.items()]
     start_date = kwargs.get('start_date')
+    all_va = kwargs.get('all_va')
+    if start_date:
+        logging.info(f'syncing consents from {start_date}')
+    if zip_files:
+        logging.info('zipping consent files')
+    if all_va:
+        logging.info('only interacting with VA files')
     file_filter = kwargs.get('file_filter', 'pdf')
     for participant_data in _iter_participants_data(org_ids, **kwargs):
         source_bucket = SOURCE_BUCKET.get(participant_data.origin_id, SOURCE_BUCKET[next(iter(SOURCE_BUCKET))])
         source = "/{source_bucket}/Participant/P{participant_id}/"\
             .format(source_bucket=source_bucket,
                     participant_id=participant_data.participant_id)
-        # if kwargs.get('all_va')
+        if all_va:
+            destination_bucket = 'aou179'
+        else:
+            destination_bucket = org_buckets[participant_data.org_id]
         destination = get_consent_destination(zip_files,
-                                              bucket_name=org_buckets[participant_data.org_id],
+                                              bucket_name=destination_bucket,
                                               org_external_id=participant_data.org_id,
                                               site_name=participant_data.google_group or DEFAULT_GOOGLE_GROUP,
                                               p_id=participant_data.participant_id)
@@ -156,10 +167,6 @@ where participant.is_ghost_id is not true
     or summary.email not like '%@example.com'
   )
 """
-
-# todo: warn on missing consents
-# todo: log when the dates are
-# todo: use authored for consent rather than time
 
 participant_filters_sql = {
     'start_date': """

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -234,6 +234,7 @@ def cloudstorage_copy_objects_task(source, destination, date_limit=None, file_fi
     path = source if source[0:1] != '/' else source[1:]
     bucket_name, _, prefix = path.partition('/')
     prefix = None if prefix == '' else prefix
+    files_found = False
     for source_blob in list_blobs(bucket_name, prefix):
         if not source_blob.name.endswith('/'):  # Exclude folders
             source_file_path = os.path.normpath('/' + bucket_name + '/' + source_blob.name)
@@ -241,8 +242,11 @@ def cloudstorage_copy_objects_task(source, destination, date_limit=None, file_fi
             if (zip_files or _not_previously_copied(source_file_path, destination_file_path)) and\
                     _after_date_limit(source_blob, date_limit) and\
                     _matches_file_filter(source_blob.name, file_filter):
+                files_found = True
                 move_file_function = _download_file if zip_files else copy_cloud_file
                 move_file_function(source_file_path, destination_file_path)
+    if not files_found:
+        logging.warning(f'No files copied from {source}')
 
 
 def _not_previously_copied(source_file_path, destination_file_path):

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -118,6 +118,7 @@ def do_sync_consent_files(zip_files=False, **kwargs):
         source = "/{source_bucket}/Participant/P{participant_id}/"\
             .format(source_bucket=source_bucket,
                     participant_id=participant_data.participant_id)
+        # if kwargs.get('all_va')
         destination = get_consent_destination(zip_files,
                                               bucket_name=org_buckets[participant_data.org_id],
                                               org_external_id=participant_data.org_id,
@@ -155,6 +156,10 @@ where participant.is_ghost_id is not true
     or summary.email not like '%@example.com'
   )
 """
+
+# todo: warn on missing consents
+# todo: log when the dates are
+# todo: use authored for consent rather than time
 
 participant_filters_sql = {
     'start_date': """

--- a/rdr_service/tools/tool_libs/sync_consent.py
+++ b/rdr_service/tools/tool_libs/sync_consent.py
@@ -112,7 +112,7 @@ class SyncConsentClass(object):
                 _logger.info("transferring files to destinations...")
                 count = 0
                 for rec in session.execute(participant_sql, params):
-                    if rec[0] not in filter_pids:
+                    if filter_pids and rec[0] not in filter_pids:
                         continue
                     if not self.args.debug:
                         print_progress_bar(
@@ -158,7 +158,8 @@ class SyncConsentClass(object):
                             date_limit=self.args.date_limit,
                             source_bucket=src_bucket, p_id=p_id)
                         if not files_in_range or len(files_in_range) == 0:
-                            _logger.info(f'No files in bucket updated after {self.args.date_limit}')
+                            # _logger.info(f'No files in bucket updated after {self.args.date_limit}')
+                            pass
                         for f in files_in_range:
                             copy_file(f, destination, p_id, dry_run=self.args.dry_run, zip_files=self.args.zip_files)
                     else:

--- a/rdr_service/tools/tool_libs/sync_consent.py
+++ b/rdr_service/tools/tool_libs/sync_consent.py
@@ -158,8 +158,7 @@ class SyncConsentClass(object):
                             date_limit=self.args.date_limit,
                             source_bucket=src_bucket, p_id=p_id)
                         if not files_in_range or len(files_in_range) == 0:
-                            # _logger.info(f'No files in bucket updated after {self.args.date_limit}')
-                            pass
+                            _logger.info(f'No files in bucket updated after {self.args.date_limit}')
                         for f in files_in_range:
                             copy_file(f, destination, p_id, dry_run=self.args.dry_run, zip_files=self.args.zip_files)
                     else:


### PR DESCRIPTION
- Scheduling VA consent sync cron job
- Setting code up to not need to read VA bucket name from cron job
- Adding log messages for assisting any troubleshooting that may need to happen (reporting on date limits for the SQL and what flags are set)
- Logging warnings if consent files haven't been found for participants
- Not requiring pid file when running tool locally