### PR TITLE
[DA-1736] Fix AW1F Alerts Job and Add Logging

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -386,7 +386,7 @@ class GenomicJobController:
         for bucket in alert_files.keys():
             email_message += f"\t{bucket}:\n"
             for file in alert_files[bucket]:
-                email_message += f"\t\t{file}:\n"
+                email_message += f"\t\t{file}\n"
 
         data = {
             "personalizations": [

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -226,6 +226,7 @@ class GenomicJobController:
         new_failure_files = dict()
 
         # Get files in each gc bucket and folder where updated date > last run date
+        logging.info("Searching buckets for accessioning FAILURE files.")
         for gc_bucket_name in self.bucket_name_list:
             failures_in_bucket = list()
 
@@ -240,16 +241,29 @@ class GenomicJobController:
 
                 if len(files_filtered) > 0:
                     for f in files_filtered:
+                        logging.info(f'Found failure file: {f}')
                         failures_in_bucket.append(f)
 
             if len(failures_in_bucket) > 0:
                 new_failure_files[gc_bucket_name] = failures_in_bucket
 
-        # Compile email message
-        email_req = self._compile_accesioning_failure_alert_email(new_failure_files)
+        self.job_result = GenomicSubProcessResult.NO_FILES
 
-        # send email
-        self._send_email_with_sendgrid(email_req)
+        if len(new_failure_files) > 0:
+            # Compile email message
+            logging.info('Compiling email...')
+            email_req = self._compile_accesioning_failure_alert_email(new_failure_files)
+
+            # send email
+            try:
+                logging.info('Sending Email to SendGrid...')
+                self._send_email_with_sendgrid(email_req)
+
+                logging.info('Email Sent.')
+                self.job_result = GenomicSubProcessResult.SUCCESS
+
+            except RuntimeError:
+                self.job_result = GenomicSubProcessResult.ERROR
 
     def run_cvl_reconciliation_report(self):
         """

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -98,7 +98,7 @@ def genomic_centers_accessioning_failures_workflow():
         Entrypoint for Accessioning Alerts:
             Failure Manifest (AW1F)
         """
-    with GenomicJobController(GenomicJob.AW1F_MANIFEST,
+    with GenomicJobController(GenomicJob.AW1F_ALERTS,
                               bucket_name=None,
                               bucket_name_list=config.GENOMIC_CENTER_BUCKET_NAME,
                               sub_folder_tuple=config.GENOMIC_AW1F_SUBFOLDERS

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1577,7 +1577,7 @@ class GenomicPipelineTest(BaseTestCase):
         # Set up expected SendGrid request
         email_message = "New AW1 Failure manifests have been found:\n"
         email_message += f"\t{_FAKE_GENOMIC_CENTER_BUCKET_A}:\n"
-        email_message += f"\t\t{_FAKE_FAILURE_FOLDER}/{gc_manifest_filename}:\n"
+        email_message += f"\t\t{_FAKE_FAILURE_FOLDER}/{gc_manifest_filename}\n"
 
         expected_email_req = {
             "personalizations": [

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1599,6 +1599,11 @@ class GenomicPipelineTest(BaseTestCase):
 
         send_email_mock.assert_called_with(expected_email_req)
 
+        # Test the end-to-end result code
+        job_run = self.job_run_dao.get(1)
+        self.assertEqual(GenomicJob.AW1F_ALERTS, job_run.jobId)
+        self.assertEqual(GenomicSubProcessResult.SUCCESS, job_run.runResult)
+
     def test_gem_a1_manifest_end_to_end(self):
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,


### PR DESCRIPTION
This PR fixes the AW1F Alerts job. The `GenomicJobController` job ID was incorrectly set to the `AW1F_MANIFEST` job ID. This has been updated to be the correct job ID: `AW1F_ALERTS`. The job was updated to provide results when completed. Logging was also added.