### PR TITLE
[DA-1729] Add Research ID to AW3 manifests

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -15,6 +15,7 @@ from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 
 from rdr_service import clock
 from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.participant import Participant
 from rdr_service.services.jira_utils import JiraTicketHandler
 from rdr_service.api_util import (
     open_cloud_file,
@@ -1932,15 +1933,19 @@ class ManifestDefinitionProvider:
                         GenomicGCValidationMetrics.vcfPath,
                         GenomicGCValidationMetrics.vcfTbiPath,
                         GenomicGCValidationMetrics.vcfMd5Path,
-                        sqlalchemy.bindparam('research_id', None),
+                        Participant.researchId,
                     ]
                 ).select_from(
                     sqlalchemy.join(
-                        sqlalchemy.join(ParticipantSummary,
-                                        GenomicSetMember,
-                                        GenomicSetMember.participantId == ParticipantSummary.participantId),
-                        GenomicGCValidationMetrics,
-                        GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
+                        sqlalchemy.join(
+                            sqlalchemy.join(ParticipantSummary,
+                                            GenomicSetMember,
+                                            GenomicSetMember.participantId == ParticipantSummary.participantId),
+                            GenomicGCValidationMetrics,
+                            GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
+                        ),
+                        Participant,
+                        Participant.participantId == ParticipantSummary.participantId
                     )
                 ).where(
                     (GenomicGCValidationMetrics.processingStatus == self.PROCESSING_STATUS_PASS) &
@@ -1977,16 +1982,20 @@ class ManifestDefinitionProvider:
                         GenomicGCValidationMetrics.cramPath,
                         GenomicGCValidationMetrics.cramMd5Path,
                         GenomicGCValidationMetrics.craiPath,
-                        sqlalchemy.bindparam('research_id', None),
+                        Participant.researchId,
                         GenomicSetMember.sampleId,
                     ]
                 ).select_from(
                     sqlalchemy.join(
-                        sqlalchemy.join(ParticipantSummary,
-                                        GenomicSetMember,
-                                        GenomicSetMember.participantId == ParticipantSummary.participantId),
-                        GenomicGCValidationMetrics,
-                        GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
+                        sqlalchemy.join(
+                            sqlalchemy.join(ParticipantSummary,
+                                            GenomicSetMember,
+                                            GenomicSetMember.participantId == ParticipantSummary.participantId),
+                            GenomicGCValidationMetrics,
+                            GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
+                        ),
+                        Participant,
+                        Participant.participantId == ParticipantSummary.participantId
                     )
                 ).where(
                     (GenomicGCValidationMetrics.processingStatus == self.PROCESSING_STATUS_PASS) &

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -140,7 +140,7 @@ class GenomicPipelineTest(BaseTestCase):
         i = self._participant_i
         self._participant_i += 1
         bid = kwargs.pop('biobankId', i)
-        participant = Participant(participantId=i, biobankId=bid, **kwargs)
+        participant = Participant(participantId=i, biobankId=bid, researchId=1000000+i, **kwargs)
         self.participant_dao.insert(participant)
         return participant
 
@@ -2154,6 +2154,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(member.sampleId, int(rows[1]['sample_id']))
             self.assertEqual(member.sexAtBirth, rows[1]['sex_at_birth'])
             self.assertEqual(member.gcSiteId, rows[1]['site_id'])
+            self.assertEqual(1000002, int(rows[1]['research_id']))
 
             # Test File Paths
             metric = self.metrics_dao.get(2)
@@ -2258,6 +2259,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(f'{member.biobankId}_{member.sampleId}', rows[0]['biobankidsampleid'])
             self.assertEqual(member.sexAtBirth, rows[0]['sex_at_birth'])
             self.assertEqual(member.gcSiteId, rows[0]['site_id'])
+            self.assertEqual(1000002, int(rows[0]['research_id']))
 
             # Test File Paths
             metric = self.metrics_dao.get(1)


### PR DESCRIPTION
This PR updates the AW3 Array and WGS source data queries to pull the research ID from `participant.research_id`.