### PR TITLE
[DA-1646] Add IGNORE state to lookups and Genomic utility tool

### DIFF
--- a/rdr_service/genomic/genomic_biobank_manifest_handler.py
+++ b/rdr_service/genomic/genomic_biobank_manifest_handler.py
@@ -26,7 +26,7 @@ _MAX_INPUT_AGE = datetime.timedelta(hours=24)
 # sample suffix: -v12019-04-05-00-30-10.csv
 _RESULT_CSV_FILE_SUFFIX_LENGTH = 26
 
-BIOBANK_ID_PREFIX = "T"
+BIOBANK_ID_PREFIX = "A" if config.GAE_PROJECT == "all-of-us-rdr-prod" else "T"
 
 
 def process_genomic_manifest_result_file_from_bucket():
@@ -161,7 +161,7 @@ def create_and_upload_genomic_biobank_manifest_file(genomic_set_id, timestamp=No
     """
     query_params = {"genomic_set_id": genomic_set_id,
                     "prefix": BIOBANK_ID_PREFIX,
-                    "aw0_ready_state": int(GenomicWorkflowState.AW0_READY)}
+                    "aw0_ready_state": int(GenomicWorkflowState.AW0_READY),}
     exporter.run_export(result_filename, export_sql, query_params)
 
 

--- a/rdr_service/genomic/genomic_state_handler.py
+++ b/rdr_service/genomic/genomic_state_handler.py
@@ -12,6 +12,15 @@ class GenomicStateBase:
         return
 
 
+class IgnoreState(GenomicStateBase):
+    """
+    Ignore State, used to effectively remove GenomicSetMembers from
+    the genomics system.
+    """
+    def transition_function(self, signal):
+        return GenomicWorkflowState.IGNORE
+
+
 class AW0ReadyState(GenomicStateBase):
     """
     State representing new Genomic Set Members
@@ -159,6 +168,7 @@ class GenomicStateHandler:
     Basic FSM for Genomic States. Returns call to state's transision_function()
     """
     states = {
+        GenomicWorkflowState.IGNORE: IgnoreState(),
         GenomicWorkflowState.AW0_READY: AW0ReadyState(),
         GenomicWorkflowState.AW0: AW0State(),
         GenomicWorkflowState.AW1: AW1State(),

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -7,7 +7,6 @@ import argparse
 
 # pylint: disable=superfluous-parens
 # pylint: disable=broad-except
-import csv
 import datetime
 import logging
 import sys

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -7,6 +7,7 @@ import argparse
 
 # pylint: disable=superfluous-parens
 # pylint: disable=broad-except
+import csv
 import datetime
 import logging
 import sys
@@ -24,7 +25,8 @@ from rdr_service.model.genomics import GenomicSetMember, GenomicSet
 from rdr_service.services.system_utils import setup_logging, setup_i18n
 from rdr_service.storage import GoogleCloudStorageProvider, LocalFilesystemStorageProvider
 from rdr_service.tools.tool_libs import GCPProcessContext, GCPEnvConfigObject
-from rdr_service.participant_enums import GenomicManifestTypes, GenomicSetStatus, GenomicJob, GenomicSubProcessResult
+from rdr_service.participant_enums import GenomicManifestTypes, GenomicSetStatus, GenomicJob, GenomicSubProcessResult, \
+    GenomicWorkflowState
 
 _logger = logging.getLogger("rdr_logger")
 
@@ -317,6 +319,64 @@ class GenerateManifestClass(GenomicManifestBase):
             member_dao.update_member_state(member, new_state)
 
 
+class IgnoreStateClass(object):
+    def __init__(self, args, gcp_env: GCPEnvConfigObject):
+        """
+        :param args: command line arguments.
+        :param gcp_env: gcp environment information, see: gcp_initialize().
+        """
+        # Tool_lib attributes
+        self.args = args
+        self.gcp_env = gcp_env
+        self.dao = None
+
+    def run(self):
+        """
+        Main program process
+        :return: Exit code value
+        """
+        _logger.info("Running ignore tool")
+
+        # Validate Aruguments
+        if self.args.csv is None:
+            _logger.error('Argument --csv must be provided.')
+            return 1
+
+        if not os.path.exists(self.args.csv):
+            _logger.error(f'File {self.args.csv} was not found.')
+            return 1
+
+        # Activate the SQL Proxy
+        self.gcp_env.activate_sql_proxy()
+        self.dao = GenomicSetMemberDao()
+
+        # Update gsm IDs from file
+        with open(self.args.csv, encoding='utf-8-sig') as f:
+            lines = f.readlines()
+            for _member_id in lines:
+                _member = self.dao.get(_member_id)
+
+                if _member is None:
+                    _logger.warning(f"Member id {_member_id.rstrip()} does not exist.")
+                    continue
+
+                self.update_genomic_set_member_state(_member)
+
+        return 0
+
+    def update_genomic_set_member_state(self, member):
+        """
+        Sets the member.genomicWorkflowState = IGNORE for member
+        :param member:
+        :return:
+        """
+        member.genomicWorkflowState = GenomicWorkflowState.IGNORE
+
+        with self.dao.session() as session:
+            _logger.info(f"Updating member id {member.id}")
+            session.merge(member)
+
+
 def run():
     # Set global debug value and setup application logging.
     setup_logging(
@@ -350,6 +410,10 @@ def run():
     new_manifest_parser.add_argument("--manifest", help=new_manifest_help, default=None)  # noqa
     new_manifest_parser.add_argument("--cohort", help="Cohort [1, 2, 3]", default=None)  # noqa
 
+    # Set GenomicWorkflowState to IGNORE for provided member IDs
+    ignore_state_parser = subparser.add_parser("ignore-state")
+    ignore_state_parser.add_argument("--csv", help="csv file with genomic_set_member ids", default=None)  # noqa
+
     args = parser.parse_args()
 
     with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
@@ -360,6 +424,11 @@ def run():
         elif args.util == 'generate-manifest':
             process = GenerateManifestClass(args, gcp_env)
             exit_code = process.run()
+
+        elif args.util == 'ignore-state':
+            process = IgnoreStateClass(args, gcp_env)
+            exit_code = process.run()
+
         else:
             _logger.info('Please select a utility option to run. For help use "genomic --help".')
             exit_code = 1

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -203,7 +203,8 @@ class GenomicPipelineTest(BaseTestCase):
                                              folder=config.GENOMIC_AW2_SUBFOLDERS[1])
 
         self._create_fake_datasets_for_gc_tests(2, arr_override=True,
-                                                array_participants=(1, 2))
+                                                array_participants=(1, 2),
+                                                genomic_workflow_state=GenomicWorkflowState.AW1)
 
         self._update_test_sample_ids()
 
@@ -322,7 +323,7 @@ class GenomicPipelineTest(BaseTestCase):
 
     def test_aw2_wgs_gc_metrics_ingestion(self):
         # Create the fake ingested data
-        self._create_fake_datasets_for_gc_tests(2)
+        self._create_fake_datasets_for_gc_tests(2, genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         self._create_ingestion_test_file('RDR_AoU_SEQ_TestDataManifest.csv',
                                          bucket_name,
@@ -554,7 +555,8 @@ class GenomicPipelineTest(BaseTestCase):
 
     def test_gc_metrics_reconciliation_vs_manifest(self):
         # Create the fake Google Cloud CSV files to ingest
-        self._create_fake_datasets_for_gc_tests(1, arr_override=True, array_participants=[1])
+        self._create_fake_datasets_for_gc_tests(1, arr_override=True, array_participants=[1],
+                                                genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest.csv',
                                          bucket_name,
@@ -585,7 +587,8 @@ class GenomicPipelineTest(BaseTestCase):
         mock_alert_handler.make_genomic_alert.return_value = 1
 
         # Create the fake ingested data
-        self._create_fake_datasets_for_gc_tests(2, arr_override=True, array_participants=[1,2])
+        self._create_fake_datasets_for_gc_tests(2, arr_override=True, array_participants=[1,2],
+                                                genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest.csv',
                                          bucket_name,
@@ -657,7 +660,7 @@ class GenomicPipelineTest(BaseTestCase):
         mock_alert_handler.make_genomic_alert.return_value = 1
 
         # Create the fake ingested data
-        self._create_fake_datasets_for_gc_tests(2)
+        self._create_fake_datasets_for_gc_tests(2, genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         self._create_ingestion_test_file('RDR_AoU_SEQ_TestDataManifest.csv',
                                          bucket_name,
@@ -1201,9 +1204,11 @@ class GenomicPipelineTest(BaseTestCase):
                                               startTime=clock.CLOCK.now(),
                                               runStatus=GenomicSubProcessStatus.COMPLETED,
                                               runResult=GenomicSubProcessResult.SUCCESS))
+
         self._create_fake_datasets_for_gc_tests(3, arr_override=True,
                                                 array_participants=range(1, 4),
-                                                recon_gc_man_id=1)
+                                                recon_gc_man_id=1,
+                                                genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest.csv',
                                          bucket_name,
@@ -1317,7 +1322,8 @@ class GenomicPipelineTest(BaseTestCase):
         # Create genomic set members
         self._create_fake_datasets_for_gc_tests(3, arr_override=True,
                                                 array_participants=range(1, 4),
-                                                gem_a1_run_id=1)
+                                                gem_a1_run_id=1,
+                                                genomic_workflow_state=GenomicWorkflowState.A1)
 
         self._update_test_sample_ids()
 
@@ -1413,7 +1419,9 @@ class GenomicPipelineTest(BaseTestCase):
                                               runStatus=GenomicSubProcessStatus.COMPLETED,
                                               runResult=GenomicSubProcessResult.SUCCESS))
 
-        self._create_fake_datasets_for_gc_tests(3, arr_override=False, recon_gc_man_id=1)
+        self._create_fake_datasets_for_gc_tests(3, arr_override=False,
+                                                recon_gc_man_id=1,
+                                                genomic_workflow_state=GenomicWorkflowState.AW1)
 
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         self._create_ingestion_test_file('RDR_AoU_SEQ_TestDataManifest.csv', bucket_name,


### PR DESCRIPTION
This PR implements a new genomic IGNORE state. The queries were updated to exclude `genomic_set_member` records that have the IGNORE state. Unit tests were updated. Other states were added to unit tests since the state was added to the lookup queries. The genomic utility tool was also updated to allow for setting the state to IGNORE for specified `genomic_set_member` records.
 