### PR TITLE
[ROC-627] Returning 400 on unrecognized enum value

### DIFF
--- a/rdr_service/dao/base_dao.py
+++ b/rdr_service/dao/base_dao.py
@@ -298,7 +298,12 @@ class BaseDao(object):
             elif property_type == PropertyType.DATETIME:
                 return api_util.parse_date(value)
             elif property_type == PropertyType.ENUM:
-                return prop.property.columns[0].type.enum_type(value)
+                enum_cls = prop.property.columns[0].type.enum_type
+                try:
+                    return enum_cls(value)
+                except (KeyError, TypeError):
+                    raise BadRequest(f'Invalid {prop} parameter: "{value}". '
+                                     f'must be one of {list(enum_cls.to_dict().keys())}')
             elif property_type == PropertyType.INTEGER:
                 return int(value)
             else:

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -3064,6 +3064,12 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual(ps['retentionEligibleStatus'], 'NOT_ELIGIBLE')
         self.assertEqual(ps.get('retentionEligibleTime'), None)
 
+    def test_enum_status_parameters(self):
+        # Unrecognized enum values should give descriptive error messages rather than 500s
+        self.send_get("ParticipantSummary?enrollmentStatus=MEMBER|FULL_PARTICIPANT", expected_status=400)
+        self.send_get("ParticipantSummary?withdrawalStatus=test", expected_status=400)
+        self.send_get("ParticipantSummary?suspensionStatus=test", expected_status=400)
+
     def _remove_participant_retention_eligible(self, participant_id):
         ps_dao = ParticipantSummaryDao()
         summary = ps_dao.get(participant_id)


### PR DESCRIPTION
A user tried to give `enrollmentStatus=MEMBER|FULL_PARTICIPANT` as a parameter to participant summary and we responded with a 500 error. This PR doesn't really help much with what they were hoping to do, but now it can be clearer what's wrong with the request.