### PR TITLE
[DA-1664] Adding tool for finalizing biobank orders

### DIFF
--- a/rdr_service/tools/tool_libs/finalize_orders.py
+++ b/rdr_service/tools/tool_libs/finalize_orders.py
@@ -1,0 +1,133 @@
+#! /bin/env python
+#
+# Finalize un-finalized biobank orders with an input file that gives finalized times
+#
+
+import argparse
+import csv
+import logging
+import sys
+
+from rdr_service.dao import database_factory
+from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderHistory, BiobankOrderedSampleHistory
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.utils import from_client_participant_id
+from rdr_service.participant_enums import OrderStatus
+from rdr_service.services.system_utils import setup_logging, setup_i18n
+from rdr_service.tools.tool_libs import GCPProcessContext
+
+_logger = logging.getLogger("rdr_logger")
+
+# Tool_cmd and tool_desc name are required.
+# Remember to add/update bash completion in 'tool_lib/tools.bash'
+tool_cmd = "finalize-orders"
+tool_desc = "Finalize un-finalized biobank orders with an input file that gives finalized times."
+
+
+class FinalizeOrdersClass(object):
+    def __init__(self, args, gcp_env):
+        self.args = args
+        self.gcp_env = gcp_env
+
+    @staticmethod
+    def load_biobank_order(session, participant_id, mayolink_id):
+        has_error = False
+
+        biobank_order = session.query(BiobankOrder).filter(
+            BiobankOrder.biobankOrderId == mayolink_id
+        ).one_or_none()
+        if biobank_order is not None and biobank_order.participantId != participant_id:
+            print('Validation Error: Participant id mis-matched on biobank order')
+            has_error = True
+
+        return biobank_order, has_error
+
+    @staticmethod
+    def finalize_biobank_order(session, biobank_order: BiobankOrder, finalized_datetime):
+        biobank_order.finalizedTime = finalized_datetime
+
+        biobank_order_history = session.query(BiobankOrderHistory).filter(
+            BiobankOrderHistory.biobankOrderId == biobank_order.biobankOrderId,
+            BiobankOrderHistory.version == biobank_order.version
+        ).one()  # I'm expecting each order to be backed by a history object
+        biobank_order_history.finalizedTime = finalized_datetime
+
+    @staticmethod
+    def finalize_biobank_ordered_samples(session, biobank_order: BiobankOrder,
+                                         participant_summary: ParticipantSummary, finalized_datetime):
+        for sample in biobank_order.samples:
+            sample.finalized = finalized_datetime
+
+            ordered_sample_history = session.query(BiobankOrderedSampleHistory).filter(
+                BiobankOrderedSampleHistory.biobankOrderId == biobank_order.biobankOrderId,
+                BiobankOrderedSampleHistory.test == sample.test
+            ).order_by(BiobankOrderedSampleHistory.version.desc()).first()
+            ordered_sample_history.finalized = finalized_datetime
+
+            order_status_field = 'sampleOrderStatus' + sample.test
+            if hasattr(participant_summary, order_status_field):
+                setattr(participant_summary, order_status_field, OrderStatus.FINALIZED)
+                setattr(participant_summary, order_status_field + 'Time', finalized_datetime)
+
+    def run(self):
+        proxy_pid = self.gcp_env.activate_sql_proxy()
+        if not proxy_pid:
+            _logger.error("activating google sql proxy failed.")
+            return 1
+
+        with open(self.args.input_file) as csv_file:
+            csv_reader = csv.DictReader(csv_file)
+            with database_factory.make_server_cursor_database().session() as session:
+                for csv_record in csv_reader:
+                    participant_id = from_client_participant_id(csv_record['Participant ID'])
+                    order_mayolink_id = csv_record['MayoLINK ID']
+
+                    biobank_order, has_error = self.load_biobank_order(session, participant_id, order_mayolink_id)
+                    if biobank_order is None:
+                        print('Biobank order not found')
+                        has_error = True
+
+                    participant_summary = session.query(ParticipantSummary).filter(
+                        ParticipantSummary.participantId == participant_id
+                    ).one_or_none()
+                    if participant_summary is None:
+                        print('Participant summary not found')
+                        has_error = True
+
+                    if has_error:
+                        print('record causing the above error:', csv_record)
+                    else:
+                        finalized_datetime = csv_record['Finalized Time (UTC)']
+                        self.finalize_biobank_order(session, biobank_order, finalized_datetime)
+                        self.finalize_biobank_ordered_samples(session, biobank_order, participant_summary,
+                                                              finalized_datetime)
+
+                    session.commit()  # Finish finalizing current order
+
+        return 0
+
+
+def run():
+    # Set global debug value and setup application logging.
+    setup_logging(
+        _logger, tool_cmd, "--debug" in sys.argv, "{0}.log".format(tool_cmd) if "--log-file" in sys.argv else None
+    )
+    setup_i18n()
+
+    # Setup program arguments.
+    parser = argparse.ArgumentParser(prog=tool_cmd, description=tool_desc)
+    parser.add_argument("--project", help="gcp project name", default="localhost")  # noqa
+    parser.add_argument("--account", help="pmi-ops account", default=None)  # noqa
+    parser.add_argument("--service-account", help="gcp iam service account", default=None)  # noqa
+    parser.add_argument('--input-file', required=True, help='File providing Biobank order IDs and finalization times')
+
+    args = parser.parse_args()
+
+    with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
+        process = FinalizeOrdersClass(args, gcp_env)
+        return process.run()
+
+
+# --- Main Program Call ---
+if __name__ == "__main__":
+    sys.exit(run())

