### PR TITLE
Removing pip from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -120,9 +120,6 @@ xmltodict==0.12.0         # via -r requirements.in
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
 
-# Fix PIP version temporarily. App Engine deployment errors out on newer version of PIP.
-pip==19.2.3
-
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools


### PR DESCRIPTION
I'd like to see what the error is again that makes us use the older pip version. I thought it might have been to do with pip-tools, but making it happen again seems more efficient than digging through the logs.

But _maybe_ it was to do with pip-tools (which is no longer installed when we deploy) so this could keep our deploys from losing track of the pip module in the python3.7.8 GAE images.