### PR TITLE
[DA-1712] Update AW2 Workflow with Fixes from E2E

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -487,11 +487,7 @@ class GenomicFileValidator:
                 "chipwellbarcode",
                 "callrate",
                 "sexconcordance",
-                "contamination",
                 "processingstatus",
-                "consentforror",
-                "withdrawnstatus",
-                "siteid",
                 "notes",
             ),
         }

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -381,6 +381,13 @@ class GenomicFileIngester:
                                 row.values()))
             row_copy['file_id'] = self.file_obj.id
             sample_id = row_copy['sampleid']
+
+            # TODO: limit call rate to 10 characters for now until clarification from GCs
+            try:
+                row_copy['callrate'] = row_copy['callrate'][:10]
+            except KeyError:
+                pass
+            
             genome_type = self.file_validator.genome_type
             member = self.member_dao.get_member_from_sample_id_with_state(int(sample_id),
                                                                           genome_type,

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -387,7 +387,7 @@ class GenomicFileIngester:
                 row_copy['callrate'] = row_copy['callrate'][:10]
             except KeyError:
                 pass
-            
+
             genome_type = self.file_validator.genome_type
             member = self.member_dao.get_member_from_sample_id_with_state(int(sample_id),
                                                                           genome_type,

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -957,7 +957,7 @@ class GenomicReconciler:
 
     def _get_full_filename(self, bucket_name, filename):
         files = list_blobs('/' + bucket_name)
-        filenames = [f.name for f in files if f.name.endswith(filename)]
+        filenames = [f.name for f in files if f.name.lower().endswith(filename.lower())]
         return filenames[0] if len(filenames) > 0 else 0
 
     def _get_sequence_files(self, bucket_name):

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -647,16 +647,16 @@ class GenomicPipelineTest(BaseTestCase):
             f'test_data_folder/10001_R01C01.vcf.gz',
             f'test_data_folder/10001_R01C01.vcf.gz.tbi',
             f'test_data_folder/10001_R01C01.vcf.gz.md5sum',
-            f'test_data_folder/10001_R01C01_red.idat',
-            f'test_data_folder/10001_R01C01_grn.idat',
-            f'test_data_folder/10001_R01C01_red.idat.md5sum',
+            f'test_data_folder/10001_R01C01_Red.idat',
+            f'test_data_folder/10001_R01C01_Grn.idat',
+            f'test_data_folder/10001_R01C01_Red.idat.md5sum',
             f'test_data_folder/10002_R01C02.vcf.gz',
             f'test_data_folder/10002_R01C02.vcf.gz.tbi',
             f'test_data_folder/10002_R01C02.vcf.gz.md5sum',
-            f'test_data_folder/10002_R01C02_red.idat',
-            f'test_data_folder/10002_R01C02_grn.idat',
-            f'test_data_folder/10002_R01C02_red.idat.md5sum',
-            f'test_data_folder/10002_R01C02_grn.idat.md5sum',
+            f'test_data_folder/10002_R01C02_Red.idat',
+            f'test_data_folder/10002_R01C02_Grn.idat',
+            f'test_data_folder/10002_R01C02_Red.idat.md5sum',
+            f'test_data_folder/10002_R01C02_Grn.idat.md5sum',
         )
         for f in sequencing_test_files:
             self._write_cloud_csv(f, 'attagc', bucket=bucket_name)

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -300,9 +300,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual('10001_R01C01', record.chipwellbarcode)
             self.assertEqual('0.996', record.callRate)
             self.assertEqual('True', record.sexConcordance)
-            self.assertEqual('0.00654', record.contamination)
             self.assertEqual('Pass', record.processingStatus)
-            self.assertEqual('JH', record.siteId)
             self.assertEqual('This sample passed', record.notes)
 
     def test_gc_metrics_ingestion_bad_files(self):

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -704,10 +704,10 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Fake alert
         summary = '[Genomic System Alert] Missing AW2 Array Manifest Files'
-        description = "The following AW2 manifest file listed missing data."
-        description += f"\nManifest File: {manifest_file.fileName}"
+        description = "The following AW2 manifests are missing data files."
         description += "\nGenomic Job Run ID: 2"
-        description += "\nMissing Genotype Data: ['10001_R01C01_grn.idat.md5sum']"
+        description += f"\n\tManifest File: {manifest_file.fileName}"
+        description += "\n\tMissing Genotype Data: ['10001_R01C01_grn.idat.md5sum']"
 
         mock_alert_handler.make_genomic_alert.assert_called_with(summary, description)
 
@@ -778,10 +778,10 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Fake alert
         summary = '[Genomic System Alert] Missing AW2 WGS Manifest Files'
-        description = "The following AW2 manifest file listed missing data."
-        description += f"\nManifest File: {manifest_file.fileName}"
+        description = "The following AW2 manifests are missing data files."
         description += "\nGenomic Job Run ID: 2"
-        description += "\nMissing Genotype Data: ['RDR_2_1002_LocalID_InternalRevisionNumber.crai']"
+        description += f"\n\tManifest File: {manifest_file.fileName}"
+        description += "\n\tMissing Genotype Data: ['RDR_2_1002_LocalID_InternalRevisionNumber.crai']"
 
         mock_alert_handler.make_genomic_alert.assert_called_with(summary, description)
 

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -298,7 +298,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(1, record.genomicSetMemberId)
             self.assertEqual('10001', record.limsId)
             self.assertEqual('10001_R01C01', record.chipwellbarcode)
-            self.assertEqual('0.996', record.callRate)
+            self.assertEqual('0.34567890', record.callRate)
             self.assertEqual('True', record.sexConcordance)
             self.assertEqual('Pass', record.processingStatus)
             self.assertEqual('This sample passed', record.notes)

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,3 +1,3 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Consent for RoR,Withdrawn_status,site_id,Notes
-T1,1001,T1_1991,10001,10001_R01C01,0.996,True,0.00654,Pass,,,JH,This sample passed
-T2,1002,T2_1992,10002,10002_R01C02,0.996,True,0.00654,Pass,,,JH,This sample passed
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Processing Status,Notes
+T1,1001,T1_1991,10001,10001_R01C01,0.996,True,Pass,This sample passed
+T2,1002,T2_1992,10002,10002_R01C02,0.996,True,Pass,This sample passed

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,3 +1,3 @@
 Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Processing Status,Notes
-T1,1001,T1_1991,10001,10001_R01C01,0.996,True,Pass,This sample passed
-T2,1002,T2_1992,10002,10002_R01C02,0.996,True,Pass,This sample passed
+T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,Pass,This sample passed
+T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,Pass,This sample passed


### PR DESCRIPTION
This PR makes the following updates to the AW2 workflows that were discovered during the E2E GEM testing:

1. Remove the following columns from AW2 Array manifest validation schema:
        consentforror
        withdrawnstatus
        siteid
        contamination
2. Looking up if data files exist now converts all filenames to lower case.
3. Generate ROC ticket once per reconciliation job run, not once per metric record.
4. Trim `callrate` length to current character length limit (10 chars).