### PR TITLE
[PDR-56], [PDR-100] Add Cohort 2 Pilot Flag, fix missing suspension_s…

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -257,6 +257,13 @@ class BQParticipantSummarySchema(BQSchema):
 
     test_participant = BQField('test_participant', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
+    suspension_status = BQField('suspension_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    suspension_status_id = BQField('suspension_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    suspension_time = BQField('suspension_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
+    cohort_2_pilot_flag = BQField('cohort_2_pilot_flag', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    cohort_2_pilot_flag_id = BQField('cohort_2_pilot_flag_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+
 
 class BQParticipantSummary(BQTable):
     """ Participant Summary BigQuery Table """

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -257,10 +257,6 @@ class BQParticipantSummarySchema(BQSchema):
 
     test_participant = BQField('test_participant', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
-    suspension_status = BQField('suspension_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-    suspension_status_id = BQField('suspension_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-    suspension_time = BQField('suspension_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-
     cohort_2_pilot_flag = BQField('cohort_2_pilot_flag', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     cohort_2_pilot_flag_id = BQField('cohort_2_pilot_flag_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -123,6 +123,13 @@ class BQPDRParticipantSummarySchema(BQSchema):
 
     test_participant = BQField('test_participant', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
+    suspension_status = BQField('suspension_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    suspension_status_id = BQField('suspension_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    suspension_time = BQField('suspension_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
+    cohort_2_pilot_flag = BQField('cohort_2_pilot_flag', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    cohort_2_pilot_flag_id = BQField('cohort_2_pilot_flag_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+
 
 class BQPDRParticipantSummary(BQTable):
     """ PDR Participant Summary BigQuery Table """
@@ -144,9 +151,9 @@ class BQPDRParticipantSummaryView(BQView):
         SELECT
           %%FIELD_NAMES%%
         FROM (
-            SELECT *, 
+            SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY modified desc, test_participant desc) AS rn
-              FROM `{project}`.{dataset}.pdr_participant 
+              FROM `{project}`.{dataset}.pdr_participant
           ) ps
           WHERE ps.rn = 1 and ps.withdrawal_status_id = 1 and ps.test_participant != 1
       """.replace('%%FIELD_NAMES%%', BQPDRParticipantSummarySchema.get_sql_field_names(
@@ -177,7 +184,7 @@ class BQPDRPMView(BQView):
     __sql__ = """
     SELECT ps.id, ps.created, ps.modified, ps.participant_id, nt.*
       FROM (
-        SELECT *, 
+        SELECT *,
             ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY modified desc, test_participant desc) AS rn
           FROM `{project}`.{dataset}.pdr_participant
       ) ps cross join unnest(pm) as nt

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -20,10 +20,11 @@ from rdr_service.model.hpo import HPO
 from rdr_service.model.measurements import PhysicalMeasurements, PhysicalMeasurementsStatus
 from rdr_service.model.organization import Organization
 from rdr_service.model.participant import Participant
+from rdr_service.model.participant_cohort_pilot import ParticipantCohortPilot
 from rdr_service.model.questionnaire import QuestionnaireConcept
 from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
-    SampleStatus, BiobankOrderStatus, PatientStatusFlag
+    SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag
 from rdr_service.resource import generators, schemas
 
 
@@ -118,6 +119,19 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         withdrawal_reason = WithdrawalReason(p.withdrawalReason if p.withdrawalReason else 0)
         suspension_status = SuspensionStatus(p.suspensionStatus)
 
+        # The cohort_2_pilot_flag field values in participant_summary were set via a one-time backfill based on a
+        # list of participant IDs provided by PTSC and archived in the participant_cohort_pilot table.  See:
+        # https://precisionmedicineinitiative.atlassian.net/browse/DA-1622
+        # TO DO:  A participant_profile table may be implemented as part of the effort to eliminate dependencies on
+        # participant_summary.  The cohort_2_pilot_flag could be queried from that new table in the future
+        #
+        # Note this query assumes participant_cohort_pilot only contains entries for the cohort 2 pilot
+        # participants for genomics and has not been used for identifying participants in more recent pilots
+        cohort_2_pilot = ro_session.query(ParticipantCohortPilot.participantCohortPilot). \
+            filter(ParticipantCohortPilot.participantId == p_id).first()
+
+        cohort_2_pilot_flag = \
+            ParticipantCohortPilotFlag.COHORT_2_PILOT if cohort_2_pilot else ParticipantCohortPilotFlag.UNSET
         data = {
             'participant_id': f'P{p_id}',
             'biobank_id': p.biobankId,
@@ -143,7 +157,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
             'site': self._lookup_site_name(p.siteId, ro_session),
             'site_id': p.siteId,
-            'is_ghost_id': 1 if p.isGhostId is True else 0
+            'is_ghost_id': 1 if p.isGhostId is True else 0,
+            'cohort_2_pilot_flag': str(cohort_2_pilot_flag),
+            'cohort_2_pilot_flag_id': int(cohort_2_pilot_flag)
         }
 
         return data


### PR DESCRIPTION
…tatus/time fields in PDR

The suspension_status and suspension_time fields were already being populated in the _prep_participant() / summary data but had not been added to the BQ schema.   (suspension_status_id is a new field to be consistent with including an integer value for the related enum string field).

The cohort_2_pilot_flag/cohort_2_pilot_flag_id fields are being added to the _prep_participant() logic and BQ schema.