### PR TITLE
[ROC-584] Adding participant_origin to biobank daily reconciliation reports

### DIFF
--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -411,5 +411,6 @@ class BiobankSamplesPipelineTest(BaseTestCase):
                 'N',  # is Native American
                 None, None, None,  # notes info: collected, processed, finalized
                 None, None, None, None, None,  # cancelled_restored info: status_flag, name, name, time, reason
-                None  # order origin
+                None,  # order origin
+                'example'  # Participant origin
             )])

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -58,6 +58,7 @@ _CSV_COLUMN_NAMES = (
     "edited_cancelled_restored_site_time",
     "edited_cancelled_restored_site_reason",
     "biobank_order_origin",
+    "participant_origin"
 )
 
 
@@ -836,6 +837,14 @@ class MySqlReconciliationTest(BaseTestCase):
                 "biobank_id": to_client_biobank_id(p_present_salivary.biobankId)
             }
         )
+
+        # Check that the reports have the participant_origin column
+        participant_origin_data = {"participant_origin": "example"}
+        exporter.assertHasRow(received, participant_origin_data)
+        exporter.assertHasRow(missing, participant_origin_data)
+        exporter.assertHasRow(modified, participant_origin_data)
+        exporter.assertHasRow(withdrawals, participant_origin_data)
+        exporter.assertHasRow(missing_salivary, participant_origin_data)
 
     def test_monthly_reconciliation_report(self):
         self.setup_codes([RACE_QUESTION_CODE], CodeType.QUESTION)


### PR DESCRIPTION
This adds participant origin to the five different reconciliation report files. This way Biobank will be able to know which system (Vibrent or CareEvolution) a participant is part of if any issues come up with the samples.