### PR TITLE
[DA-1631] Import questionnaire codes from Redcap

### DIFF
--- a/rdr_service/model/database.py
+++ b/rdr_service/model/database.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 import backoff
 from sqlalchemy import create_engine
 from sqlalchemy.exc import DBAPIError
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 from rdr_service.model.base import Base, MetricsBase
 
@@ -85,7 +85,7 @@ class Database(object):
     def create_metrics_schema(self):
         MetricsBase.metadata.create_all(self._engine)
 
-    def make_session(self):
+    def make_session(self) -> Session:
         return self._Session()
 
     @contextmanager

--- a/rdr_service/tools/tool_libs/_tool_base.py
+++ b/rdr_service/tools/tool_libs/_tool_base.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 
+from rdr_service.dao import database_factory
 from rdr_service.services.system_utils import setup_logging, setup_i18n
 from rdr_service.tools.tool_libs import GCPProcessContext
 
@@ -18,6 +19,10 @@ class ToolBase(object):
         if not proxy_pid:
             logger.error("activating google sql proxy failed.")
             return 1
+
+    @staticmethod
+    def get_session():
+        return database_factory.make_server_cursor_database().session()
 
 
 def cli_run(tool_cmd, tool_desc, tool_class, parser_hook=None):
@@ -40,4 +45,5 @@ def cli_run(tool_cmd, tool_desc, tool_class, parser_hook=None):
     with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
         process = tool_class(args, gcp_env)
         exit_code = process.run()
+
         return exit_code

--- a/rdr_service/tools/tool_libs/_tool_base.py
+++ b/rdr_service/tools/tool_libs/_tool_base.py
@@ -1,0 +1,43 @@
+import argparse
+import logging
+import sys
+
+from rdr_service.services.system_utils import setup_logging, setup_i18n
+from rdr_service.tools.tool_libs import GCPProcessContext
+
+logger = logging.getLogger("rdr_logger")
+
+
+class ToolBase(object):
+    def __init__(self, args, gcp_env):
+        self.args = args
+        self.gcp_env = gcp_env
+
+    def run(self):
+        proxy_pid = self.gcp_env.activate_sql_proxy()
+        if not proxy_pid:
+            logger.error("activating google sql proxy failed.")
+            return 1
+
+
+def cli_run(tool_cmd, tool_desc, tool_class, parser_hook=None):
+    # Set global debug value and setup application logging.
+    setup_logging(
+        logger, tool_cmd, "--debug" in sys.argv, "{0}.log".format(tool_cmd) if "--log-file" in sys.argv else None
+    )
+    setup_i18n()
+
+    # Setup program arguments.
+    parser = argparse.ArgumentParser(prog=tool_cmd, description=tool_desc)
+    parser.add_argument("--project", help="gcp project name", default="localhost")  # noqa
+    parser.add_argument("--account", help="pmi-ops account", default=None)  # noqa
+    parser.add_argument("--service-account", help="gcp iam service account", default=None)  # noqa
+    if parser_hook:
+        parser_hook(parser)
+
+    args = parser.parse_args()
+
+    with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
+        process = tool_class(args, gcp_env)
+        exit_code = process.run()
+        return exit_code

--- a/rdr_service/tools/tool_libs/cope_answers.py
+++ b/rdr_service/tools/tool_libs/cope_answers.py
@@ -5,7 +5,6 @@
 
 import json
 
-from rdr_service.dao import database_factory
 from rdr_service.tools.tool_libs._tool_base import cli_run, ToolBase
 
 # Tool_cmd and tool_desc name are required.
@@ -48,7 +47,7 @@ class CopeAnswersClass(ToolBase):
         super(CopeAnswersClass, self).run()
 
         question_totals = {}
-        with database_factory.make_server_cursor_database().session() as session:
+        with self.get_session() as session:
             answer_counts = session.execute(ANSWER_COUNT_SQL, params={'cope_month': self.args.cope_month})
             for count in answer_counts:
                 # Get the running totals for the question and answer

--- a/rdr_service/tools/tool_libs/sync_codes.py
+++ b/rdr_service/tools/tool_libs/sync_codes.py
@@ -137,6 +137,10 @@ class SyncCodesClass(ToolBase):
             # Don't save anything if codes were unintentionally reused
             if not self.is_saving_codes:
                 session.rollback()
+                logger.error('The above codes were already in the RDR database. '
+                             'Please verify with the team creating questionnaires in Redcap that this was intentional, '
+                             'and then re-run the tool with the "--reuse-codes" arguement to specify that they should '
+                             'be allowed.')
                 return 1
 
         return 0

