### PR TITLE
[DA-1654] Adding PrimaryConsentUpdate to BigQuery and ResourceAPI

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -39,7 +39,8 @@ _consent_expired_question_map = {
     'ConsentPII': None,
     'DVEHRSharing': None,
     'EHRConsentPII': 'EHRConsentPII_ConsentExpired',
-    'GROR': None
+    'GROR': None,
+    'PrimaryConsentUpdate': None
 }
 
 class BQParticipantSummaryGenerator(BigQueryGenerator):

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -30,7 +30,8 @@ _consent_module_question_map = {
     'ConsentPII': None,
     'DVEHRSharing': 'DVEHRSharing_AreYouInterested',
     'EHRConsentPII': 'EHRConsentPII_ConsentPermission',
-    'GROR': 'ResultsConsent_CheckDNA'
+    'GROR': 'ResultsConsent_CheckDNA',
+    'PrimaryConsentUpdate': 'Reconsent_ReviewConsentAgree'
 }
 
 # _consent_expired_question_map must contain every module ID from _consent_module_question_map.

--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -7,7 +7,7 @@ from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_questionnaires import BQPDRTheBasics, BQPDRConsentPII, BQPDRLifestyle, \
     BQPDROverallHealth, BQPDRDVEHRSharing, BQPDREHRConsentPII, BQPDRFamilyHistory, \
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRReConsentPII
+    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRConsentUpdate
 
 
 class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
@@ -39,7 +39,7 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
             'HealthcareAccess': BQPDRHealthcareAccess,
             'PersonalMedicalHistory': BQPDRPersonalMedicalHistory,
             'COPE': BQPDRCOPEMay,
-            'ReConsentPII': BQPDRReConsentPII
+            'PrimaryConsentUpdate': BQPDRConsentUpdate
         }
         table = table_map.get(module_id, None)
         if table is None:

--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -7,7 +7,7 @@ from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_questionnaires import BQPDRTheBasics, BQPDRConsentPII, BQPDRLifestyle, \
     BQPDROverallHealth, BQPDRDVEHRSharing, BQPDREHRConsentPII, BQPDRFamilyHistory, \
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay
+    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRReConsentPII
 
 
 class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
@@ -28,27 +28,21 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
         if not self.ro_dao:
             self.ro_dao = BigQuerySyncDao(backup=True)
 
-        if module_id == 'TheBasics':
-            table = BQPDRTheBasics
-        elif module_id == 'ConsentPII':
-            table = BQPDRConsentPII
-        elif module_id == 'Lifestyle':
-            table = BQPDRLifestyle
-        elif module_id == 'OverallHealth':
-            table = BQPDROverallHealth
-        elif module_id == 'DVEHRSharing':
-            table = BQPDRDVEHRSharing
-        elif module_id == 'EHRConsentPII':
-            table = BQPDREHRConsentPII
-        elif module_id == 'FamilyHistory':
-            table = BQPDRFamilyHistory
-        elif module_id == 'HealthcareAccess':
-            table = BQPDRHealthcareAccess
-        elif module_id == 'PersonalMedicalHistory':
-            table = BQPDRPersonalMedicalHistory
-        elif module_id == 'COPE':
-            table = BQPDRCOPEMay
-        else:
+        table_map = {
+            'TheBasics': BQPDRTheBasics,
+            'ConsentPII': BQPDRConsentPII,
+            'Lifestyle': BQPDRLifestyle,
+            'OverallHealth': BQPDROverallHealth,
+            'DVEHRSharing': BQPDRDVEHRSharing,
+            'EHRConsentPII': BQPDREHRConsentPII,
+            'FamilyHistory': BQPDRFamilyHistory,
+            'HealthcareAccess': BQPDRHealthcareAccess,
+            'PersonalMedicalHistory': BQPDRPersonalMedicalHistory,
+            'COPE': BQPDRCOPEMay,
+            'ReConsentPII': BQPDRReConsentPII
+        }
+        table = table_map.get(module_id, None)
+        if table is None:
             logging.info('Generator: ignoring questionnaire module id [{0}].'.format(module_id))
             return None, list()
 

