### PR TITLE
Gracefully handling invalid json

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -44,7 +44,11 @@ def log_api_request(log: RequestsLog = None, model_obj=None):
             # We don't want to use request.json or request.get_json here.
             log.resource = json.loads(request.data)
         except ValueError:
-            log.resource = request.data
+            # Serialization failed
+            # so to store the request body in our JSON column we need to make it valid JSON
+            request_contents_string = request.data.decode('utf-8')
+            log.resource = json.dumps(request_contents_string)  # JSON escape the string
+
     parts = request.url.split('/')
     try:
         log.version = int(parts[4][1:]) if len(parts) > 4 else 0

--- a/tests/api_tests/test_generic_api_functionality.py
+++ b/tests/api_tests/test_generic_api_functionality.py
@@ -1,0 +1,14 @@
+from rdr_service import main
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class GenericApiFunctionalityTest(BaseTestCase):
+
+    def test_server_graceful_with_invalid_json(self):
+        response = self.app.open(
+            main.API_PREFIX + 'Participant/P1234/Observation',
+            method='POST',
+            data="{invalid json",
+            content_type="application/json"
+        )
+        self.assertNotEqual(500, response.status_code, 'Server crashed when given invalid JSON')


### PR DESCRIPTION
I noticed this when trying to debug something with the deceased reports. If the server receives invalid JSON and tries to create an entry in the request_logs table with it, it will fail to insert the record because the JSON serialization in MySQL will fail.