--- a/rdr_service/tools/tool_libs/sync_codes.py
+++ b/rdr_service/tools/tool_libs/sync_codes.py
@@ -1,6 +1,7 @@
 import requests
 from sqlalchemy.orm.session import Session
 
+from rdr_service.clock import CLOCK
 from rdr_service.model.code import Code, CodeType
 from rdr_service.tools.tool_libs._tool_base import cli_run, logger, ToolBase
 from rdr_service.tools.tool_libs.app_engine_manager import AppConfigClass
@@ -44,7 +45,8 @@ class SyncCodesClass(ToolBase):
             shortValue=value[:50],
             display=display,
             system=CODE_SYSTEM,
-            mapped=True
+            mapped=True,
+            created=CLOCK.now()
         )
         session.add(new_code)
         return new_code
@@ -69,12 +71,12 @@ class SyncCodesClass(ToolBase):
 
     @staticmethod
     def retrieve_data_dictionary(api_key):
-        response = requests.post('https://redcap.pmi-ops.org/api/', json={
+        response = requests.post('https://redcap.pmi-ops.org/api/', data={
             'token': api_key,
             'content': 'metadata',
             'format': 'json',
             'returnFormat': 'json'
-        }, headers={'User-Agent': 'bot'})
+        })
         if response.status_code != 200:
             logger.error(f'ERROR: Received status code {response.status_code} from API')
 

--- a/rdr_service/tools/tool_libs/sync_codes.py
+++ b/rdr_service/tools/tool_libs/sync_codes.py
@@ -71,12 +71,19 @@ class SyncCodesClass(ToolBase):
 
     @staticmethod
     def retrieve_data_dictionary(api_key):
+        # https://precisionmedicineinitiative.atlassian.net/browse/PD-5404
+        headers = {
+            'User-Agent': 'RDR code sync tool',
+            'Accept': None,
+            'Connection': None,
+        }
+
         response = requests.post('https://redcap.pmi-ops.org/api/', data={
             'token': api_key,
             'content': 'metadata',
             'format': 'json',
             'returnFormat': 'json'
-        })
+        }, headers=headers)
         if response.status_code != 200:
             logger.error(f'ERROR: Received status code {response.status_code} from API')
 

--- a/rdr_service/tools/tool_libs/sync_codes.py
+++ b/rdr_service/tools/tool_libs/sync_codes.py
@@ -1,0 +1,105 @@
+import requests
+from sqlalchemy.orm.session import Session
+
+from rdr_service.model.code import Code, CodeType
+from rdr_service.tools.tool_libs._tool_base import cli_run, logger, ToolBase
+from rdr_service.tools.tool_libs.app_engine_manager import AppConfigClass
+
+# Tool_cmd and tool_desc name are required.
+# Remember to add/update bash completion in 'tool_lib/tools.bash'
+tool_cmd = "sync-codes"
+tool_desc = "Syncs codes from the provided Redcap project"
+
+REDCAP_PROJECT_KEYS = 'project_api_keys'
+CODE_SYSTEM = 'http://terminology.pmi-ops.org/CodeSystem/ppi'
+META_DATA_FIELD_TYPE = ['text', 'radio', 'dropdown', 'checkbox', 'yesno', 'truefalse']
+
+
+class SyncCodesClass(ToolBase):
+    def get_api_key(self, redcap_project_name):
+        # The AppConfig class uses the git_project field from args when initializing,
+        # looks like it uses it as a root directory for other purposes.
+        self.args.git_project = self.gcp_env.git_project
+
+        # Get the server config
+        app_config_manager = AppConfigClass(self.args, self.gcp_env)
+        server_config = app_config_manager.get_bucket_app_config()
+
+        if REDCAP_PROJECT_KEYS not in server_config:
+            logger.error('ERROR: Server config file does not list any API keys')
+            return None
+
+        keys = server_config[REDCAP_PROJECT_KEYS]
+        if redcap_project_name not in keys:
+            logger.error(f'ERROR: Project "{redcap_project_name}" not listed with key in server config')
+            return None
+
+        return server_config[REDCAP_PROJECT_KEYS][redcap_project_name]
+
+    @staticmethod
+    def initialize_code(session: Session, value, display, code_type=None):
+        new_code = Code(
+            codeType=code_type,
+            value=value,
+            shortValue=value[:50],
+            display=display,
+            system=CODE_SYSTEM,
+            mapped=True
+        )
+        session.add(new_code)
+        return new_code
+
+    def import_answer_code(self, session: Session, answer_text, question_code):
+        # There may be multiple commas in the display string, we want to split on the first to get the code
+        code, display = (part.strip() for part in answer_text.split(',', 1))
+        answer_code = self.initialize_code(session, code, display, CodeType.ANSWER)
+        answer_code.parent = question_code
+
+    def import_data_dictionary_item(self, session: Session, code_json):
+        new_code = self.initialize_code(session, code_json['field_name'], code_json['field_label'])
+
+        if code_json['field_type'] == 'descriptive':
+            new_code.codeType = CodeType.MODULE
+        else:
+            new_code.codeType = CodeType.QUESTION
+            answers_string = code_json['select_choices_or_calculations']
+            if answers_string:
+                for answer_text in answers_string.split('|'):
+                    self.import_answer_code(session, answer_text.strip(), new_code)
+
+    @staticmethod
+    def retrieve_data_dictionary(api_key):
+        response = requests.post('https://redcap.pmi-ops.org/api/', json={
+            'token': api_key,
+            'content': 'metadata',
+            'format': 'json',
+            'returnFormat': 'json'
+        }, headers={'User-Agent': 'bot'})
+        if response.status_code != 200:
+            logger.error(f'ERROR: Received status code {response.status_code} from API')
+
+        return response.content
+
+    def run(self):
+        super(SyncCodesClass, self).run()
+
+        # Get the server config to read Redcap API keys
+        project_api_key = self.get_api_key(self.args.redcap_project)
+        if project_api_key is None:
+            logger.error('Unable to find project API key')
+            return 1
+        dictionary_json = self.retrieve_data_dictionary(project_api_key)
+
+        with self.get_session() as session:
+            for item_json in dictionary_json:
+                self.import_data_dictionary_item(session, item_json)
+
+        return 0
+
+
+def add_additional_arguments(parser):
+    parser.add_argument('--redcap-project', required=True, help='Name of Redcap project to sync')
+
+
+def run():
+    cli_run(tool_cmd, tool_desc, SyncCodesClass)

