### PR TITLE
[DA-1693] Add AW4 workflow cron job

### DIFF
--- a/rdr_service/cron_careevo.yaml
+++ b/rdr_service/cron_careevo.yaml
@@ -13,6 +13,7 @@ cron:
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
 - description: Genomic AW3 Workflow (Manual)
+- description: Genomic AW4 Workflow (Manual)
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport
   schedule: every day 03:00

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -119,3 +119,8 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
+- description: Genomic AW4 Workflow (Manual)
+  url: /offline/GenomicAW4Workflow
+  timezone: America/New_York
+  schedule: 1 of jan 12:00
+  target: offline

--- a/rdr_service/cron_ptsc.yaml
+++ b/rdr_service/cron_ptsc.yaml
@@ -13,6 +13,7 @@ cron:
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
 - description: Genomic AW3 Workflow (Manual)
+- description: Genomic AW4 Workflow (Manual)
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport
   schedule: every day 03:00

--- a/rdr_service/cron_sandbox.yaml
+++ b/rdr_service/cron_sandbox.yaml
@@ -15,6 +15,7 @@ cron:
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
 - description: Genomic AW3 Workflow (Manual)
+- description: Genomic AW4 Workflow (Manual)
 - description: Rotate service account keys older than 3 days
   url: /offline/DeleteOldKeys
   schedule: every day 01:00

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -371,6 +371,19 @@ def genomic_aw3_workflow():
 
 @app_util.auth_required_cron
 @_alert_on_exceptions
+def genomic_aw4_workflow():
+    """Temporarily running this manually for E2E Testing"""
+    now = datetime.utcnow()
+    if now.day == 0o1 and now.month == 0o1:
+        logging.info("skipping the scheduled run.")
+        return '{"success": "true"}'
+    genomic_pipeline.aw4_array_manifest_workflow()
+    genomic_pipeline.aw4_wgs_manifest_workflow()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
 def bigquery_rebuild_cron():
     """ this should always be a manually run job, but we have to schedule it at least once a year. """
     now = datetime.utcnow()
@@ -570,6 +583,11 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicAW3Workflow",
         endpoint="genomic_aw3_workflow",
         view_func=genomic_aw3_workflow, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicAW4Workflow",
+        endpoint="genomic_aw4_workflow",
+        view_func=genomic_aw4_workflow, methods=["GET"]
     )
     # END Genomic Pipeline Jobs
 


### PR DESCRIPTION
This PR adds the AW4 workflow to the cron scheduler. This is in support of Genomics E2E testing.