### PR TITLE
Deceased report performer array update

### DIFF
--- a/rdr_service/dao/deceased_report_dao.py
+++ b/rdr_service/dao/deceased_report_dao.py
@@ -261,7 +261,6 @@ class DeceasedReportDao(UpdatableDao):
         observation.performer = []
         self._add_performer_data(observation, model.author, model.authored, is_author=True)
         try:
-            # Automatically approved reports don't currently have a reviewer user set
             if model.reviewer:
                 self._add_performer_data(observation, model.reviewer, model.reviewed, is_author=False)
         except DetachedInstanceError:


### PR DESCRIPTION
This updates the deceased report API to return author and reviewer information together in the performer array. It also gives an extension on each user-reference to be able to specify what the user did and when.