### PR TITLE
Adding participant id prefix for deceased reports

### DIFF
--- a/rdr_service/api/deceased_report_api.py
+++ b/rdr_service/api/deceased_report_api.py
@@ -19,6 +19,7 @@ class DeceasedReportApi(DeceasedReportApiMixin, BaseApi):
         search_kwargs = {key: value for key, value in request.args.items()}
 
         if participant_id is not None:
+            participant_id = from_client_participant_id(participant_id)
             found_reports = self.dao.load_reports(participant_id=participant_id, **search_kwargs)
         else:
             # Only HEALTHPRO should be able to pull reports for multiple participants

--- a/tests/api_tests/test_deceased_report_api.py
+++ b/tests/api_tests/test_deceased_report_api.py
@@ -586,7 +586,7 @@ class ParticipantDeceasedReportApiTest(DeceasedReportTestBase):
             authored=datetime(2020, 4, 1, tzinfo=pytz.utc)
         )
 
-        report_list_response = self.send_get(f'Participant/{participant.participantId}/DeceasedReport')
+        report_list_response = self.send_get(f'Participant/P{participant.participantId}/DeceasedReport')
 
         first_report = report_list_response[0]  # Most recent report
         self.assertEqual('cancelled', first_report['status'])


### PR DESCRIPTION
I forgot to have the participant id prefix parse out of the url.