### PR TITLE
[ROC-628] Endless July COPE survey

### DIFF
--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -723,6 +723,23 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
         participant_summary = self.participant_summary_dao.get(1)
         self.assertEqual(QuestionnaireStatus.SUBMITTED, participant_summary.questionnaireOnCopeJune)
 
+    def test_july_cope_survey_updated_in_august(self):
+        # The July survey didn't close with July,
+        # any questionnaires that have been updated after the start of August should still count for July
+
+        self.insert_codes()
+        p = Participant(participantId=1, biobankId=2)
+        self.participant_dao.insert(p)
+
+        self._setup_participant()
+        self._create_cope_questionnaire()
+        self._bump_questionnaire_version(2, updated_time=datetime.datetime(2020, 8, 28))  # update for July survey
+
+        self._submit_questionnaire_response(self.cope_consent_yes, questionnaire_version=2, consent_question_id=8)
+
+        participant_summary = self.participant_summary_dao.get(1)
+        self.assertEqual(QuestionnaireStatus.SUBMITTED, participant_summary.questionnaireOnCopeJuly)
+
     def test_cope_june_survey_consent_deferred(self):
         self.insert_codes()
         p = Participant(participantId=1, biobankId=2)


### PR DESCRIPTION
The algorithm for detecting what month a given questionnaire belongs to needs some updates. But while we wait to get more information on what we can do about that we should update the current one with how it handles July (because there are about a hundred participants that are recorded incorrectly for it right now).

July was different that the others in that it didn't close with the end of its month. July responses authored in August should still be recorded in the summary's July COPE columns. That works for most questionnaires, but there's atleast one version of the questionnaire that has a modified date in August, so we don't recognize it as a July response.

This will need to be modified again when the next COPE survey is released, but we'll cross that bridge when we get to it.

I'll also be writing a backfill SQL statement to correct for the responses we've already received.