### PR TITLE
Optimizing reconciliation report sql

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -666,6 +666,10 @@ _RECONCILIATION_REPORT_SQL = (
         SELECT 0 FROM participant
         WHERE participant.participant_id = dv_order.participant_id
       )
+      AND
+        (
+            (confirmed IS NOT NULL AND confirmed >= :n_days_ago) OR (collected IS NOT NULL AND collected >= :n_days_ago)
+        )
     UNION ALL
     SELECT
       biobank_stored_sample.biobank_id raw_biobank_id,
@@ -727,17 +731,8 @@ _RECONCILIATION_REPORT_SQL = (
                 ELSE TRUE
             END
         )
+    AND reconciled.confirmed IS NOT NULL AND reconciled.confirmed >= :n_days_ago
   ) reconciled
-  WHERE (reconciled.collected IS NOT NULL
-    AND reconciled.confirmed IS NOT NULL
-    AND reconciled.collected >= reconciled.confirmed
-    AND reconciled.collected >= :n_days_ago)
-  OR (reconciled.collected IS NOT NULL
-    AND reconciled.confirmed IS NOT NULL
-    AND reconciled.confirmed >= reconciled.collected
-    AND reconciled.confirmed >= :n_days_ago)
-  OR (reconciled.collected IS NULL AND reconciled.confirmed  IS NOT NULL AND reconciled.confirmed >= :n_days_ago)
-  OR (reconciled.collected IS NOT NULL AND reconciled.confirmed  IS NULL AND reconciled.collected >= :n_days_ago)
   GROUP BY
     biobank_id, sent_order_id, order_test, test
   ORDER BY

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -731,7 +731,7 @@ _RECONCILIATION_REPORT_SQL = (
                 ELSE TRUE
             END
         )
-    AND reconciled.confirmed IS NOT NULL AND reconciled.confirmed >= :n_days_ago
+    AND confirmed IS NOT NULL AND confirmed >= :n_days_ago
   ) reconciled
   GROUP BY
     biobank_id, sent_order_id, order_test, test

--- a/rdr_service/offline/sql_exporter.py
+++ b/rdr_service/offline/sql_exporter.py
@@ -76,8 +76,10 @@ class SqlExporter(object):
         # Each query from AppEngine standard environment must finish in 60 seconds.
         # If we start running into trouble with that, we'll either
         # need to break the SQL up into pages, or (more likely) switch to cloud SQL export.
+        logging.info('Processing export SQL')
         cursor = session.execute(text(sql), params=query_params)
         try:
+            logging.info('Writing data to file')
             fields = list(cursor.keys())
             writer.write_header(fields)
             results = cursor.fetchmany(_BATCH_SIZE)


### PR DESCRIPTION
UNION-ing rows together has a bit of overhead. I got really lucky and found that we can speed this up a bit by narrowing down the biobank data before the UNION ALL. I pulled all the pieces of SQL together and ran the original and this against production. Before this it was running for more than 8 minutes, I stopped it before it could complete. But I think it might be what is taking the most amount of time for creating each of the reports. After moving the date checks to process before the union it runs in a little over a minute.

I've simplified the logic of the checks too. For the second part of the union `confirmed` doesn't exist, so we need only check that collected within the time range. The original logic seems to only be attempting to ensure that `collected` or `confirmed` are within the time range, so I reduced the logic down to that.

I've also added log statements to the SQL exporter so we can verify how long the SQL takes versus other overhead.