### PR TITLE
[DA-1719] Add tz offset to returned timestamps.

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1,4 +1,6 @@
 import collections
+
+import pytz
 import sqlalchemy
 import logging
 
@@ -956,7 +958,7 @@ class GenomicOutreachDao(BaseDao):
 
         client_json = {
             "participant_report_statuses": report_statuses,
-            "timestamp": result['date']
+            "timestamp": result['date'].replace(tzinfo=pytz.UTC)
         }
         return client_json
 

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -958,7 +958,7 @@ class GenomicOutreachDao(BaseDao):
 
         client_json = {
             "participant_report_statuses": report_statuses,
-            "timestamp": result['date'].replace(tzinfo=pytz.UTC)
+            "timestamp": pytz.utc.localize(result['date'])
         }
         return client_json
 

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -1,4 +1,6 @@
 import datetime
+
+import pytz
 from dateutil import parser
 
 from tests.helpers.unittest_base import BaseTestCase
@@ -207,7 +209,7 @@ class GenomicOutreachApiTest(GenomicApiTestBase):
                     "report_status": "pending_delete"
                 }
             ],
-            "timestamp": fake_now.replace(microsecond=0).isoformat()
+            "timestamp": fake_now.replace(microsecond=0, tzinfo=pytz.UTC).isoformat()
         }
 
         self.assertEqual(expected_response, resp)
@@ -240,7 +242,7 @@ class GenomicOutreachApiTest(GenomicApiTestBase):
                     "report_status": "ready"
                 }
             ],
-            "timestamp": fake_now.replace(microsecond=0).isoformat()
+            "timestamp": fake_now.replace(microsecond=0, tzinfo=pytz.UTC).isoformat()
         }
 
         self.assertEqual(expected_response, resp)
@@ -266,7 +268,7 @@ class GenomicOutreachApiTest(GenomicApiTestBase):
                     "report_status": "ready"
                 }
             ],
-            "timestamp": fake_now.replace(microsecond=0).isoformat()
+            "timestamp": fake_now.replace(microsecond=0, tzinfo=pytz.UTC).isoformat()
         }
 
         self.assertEqual(expected_response, resp)


### PR DESCRIPTION
The Genomic Outreach API response is returning timestamps that are timezone naive. The timezone offset needs to be included in timestamps in the JSON response.