--- a/rdr_service/tools/tool_libs/finalize_orders.py
+++ b/rdr_service/tools/tool_libs/finalize_orders.py
@@ -62,7 +62,10 @@ class FinalizeOrdersClass(object):
                 BiobankOrderedSampleHistory.biobankOrderId == biobank_order.biobankOrderId,
                 BiobankOrderedSampleHistory.test == sample.test
             ).order_by(BiobankOrderedSampleHistory.version.desc()).first()
-            ordered_sample_history.finalized = finalized_datetime
+            if ordered_sample_history is None:
+                print('no ordered sample history found for', biobank_order.biobankOrderId)
+            else:
+                ordered_sample_history.finalized = finalized_datetime
 
             order_status_field = 'sampleOrderStatus' + sample.test
             if hasattr(participant_summary, order_status_field):

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderedSample, BiobankOrderIdentifier
+from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderHistory, BiobankOrderedSample,\
+    BiobankOrderedSampleHistory, BiobankOrderIdentifier
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import Code
 from rdr_service.model.log_position import LogPosition
@@ -271,6 +272,11 @@ class DataGenerator:
     def create_database_biobank_order(self, **kwargs):
         biobank_order = self._biobank_order(**kwargs)
         self._commit_to_database(biobank_order)
+
+        order_history = BiobankOrderHistory()
+        order_history.fromdict(biobank_order.asdict(follow=["logPosition"]), allow_pk=True)
+        self._commit_to_database(order_history)
+
         return biobank_order
 
     def _biobank_order(self, log_position=None, **kwargs):
@@ -299,6 +305,12 @@ class DataGenerator:
     def create_database_biobank_ordered_sample(self, **kwargs):
         biobank_ordered_sample = self._biobank_ordered_sample(**kwargs)
         self._commit_to_database(biobank_ordered_sample)
+
+        ordered_sample_history = BiobankOrderedSampleHistory()
+        ordered_sample_history.fromdict(biobank_ordered_sample.asdict(), allow_pk=True)
+        ordered_sample_history.version = 1
+        self._commit_to_database(ordered_sample_history)
+
         return biobank_ordered_sample
 
     def _biobank_ordered_sample(self, **kwargs):

