### PR TITLE
Preserving duplicated query parameters

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -253,7 +253,7 @@ class BaseApi(Resource):
             query_params = request.args.copy()
             query_params["_token"] = results.pagination_token
 
-            next_url = main.api.url_for(self.__class__, _external=True, **query_params)
+            next_url = main.api.url_for(self.__class__, _external=True, **query_params.to_dict(flat=False))
             bundle_dict["link"] = [{"relation": "next", "url": next_url}]
         entries = []
         for item in results.items:

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1,5 +1,6 @@
 import datetime
 import http.client
+from mock import patch
 import threading
 import unittest
 from urllib.parse import urlencode
@@ -3063,6 +3064,22 @@ class ParticipantSummaryApiTest(BaseTestCase):
         ps = self.send_get("Participant/%s/Summary" % participant_id)
         self.assertEqual(ps['retentionEligibleStatus'], 'NOT_ELIGIBLE')
         self.assertEqual(ps.get('retentionEligibleTime'), None)
+
+    @patch('rdr_service.api.base_api.DEFAULT_MAX_RESULTS', 1)
+    def test_parameter_pagination(self):
+        # Duplicated parameters should appear in the next link when paging results
+
+        # Force a paged response
+        self.data_generator.create_database_participant_summary(consentForStudyEnrollmentAuthored='2019-04-01')
+        self.data_generator.create_database_participant_summary(consentForStudyEnrollmentAuthored='2019-04-01')
+
+        response = self.send_get("ParticipantSummary?"
+                                 "consentForStudyEnrollmentAuthored=lt2020-01-01T00:00:00"
+                                 "&consentForStudyEnrollmentAuthored=gt2019-01-01T00:00:00")
+
+        next_url = response['link'][0]['url']
+        self.assertIn('Authored=lt2020', next_url)
+        self.assertIn('Authored=gt2019', next_url)
 
     def _remove_participant_retention_eligible(self, participant_id):
         ps_dao = ParticipantSummaryDao()


### PR DESCRIPTION
A developer from the curation team ran into an issue with the way the next-page link was constructed when getting participant summaries. A request that looked like `ParticipantSummary?consentForStudyEnrollmentAuthored=lt2020-01-01T00:00:00&consentForStudyEnrollmentAuthored=gt2019-01-01T00:00:00` (with duplicated request parameters) would give a response that had a link for the next page, but it would drop one of the copied parameters. So the next-page link would appear as something like `ParticipantSummary?consentForStudyEnrollmentAuthored=lt2020-01-01T00:00:00&_token=...`.

This uses functionality in the MultiDict structure (`request.args`'s type) and Flask to preserve the duplication of the arguements.