### PR TITLE
[ROC-576] Allowing for questionnaire response without the 'group' field

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -549,15 +549,16 @@ class QuestionnaireResponseDao(BaseDao):
             resource=json.dumps(resource_json),
         )
 
-        # Extract a code map and answers from the questionnaire response.
-        code_map, answers = self._extract_codes_and_answers(fhir_qr.group, questionnaire)
-        if not answers:
-            logging.error("No answers from QuestionnaireResponse JSON. This is harmless but probably an error.")
-        # Get or insert codes, and retrieve their database IDs.
-        code_id_map = CodeDao().get_or_add_codes(code_map, add_codes_if_missing=_add_codes_if_missing(client_id))
+        if fhir_qr.group is not None:
+            # Extract a code map and answers from the questionnaire response.
+            code_map, answers = self._extract_codes_and_answers(fhir_qr.group, questionnaire)
+            if not answers:
+                logging.error("No answers from QuestionnaireResponse JSON. This is harmless but probably an error.")
+            # Get or insert codes, and retrieve their database IDs.
+            code_id_map = CodeDao().get_or_add_codes(code_map, add_codes_if_missing=_add_codes_if_missing(client_id))
 
-        # Now add the child answers, using the IDs in code_id_map
-        self._add_answers(qr, code_id_map, answers)
+            # Now add the child answers, using the IDs in code_id_map
+            self._add_answers(qr, code_id_map, answers)
 
         return qr
 

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -753,6 +753,18 @@ class QuestionnaireResponseApiTest(BaseTestCase):
         resource["questionnaire"]["reference"] = "Questionnaire/%s/_history/2" % questionnaire_id
         self.send_post(_questionnaire_response_url(participant_id), resource, expected_status=http.client.BAD_REQUEST)
 
+    def test_response_allows_for_missing_group(self):
+        participant_id = self.create_participant()
+        self.send_consent(participant_id)
+
+        questionnaire_id = self.create_questionnaire("questionnaire1.json")
+
+        with open(data_path("questionnaire_response_empty.json")) as fd:
+            resource = json.load(fd)
+        resource["subject"]["reference"] = resource["subject"]["reference"].format(participant_id=participant_id)
+        resource["questionnaire"]["reference"] = "Questionnaire/%s" % questionnaire_id
+        self.send_post(_questionnaire_response_url(participant_id), resource)  # will fail if status 200 isn't returned
+
     def test_invalid_questionnaire_linkid(self):
         """
     DA-623 - Make sure that an invalid link id in response triggers a BadRequest status.

--- a/tests/test-data/questionnaire_response_empty.json
+++ b/tests/test-data/questionnaire_response_empty.json
@@ -1,0 +1,14 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "status": "completed",
+  "subject": {
+    "reference": "Patient/{participant_id}"
+  },
+  "questionnaire": {
+    "reference": "Questionnaire/{questionnaire_id}"
+  },
+  "author": {
+    "reference": "http://hl7.org/fhir/Practitioner/example"
+  },
+  "authored": "2013-02-19T14:15:00+10:00"
+}


### PR DESCRIPTION
Summarizing from the ticket: CE would like to be able to send ProgramUpdate questionnaire responses without any `group` field (since there aren't really any answers given by the participants). This fixes the API so it doesn't crash when group is missing.