--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -7,7 +7,7 @@ from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_questionnaires import BQPDRTheBasics, BQPDRConsentPII, BQPDRLifestyle, \
     BQPDROverallHealth, BQPDRDVEHRSharing, BQPDREHRConsentPII, BQPDRFamilyHistory, \
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRConsentUpdate
+    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay
 
 
 class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
@@ -38,8 +38,7 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
             'FamilyHistory': BQPDRFamilyHistory,
             'HealthcareAccess': BQPDRHealthcareAccess,
             'PersonalMedicalHistory': BQPDRPersonalMedicalHistory,
-            'COPE': BQPDRCOPEMay,
-            'PrimaryConsentUpdate': BQPDRConsentUpdate
+            'COPE': BQPDRCOPEMay
         }
         table = table_map.get(module_id, None)
         if table is None:

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -196,6 +196,32 @@ class BQPDRConsentPIIView(BQView):
 
 
 #
+# ReConsentPII
+#
+class BQPDRReConsentPIISchema(_BQModuleSchema):
+    """ ConsentPII Module """
+    _module = 'ReConsentPII'
+
+
+class BQPDRReConsentPII(BQTable):
+    """ PDR ReConsentPII BigQuery Table """
+    __tablename__ = 'pdr_mod_reconsentpii'
+    __schema__ = BQPDRReConsentPIISchema
+    __project_map__ = [
+        ('all-of-us-rdr-prod', ('aou-pdr-data-prod', 'rdr_ops_data_view')),
+    ]
+
+
+class BQPDRReConsentPIIView(BQView):
+    """ PDR ReConsentPII BigQuery View """
+    __viewname__ = 'v_pdr_mod_reconsentpii'
+    __viewdescr__ = 'PDR ReConsentPII Module View'
+    __table__ = BQPDRReConsentPII
+    __pk_id__ = 'participant_id'
+    _show_created = True
+
+
+#
 # TheBasics
 #
 class BQPDRTheBasicsSchema(_BQModuleSchema):

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -196,32 +196,6 @@ class BQPDRConsentPIIView(BQView):
 
 
 #
-# PrimaryConsentUpdate
-#
-class BQPDRConsentUpdateSchema(_BQModuleSchema):
-    """ Consent Update Module """
-    _module = 'PrimaryConsentUpdate'
-
-
-class BQPDRConsentUpdate(BQTable):
-    """ PDR Consent Update BigQuery Table """
-    __tablename__ = 'pdr_mod_consentupdate'
-    __schema__ = BQPDRConsentUpdateSchema
-    __project_map__ = [
-        ('all-of-us-rdr-prod', ('aou-pdr-data-prod', 'rdr_ops_data_view')),
-    ]
-
-
-class BQPDRConsentUpdatePIIView(BQView):
-    """ PDR Consent Update BigQuery View """
-    __viewname__ = 'v_pdr_mod_consentupdate'
-    __viewdescr__ = 'PDR PrimaryConsentUpdate Module View'
-    __table__ = BQPDRConsentUpdate
-    __pk_id__ = 'participant_id'
-    _show_created = True
-
-
-#
 # TheBasics
 #
 class BQPDRTheBasicsSchema(_BQModuleSchema):

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -196,27 +196,27 @@ class BQPDRConsentPIIView(BQView):
 
 
 #
-# ReConsentPII
+# PrimaryConsentUpdate
 #
