### PR TITLE
HOTFIX: Changing datatypes for sample_id and collection_tube_id back to string.

### DIFF
--- a/rdr_service/alembic/versions/a4ab3afcb460_remove_columns_and_add_indexes_genomic_.py
+++ b/rdr_service/alembic/versions/a4ab3afcb460_remove_columns_and_add_indexes_genomic_.py
@@ -52,11 +52,11 @@ def upgrade_rdr():
     op.execute('ALTER TABLE genomic_set_member MODIFY `biobank_id` INTEGER;')
     op.execute('ALTER TABLE genomic_set_member_history MODIFY `biobank_id` INTEGER;')
 
-    op.execute('ALTER TABLE genomic_set_member MODIFY `collection_tube_id` INTEGER;')
-    op.execute('ALTER TABLE genomic_set_member_history MODIFY `collection_tube_id` INTEGER;')
+    op.execute('ALTER TABLE genomic_set_member MODIFY `collection_tube_id` VARCHAR(80);')
+    op.execute('ALTER TABLE genomic_set_member_history MODIFY `collection_tube_id` VARCHAR(80);')
 
-    op.execute('ALTER TABLE genomic_set_member MODIFY `sample_id` INTEGER;')
-    op.execute('ALTER TABLE genomic_set_member_history MODIFY `sample_id` INTEGER;')
+    op.execute('ALTER TABLE genomic_set_member MODIFY `sample_id` VARCHAR(80);')
+    op.execute('ALTER TABLE genomic_set_member_history MODIFY `sample_id` VARCHAR(80);')
     # ### end Alembic commands ###
 
 

