### PR TITLE
[DA-1690] Tool for reversing approval of a deceased report

### DIFF
--- a/rdr_service/tools/tool_libs/resurrect.py
+++ b/rdr_service/tools/tool_libs/resurrect.py
@@ -1,0 +1,108 @@
+#! /bin/env python
+#
+# Remove an approved deceased report from a given participant
+#
+
+import argparse
+import logging
+import sys
+
+from rdr_service.dao.deceased_report_dao import DeceasedReportDao
+from rdr_service.model.deceased_report import DeceasedReport
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.participant_enums import DeceasedReportDenialReason, DeceasedReportStatus, DeceasedStatus
+from rdr_service.services.system_utils import setup_logging, setup_i18n
+from rdr_service.tools.tool_libs import GCPProcessContext
+
+_logger = logging.getLogger("rdr_logger")
+
+# Tool_cmd and tool_desc name are required.
+# Remember to add/update bash completion in 'tool_lib/tools.bash'
+tool_cmd = "resurrect"
+tool_desc = "remove an approved deceased report from a given participant"
+
+
+class ResurrectClass(object):
+    def __init__(self, args, gcp_env):
+        self.args = args
+        self.gcp_env = gcp_env
+        self.dao = DeceasedReportDao()
+
+    def update_approved_deceased_report(self, participant_id):
+        with self.dao.session() as session:
+            report = session.query(DeceasedReport).filter(
+                DeceasedReport.participantId == participant_id,
+                DeceasedReport.status == DeceasedReportStatus.APPROVED
+            ).one_or_none()
+        if report is None:
+            print('ERROR: no approved deceased report found')
+
+        report.status = DeceasedReportStatus.DENIED
+        # todo: set the reviewer to the current account setting
+
+        report.denialReason = DeceasedReportDenialReason(self.args.reason)
+        if report.denialReason == DeceasedReportDenialReason.OTHER:
+            if self.args.reason_desc is None:
+                print('ERROR: reason description required when denial reason is OTHER')
+                sys.exit(1)
+            report.denialReasonOther = self.args.reason_desc
+
+    def update_participant_summary(self, participant_id):
+        with self.dao.session() as session:
+            participant_summary = session.query(ParticipantSummary).filter(
+                ParticipantSummary.participantId == participant_id
+            ).one_or_none()
+        if participant_summary is None:
+            print('WARNING: participant summary not found')
+        else:
+            participant_summary.deceasedStatus = DeceasedStatus.UNSET
+            participant_summary.deceasedAuthored = None
+            participant_summary.dateOfDeath = None
+
+    def run(self):
+        proxy_pid = self.gcp_env.activate_sql_proxy()
+        if not proxy_pid:
+            _logger.error("activating google sql proxy failed.")
+            return 1
+
+        participant_id = self.args.pid
+        self.update_approved_deceased_report(participant_id)
+        self.update_participant_summary(participant_id)
+
+        return 0
+
+
+def run():
+    # Set global debug value and setup application logging.
+    setup_logging(
+        _logger, tool_cmd, "--debug" in sys.argv, "{0}.log".format(tool_cmd) if "--log-file" in sys.argv else None
+    )
+    setup_i18n()
+
+    # Setup program arguments.
+    parser = argparse.ArgumentParser(prog=tool_cmd, description=tool_desc)
+    parser.add_argument("--project", help="gcp project name", default="localhost")  # noqa
+    parser.add_argument("--account", help="pmi-ops account", default=None)  # noqa
+    parser.add_argument("--service-account", help="gcp iam service account", default=None)  # noqa
+    parser.add_argument("--pid", required=True, help="Id of participant to remove deceased status from")
+    parser.add_argument(
+        "--reason",
+        help="Valid DeceasedReportDenialReason value for setting on the report",
+        default='MARKED_IN_ERROR'
+    )
+    parser.add_argument(
+        "--reason-desc",
+        help="Text description for setting the deceased report to denied. Required if the reason is set as OTHER"
+    )
+
+    args = parser.parse_args()
+
+    with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
+        process = ResurrectClass(args, gcp_env)
+        exit_code = process.run()
+        return exit_code
+
+
+# --- Main Program Call ---
+if __name__ == "__main__":
+    sys.exit(run())

--- a/rdr_service/tools/tool_libs/resurrect.py
+++ b/rdr_service/tools/tool_libs/resurrect.py
@@ -60,7 +60,7 @@ class ResurrectClass(object):
         ).one_or_none()
 
         if participant_summary is None:
-            print('WARNING: participant summary not found')
+            _logger.warning('WARNING: participant summary not found')
         else:
             participant_summary.deceasedStatus = DeceasedStatus.UNSET
             participant_summary.deceasedAuthored = None

--- a/rdr_service/tools/tool_libs/tools.bash
+++ b/rdr_service/tools/tool_libs/tools.bash
@@ -225,6 +225,12 @@ _python()
             fi
             return 0
             ;;
+        resurrect)
+            # These are options specific to this tool.
+            local toolopts="--help --pid --reason --reason-desc"
+            COMPREPLY=( $(compgen -W "${stdopts} ${toolopts}" -- ${cur}) )
+            return 0
+            ;;
         *)
         ;;
     esac

