### PR TITLE
[PDR-118] Exclude free text fields from BQ OverallHealth module

### DIFF
--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -307,6 +307,8 @@ class BQPDROverallHealthSchema(_BQModuleSchema):
         'OrganTransplantDescription_OtherOrgan',
         'OrganTransplantDescription_OtherTissue',
         'OutsideTravel6Month_OutsideTravel6MonthWhereTraveled',
+        'OtherOrgan_FreeTextBox',
+        'OtherTissue_FreeTextBox'
     )
 
 


### PR DESCRIPTION
Schema changes tested on sandbox BQ.  Will manually migrate schema changes to production upon PR approval.
None of the existing PDR records currently have any data in these fields (all null as of 8/25)