### PR TITLE
[DA-1693] Add AW3 workflow to cron.

### DIFF
--- a/rdr_service/cron_careevo.yaml
+++ b/rdr_service/cron_careevo.yaml
@@ -2,11 +2,16 @@ cron:
 - description: Monthly reconciliation report
 - description: Participant count metrics (Do not manually start)
 - description: Flag ghost participants
-- description: Genomic new participant workflow (Cohort 3) from Biobank Samples
-- description: Genomic GC Manifest Workflow
-- description: Genomic Data Manifest Workflow (ingestion and reconciliation of data)
-- description: Genomic GEM A1 and A2 Workflow
-- description: Genomic GEM A3 (Delete Report) Manifest Workflow
+- description: Genomic Pipeline AW0 (Cohort 2) Workflow
+- description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
+- description: Genomic AW1 Workflow (Manual)
+- description: Genomic AW2 Workflow (Manual)
+- description: Genomic GEM A1-A2 Workflow (Manual)
+- description: Genomic GEM A2 Workflow (Manual)
+- description: Genomic CVL W1 Workflow (Manual)
+- description: Genomic CVL W2 Workflow (Manual)
+- description: Genomic CVL W3 Workflow (Manual)
+- description: Genomic AW3 Workflow (Manual)
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport
   schedule: every day 03:00

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -109,3 +109,8 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
+- description: Genomic CVL AW3 Workflow (Manual)
+  url: /offline/GenomicAW3Workflow
+  timezone: America/New_York
+  schedule: 1 of jan 12:00
+  target: offline

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -109,7 +109,7 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
-- description: Genomic CVL AW3 Workflow (Manual)
+- description: Genomic AW3 Workflow (Manual)
   url: /offline/GenomicAW3Workflow
   timezone: America/New_York
   schedule: 1 of jan 12:00

--- a/rdr_service/cron_ptsc.yaml
+++ b/rdr_service/cron_ptsc.yaml
@@ -11,6 +11,7 @@ cron:
 - description: Genomic CVL W1 Workflow (Manual)
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
+- description: Genomic AW3 Workflow (Manual)
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport
   schedule: every day 03:00

--- a/rdr_service/cron_sandbox.yaml
+++ b/rdr_service/cron_sandbox.yaml
@@ -13,6 +13,7 @@ cron:
 - description: Genomic CVL W1 Workflow (Manual)
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
+- description: Genomic AW3 Workflow (Manual)
 - description: Rotate service account keys older than 3 days
   url: /offline/DeleteOldKeys
   schedule: every day 01:00

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -347,6 +347,19 @@ def genomic_cvl_w3_workflow():
 
 @app_util.auth_required_cron
 @_alert_on_exceptions
+def genomic_aw3_workflow():
+    """Temporarily running this manually for E2E Testing"""
+    now = datetime.utcnow()
+    if now.day == 0o1 and now.month == 0o1:
+        logging.info("skipping the scheduled run.")
+        return '{"success": "true"}'
+    genomic_pipeline.aw3_array_manifest_workflow()
+    genomic_pipeline.aw3_wgs_manifest_workflow()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
 def bigquery_rebuild_cron():
     """ this should always be a manually run job, but we have to schedule it at least once a year. """
     now = datetime.utcnow()
@@ -536,6 +549,11 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicCvlW3Workflow",
         endpoint="genomic_cvl_w3_workflow",
         view_func=genomic_cvl_w3_workflow, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicAW3Workflow",
+        endpoint="genomic_aw3_workflow",
+        view_func=genomic_aw3_workflow, methods=["GET"]
     )
     # END Genomic Pipeline Jobs
 


### PR DESCRIPTION
This PR adds the AW3 workflow to the cron schedule. This is set up to run manually for E2E testing. This PR also updates the careevo environment to remove previous genomic cron jobs.