--- a/tests/tool_tests/test_sync_codes.py
+++ b/tests/tool_tests/test_sync_codes.py
@@ -15,11 +15,33 @@ class CopeAnswerTest(BaseTestCase):
         super().setUp()
 
     @staticmethod
-    def run_tool():
+    def _get_mock_dictionary_item(code_value, description, field_type, answers=''):
+        return {
+            "field_name": code_value,
+            "form_name": "survey",
+            "section_header": "",
+            "field_type": field_type,
+            "field_label": description,
+            "select_choices_or_calculations": answers,
+            "field_note": "",
+            "text_validation_type_or_show_slider_number": "",
+            "text_validation_min": "",
+            "text_validation_max": "",
+            "identifier": "",
+            "branching_logic": "",
+            "required_field": "",
+            "custom_alignment": "",
+            "question_number": "",
+            "matrix_group_name": "",
+            "matrix_ranking": "",
+            "field_annotation": ""
+        }
+
+    def run_tool(self, redcap_data_dictionary):
         def get_server_config(*_):
             config = {
                 REDCAP_PROJECT_KEYS: {
-                    'project_one': ''  # '1234ABC'
+                    'project_one': '1234ABC'
                 }
             }
             return json.dumps(config), 'test-file-name'
@@ -32,57 +54,28 @@ class CopeAnswerTest(BaseTestCase):
         args = mock.MagicMock()
         args.redcap_project = 'project_one'
 
