### PR TITLE
[DA-1718] Split AW1 and AW1F Workflows to 2 Cron Jobs

### DIFF
--- a/rdr_service/cron_careevo.yaml
+++ b/rdr_service/cron_careevo.yaml
@@ -5,6 +5,7 @@ cron:
 - description: Genomic Pipeline AW0 (Cohort 2) Workflow
 - description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
 - description: Genomic AW1 Workflow (Manual)
+- description: Genomic AW1 Failures Workflow (Manual)
 - description: Genomic AW2 Workflow (Manual)
 - description: Genomic GEM A1-A2 Workflow (Manual)
 - description: Genomic GEM A2 Workflow (Manual)

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -79,6 +79,11 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
+- description: Genomic AW1 Failures Workflow (Manual)
+  url: /offline/GenomicFailuresWorkflow
+  timezone: America/New_York
+  schedule: 1 of jan 12:00
+  target: offline
 - description: Genomic AW2 Workflow (Manual)
   url: /offline/GenomicDataManifestWorkflow
   timezone: America/New_York

--- a/rdr_service/cron_ptsc.yaml
+++ b/rdr_service/cron_ptsc.yaml
@@ -5,6 +5,7 @@ cron:
 - description: Genomic Pipeline AW0 (Cohort 2) Workflow
 - description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
 - description: Genomic AW1 Workflow (Manual)
+- description: Genomic AW1 Failures Workflow (Manual)
 - description: Genomic AW2 Workflow (Manual)
 - description: Genomic GEM A1-A2 Workflow (Manual)
 - description: Genomic GEM A2 Workflow (Manual)

--- a/rdr_service/cron_sandbox.yaml
+++ b/rdr_service/cron_sandbox.yaml
@@ -7,6 +7,7 @@ cron:
 - description: Genomic Pipeline AW0 (Cohort 2) Workflow
 - description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
 - description: Genomic AW1 Workflow (Manual)
+- description: Genomic AW1 Failures Workflow (Manual)
 - description: Genomic AW2 Workflow (Manual)
 - description: Genomic GEM A1-A2 Workflow (Manual)
 - description: Genomic GEM A2 Workflow (Manual)

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -597,7 +597,6 @@ class GenomicFileValidator:
             """GC metrics file name rule"""
             filename_components = [x.lower() for x in fn.split('/')[-1].split("_")]
             return (
-                len(filename_components) == 5 and
                 filename_components[0] in self.VALID_GENOME_CENTERS and
                 filename_components[1] == 'aou' and
                 filename_components[2] in self.GC_METRICS_SCHEMAS.keys()

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -265,6 +265,17 @@ def genomic_gc_manifest_workflow():
         logging.info("skipping the scheduled run.")
         return '{"success": "true"}'
     genomic_pipeline.genomic_centers_manifest_workflow()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
+def genomic_aw1f_failures_workflow():
+    """Temporarily running this manually for E2E Testing"""
+    now = datetime.utcnow()
+    if now.day == 0o1 and now.month == 0o1:
+        logging.info("skipping the scheduled run.")
+        return '{"success": "true"}'
     genomic_pipeline.genomic_centers_aw1f_manifest_workflow()
     genomic_pipeline.genomic_centers_accessioning_failures_workflow()
     return '{"success": "true"}'
@@ -519,6 +530,11 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicGCManifestWorkflow",
         endpoint="genomic_gc_manifest_workflow",
         view_func=genomic_gc_manifest_workflow, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicFailuresWorkflow",
+        endpoint="genomic_aw1f_failures_workflow",
+        view_func=genomic_aw1f_failures_workflow, methods=["GET"]
     )
     offline_app.add_url_rule(
         OFFLINE_PREFIX + "GenomicDataManifestWorkflow",

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -222,7 +222,8 @@ class GenomicPipelineTest(BaseTestCase):
         )
         for test_file in end_to_end_test_files:
             self._create_ingestion_test_file(test_file, bucket_name,
-                                             folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1]))
+                                             folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1]),
+                                             include_sub_num=True)
 
         self._create_fake_datasets_for_gc_tests(2, arr_override=True,
                                                 array_participants=(1, 2),
@@ -277,13 +278,13 @@ class GenomicPipelineTest(BaseTestCase):
             else:
                 self.assertEqual(
                     f.fileName,
-                    'RDR_AoU_GEN_TestDataManifest_11192019.csv'
+                    'RDR_AoU_GEN_TestDataManifest_11192019_1.csv'
                 )
                 self.assertEqual(
                     f.filePath,
                     f'/{_FAKE_GENOMIC_CENTER_BUCKET_A}/'
                     f'{config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1])}/'
-                    f'RDR_AoU_GEN_TestDataManifest_11192019.csv'
+                    f'RDR_AoU_GEN_TestDataManifest_11192019_1.csv'
                 )
 
             self.assertEqual(f.fileStatus,
@@ -382,12 +383,14 @@ class GenomicPipelineTest(BaseTestCase):
                                     test_data_filename,
                                     bucket_name,
                                     folder=None,
-                                    include_timestamp=True):
+                                    include_timestamp=True,
+                                    include_sub_num=False,):
         test_data_file = test_data.open_genomic_set_file(test_data_filename)
 
-        input_filename = '{}{}.csv'.format(
+        input_filename = '{}{}{}.csv'.format(
             test_data_filename.replace('.csv', ''),
-            '_11192019' if include_timestamp else ''
+            '_11192019' if include_timestamp else '',
+            '_1' if include_sub_num else ''
         )
 
         self._write_cloud_csv(input_filename,


### PR DESCRIPTION
This PR moves the AW1F and the related Accessioning workflows into a separate cron job from the AW1 workflow. This allows them to be executed separately. An additional update to the AW2 naming convention was included in this PR to fulfill a request that came from the GCs to allow for a submission number at the end of the file name. The file name validation was made less strict to accommodate this request.