--- a/tests/tool_tests/test_resurrect.py
+++ b/tests/tool_tests/test_resurrect.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 from datetime import  date, datetime
 import mock
 
@@ -8,8 +7,6 @@ from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.tools.tool_libs.resurrect import ResurrectClass, PMI_OPS_URL
 from tests.helpers.unittest_base import BaseTestCase
-
-FakeFile = namedtuple('FakeFile', ['name', 'updated'])
 
 
 class ResurrectTest(BaseTestCase):

--- a/tests/tool_tests/test_resurrect.py
+++ b/tests/tool_tests/test_resurrect.py
@@ -1,0 +1,93 @@
+from collections import namedtuple
+from datetime import  date, datetime
+import mock
+
+from rdr_service.dao.deceased_report_dao import DeceasedReportDao
+from rdr_service.participant_enums import DeceasedStatus, DeceasedReportDenialReason, DeceasedReportStatus
+from rdr_service.model.deceased_report import DeceasedReport
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.tools.tool_libs.resurrect import ResurrectClass, PMI_OPS_URL
+from tests.helpers.unittest_base import BaseTestCase
+
+FakeFile = namedtuple('FakeFile', ['name', 'updated'])
+
+
+class ResurrectTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.dao = DeceasedReportDao()
+        self.deceased_participant_id = self.initialize_deceased_participant()
+
+    @staticmethod
+    def run_tool(participant_id, reason=DeceasedReportDenialReason.MARKED_IN_ERROR, reason_description=None):
+        environment = mock.MagicMock()
+        environment.project = 'unit_test'
+        environment.account = 'resurrecting-username'
+
+        args = mock.MagicMock(spec=['pid', 'reason', 'reason-desc'])
+        args.pid = participant_id
+        args.reason = reason
+        args.reason_desc = reason_description
+
+        resurrect_tool = ResurrectClass(args, environment)
+        resurrect_tool.run()
+
+    def initialize_deceased_participant(self):
+        participant = self.data_generator.create_database_participant()
+        self.data_generator.create_database_participant_summary(
+            participantId=participant.participantId,
+            deceasedStatus=DeceasedStatus.APPROVED,
+            deceasedAuthored=datetime(2020, 1, 1),
+            dateOfDeath=date(2020, 1, 1)
+        )
+        external_user = self.data_generator.create_database_api_user(
+            system='external-url',
+            username='external-user'
+        )
+        self.data_generator.create_database_deceased_report(
+            participantId=participant.participantId,
+            status=DeceasedReportStatus.APPROVED,
+            reviewerId=external_user.id
+        )
+
+        return participant.participantId
+
+    def retrieve_object_from_database(self, model_class, participant_id):
+        # Resetting the session since it would have cached the summary or deceased report
+        self.session.commit()
+        self.session.close()
+
+        return self.session.query(model_class).filter(
+            model_class.participantId == participant_id
+        ).one()
+
+    def test_resurrecting_participant(self):
+        self.run_tool(self.deceased_participant_id)
+
+        participant_summary = self.retrieve_object_from_database(ParticipantSummary, self.deceased_participant_id)
+        self.assertEqual(DeceasedStatus.UNSET, participant_summary.deceasedStatus)
+        self.assertIsNone(participant_summary.deceasedAuthored)
+        self.assertIsNone(participant_summary.dateOfDeath)
+
+        deceased_report = self.retrieve_object_from_database(DeceasedReport, self.deceased_participant_id)
+        self.assertEqual(DeceasedReportStatus.DENIED, deceased_report.status)
+        self.assertEqual(PMI_OPS_URL, deceased_report.reviewer.system)
+        self.assertEqual('resurrecting-username', deceased_report.reviewer.username)
+
+    def test_other_denial_reason_description(self):
+        self.run_tool(self.deceased_participant_id, reason=DeceasedReportDenialReason.OTHER, reason_description='test')
+
+        deceased_report = self.retrieve_object_from_database(DeceasedReport, self.deceased_participant_id)
+        self.assertEqual('test', deceased_report.denialReasonOther)
+
+    def test_error_on_missing_other_description(self):
+        with self.assertRaises(Exception):
+            self.run_tool(self.deceased_participant_id, reason=DeceasedReportDenialReason.OTHER)
+
+    def test_error_on_modifying_report_not_approved(self):
+        report = self.retrieve_object_from_database(DeceasedReport, self.deceased_participant_id)
+        report.status = DeceasedReportStatus.PENDING
+        self.session.commit()
+
+        with self.assertRaises(Exception):
+            self.run_tool(self.deceased_participant_id)


### PR DESCRIPTION
By design the API has doesn't have a way of reversing an approved deceased report. We'll be correcting any errors that come up manually. Since there are a few fields across a couple of data models that need to be set in a specific way I made this tool to make that job easier. I'll also update the playbook with an entry on what to do if we need to reverse an approved report.

Note: this will set whoever is running the tool as the reviewer of the report