### PR TITLE
Addressing deadlock between cron jobs

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -6,7 +6,7 @@ cron:
   target: offline
 - description: Skew duplicate last modified
   url: /offline/SkewDuplicates
-  schedule: every day 01:00
+  schedule: every day 01:30
   timezone: America/New_York
   target: offline
 - description: Daily reconciliation report

--- a/rdr_service/offline/participant_maint.py
+++ b/rdr_service/offline/participant_maint.py
@@ -1,3 +1,5 @@
+import logging
+
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 
 
@@ -15,21 +17,26 @@ def skew_duplicate_last_modified():
         # Find last modified dates from participant summary where there are
         # at least 6 duplicates.
         sql = """
-      select last_modified, count from (
-        select last_modified, count(1) as count 
-          from participant_summary group by last_modified order by count desc
-      ) a where a.count > :min_dups
-    """
+            select last_modified, count from (
+                select last_modified, count(1) as count
+                from participant_summary group by last_modified order by count desc
+            ) a where a.count > :min_dups
+        """
         results = session.execute(sql, {"min_dups": min_dups}).fetchall()
 
         if results and len(results) > 0:
             # loop over results and randomize only the microseconds value of the timestamp.
             for rec in results:
                 sql = """
-          update participant_summary set last_modified =
-                date_add(date_format(last_modified, '%Y-%m-%d %H:%i:%S'), 
-                         INTERVAL (FLOOR(RAND() * 999998) + 1) MICROSECOND)
-             where last_modified = :ts
-          """
+                    update participant_summary
+                    set last_modified = date_add(
+                        date_format(last_modified, '%Y-%m-%d %H:%i:%S'),
+                        INTERVAL (FLOOR(RAND() * 999998) + 1) MICROSECOND
+                    )
+                    where last_modified = :ts
+                """
 
                 session.execute(sql, {"ts": rec["last_modified"]})
+                session.commit()  # Release write locks
+
+    logging.info('Skewing duplicate lastModified times complete')

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -16,6 +16,7 @@ def update_ehr_status():
   """
     update_particiant_summaries()
     update_organizations()
+    logging.info('Update EHR complete')
 
 
 def make_update_participant_summaries_job():


### PR DESCRIPTION
Making three changes to try to address the deadlock issue:
1. Putting some time between the UpdateEhr and SkewDuplicates cron jobs by moving skew to a little later
1. Adding log statements to better understand how long each job takes
1. Committing after each batch that skew works with to release the write locks it obtained for the batch