### PR TITLE
[DA-1689] API endpoints for retrieving lists of deceased reports

### DIFF
--- a/rdr_service/api/deceased_report_api.py
+++ b/rdr_service/api/deceased_report_api.py
@@ -8,12 +8,20 @@ from rdr_service.dao.deceased_report_dao import DeceasedReportDao
 from rdr_service.model.utils import from_client_participant_id
 
 
-class DeceasedReportApiMixin():
+class DeceasedReportApiMixin:
     def __init__(self):
         super().__init__(DeceasedReportDao())
 
 
 class DeceasedReportApi(DeceasedReportApiMixin, BaseApi):
+    def list(self, participant_id=None):
+        search_kwargs = {key: value for key, value in request.args.items()}
+        reports = []
+        for report in self.dao.load_reports(participant_id=participant_id, **search_kwargs):
+            reports.append(self.dao.to_client_json(report))
+
+        return reports
+
     @auth_required(PTC_AND_HEALTHPRO)
     def post(self, participant_id=None):
         resource = request.get_json(force=True)

--- a/rdr_service/dao/deceased_report_dao.py
+++ b/rdr_service/dao/deceased_report_dao.py
@@ -9,6 +9,7 @@ from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.organization import Organization
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.utils import to_client_participant_id
 from rdr_service.participant_enums import DeceasedNotification, DeceasedReportDenialReason, DeceasedReportStatus,\
     DeceasedStatus
 
@@ -201,6 +202,9 @@ class DeceasedReportDao(UpdatableDao):
             'identifier': {
                 'value': model.id
             },
+            'subject': {
+                'reference': to_client_participant_id(model.participantId)
+            },
             'status': status_map[model.status],
             'performer': api_user_dao.to_client_json(model.author),
             'issued': authored_timestamp.isoformat()
@@ -292,7 +296,7 @@ class DeceasedReportDao(UpdatableDao):
                         query = query.join(Participant).filter(Participant.organizationId.is_(None))
                     else:
                         query = query.join(Participant).join(Organization).filter(Organization.externalId == org_id)
-                elif status is not None:
+                if status is not None:
                     if status not in self.status_map:
                         raise BadRequest(f'Invalid status "{status}"')
                     query = query.filter(DeceasedReport.status == self.status_map[status])

--- a/rdr_service/dao/deceased_report_dao.py
+++ b/rdr_service/dao/deceased_report_dao.py
@@ -1,10 +1,12 @@
 import pytz
+from sqlalchemy import desc
 from werkzeug.exceptions import BadRequest, NotFound, Conflict
 
 from rdr_service.api_util import parse_date
 from rdr_service.dao.api_user_dao import ApiUserDao
 from rdr_service.dao.base_dao import UpdatableDao
 from rdr_service.model.deceased_report import DeceasedReport
+from rdr_service.model.organization import Organization
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.participant_enums import DeceasedNotification, DeceasedReportDenialReason, DeceasedReportStatus,\
@@ -14,25 +16,24 @@ from rdr_service.participant_enums import DeceasedNotification, DeceasedReportDe
 class DeceasedReportDao(UpdatableDao):
 
     validate_version_match = False
+    status_map = {
+        'preliminary': DeceasedReportStatus.PENDING,
+        'final': DeceasedReportStatus.APPROVED,
+        'cancelled': DeceasedReportStatus.DENIED
+    }
 
     def __init__(self):
         super().__init__(DeceasedReport)
 
-    @staticmethod
-    def _read_report_status(resource):
+    def _read_report_status(self, resource):
         if 'status' not in resource:
             raise BadRequest('Missing required field: status')
 
-        status_map = {
-            'preliminary': DeceasedReportStatus.PENDING,
-            'final': DeceasedReportStatus.APPROVED,
-            'cancelled': DeceasedReportStatus.DENIED
-        }
         status_string = resource['status']
-        if status_string not in status_map:
+        if status_string not in self.status_map:
             raise BadRequest(f'Invalid status "{status_string}"')
 
-        return status_map[status_string]
+        return self.status_map[status_string]
 
     @staticmethod
     def _read_api_request_author(resource):
@@ -279,3 +280,20 @@ class DeceasedReportDao(UpdatableDao):
 
     def get_etag(self, id_, participant_id):  # pylint: disable=unused-argument
         return None