-        # with mock.patch('rdr_service.tools.tool_libs.sync_codes.requests') as mock_requests:
-        #     mock_response = mock_requests.post.return_value
-        #     mock_response.status_code = 200
-        #     mock_response.content = [
-        #         {
-        #             "field_name": "participant_id",
-        #             "form_name": "survey",
-        #             "section_header": "",
-        #             "field_type": "text",
-        #             "field_label": "Participant ID",
-        #             "select_choices_or_calculations": "",
-        #             "field_note": "",
-        #             "text_validation_type_or_show_slider_number": "",
-        #             "text_validation_min": "",
-        #             "text_validation_max": "",
-        #             "identifier": "",
-        #             "branching_logic": "",
-        #             "required_field": "",
-        #             "custom_alignment": "",
-        #             "question_number": "",
-        #             "matrix_group_name": "",
-        #             "matrix_ranking": "",
-        #             "field_annotation": ""
-        #         },
-        #         {
-        #             "field_name": "radio",
-        #             "form_name": "survey",
-        #             "section_header": "Section 1 (This is a section header with descriptive text. It only provides informational text and is used to divide the survey into sections for organization. If the survey is set to be displayed as \"one section per page\", then these section headers will begin each new page of the survey.)",
-        #             "field_type": "radio",
-        #             "field_label": "You may create MULTIPLE CHOICE questions and set the answer choices for them. You can have as many answer choices as you need. This multiple choice question is rendered as RADIO buttons.",
-        #             "select_choices_or_calculations": "1, Choice One | 2, Choice Two | 3, Choice Three | 4, Etc.",
-        #             "field_note": "",
-        #             "text_validation_type_or_show_slider_number": "",
-        #             "text_validation_min": "",
-        #             "text_validation_max": "",
-        #             "identifier": "",
-        #             "branching_logic": "",
-        #             "required_field": "",
-        #             "custom_alignment": "",
-        #             "question_number": "",
-        #             "matrix_group_name": "",
-        #             "matrix_ranking": "",
-        #             "field_annotation": ""
-        #         }
-        #     ]
+        with mock.patch('rdr_service.tools.tool_libs.sync_codes.requests') as mock_requests:
+            mock_response = mock_requests.post.return_value
+            mock_response.status_code = 200
+            mock_response.content = redcap_data_dictionary
 
-        sync_codes_tool = SyncCodesClass(args, gcp_env)
-        sync_codes_tool.run()
+            sync_codes_tool = SyncCodesClass(args, gcp_env)
+            sync_codes_tool.run()
 
     def test_code_sync(self):
-        self.run_tool()
+        self.run_tool([
+            self._get_mock_dictionary_item(
+                'participant_id',
+                'Participant ID',
+                'text'
+            ),
+            self._get_mock_dictionary_item(
+                'radio',
+                'This is a single select question',
+                'radio',
+                answers='1, Choice One | 2, Choice Two | 3, Choice Three | 4, Etc.'
+            )
+        ])
 
         codes = self.session.query(Code).all()
         print(codes)

--- a/tests/tool_tests/test_sync_codes.py
+++ b/tests/tool_tests/test_sync_codes.py
@@ -1,0 +1,88 @@
+import json
+import mock
+import os
+
+import rdr_service
+from rdr_service.model.code import Code
+from rdr_service.tools.tool_libs.sync_codes import SyncCodesClass, REDCAP_PROJECT_KEYS
+from tests.helpers.unittest_base import BaseTestCase
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(rdr_service.__file__))
+
+
+class CopeAnswerTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+    @staticmethod
+    def run_tool():
+        def get_server_config(*_):
+            config = {
+                REDCAP_PROJECT_KEYS: {
+                    'project_one': ''  # '1234ABC'
+                }
+            }
+            return json.dumps(config), 'test-file-name'
+
+        gcp_env = mock.MagicMock()
+        gcp_env.project = 'unit_test'
+        gcp_env.git_project = PROJECT_ROOT
+        gcp_env.get_latest_config_from_bucket = get_server_config
+
+        args = mock.MagicMock()
+        args.redcap_project = 'project_one'
+
+        # with mock.patch('rdr_service.tools.tool_libs.sync_codes.requests') as mock_requests:
+        #     mock_response = mock_requests.post.return_value
+        #     mock_response.status_code = 200
+        #     mock_response.content = [
+        #         {
+        #             "field_name": "participant_id",
+        #             "form_name": "survey",
+        #             "section_header": "",
+        #             "field_type": "text",
+        #             "field_label": "Participant ID",
+        #             "select_choices_or_calculations": "",
+        #             "field_note": "",
+        #             "text_validation_type_or_show_slider_number": "",
+        #             "text_validation_min": "",
+        #             "text_validation_max": "",
+        #             "identifier": "",
+        #             "branching_logic": "",
+        #             "required_field": "",
+        #             "custom_alignment": "",
+        #             "question_number": "",
+        #             "matrix_group_name": "",
+        #             "matrix_ranking": "",
+        #             "field_annotation": ""
+        #         },
+        #         {
+        #             "field_name": "radio",
+        #             "form_name": "survey",
+        #             "section_header": "Section 1 (This is a section header with descriptive text. It only provides informational text and is used to divide the survey into sections for organization. If the survey is set to be displayed as \"one section per page\", then these section headers will begin each new page of the survey.)",
+        #             "field_type": "radio",
+        #             "field_label": "You may create MULTIPLE CHOICE questions and set the answer choices for them. You can have as many answer choices as you need. This multiple choice question is rendered as RADIO buttons.",
+        #             "select_choices_or_calculations": "1, Choice One | 2, Choice Two | 3, Choice Three | 4, Etc.",
+        #             "field_note": "",
+        #             "text_validation_type_or_show_slider_number": "",
+        #             "text_validation_min": "",
+        #             "text_validation_max": "",
+        #             "identifier": "",
+        #             "branching_logic": "",
+        #             "required_field": "",
+        #             "custom_alignment": "",
+        #             "question_number": "",
+        #             "matrix_group_name": "",
+        #             "matrix_ranking": "",
+        #             "field_annotation": ""
+        #         }
+        #     ]
+
+        sync_codes_tool = SyncCodesClass(args, gcp_env)
+        sync_codes_tool.run()
+
+    def test_code_sync(self):
+        self.run_tool()
+
+        codes = self.session.query(Code).all()
+        print(codes)

