### PR TITLE
[DA-1628] Finding files by name for samples import

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -85,8 +85,8 @@ EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT = "ehr_status_bigquery_view_participant"
 EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION = "ehr_status_bigquery_view_organization"
 HPO_REPORT_CONFIG_MIXIN_PATH = "hpo_report_config_mixin_path"
 LOCALHOST_DEFAULT_BUCKET_NAME = 'local_bucket'
-BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN = 'biobank_samples_inventory_file_pattern'
-BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN = 'biobank_samples_inventory_manifest_file_pattern'
+BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN = 'biobank_samples_daily_inventory_file_pattern'
+BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN = 'biobank_samples_monthly_inventory_file_pattern'
 
 # Questionnaire Codes
 DNA_PROGRAM_CONSENT_UPDATE_CODE = 'dna_program_consent_update_code'

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -85,6 +85,8 @@ EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT = "ehr_status_bigquery_view_participant"
 EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION = "ehr_status_bigquery_view_organization"
 HPO_REPORT_CONFIG_MIXIN_PATH = "hpo_report_config_mixin_path"
 LOCALHOST_DEFAULT_BUCKET_NAME = 'local_bucket'
+BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN = 'biobank_samples_inventory_file_pattern'
+BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN = 'biobank_samples_inventory_manifest_file_pattern'
 
 # Questionnaire Codes
 DNA_PROGRAM_CONSENT_UPDATE_CODE = 'dna_program_consent_update_code'

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -15,7 +15,8 @@ from rdr_service import clock, config
 from rdr_service.api_util import list_blobs, open_cloud_file
 from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.code_constants import PPI_SYSTEM, RACE_AIAN_CODE, RACE_QUESTION_CODE