--- a/rdr_service/model/bq_genomics.py
+++ b/rdr_service/model/bq_genomics.py
@@ -81,7 +81,7 @@ class BQGenomicSetMemberSchema(BQSchema):
     # validation_flags is an array of GenomicValidationFlag Enum values.
     validation_flags = BQField('validation_flags', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     validated_time = BQField('validated_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
-    sample_id = BQField('sample_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    sample_id = BQField('sample_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     sample_type = BQField('sample_type', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     reconcile_cvl_job_run_id = BQField('reconcile_cvl_job_run_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     sequencing_file_name = BQField('sequencing_file_name', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
@@ -147,7 +147,7 @@ class BQGenomicSetMemberSchema(BQSchema):
     genomic_workflow_state_history = BQField('genomic_workflow_state_history', BQFieldTypeEnum.STRING,
                                              BQFieldModeEnum.NULLABLE)
 
-    collection_tube_id = BQField('collection_tube_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    collection_tube_id = BQField('collection_tube_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     gc_site_id = BQField('gc_site_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     arr_aw3_manifest_job_run_id = BQField('arr_aw3_manifest_job_run_id', BQFieldTypeEnum.INTEGER,
                                           BQFieldModeEnum.NULLABLE)

--- a/rdr_service/model/genomics.py
+++ b/rdr_service/model/genomics.py
@@ -87,10 +87,10 @@ class GenomicSetMember(Base):
     validatedTime = Column("validated_time", DateTime, nullable=True)
 
     # collectionTubeId corresponds to biobank_stored_sample_id
-    collectionTubeId = Column('collection_tube_id', Integer, nullable=True, index=True)
+    collectionTubeId = Column('collection_tube_id', String(80), nullable=True, index=True)
 
     # sampleId is the great-grandchild aliquot of collectionTubeID
-    sampleId = Column('sample_id', Integer, nullable=True, index=True)
+    sampleId = Column('sample_id', String(80), nullable=True, index=True)
     sampleType = Column('sample_type', String(50), nullable=True)
 
     sequencingFileName = Column('sequencing_file_name',

--- a/rdr_service/resource/schemas/genomics.py
+++ b/rdr_service/resource/schemas/genomics.py
@@ -63,7 +63,7 @@ class GenomicSetMemberSchema(Schema):
     # validation_flags is an array of GenomicValidationFlag Enum values.
     validation_flags = fields.String(validate=validate.Length(max=80))
     validated_time = fields.DateTime()
-    sample_id = fields.Int32()
+    sample_id = fields.String(validate=validate.Length(max=80))
     sample_type = fields.String(validate=validate.Length(max=50))
     reconcile_cvl_job_run_id = fields.Int32()
     sequencing_file_name = fields.String(validate=validate.Length(max=128))
@@ -105,7 +105,7 @@ class GenomicSetMemberSchema(Schema):
     genomic_workflow_state_id = fields.EnumInteger(enum=GenomicWorkflowState)
 
     genomic_workflow_state_history = fields.JSON()
-    collection_tube_id = fields.Int32()
+    collection_tube_id = fields.String(validate=validate.Length(max=80))
     gc_site_id = fields.String(validate=validate.Length(max=11))
     arr_aw3_manifest_job_run_id = fields.Int32()
     wgs_aw3_manifest_job_run_id = fields.Int32()

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -248,7 +248,7 @@ class GenomicPipelineTest(BaseTestCase):
         # Test Genomic State updated
         member = self.member_dao.get(1)
         self.assertEqual(GenomicWorkflowState.AW2, member.genomicWorkflowState)
-        self.assertEqual(1001, member.sampleId)
+        self.assertEqual('1001', member.sampleId)
 
         # Test successful run result
         run_obj = self.job_run_dao.get(1)
@@ -1702,7 +1702,7 @@ class GenomicPipelineTest(BaseTestCase):
             rows = list(csv_reader)
             self.assertEqual(2, len(rows))
             self.assertEqual(test_member_1.biobankId, int(rows[0]['biobank_id']))
-            self.assertEqual(test_member_1.sampleId, int(rows[0]['sample_id']))
+            self.assertEqual(test_member_1.sampleId, rows[0]['sample_id'])
             self.assertEqual(test_member_1.sexAtBirth, rows[0]['sex_at_birth'])
             self.assertEqual("yes", rows[0]['consent_for_ror'])
             self.assertEqual(test_member_1.consentForGenomicsRORAuthored, parse(rows[0]['date_of_consent_for_ror']))
@@ -1841,7 +1841,7 @@ class GenomicPipelineTest(BaseTestCase):
             rows = list(csv_reader)
             self.assertEqual(1, len(rows))
             self.assertEqual(test_member.biobankId, int(rows[0]['biobank_id']))
-            self.assertEqual(test_member.sampleId, int(rows[0]['sample_id']))
+            self.assertEqual(test_member.sampleId, rows[0]['sample_id'])
 
         # Array
         file_record = self.file_processed_dao.get(1)  # remember, GC Metrics is #1
@@ -1929,7 +1929,7 @@ class GenomicPipelineTest(BaseTestCase):
 
             self.assertEqual(1, len(rows))
             self.assertEqual(member.biobankId, int(rows[0]['biobank_id']))
-            self.assertEqual(member.sampleId, int(rows[0]['sample_id']))
+            self.assertEqual(member.sampleId, rows[0]['sample_id'])
             self.assertEqual("", rows[0]['secondary_validation'])
 
         # Test file processed is recorded
@@ -2050,8 +2050,8 @@ class GenomicPipelineTest(BaseTestCase):
 
             self.assertEqual(3, len(rows))
             self.assertEqual(member.biobankId, int(rows[0]['biobank_id']))
-            self.assertEqual(member.collectionTubeId, int(rows[0]['collection_tubeid']))
-            self.assertEqual(member.sampleId, int(rows[0]['sample_id']))
+            self.assertEqual(member.collectionTubeId, rows[0]['collection_tubeid'])
+            self.assertEqual(member.sampleId, rows[0]['sample_id'])
             self.assertEqual(member.gcSiteId, rows[0]['site_id'])
 
         # Test Manifest File Record Created
@@ -2151,7 +2151,7 @@ class GenomicPipelineTest(BaseTestCase):
 
             self.assertEqual(2, len(rows))
             self.assertEqual(member.biobankId, int(rows[1]['biobank_id']))
-            self.assertEqual(member.sampleId, int(rows[1]['sample_id']))
+            self.assertEqual(member.sampleId, rows[1]['sample_id'])
             self.assertEqual(member.sexAtBirth, rows[1]['sex_at_birth'])
             self.assertEqual(member.gcSiteId, rows[1]['site_id'])
             self.assertEqual(1000002, int(rows[1]['research_id']))


### PR DESCRIPTION
This PR fixes a migration issue found on Stable for the `genomic_set_member` table. The data on stable for `sample_id` and `collection_tube_id` contains values that are too large to convert to integers. These fields must be strings. Unit tests and the Resource and BQ schemas were updated accordingly.