### PR TITLE
[PDR-82] Use on DNA tests and disposed time when calculating enrollme…

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -680,11 +680,40 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
 
         # Calculate the earliest ordered sample and stored sample times.
         ordered_time = stored_time = datetime.datetime.max
+        stored_sample_times = dict(zip(self._dna_sample_test_codes, [
+            {
+                'confirmed': datetime.datetime.min, 'confirmed_count': 0,
+                'disposed': datetime.datetime.min, 'disposed_count': 0
+            } for i in range(0, 5)]))  # pylint: disable=unused-variable
+
         for bbo in summary['biobank_orders']:
+            if not bbo['bbo_samples']:
+                continue
+
             for bboi in bbo['bbo_samples']:
-                if bboi['bbs_baseline_test'] == 1:
+                if bboi['bbs_dna_test'] == 1:
                     ordered_time = min(ordered_time, bboi['bbs_finalized'] or datetime.datetime.max)
-                    stored_time = min(stored_time, bboi['bbs_confirmed'] or datetime.datetime.max)
+                    # See: participant_summary_dao.py:calculate_max_core_sample_time() and
+                    #       _participant_summary_dao.py:126
+                    sst = stored_sample_times[bboi['bbs_test']]
+                    if bboi['bbs_confirmed']:
+                        sst['confirmed'] = max(sst['confirmed'], bboi['bbs_confirmed'])
+                        sst['confirmed_count'] += 1
+                    if bboi['bbs_disposed']:
+                        sst['disposed'] = max(sst['disposed'], bboi['bbs_disposed'])
+                        sst['disposed_count'] += 1
+
+        sstl = list()
+        for k, v in stored_sample_times.items():  # pylint: disable=unused-variable
+            if v['confirmed_count'] != v['disposed_count']:
+                ts = v['confirmed']
+            else:
+                ts = v['disposed']
+            if ts != datetime.datetime.min:
+                sstl.append(ts)
+
+        if sstl:
+            stored_time = min(sstl)
 
         data = {
             'enrollment_core_ordered': ordered_time if ordered_time != datetime.datetime.max else None,


### PR DESCRIPTION
…nt_core_stored (#1873)

* Use on DNA tests and disposed time when calculating enrollment_core_stored

* Redo enrollment core stored timestamp logic

* Rework logic to exactly match SQL logic in PS dao.