--- a/tests/tool_tests/test_sync_codes.py
+++ b/tests/tool_tests/test_sync_codes.py
@@ -101,3 +101,26 @@ class CopeAnswerTest(BaseTestCase):
         self.assertCodeExists('A3', 'Choice Three', CodeType.ANSWER, radio_code)
         self.assertCodeExists('A4', 'Etc.', CodeType.ANSWER, radio_code)
 
+    def test_detection_of_module_code(self):
+        self.run_tool([
+            self._get_mock_dictionary_item(
+                'TestQuestionnaire',
+                'Test Questionnaire Module',
+                'descriptive'
+            ),
+            self._get_mock_dictionary_item(
+                'participant_id',
+                'Participant ID',
+                'text'
+            ),
+            self._get_mock_dictionary_item(
+                'another_descriptive',
+                'This is another readonly section of the questionnaire',
+                'descriptive'
+            )
+        ])
+        self.assertEqual(2, self.session.query(Code).count(), "Only 2 codes should have been created")
+
+        module_code = self.assertCodeExists('TestQuestionnaire', 'Test Questionnaire Module', CodeType.MODULE)
+        self.assertCodeExists('participant_id', 'Participant ID', CodeType.QUESTION, module_code)
+

--- a/tests/tool_tests/test_sync_codes.py
+++ b/tests/tool_tests/test_sync_codes.py
@@ -46,7 +46,7 @@ class SyncCodesTest(BaseTestCase):
             return json.dumps(config), 'test-file-name'
 
         gcp_env = mock.MagicMock()
-        gcp_env.project = 'unit_test'
+        gcp_env.project = 'localhost'
         gcp_env.git_project = PROJECT_ROOT
         gcp_env.get_latest_config_from_bucket = get_server_config
 
@@ -92,7 +92,7 @@ class SyncCodesTest(BaseTestCase):
                 answers='A1, Choice One | A2, Choice Two | A3, Choice Three | A4, Etc.'
             )
         ])
-        self.assertEqual(6, self.session.query(Code).count(), "Only 6 codes should have been created")
+        self.assertEqual(6, self.session.query(Code).count(), "6 codes should have been created")
 
         self.assertCodeExists('participant_id', 'Participant ID', CodeType.QUESTION)
         radio_code = self.assertCodeExists(
@@ -123,7 +123,7 @@ class SyncCodesTest(BaseTestCase):
                 'descriptive'
             )
         ])
-        self.assertEqual(2, self.session.query(Code).count(), "Only 2 codes should have been created")
+        self.assertEqual(2, self.session.query(Code).count(), "2 codes should have been created")
 
         module_code = self.assertCodeExists('TestQuestionnaire', 'Test Questionnaire Module', CodeType.MODULE)
         self.assertCodeExists('participant_id', 'Participant ID', CodeType.QUESTION, module_code)


### PR DESCRIPTION
This PR adds a tool to bring new questionnaire codes from the Redcap API. Each questionnaire will exist as a project in Redcap and this tool will pull in the data dictionary of the project being updated (or added) to add the codes from that questionnaire.

In special cases (like the COPE survey) multiple projects will need to share question (or module) codes. So there is a feature for specifying that this code re-use should be allowed. I tried to make it clear in the error logs, and I'll do the same with the steps I add for the playbook, that these should be verified with the team responsible for the Redcap questionnaire projects. It also sounds like previously there was a process for reusing answer codes between questions, so that is automatically allowed to happen.

Each Redcap project will need to be accessed individually with its own API key. I set the tool up to be able to read them from the config of a server so that we'll be able to have them in a shared place without having them actually in the code.

I also refactored away a bit of the boilerplate for the tool code. I think it'd take a refactor of how they're run to get rid of all of it, but this atleast minimized the amount of code I needed to copy to create the tool.
