### PR TITLE
[DA-1698] Update Columns for AW3 Manifests

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1757,6 +1757,7 @@ class ManifestDefinitionProvider:
                         GenomicGCValidationMetrics.idatGreenPath,
                         GenomicGCValidationMetrics.idatGreenMd5Path,
                         GenomicGCValidationMetrics.vcfPath,
+                        GenomicGCValidationMetrics.vcfTbiPath,
                         GenomicGCValidationMetrics.vcfMd5Path,
                         sqlalchemy.bindparam('research_id', None),
                     ]
@@ -2005,11 +2006,12 @@ class ManifestDefinitionProvider:
                 "sex_at_birth",
                 "site_id",
                 "red_idat_path",
-                "red_idat_index_path",
+                "red_idat_md5_path",
                 "green_idat_path",
-                "green_idat_index_path",
+                "green_idat_md5_path",
                 "vcf_path",
                 "vcf_index_path",
+                "vcf_md5_path",
                 "research_id",
             )
 

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1790,15 +1790,17 @@ class ManifestDefinitionProvider:
             query_sql = (
                 sqlalchemy.select(
                     [
+                        GenomicSetMember.biobankId,
+                        GenomicSetMember.sampleId,
                         (GenomicSetMember.biobankId + '_' + GenomicSetMember.sampleId),
                         GenomicSetMember.sexAtBirth,
                         GenomicSetMember.gcSiteId,
                         GenomicGCValidationMetrics.hfVcfPath,
                         GenomicGCValidationMetrics.hfVcfTbiPath,
-                        GenomicGCValidationMetrics.hfVcfMd5Path,
+                        #GenomicGCValidationMetrics.hfVcfMd5Path,
                         GenomicGCValidationMetrics.rawVcfPath,
                         GenomicGCValidationMetrics.rawVcfTbiPath,
-                        GenomicGCValidationMetrics.rawVcfMd5Path,
+                        #GenomicGCValidationMetrics.rawVcfMd5Path,
                         GenomicGCValidationMetrics.cramPath,
                         GenomicGCValidationMetrics.cramMd5Path,
                         GenomicGCValidationMetrics.craiPath,
@@ -2017,17 +2019,17 @@ class ManifestDefinitionProvider:
 
         elif manifest_type == GenomicManifestTypes.AW3_WGS:
             columns = (
+                "biobank_id",
+                "sample_id",
                 "biobankidsampleid",
                 "sex_at_birth",
                 "site_id",
-                "gvcf_hf_path",
-                "gvcf_hf_tbi_path",
-                "gvcf_hf_index_path",
-                "gvcf_raw_path",
-                "gvcf_raw_tbi_path",
-                "gvcf_raw_index_path",
+                "vcf_hf_path",
+                "vcf_hf_index_path",
+                "vcf_raw_path",
+                "vcf_raw_index_path",
                 "cram_path",
-                "cram_index_path",
+                "cram_md5_path",
                 "crai_path",
                 "research_id"
             )

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -2211,17 +2211,19 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test the manifest file contents
         expected_aw3_columns = (
+            "biobank_id",
+            "sample_id",
             "biobankidsampleid",
             "sex_at_birth",
             "site_id",
-            "gvcf_hf_path",
-            "gvcf_hf_tbi_path",
-            "gvcf_hf_index_path",
-            "gvcf_raw_path",
-            "gvcf_raw_tbi_path",
-            "gvcf_raw_index_path",
+            "vcf_hf_path",
+            "vcf_hf_index_path",
+            # "vcf_hf_md5_path",
+            "vcf_raw_path",
+            "vcf_raw_index_path",
+            # "vcf_raw_md5_path",
             "cram_path",
-            "cram_index_path",
+            "cram_md5_path",
             "crai_path",
             "research_id"
         )
@@ -2243,14 +2245,14 @@ class GenomicPipelineTest(BaseTestCase):
 
             # Test File Paths
             metric = self.metrics_dao.get(1)
-            self.assertEqual(metric.hfVcfPath, rows[0]["gvcf_hf_path"])
-            self.assertEqual(metric.hfVcfTbiPath, rows[0]["gvcf_hf_tbi_path"])
-            self.assertEqual(metric.hfVcfMd5Path, rows[0]["gvcf_hf_index_path"])
-            self.assertEqual(metric.rawVcfPath, rows[0]["gvcf_raw_path"])
-            self.assertEqual(metric.rawVcfTbiPath, rows[0]["gvcf_raw_tbi_path"])
-            self.assertEqual(metric.rawVcfMd5Path, rows[0]["gvcf_raw_index_path"])
+            self.assertEqual(metric.hfVcfPath, rows[0]["vcf_hf_path"])
+            self.assertEqual(metric.hfVcfTbiPath, rows[0]["vcf_hf_index_path"])
+            # self.assertEqual(metric.hfVcfTbiPath, rows[0]["vcf_hf_md5_path"])
+            self.assertEqual(metric.rawVcfPath, rows[0]["vcf_raw_path"])
+            self.assertEqual(metric.rawVcfTbiPath, rows[0]["vcf_raw_index_path"])
+            # self.assertEqual(metric.rawVcfTbiPath, rows[0]["vcf_raw_md5_path"])
             self.assertEqual(metric.cramPath, rows[0]["cram_path"])
-            self.assertEqual(metric.cramMd5Path, rows[0]["cram_index_path"])
+            self.assertEqual(metric.cramMd5Path, rows[0]["cram_md5_path"])
             self.assertEqual(metric.craiPath, rows[0]["crai_path"])
 
             # Test run record is success

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -2115,9 +2115,9 @@ class GenomicPipelineTest(BaseTestCase):
             "sex_at_birth",
             "site_id",
             "red_idat_path",
-            "red_idat_index_path",
+            "red_idat_md5_path",
             "green_idat_path",
-            "green_idat_index_path",
+            "green_idat_md5_path",
             "vcf_path",
             "vcf_index_path",
             "research_id"
@@ -2142,11 +2142,12 @@ class GenomicPipelineTest(BaseTestCase):
             # Test File Paths
             metric = self.metrics_dao.get(2)
             self.assertEqual(metric.idatRedPath, rows[1]['red_idat_path'])
-            self.assertEqual(metric.idatRedMd5Path, rows[1]['red_idat_index_path'])
+            self.assertEqual(metric.idatRedMd5Path, rows[1]['red_idat_md5_path'])
             self.assertEqual(metric.idatGreenPath, rows[1]['green_idat_path'])
-            self.assertEqual(metric.idatGreenMd5Path, rows[1]['green_idat_index_path'])
+            self.assertEqual(metric.idatGreenMd5Path, rows[1]['green_idat_md5_path'])
             self.assertEqual(metric.vcfPath, rows[1]['vcf_path'])
-            self.assertEqual(metric.vcfMd5Path, rows[1]['vcf_index_path'])
+            self.assertEqual(metric.vcfTbiPath, rows[1]['vcf_index_path'])
+            self.assertEqual(metric.vcfMd5Path, rows[1]['vcf_md5_path'])
 
             # Test run record is success
             run_obj = self.job_run_dao.get(5)


### PR DESCRIPTION
This PR updates the columns for the AW3 Array and WGS manifests. The two VCF md5 columns for the WGS are currently commented out. These are currently not requested but it is anticipated that the Broad Institute will want these columns as well.