### PR TITLE
[DA-1654] Updating primary consent authored time when receiving Yes for reconsent

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -35,6 +35,7 @@ DVEHR_SHARING_QUESTION_CODE = "DVEHRSharing_AreYouInterested"
 CABOR_SIGNATURE_QUESTION_CODE = "ExtraConsent_CABoRSignature"
 GROR_CONSENT_QUESTION_CODE = "ResultsConsent_CheckDNA"
 COPE_CONSENT_QUESTION_CODE = "section_participation"
+PRIMARY_CONSENT_UPDATE_QUESTION_CODE = "Reconsent_ReviewConsentAgree"
 
 DATE_OF_BIRTH_QUESTION_CODE = "PIIBirthInformation_BirthDate"
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -39,7 +39,9 @@ from rdr_service.code_constants import (
     COPE_CONSENT_QUESTION_CODE,
     STREET_ADDRESS_QUESTION_CODE,
     STREET_ADDRESS2_QUESTION_CODE,
-    EHR_CONSENT_EXPIRED_YES)
+    EHR_CONSENT_EXPIRED_YES,
+    PRIMARY_CONSENT_UPDATE_QUESTION_CODE,
+    COHORT_1_REVIEW_CONSENT_YES_CODE)
 from rdr_service.config_api import is_config_admin
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.code_dao import CodeDao
@@ -377,6 +379,10 @@ class QuestionnaireResponseDao(BaseDao):
 
                             # COPE Survey changes need to update number of modules complete in summary
                             module_changed = True
+                    elif code.value == PRIMARY_CONSENT_UPDATE_QUESTION_CODE:
+                        answer_value = code_dao.get(answer.valueCodeId).value
+                        if answer_value == COHORT_1_REVIEW_CONSENT_YES_CODE:
+                            participant_summary.consentForStudyEnrollmentAuthored = authored
 
         # If the answer for line 2 of the street address was left out then it needs to be clear on summary.
         # So when it hasn't been submitted and there is something set for streetAddress2 we want to clear it out.

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderHistory, BiobankOrderedSample,\
     BiobankOrderedSampleHistory, BiobankOrderIdentifier
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
@@ -260,7 +261,7 @@ class DataGenerator:
         return code
 
     def _code(self, **kwargs):
-        for field, default in [('system', 'test'),
+        for field, default in [('system', PPI_SYSTEM),
                                ('codeType', 1),
                                ('mapped', False),
                                ('created', datetime.now())]:


### PR DESCRIPTION
When we receive a YES response for the reconsent, we need to store the authored time in the `consentForStudyEnrollmentAuthored` field.