### PR TITLE
app-engine deploy fix: make sure all services restart

### DIFF
--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -827,6 +827,7 @@ def gcp_restart_instances(project, service='default'):
     :return: True if successful, else False.
     """
 
+    _logger.debug(f'Restarting instances for project {project}, service {service}')
     # First get instance ID's
     args = "instances list --format json --project {}".format(project)
     pcode, so, se = gcp_gcloud_command("app", args)

--- a/rdr_service/services/system_utils.py
+++ b/rdr_service/services/system_utils.py
@@ -265,7 +265,7 @@ def run_external_program(args, cwd=None, env=None, shell=False, debug=False):
     if debug is True and "--debug" in sys.argv and "--debug" not in args:
         args.append("--debug")
 
-    _logger.debug("external: {0}".format(os.path.basename(args[0])))
+    _logger.debug("external: {0} {1}".format(os.path.basename(args[0]), ' '.join(args[1:])))
 
     p = subprocess.Popen(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, shell=shell)
     stdoutdata, stderrdata = p.communicate()

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -342,7 +342,10 @@ class DeployAppClass(object):
         _logger.info('Cleaning up...')
         self.clean_up_config_files(config_files)
 
-        gcp_restart_instances(self.gcp_env.project)
+        # Note: self.services will either be a user-provided list from --services arg, or the GCP_SERVICES list from
+        # gcp_config.  Need to iterate through each service to make sure appropriate instances get restarted
+        for service in self.services:
+            gcp_restart_instances(self.gcp_env.project, service=service)
 
         return 0 if result else 1
 
@@ -432,7 +435,6 @@ class DeployAppClass(object):
 
         _logger.info('')
         _logger.info('=' * 90)
-
 
         if not self.args.quiet:
             confirm = input('\nStart deployment (Y/n)? : ')


### PR DESCRIPTION
After the 1.77.1 deploy last week, we found 'resource' service instance(s) did not appear to get restarted during the deploy operation and were still running the prior version, which impacted the BiqQuery rebuild.   The gcp_restart_instances() function which is called at the end of deploy_app() only appeared to only explicitly handle deleting old instances for the 'default' service.

This change will make calls to gcp_restart_instances() for each service separately.