--- a/tests/tool_tests/test_finalize_orders.py
+++ b/tests/tool_tests/test_finalize_orders.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+import mock
+
+from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderHistory, BiobankOrderedSample,\
+    BiobankOrderedSampleHistory
+from rdr_service.participant_enums import OrderStatus
+from rdr_service.tools.tool_libs.finalize_orders import FinalizeOrdersClass
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class FinalizeOrdersTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+    @staticmethod
+    def run_tool(input_data):
+        environment = mock.MagicMock()
+        environment.project = 'unit_test'
+
+        args = mock.MagicMock()
+
+        # Patching to bypass opening file and provide input data
+        with mock.patch('rdr_service.tools.tool_libs.finalize_orders.open'),\
+                mock.patch('rdr_service.tools.tool_libs.finalize_orders.csv') as mock_csv:
+            mock_csv.DictReader.return_value = input_data
+
+            finalize_orders_tool = FinalizeOrdersClass(args, environment)
+            finalize_orders_tool.run()
+
+    def test_order_finalization(self):
+        participant_summary = self.data_generator.create_database_participant_summary()
+        participant_id = participant_summary.participantId
+
+        biobank_order_id = 'WEB1234'
+        self.data_generator.create_database_biobank_order(biobankOrderId=biobank_order_id, participantId=participant_id)
+        self.data_generator.create_database_biobank_ordered_sample(biobankOrderId=biobank_order_id, test='1ED10')
+        self.data_generator.create_database_biobank_ordered_sample(biobankOrderId=biobank_order_id, test='1SAL')
+
+        finalized_time = datetime(2020, 7, 3, 15, 1, 23)
+        self.run_tool([{
+            'Participant ID': f'P{participant_id}',
+            'MayoLINK ID': biobank_order_id,
+            'Finalized Time (UTC)': finalized_time.strftime('%Y-%m-%d %H:%M:%S')
+        }])
+
+        biobank_order = self.session.query(BiobankOrder).filter(BiobankOrder.biobankOrderId == biobank_order_id).one()
+        self.assertEqual(finalized_time, biobank_order.finalizedTime)
+
+        order_history = self.session.query(BiobankOrderHistory).filter(
+            BiobankOrder.biobankOrderId == biobank_order_id
+        ).one()
+        self.assertEqual(finalized_time, order_history.finalizedTime)
+
+        ordered_samples = self.session.query(BiobankOrderedSample).filter(
+            BiobankOrderedSample.biobankOrderId == biobank_order_id
+        ).all()
+        for ordered_sample in ordered_samples:
+            self.assertEqual(finalized_time, ordered_sample.finalized)
+
+        ordered_samples_history = self.session.query(BiobankOrderedSampleHistory).filter(
+            BiobankOrderedSample.biobankOrderId == biobank_order_id
+        ).all()
+        for ordered_sample_history in ordered_samples_history:
+            self.assertEqual(finalized_time, ordered_sample_history.finalized)
+
+        self.session.refresh(participant_summary)  # Reload data for the object we held onto
+        self.assertEqual(OrderStatus.FINALIZED, participant_summary.sampleOrderStatus1ED10)
+        self.assertEqual(finalized_time, participant_summary.sampleOrderStatus1ED10Time)
+        self.assertEqual(OrderStatus.FINALIZED, participant_summary.sampleOrderStatus1SAL)
+        self.assertEqual(finalized_time, participant_summary.sampleOrderStatus1SALTime)


### PR DESCRIPTION
A bunch of biobank orders exist in the RDR database that are not finalized, but have stored samples at the Biobank. A spreadsheet was provided by HPRO to give us the finalized times for the orders (link in ticket DA-1664).

This PR adds a tool for setting up the finalized data. There shouldn't be a need to run it again in the future, but the SQL would have been complicated (particularly around participant_summary) and it seemed like a good thing to have just in case. It gets finalized times set everywhere I believe they need to be: biobank orders, order history, ordered samples, ordered samples history, and participant summary's ordered status and ordered status time. I'm hoping to run it before the BigQuery rebuild to not have to rebuild participants as part of this as well.