-class BQPDRReConsentPIISchema(_BQModuleSchema):
-    """ ConsentPII Module """
-    _module = 'ReConsentPII'
+class BQPDRConsentUpdateSchema(_BQModuleSchema):
+    """ Consent Update Module """
+    _module = 'PrimaryConsentUpdate'
 
 
-class BQPDRReConsentPII(BQTable):
-    """ PDR ReConsentPII BigQuery Table """
-    __tablename__ = 'pdr_mod_reconsentpii'
-    __schema__ = BQPDRReConsentPIISchema
+class BQPDRConsentUpdate(BQTable):
+    """ PDR Consent Update BigQuery Table """
+    __tablename__ = 'pdr_mod_consentupdate'
+    __schema__ = BQPDRConsentUpdateSchema
     __project_map__ = [
         ('all-of-us-rdr-prod', ('aou-pdr-data-prod', 'rdr_ops_data_view')),
     ]
 
 
-class BQPDRReConsentPIIView(BQView):
-    """ PDR ReConsentPII BigQuery View """
-    __viewname__ = 'v_pdr_mod_reconsentpii'
-    __viewdescr__ = 'PDR ReConsentPII Module View'
-    __table__ = BQPDRReConsentPII
+class BQPDRConsentUpdatePIIView(BQView):
+    """ PDR Consent Update BigQuery View """
+    __viewname__ = 'v_pdr_mod_consentupdate'
+    __viewdescr__ = 'PDR PrimaryConsentUpdate Module View'
+    __table__ = BQPDRConsentUpdate
     __pk_id__ = 'participant_id'
     _show_created = True
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -31,7 +31,8 @@ _consent_module_question_map = {
     'ConsentPII': None,
     'DVEHRSharing': 'DVEHRSharing_AreYouInterested',
     'EHRConsentPII': 'EHRConsentPII_ConsentPermission',
-    'GROR': 'ResultsConsent_CheckDNA'
+    'GROR': 'ResultsConsent_CheckDNA',
+    'PrimaryConsentUpdate': 'Reconsent_ReviewConsentAgree'
 }
 
 # _consent_expired_question_map must contain every module ID from _consent_module_question_map.

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -10,7 +10,7 @@ from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGener
 from rdr_service.dao.bq_pdr_participant_summary_dao import BQPDRParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRReConsentPII
+    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRConsentUpdate
 from rdr_service.resource.generators import ParticipantSummaryGenerator
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
 
@@ -53,7 +53,7 @@ def batch_rebuild_participants_task(payload):
             BQPDREHRConsentPII,
             BQPDRDVEHRSharing,
             BQPDRCOPEMay,
-            BQPDRReConsentPII
+            BQPDRConsentUpdate
         )
         for module in modules:
             mod = module()

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -10,7 +10,7 @@ from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGener
 from rdr_service.dao.bq_pdr_participant_summary_dao import BQPDRParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRConsentUpdate
+    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay
 from rdr_service.resource.generators import ParticipantSummaryGenerator
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
 
@@ -52,8 +52,7 @@ def batch_rebuild_participants_task(payload):
             BQPDROverallHealth,
             BQPDREHRConsentPII,
             BQPDRDVEHRSharing,
-            BQPDRCOPEMay,
-            BQPDRConsentUpdate
+            BQPDRCOPEMay
         )
         for module in modules:
             mod = module()

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -10,7 +10,7 @@ from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGener
 from rdr_service.dao.bq_pdr_participant_summary_dao import BQPDRParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay
+    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRReConsentPII
 from rdr_service.resource.generators import ParticipantSummaryGenerator
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
 
@@ -53,6 +53,7 @@ def batch_rebuild_participants_task(payload):
             BQPDREHRConsentPII,
             BQPDRDVEHRSharing,
             BQPDRCOPEMay,
+            BQPDRReConsentPII
         )
         for module in modules:
             mod = module()


### PR DESCRIPTION
Cohort 1 will be will be responding to an updated consent with a questionnaire that has the module code of PrimaryConsentUpdate. These are the changes that are needed for getting having PDR pick up the changes for the new questionnaire responses. Per discussion on the ticket we will only be passing the reconsent answer through to PDR and not the entire module response.