-from rdr_service.config import BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN
+from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN,\
+    BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.database_utils import parse_datetime, replace_isodate
@@ -185,9 +186,9 @@ def _find_latest_samples_csv(cloud_bucket_name, monthly=False):
     RuntimeError: if no CSVs are found in the cloud storage bucket.
   """
     if monthly:
-        file_name_pattern = config.getSettingJson(BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN)
+        file_name_pattern = config.getSettingJson(BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN)
     else:
-        file_name_pattern = config.getSettingJson(BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN)
+        file_name_pattern = config.getSettingJson(BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN)
 
     bucket_stat_list = list_blobs(cloud_bucket_name)
     if not bucket_stat_list:

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -13,7 +13,6 @@ import pytz
 
 from rdr_service import clock, config
 from rdr_service.api_util import list_blobs, open_cloud_file
-from rdr_service.services.gcp_logging import flush_request_logs
 from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.code_constants import PPI_SYSTEM, RACE_AIAN_CODE, RACE_QUESTION_CODE
 from rdr_service.config import BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -118,6 +118,8 @@ def biobank_daily_reconciliation_report():
     # TODO: setup to only run after import_biobank_samples completion instead of 1hr after start.
     timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info()[2]
     logging.info("Generating reconciliation report.")
+    sample_file_path, sample_file, timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info(monthly=False)
+    logging.info(f"Generating reconciliation report from {sample_file_path}, {sample_file}")
     # iterate new list and write reports
     biobank_samples_pipeline.write_reconciliation_report(timestamp)
     logging.info("Generated reconciliation report.")
@@ -127,9 +129,8 @@ def biobank_daily_reconciliation_report():
 @_alert_on_exceptions
 def biobank_monthly_reconciliation_report():
     # make sure this cron job is executed after import_biobank_samples
-    timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info(monthly=True)[2]
-
-    logging.info("Generating monthly reconciliation report.")
+    sample_file_path, sample_file, timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info(monthly=True)
+    logging.info(f"Generating reconciliation report from {sample_file_path}, {sample_file}")
     # iterate new list and write reports
     biobank_samples_pipeline.write_reconciliation_report(timestamp, "monthly")
     logging.info("Generated monthly reconciliation report.")

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -116,8 +116,6 @@ def import_biobank_samples():
 #@_alert_on_exceptions
 def biobank_daily_reconciliation_report():
     # TODO: setup to only run after import_biobank_samples completion instead of 1hr after start.
-    timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info()[2]
-    logging.info("Generating reconciliation report.")
     sample_file_path, sample_file, timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info(monthly=False)
     logging.info(f"Generating reconciliation report from {sample_file_path}, {sample_file}")
     # iterate new list and write reports

--- a/rdr_service/services/gcp_logging.py
+++ b/rdr_service/services/gcp_logging.py
@@ -105,6 +105,10 @@ def setup_log_line(record: logging.LogRecord, resource=None, method=None):
     if isinstance(message, dict):
         message = json.dumps(message)
 
+    # At this point the message is expected to be a string
+    if not isinstance(message, str):
+        message = str(message)
+
     # Look for embedded traceback source location override information
     if '%%' in message:
         tmp_sl = message[message.find('%%'):message.rfind('%%')+2]

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -11,7 +11,8 @@ import pytz
 from rdr_service import clock, config
 from rdr_service.api_util import open_cloud_file
 from rdr_service.code_constants import BIOBANK_TESTS, PPI_SYSTEM, RACE_QUESTION_CODE, RACE_AIAN_CODE
-from rdr_service.config import BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN
+from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN,\
+    BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.participant_dao import ParticipantDao
@@ -43,8 +44,8 @@ class BiobankSamplesPipelineTest(BaseTestCase):
         self.participant_dao = ParticipantDao()
         self.summary_dao = ParticipantSummaryDao()
 
-        config.override_setting(BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, 'Sample Inventory Report v1')
-        config.override_setting(BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN, 'Sample Inventory Report 60d')
+        config.override_setting(BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN, 'Sample Inventory Report v1')
+        config.override_setting(BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN, 'Sample Inventory Report 60d')
 
     mock_bucket_paths = [_FAKE_BUCKET, _FAKE_BUCKET + os.sep + biobank_samples_pipeline._REPORT_SUBDIR]
 
@@ -120,7 +121,7 @@ class BiobankSamplesPipelineTest(BaseTestCase):
         self.assertEqual(ps.sampleStatus1SAL2Time, confirmed_ts)
 
     def test_end_to_end(self):
-        config.override_setting(BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, 'cloud')
+        config.override_setting(BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN, 'cloud')
 
         self.clear_default_storage()
         self.create_mock_buckets(self.mock_bucket_paths)

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -5,7 +5,6 @@ import io
 from datetime import datetime, timedelta
 import mock
 import random
-import time
 import os
 import pytz
 

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -43,6 +43,9 @@ class BiobankSamplesPipelineTest(BaseTestCase):
         self.participant_dao = ParticipantDao()
         self.summary_dao = ParticipantSummaryDao()
 
+        config.override_setting(BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, 'Sample Inventory Report v1')
+        config.override_setting(BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN, 'Sample Inventory Report 60d')
+
     mock_bucket_paths = [_FAKE_BUCKET, _FAKE_BUCKET + os.sep + biobank_samples_pipeline._REPORT_SUBDIR]
 
     def _write_cloud_csv(self, file_name, contents_str):
@@ -117,6 +120,8 @@ class BiobankSamplesPipelineTest(BaseTestCase):
         self.assertEqual(ps.sampleStatus1SAL2Time, confirmed_ts)
 
     def test_end_to_end(self):
+        config.override_setting(BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, 'cloud')
+
         self.clear_default_storage()
         self.create_mock_buckets(self.mock_bucket_paths)
         dao = BiobankStoredSampleDao()
@@ -198,8 +203,6 @@ class BiobankSamplesPipelineTest(BaseTestCase):
 
     @mock.patch('rdr_service.offline.biobank_samples_pipeline.list_blobs')
     def test_find_latest_csv(self, mock_list_blobs):
-        config.override_setting(BIOBANK_SAMPLES_INVENTORY_FILE_PATTERN, 'Sample Inventory Report v1')
-
         mock_list_blobs.return_value = [
             FakeBlob(name='Sample Inventory Report v12020-06-01.csv',  # older file
                      updated=datetime(2020, 6, 1)),
@@ -220,8 +223,6 @@ class BiobankSamplesPipelineTest(BaseTestCase):
 
     @mock.patch('rdr_service.offline.biobank_samples_pipeline.list_blobs')
     def test_find_latest_csv(self, mock_list_blobs):
-        config.override_setting(BIOBANK_SAMPLES_INVENTORY_MANIFEST_FILE_PATTERN, 'Sample Inventory Report 60d')
-
         mock_list_blobs.return_value = [
             FakeBlob(name='60_day_manifests/Sample Inventory Report 60d2020-06-01-04-00-21.csv',  # older file
                      updated=datetime(2020, 6, 1)),


### PR DESCRIPTION
The samples import and reconciliation report cron jobs attempt to find the latest samples inventory CSV by looking at a set of files in the bucket and then trying to use the newest one. This restricts that set of files down to ones that match a specific name.

While working on this I found that if we try to log anything that's not a string then we don't get the GAE logs at all. I don't think this was contributing to anything we've seen so far, but I thought adding some extra processing for that in the gcp_logger could help prevent that issue in the future.