### PR TITLE
[DA-1680] Add Sex at Birth to GenomicPII (Color) API

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -5,7 +5,7 @@ from werkzeug.exceptions import NotFound, BadRequest
 
 from rdr_service import clock
 from rdr_service.api.base_api import BaseApi
-from rdr_service.api_util import GEM, RDR_AND_PTC
+from rdr_service.api_util import GEM, RDR_AND_PTC, RDR
 from rdr_service.app_util import auth_required
 from rdr_service.dao.genomics_dao import GenomicPiiDao, GenomicOutreachDao
 
@@ -14,7 +14,7 @@ class GenomicPiiApi(BaseApi):
     def __init__(self):
         super(GenomicPiiApi, self).__init__(GenomicPiiDao())
 
-    @auth_required(GEM)
+    @auth_required([GEM, RDR])
     def get(self, mode=None, p_id=None):
         if mode not in ('GEM', 'RHP'):
             raise BadRequest("GenomicPII Mode required to be \"GEM\" or \"RHP\".")

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -871,6 +871,7 @@ class GenomicPiiDao(BaseDao):
                     "biobank_id": result['data'].biobankId,
                     "first_name": result['data'].firstName,
                     "last_name": result['data'].lastName,
+                    "sex_at_birth": result['data'].sexAtBirth,
                 }
 
             elif result['mode'] == 'RHP':
@@ -879,6 +880,7 @@ class GenomicPiiDao(BaseDao):
                     "first_name": result['data'].firstName,
                     "last_name": result['data'].lastName,
                     "date_of_birth": result['data'].dateOfBirth,
+                    "sex_at_birth": result['data'].sexAtBirth,
                 }
             else:
                 return {"message": "Only GEM and RHP modes supported."}
@@ -898,7 +900,8 @@ class GenomicPiiDao(BaseDao):
                               ParticipantSummary.firstName,
                               ParticipantSummary.lastName,
                               ParticipantSummary.consentForGenomicsROR,
-                              ParticipantSummary.dateOfBirth,)
+                              ParticipantSummary.dateOfBirth,
+                              GenomicSetMember.sexAtBirth,)
                 .join(
                     ParticipantSummary,
                     GenomicSetMember.participantId == ParticipantSummary.participantId,

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -104,6 +104,7 @@ class GenomicApiTestBase(BaseTestCase):
             participantId=participant.participantId,
             gemPass='Y',
             biobankId=participant.biobankId,
+            sexAtBirth='F',
             genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY)
 
         kwargs = dict(valid_kwargs, **override_kwargs)
@@ -121,6 +122,7 @@ class GemApiTest(GenomicApiTestBase):
         self.assertEqual(p1_pii['biobank_id'], '1')
         self.assertEqual(p1_pii['first_name'], 'TestFN')
         self.assertEqual(p1_pii['last_name'], 'TestLN')
+        self.assertEqual(p1_pii['sex_at_birth'], 'F')
 
     def test_get_pii_invalid_pid(self):
         p = self._make_participant()


### PR DESCRIPTION
This PR adds the `sex_at_birth` field to the Genomic PII API response. Additionally, RDR was added as a role to facilitate with E2E testing.