### PR TITLE
[DOCS] Only build documentation once when deploying to prod

### DIFF
--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -283,12 +283,14 @@ class DeployAppClass(object):
         docs = ReadTheDocsHandler(api_token)
 
         try:
+            # If deploying to prod, only need to update readthedocs with the correct git branch,
+            # Readthedocs will automatically build the documentation when that happens.
             if self.deploy_type == 'prod':
                 docs.update_project_to_release(self.args.git_target)
                 _logger.info(f'ReadTheDocs latest version default branch/tag updated to {self.args.git_target}')
-
-            build_id = docs.build_the_docs(self.docs_version)
-            _logger.info(f'Started documentation build for version {self.docs_version} (build ID: {build_id})')
+            else:
+                build_id = docs.build_the_docs(self.docs_version)
+                _logger.info(f'Started documentation build for version {self.docs_version} (build ID: {build_id})')
         except (ValueError, RuntimeError) as e:
             _logger.error(f'Failed to trigger readthedocs documentation build for version {self.docs_version}.  {e}')
 


### PR DESCRIPTION
I've noticed that deploying to prod or stable will kick off a pair of builds on ReadTheDocs. I'm not sure yet what's going on with the stable build, but it looks like ReadTheDocs automatically starts a build when we change the default branch it uses. So I modified the deploy script to skip a second trigger of the docs-build when it's already updated the default branch.