### PR TITLE
[ROC-574] Keeping core participants as core in the biobank pipeline

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -112,7 +112,7 @@ _ENROLLMENT_STATUS_SQL = """
       enrollment_status = {enrollment_status_case_sql},
       last_modified = :now
     WHERE
-      enrollment_status != {enrollment_status_case_sql}
+      enrollment_status != :full_participant AND enrollment_status != {enrollment_status_case_sql}
    """.format(
     enrollment_status_case_sql=_ENROLLMENT_STATUS_CASE_SQL
 )


### PR DESCRIPTION
Each run of the biobank pipeline was setting enrollment status for participants and not accounting for whether they would be switching from Core status.