### PR TITLE
Logging additional information for debugging authentication issues

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -119,6 +119,8 @@ def get_oauth_id():
             response = get_token_info_response(token)
             data = response.json()
             if response.status_code == 200:
+                token_expiry_seconds = data.get('expires_in')
+                logging.info(f'Token expiring in {token_expiry_seconds} seconds')
                 return data.get('email')
             else:
                 message = str(data.get("error_description", response.content))

--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -124,7 +124,7 @@ def get_oauth_id():
                 return data.get('email')
             else:
                 message = str(data.get("error_description", response.content))
-                logging.info(f"Oauth failure: {message}")
+                logging.info(f"Oauth failure: {message} (status: {response.status_code})")
 
         sleep(0.25)
         logging.info('Retrying authentication call to Google after failure.')


### PR DESCRIPTION
I couldn't find any solid documentation on it, so it likely changes. But it looks like Google API access tokens expire an hour after they're created. Any long-running processes making multiple requests to the server likely see the 502 error code if their tokens expire and they don't refresh them. I'm pushing to see if we can change the status code that gets sent back. But for now I've added some more logging messages that might help give more insight into what happened.

Just recently there were a bunch of requests that were getting participant summaries from the API. And for a while they worked but after an hour some were failing while others succeeded. This could help give more information around how tokens are being used when a user is making a batch of requests, and help show why a set of them might fail.

https://any-api.com/googleapis_com/oauth2/docs/Definitions/Tokeninfo documents the response content we receive from Google's `tokeninfo` endpoint (called by the `get_token_info_response` method).