+
+    def load_reports(self, participant_id=None, org_id=None, status=None):
+        with self.session() as session:
+            query = session.query(DeceasedReport).order_by(desc(DeceasedReport.authored))
+            if participant_id is not None:
+                query = query.filter(DeceasedReport.participantId == participant_id)
+            else:
+                if org_id is not None:
+                    if org_id == 'UNSET':
+                        query = query.join(Participant).filter(Participant.organizationId.is_(None))
+                    else:
+                        query = query.join(Participant).join(Organization).filter(Organization.externalId == org_id)
+                elif status is not None:
+                    if status not in self.status_map:
+                        raise BadRequest(f'Invalid status "{status}"')
+                    query = query.filter(DeceasedReport.status == self.status_map[status])
+            return query.all()

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -308,6 +308,14 @@ api.add_resource(
 )
 
 api.add_resource(
+    DeceasedReportApi,
+    API_PREFIX + 'DeceasedReports',
+    API_PREFIX + 'Participant/<string:participant_id>/DeceasedReport',
+    endpoint='deceased_report.list',
+    methods=['GET']
+)
+
+api.add_resource(
     DeceasedReportReviewApi,
     API_PREFIX + "Participant/<string:participant_id>/Observation/<string:report_id>/Review",
     endpoint='observation.review',

--- a/rdr_service/model/deceased_report.py
+++ b/rdr_service/model/deceased_report.py
@@ -29,6 +29,7 @@ class DeceasedReport(Base):
 
     author = relationship("ApiUser", foreign_keys='DeceasedReport.authorId', lazy='joined')
     reviewer = relationship("ApiUser", foreign_keys='DeceasedReport.reviewerId', lazy='joined')
+    participant = relationship("Participant", foreign_keys='DeceasedReport.participantId')
 
 
 event.listen(DeceasedReport, "before_insert", model_insert_listener)

--- a/rdr_service/model/participant.py
+++ b/rdr_service/model/participant.py
@@ -88,6 +88,8 @@ class Participant(ParticipantBase, Base):
     )
     __table_args__ = (UniqueConstraint("external_id"),)
 
+    organization = relationship("Organization", foreign_keys='Participant.organizationId')
+
 
 Index("participant_biobank_id", Participant.biobankId, unique=True)
 Index("participant_hpo_id", Participant.hpoId)

--- a/tests/api_tests/test_deceased_report_api.py
+++ b/tests/api_tests/test_deceased_report_api.py
@@ -708,7 +708,7 @@ class SearchDeceasedReportApiTest(DeceasedReportTestBase):
         ], self.send_get(f'DeceasedReports?org_id=UNSET&status=preliminary'))
 
     def test_searching_api_by_org_and_status(self):
-        self.overwrite_test_user_roles(['TEST'], save_current=False)
+        self.overwrite_test_user_roles(['TEST'])
         self.send_get(f'DeceasedReports', expected_status=403)
 
         self.overwrite_test_user_roles([PTC], save_current=False)

--- a/tests/api_tests/test_deceased_report_api.py
+++ b/tests/api_tests/test_deceased_report_api.py
@@ -706,3 +706,13 @@ class SearchDeceasedReportApiTest(DeceasedReportTestBase):
             self.unpaired_1_report_id,  # Authored 04/01
             self.unpaired_3_report_id  # Authored 02/18
         ], self.send_get(f'DeceasedReports?org_id=UNSET&status=preliminary'))
+
+    def test_searching_api_by_org_and_status(self):
+        self.overwrite_test_user_roles(['TEST'], save_current=False)
+        self.send_get(f'DeceasedReports', expected_status=403)
+
+        self.overwrite_test_user_roles([PTC], save_current=False)
+        self.send_get(f'DeceasedReports', expected_status=403)
+
+        self.overwrite_test_user_roles([HEALTHPRO], save_current=False)
+        self.send_get(f'DeceasedReports', expected_status=200)

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 from rdr_service.code_constants import PPI_SYSTEM
+from rdr_service.model.api_user import ApiUser
 from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderHistory, BiobankOrderedSample,\
     BiobankOrderedSampleHistory, BiobankOrderIdentifier
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import Code
+from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.log_position import LogPosition
 from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
@@ -14,6 +16,8 @@ from rdr_service.model.questionnaire import Questionnaire, QuestionnaireConcept,
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.model.site import Site
 from rdr_service.participant_enums import (
+    DeceasedNotification,
+    DeceasedReportStatus,
     DeceasedStatus,
     EnrollmentStatus,
     SuspensionStatus,
@@ -343,3 +347,34 @@ class DataGenerator:
 
     def _log_position(self, **kwargs):
         return LogPosition(**kwargs)
+
+    def create_database_api_user(self, **kwargs):
+        api_user = self._api_user(**kwargs)
+        self._commit_to_database(api_user)
+        return api_user
+
+    def _api_user(self, **kwargs):
+        if 'system' not in kwargs:
+            kwargs['system'] = 'unit_test'
+        if 'username' not in kwargs:
+            kwargs['username'] = 'me@test.com'
+        return ApiUser(**kwargs)
+
+    def create_database_deceased_report(self, **kwargs):
+        deceased_report = self._deceased_report(**kwargs)
+        self._commit_to_database(deceased_report)
+        return deceased_report
+
+    def _deceased_report(self, **kwargs):
+        if 'participantId' not in kwargs:
+            participant = self.create_database_participant()
+            kwargs['participantId'] = participant.participantId
+        if 'notification' not in kwargs:
+            kwargs['notification'] = DeceasedNotification.EHR
+        if 'author' not in kwargs:
+            kwargs['author'] = self.create_database_api_user()
+        if 'authored' not in kwargs:
+            kwargs['authored'] = datetime.now()
+        if 'status' not in kwargs:
+            kwargs['status'] = DeceasedReportStatus.PENDING
+        return DeceasedReport(**kwargs)


### PR DESCRIPTION
Part two of the work for deceased reports is to be able to see them externally: both for a specific participant and all the reports by organization and/or status. HPRO will be pulling pending reports by organization in order to have them reviewed. While PTSC will be pulling reports for specific participants to determine if they've been reviewed and, if they've been denied, see why.

While implementing this I also realized that we'll probably need to return the participant that a report is for in the response. So I added that to the JSON output for deceased reports.