### PR TITLE
[ROC-652] De-duplicating response answers in curation ETL

### DIFF
--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -634,11 +634,11 @@ JOIN ( -- Filter question answers down to the latest we have from each participa
             WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
             ELSE c_inner.value
         END survey
-	FROM rdr.questionnaire_response qr_inner
-	JOIN rdr.questionnaire_response_answer qra_inner
-	    ON qra_inner.questionnaire_response_id = qr_inner.questionnaire_response_id
-	JOIN rdr.questionnaire_question qq_inner
-	    ON qq_inner.questionnaire_question_id = qra_inner.question_id
+    FROM rdr.questionnaire_response qr_inner
+    JOIN rdr.questionnaire_response_answer qra_inner
+        ON qra_inner.questionnaire_response_id = qr_inner.questionnaire_response_id
+    JOIN rdr.questionnaire_question qq_inner
+        ON qq_inner.questionnaire_question_id = qra_inner.question_id
     JOIN rdr.questionnaire_concept qc_inner
         ON qr_inner.questionnaire_id = qc_inner.questionnaire_id
             AND qr_inner.questionnaire_version = qc_inner.questionnaire_version
@@ -649,10 +649,10 @@ JOIN ( -- Filter question answers down to the latest we have from each participa
         FROM questionnaire_history qh
     ) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
         ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
-	GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
-	    WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
-	    ELSE c_inner.value
-	END
+    GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
+        WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
+        ELSE c_inner.value
+    END
 ) latest
     ON latest.participant_id = qr.participant_id
         AND latest.authored = qr.authored

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -615,12 +615,50 @@ JOIN rdr.questionnaire_response_answer qra
     ON  qra.questionnaire_response_id = qr.questionnaire_response_id
 JOIN rdr.questionnaire_question qq
     ON qra.question_id = qq.questionnaire_question_id
+JOIN (
+    SELECT qh.questionnaire_id, qh.version,
+        json_unquote(json_extract(convert(qh.resource using utf8), '$.identifier[0].value')) vibrent_form_id
+    FROM questionnaire_history qh
+) qvf
+    ON qvf.questionnaire_id = qr.questionnaire_id AND qvf.version = qr.questionnaire_version
 JOIN rdr.code co_q
     ON  qq.code_id = co_q.code_id
 LEFT JOIN rdr.code co_a
     ON  qra.value_code_id = co_a.code_id
 LEFT JOIN rdr.code co_b
     ON qc.code_id = co_b.code_id
+JOIN ( -- Filter question answers down to the latest we have from each participant for each question
+    SELECT qr_inner.participant_id, qq_inner.code_id question_code_id, MAX(qr_inner.authored) as authored, CASE
+            WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
+            ELSE c_inner.value
+        END survey
+	FROM rdr.questionnaire_response qr_inner
+	JOIN rdr.questionnaire_response_answer qra_inner
+	    ON qra_inner.questionnaire_response_id = qr_inner.questionnaire_response_id
+	JOIN rdr.questionnaire_question qq_inner
+	    ON qq_inner.questionnaire_question_id = qra_inner.question_id
+    JOIN rdr.questionnaire_concept qc_inner
+        ON qr_inner.questionnaire_id = qc_inner.questionnaire_id
+            AND qr_inner.questionnaire_version = qc_inner.questionnaire_version
+    JOIN rdr.code c_inner on c_inner.code_id = qc_inner.code_id
+	JOIN (
+        SELECT qh.questionnaire_id, qh.version,
+            json_unquote(json_extract(convert(qh.resource using utf8), '$.identifier[0].value')) vibrent_form_id
+        FROM questionnaire_history qh
+	) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
+	    ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
+	GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
+	    WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
+	    ELSE c_inner.value
+	END
+) latest
+    ON latest.participant_id = qr.participant_id
+	    AND latest.authored = qr.authored
+	    AND latest.question_code_id = qq.code_id
+	    AND latest.survey = CASE
+            WHEN co_b.value = 'COPE' THEN qvf.vibrent_form_id
+            ELSE co_b.value
+        END
 WHERE
     pa.withdrawal_status != 2
     AND pa.is_ghost_id IS NOT TRUE

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -642,22 +642,22 @@ JOIN ( -- Filter question answers down to the latest we have from each participa
     JOIN rdr.questionnaire_concept qc_inner
         ON qr_inner.questionnaire_id = qc_inner.questionnaire_id
             AND qr_inner.questionnaire_version = qc_inner.questionnaire_version
-    JOIN rdr.code c_inner on c_inner.code_id = qc_inner.code_id
-	JOIN (
+    JOIN rdr.code c_inner ON c_inner.code_id = qc_inner.code_id
+    JOIN (
         SELECT qh.questionnaire_id, qh.version,
             json_unquote(json_extract(convert(qh.resource using utf8), '$.identifier[0].value')) vibrent_form_id
         FROM questionnaire_history qh
-	) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
-	    ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
+    ) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
+        ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
 	GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
 	    WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
 	    ELSE c_inner.value
 	END
 ) latest
     ON latest.participant_id = qr.participant_id
-	    AND latest.authored = qr.authored
-	    AND latest.question_code_id = qq.code_id
-	    AND latest.survey = CASE
+        AND latest.authored = qr.authored
+        AND latest.question_code_id = qq.code_id
+        AND latest.survey = CASE
             WHEN co_b.value = 'COPE' THEN qvf.vibrent_form_id
             ELSE co_b.value
         END

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -537,7 +537,8 @@ DROP TABLE IF EXISTS cdm.questionnaire_vibrent_forms;
 CREATE TABLE cdm.questionnaire_vibrent_forms (
     questionnaire_id            bigint,
     version                     bigint,
-    vibrent_form_id             varchar(1024)
+    vibrent_form_id             varchar(1024),
+    INDEX vibrent_form_index    (questionnaire_id, version)
 );
 
 INSERT INTO cdm.questionnaire_vibrent_forms
@@ -557,7 +558,8 @@ CREATE TABLE cdm.questionnaire_latest_answers (
     participant_id              bigint,
     question_code_id            bigint,
     authored                    datetime,
-    survey                      varchar(1024)
+    survey                      varchar(1024),
+    INDEX latest_asnswers_index (participant_id, question_code_id, authored, survey)
 );
 
 -- -------------------------------------------------------------------

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -572,7 +572,9 @@ SELECT
     pa.participant_id               AS participant_id,
     pa.research_id                  AS research_id,
     co_b.value                      AS survey_name,
-    qr.created                      AS date_of_survey,
+    COALESCE(
+        qr.authored,
+        qr.created)                 AS date_of_survey,
     co_q.short_value                AS question_ppi_code,
     qq.code_id                      AS question_code_id,
     co_a.short_value                AS value_ppi_code,


### PR DESCRIPTION
Curation would like to have the authored time rather than created time, as long as authored isn't Null.

The also only need the latest answer to a particular survey's question. For the most part we can filter out everything but the latest for a responses question and module codes. But the COPE survey's all use the same module code while sharing question codes. So for them I retrieve the Vibrent Form ID we get in (almost) every questionnaire payload. The COPE surveys have a unique Vibrent Form ID for each month, so grouping by that instead of the module value (COPE) will preserve the individual responses that each month has for a shared question code.