### PR TITLE
Sync doc/requirements.txt with latest

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -73,7 +73,7 @@ oauthlib[signedtoken]==3.1.0  # via jira, requests-oauthlib
 packaging==20.4           # via sphinx
 parameterized==0.7.4      # via -r requirements.in
 pbr==5.4.5                # via jira
-pip-tools==5.1.2          # via -r requirements.in
+# pip-tools==5.1.2          # via -r requirements.in
 protobuf==3.12.1          # via -r requirements.in, google-api-core, google-cloud-bigquery, googleapis-common-protos
 protorpc==0.12.0          # via -r requirements.in
 psutil==5.7.0             # via locust
@@ -87,6 +87,7 @@ pyopenssl==19.1.0         # via requests
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via alembic, faker
 python-editor==1.0.4      # via alembic
+python-http-client==3.2.7  # via sendgrid
 pytz==2020.1              # via babel, flask-restful, google-api-core, google-cloud-firestore
 pyyaml==5.3.1             # via google-python-cloud-debugger
 pyzmq==19.0.1             # via locust
@@ -94,6 +95,7 @@ requests-oauthlib==1.3.0  # via jira
 requests-toolbelt==0.9.1  # via jira
 requests[security]==2.23.0  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
 rsa==4.0                  # via google-auth, oauth2client
+sendgrid==6.3.1           # via -r requirements.in
 simplejson==3.17.0        # via -r requirements.in
 six==1.15.0               # via astroid, cryptography, flask-restful, geventhttpclient, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-python-cloud-debugger, google-resumable-media, grpcio, isodate, jira, oauth2client, packaging, pip-tools, protobuf, protorpc, pyopenssl, python-dateutil
 snowballstemmer==2.0.0    # via sphinx
@@ -117,9 +119,6 @@ wrapt==1.12.1             # via astroid
 xmltodict==0.12.0         # via -r requirements.in
 zope.event==4.4           # via gevent
 zope.interface==5.1.0     # via gevent
-
-# Fix PIP version temporarily. App Engine deployment errors out on newer version of PIP.
-pip==19.2.3
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
There is a copy of our requirements.txt file under the doc/ directory to enable ReadTheDocs.   It needs to be kept in sync with our project requirements.txt.   This pulls in the most recent changes.