### PR TITLE
[DA-1607] DV salivary orders: creating barcode BiobankOrderIdentifier and finalized BiobankOrder

### DIFF
--- a/rdr_service/dao/dv_order_dao.py
+++ b/rdr_service/dao/dv_order_dao.py
@@ -28,6 +28,7 @@ from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderIdentifier
     MayolinkCreateOrderHistory
 from rdr_service.model.config_utils import to_client_biobank_id
 from rdr_service.model.utils import to_client_participant_id
+from rdr_service.offline.biobank_samples_pipeline import _PMI_OPS_SYSTEM
 from rdr_service.participant_enums import BiobankOrderStatus, OrderShipmentStatus, OrderShipmentTrackingStatus
 
 
@@ -285,7 +286,9 @@ class DvOrderDao(UpdatableDao):
         biobank_order_dao.insert_mayolink_create_order_history(mayolink_create_order_history)
 
     def _add_identifiers_and_main_id(self, order, resource):
-        order.identifiers = []
+        order.identifiers = [
+            BiobankOrderIdentifier(system=_PMI_OPS_SYSTEM, value=resource.barcode)
+        ]
         client_id = app_util.lookup_user_info(resource.auth_user).get('clientId')
         for i in resource.identifier:
             try:

--- a/rdr_service/dao/dv_order_dao.py
+++ b/rdr_service/dao/dv_order_dao.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 import pytz
@@ -260,7 +259,7 @@ class DvOrderDao(UpdatableDao):
         obj = BiobankOrder()
         obj.participantId = int(pid)
         obj.created = clock.CLOCK.now()
-        obj.created = datetime.datetime.now()
+        obj.finalizedTime = obj.created
         obj.orderStatus = BiobankOrderStatus.UNSET
         obj.biobankOrderId = resource["biobankOrderId"]
         obj.orderOrigin = resource.get("orderOrigin")

--- a/tests/api_tests/test_dv_order_api.py
+++ b/tests/api_tests/test_dv_order_api.py
@@ -19,6 +19,7 @@ from rdr_service.model.biobank_order import (
 )
 from rdr_service.model.code import Code, CodeType
 from rdr_service.model.participant import Participant
+from rdr_service.offline.biobank_samples_pipeline import _PMI_OPS_SYSTEM
 from tests.test_data import load_test_data_json
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -131,9 +132,9 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
             self.assertEqual(i.biobankTrackingId, "PAT-123-456")
 
         with self.dv_order_dao.session() as session:
-            # there should be two identifier records in the BiobankOrderIdentifier table
+            # there should be three identifier records in the BiobankOrderIdentifier table
             identifiers = session.query(BiobankOrderIdentifier).all()
-            self.assertEqual(2, len(identifiers))
+            self.assertEqual(3, len(identifiers))
             # there should be one ordered sample in the BiobankOrderedSample table
             samples = session.query(BiobankOrderedSample).all()
             self.assertEqual(1, len(samples))
@@ -199,6 +200,9 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
                     for identifier in identifiers:
                         if identifier.system.endswith('/trackingId'):
                             self.assertEqual(identifier.system, expected_system_identifier[1] + "/trackingId")
+                        elif identifier.system == _PMI_OPS_SYSTEM:
+                            # Skip identifier that is created for each dv salivary order regardless of user
+                            continue
                         else:
                             self.assertEqual(identifier.system, expected_system_identifier[1])
                         session.delete(identifier)


### PR DESCRIPTION
The ticket mentions saliva pilot instead of all saliva dv orders, but based on some tickets I've been digging through the terms seem to be interchangeable.

These changes work with BiobankOrders created when we receive DV orders. Since the RDR is creating biobank orders internally at the same time they're sent to MayoLink this sets the finalized time for the orders. And (per the ticket) this also creates a BiobankOrderIdentifier for the order that has the MayoLink barcode as a value and pmi-ops as the system.