### PR TITLE
[DA-1739] Exporting codes from RDR database to Google drive

### DIFF
--- a/rdr_service/tools/tool_libs/_tool_base.py
+++ b/rdr_service/tools/tool_libs/_tool_base.py
@@ -25,7 +25,7 @@ class ToolBase(object):
         return database_factory.make_server_cursor_database().session()
 
 
-def cli_run(tool_cmd, tool_desc, tool_class, parser_hook=None):
+def cli_run(tool_cmd, tool_desc, tool_class, parser_hook=None, defaults={}):
     # Set global debug value and setup application logging.
     setup_logging(
         logger, tool_cmd, "--debug" in sys.argv, "{0}.log".format(tool_cmd) if "--log-file" in sys.argv else None
@@ -36,7 +36,9 @@ def cli_run(tool_cmd, tool_desc, tool_class, parser_hook=None):
     parser = argparse.ArgumentParser(prog=tool_cmd, description=tool_desc)
     parser.add_argument("--project", help="gcp project name", default="localhost")  # noqa
     parser.add_argument("--account", help="pmi-ops account", default=None)  # noqa
-    parser.add_argument("--service-account", help="gcp iam service account", default=None)  # noqa
+    parser.add_argument("--service-account",
+                        help="gcp iam service account",
+                        default=defaults.get('service_account', None))  # noqa
     if parser_hook:
         parser_hook(parser)
 

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -8,15 +8,15 @@ from rdr_service.tools.tool_libs.app_engine_manager import AppConfigClass
 
 # Tool_cmd and tool_desc name are required.
 # Remember to add/update bash completion in 'tool_lib/tools.bash'
-tool_cmd = "sync-codes"
-tool_desc = "Syncs codes from the provided Redcap project"
+tool_cmd = "codes"
+tool_desc = "Manage code import/export process. Syncing codes from the provided Redcap project and/or exporting " \
+            "codes that the RDR is aware of to the Ops team's Drive folder."
 
 REDCAP_PROJECT_KEYS = 'project_api_keys'
 CODE_SYSTEM = 'http://terminology.pmi-ops.org/CodeSystem/ppi'
-META_DATA_FIELD_TYPE = ['text', 'radio', 'dropdown', 'checkbox', 'yesno', 'truefalse']
 
 
-class SyncCodesClass(ToolBase):
+class CodesManagementClass(ToolBase):
     module_code = None
     codes_allowed_for_reuse = []
     is_saving_codes = True
@@ -117,7 +117,7 @@ class SyncCodesClass(ToolBase):
         return response.content
 
     def run(self):
-        super(SyncCodesClass, self).run()
+        super(CodesManagementClass, self).run()
 
         if hasattr(self.args, 'reuse_codes'):
             self.codes_allowed_for_reuse = [code_val.strip() for code_val in self.args.reuse_codes.split(',')]
@@ -147,9 +147,9 @@ class SyncCodesClass(ToolBase):
 
 
 def add_additional_arguments(parser):
-    parser.add_argument('--redcap-project', required=True, help='Name of Redcap project to sync')
+    parser.add_argument('--redcap-project', required=False, help='Name of Redcap project to sync')
     parser.add_argument('--reuse-codes', help='Codes that have intentionally been reused from another project')
 
 
 def run():
-    cli_run(tool_cmd, tool_desc, SyncCodesClass, add_additional_arguments)
+    cli_run(tool_cmd, tool_desc, CodesManagementClass, add_additional_arguments)

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -1,14 +1,14 @@
 import csv
 from datetime import datetime
-# from googleapiclient.discovery import build
-# from oauth2client.service_account import ServiceAccountCredentials
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+from oauth2client.service_account import ServiceAccountCredentials
 import os
 import requests
 from sqlalchemy.orm.session import Session
-# import sys
 
 from rdr_service.clock import CLOCK
-# from rdr_service.services.gcp_utils import gcp_get_iam_service_key_info
+from rdr_service.services.gcp_utils import gcp_get_iam_service_key_info
 from rdr_service.model.code import Code, CodeType
 from rdr_service.tools.tool_libs._tool_base import cli_run, logger, ToolBase
 from rdr_service.tools.tool_libs.app_engine_manager import AppConfigClass
@@ -20,15 +20,68 @@ tool_desc = "Manage code import/export process. Syncing codes from the provided 
             "codes that the RDR is aware of to the Ops team's Drive folder."
 
 REDCAP_PROJECT_KEYS = 'project_api_keys'
+DRIVE_EXPORT_FOLDER_ID = 'drive_export_folder'
+EXPORT_SERVICE_ACCOUNT_NAME = 'code_export_service_account'
 CODE_SYSTEM = 'http://terminology.pmi-ops.org/CodeSystem/ppi'
 
+CODE_EXPORT_NAME_PREFIX = 'codes_'
 
-# class CodesExportClass(ToolBase):
-#     def run(self):
-#         # Intentionally not calling super's run because the SA with
+# data shared between tool classes
+_now_string = datetime.now().strftime('%Y-%m-%d_%H%M')
+code_export_file_path = f'{CODE_EXPORT_NAME_PREFIX}{_now_string}.csv'
+drive_folder_id = ''
+exporter_service_account_name = ''
 
 
-class CodesManagementClass(ToolBase):
+class CodesExportClass(ToolBase):
+    @staticmethod
+    def trash_previous_exports(credentials, v3_drive_service):
+        # I haven't been able to figure out how to use only version 2 or only version 3 of drive.
+        # We don't have permissions to outright delete files, but V2 allows us to move files to the trash.
+        # However, I can't figure out how to see the files with V2 to be able to delete them. Hence the mix.
+
+        # https://developers.google.com/drive/api/v3/reference/files/list
+        response = v3_drive_service.files().list(
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
+            q=f"'{drive_folder_id}' in parents"
+        ).execute()
+        files = response.get('files', [])
+
+        # v2 lets us 'trash' files without further permissions
+        v2_drive_service = build('drive', 'v2', credentials=credentials)
+        for file in files:
+            if file['name'].startswith(CODE_EXPORT_NAME_PREFIX):
+                v2_drive_service.files().trash(
+                    supportsAllDrives=True,
+                    fileId=file['id']
+                ).execute()
+
+    @staticmethod
+    def upload_file(drive_service):
+        # https://developers.google.com/drive/api/v3/reference/files/create
+        file_metadata = {
+            'name': code_export_file_path,
+            'parents': [drive_folder_id]
+        }
+        media = MediaFileUpload(code_export_file_path, mimetype='text/csv')
+        drive_service.files().create(body=file_metadata, media_body=media, supportsAllDrives=True).execute()
+
+    def run(self):
+        # Intentionally not calling super's run
+        # since the SA for exporting probably doesn't have SQL permissions
+        # and super's run would currently tries to activate the sql proxy
+
+        service_key_info = gcp_get_iam_service_key_info(self.gcp_env.service_key_id)
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(service_key_info['key_path'])
+        drive_service = build('drive', 'v3', credentials=credentials)
+
+        self.trash_previous_exports(credentials, drive_service)
+        self.upload_file(drive_service)
+        os.remove(code_export_file_path)
+
+
+class CodesSyncClass(ToolBase):
     module_code = None
     codes_allowed_for_reuse = []
     code_reuse_found = False
@@ -50,6 +103,20 @@ class CodesManagementClass(ToolBase):
         if redcap_project_name not in keys:
             logger.error(f'ERROR: Project "{redcap_project_name}" not listed with key in server config')
             return None
+
+        # Getting folder ID for export while syncing since export SA might not have permissions to the server config
+        if DRIVE_EXPORT_FOLDER_ID not in server_config:
+            logger.error('ERROR: Server config file does not list drive export folder id')
+            return None
+        global drive_folder_id
+        drive_folder_id = server_config[DRIVE_EXPORT_FOLDER_ID]
+
+        # And since we're here anyway... let's get the service account that should do the export
+        if EXPORT_SERVICE_ACCOUNT_NAME not in server_config:
+            logger.error('ERROR: Server config file does not list the export service account')
+            return None
+        global exporter_service_account_name
+        exporter_service_account_name = server_config[EXPORT_SERVICE_ACCOUNT_NAME]
 
         return server_config[REDCAP_PROJECT_KEYS][redcap_project_name]
 
@@ -134,9 +201,7 @@ class CodesManagementClass(ToolBase):
 
     @staticmethod
     def write_export_file(session):
-        now_string = datetime.now().strftime('%Y-%m-%d_%H%M')
-        export_file_name = f'codes_{now_string}.csv'
-        with open(export_file_name, 'w') as output_file:
+        with open(code_export_file_path, 'w') as output_file:
             code_csv_writer = csv.writer(output_file)
             code_csv_writer.writerow([
                 'Code Value',
@@ -158,10 +223,8 @@ class CodesManagementClass(ToolBase):
                         row_data.append(possible_module_code.value)
                 code_csv_writer.writerow(row_data)
 
-        return export_file_name
-
     def run(self):
-        super(CodesManagementClass, self).run()
+        super(CodesSyncClass, self).run()
 
         if self.args.reuse_codes:
             self.codes_allowed_for_reuse = [code_val.strip() for code_val in self.args.reuse_codes.split(',')]
@@ -189,23 +252,7 @@ class CodesManagementClass(ToolBase):
                     return 1
 
             if not self.args.dry_run:
-                export_file_name = self.write_export_file(session)
-
-                # TODO:  get this to upload the file just written
-                # service_key_info = gcp_get_iam_service_key_info(self.gcp_env.service_key_id)
-                # credentials = ServiceAccountCredentials.from_json_keyfile_name(service_key_info['key_path'])
-                #
-                # service = build('drive', 'v3', credentials=credentials)
-                #
-                # folder_id = '1PdtB30wbKWaoktgZtw5gwTpmL6U4mYDB'
-                # file_metadata = {
-                #     'name': 'text.txt',
-                #     'parents': [folder_id]
-                # }
-                #
-                # service.files().create(body=file_metadata).execute()
-
-                os.remove(export_file_name)
+                self.write_export_file(session)
 
         return 0
 
@@ -220,4 +267,8 @@ def add_additional_arguments(parser):
 
 
 def run():
-    cli_run(tool_cmd, tool_desc, CodesManagementClass, add_additional_arguments)
+    import_exit_code = cli_run(tool_cmd, tool_desc, CodesSyncClass, add_additional_arguments)
+    if import_exit_code == 0:
+        return cli_run(tool_cmd, tool_desc, CodesExportClass, add_additional_arguments, defaults={
+            'service_account': exporter_service_account_name
+        })

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -70,7 +70,7 @@ class CodesExportClass(ToolBase):
     def run(self):
         # Intentionally not calling super's run
         # since the SA for exporting probably doesn't have SQL permissions
-        # and super's run would currently tries to activate the sql proxy
+        # and super's run currently tries to activate the sql proxy
 
         service_key_info = gcp_get_iam_service_key_info(self.gcp_env.service_key_id)
         credentials = ServiceAccountCredentials.from_json_keyfile_name(service_key_info['key_path'])

--- a/tests/tool_tests/test_codes_management.py
+++ b/tests/tool_tests/test_codes_management.py
@@ -4,13 +4,13 @@ import os
 
 import rdr_service
 from rdr_service.model.code import Code, CodeType
-from rdr_service.tools.tool_libs.sync_codes import SyncCodesClass, REDCAP_PROJECT_KEYS
+from rdr_service.tools.tool_libs.codes_management import CodesManagementClass, REDCAP_PROJECT_KEYS
 from tests.helpers.unittest_base import BaseTestCase
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(rdr_service.__file__))
 
 
-class SyncCodesTest(BaseTestCase):
+class CodesManagementTest(BaseTestCase):
 
     @staticmethod
     def _get_mock_dictionary_item(code_value, description, field_type, answers=''):
@@ -55,12 +55,12 @@ class SyncCodesTest(BaseTestCase):
         if reuse_codes:
             args.reuse_codes = ','.join(reuse_codes)
 
-        with mock.patch('rdr_service.tools.tool_libs.sync_codes.requests') as mock_requests:
+        with mock.patch('rdr_service.tools.tool_libs.codes_management.requests') as mock_requests:
             mock_response = mock_requests.post.return_value
             mock_response.status_code = 200
             mock_response.content = redcap_data_dictionary
 
-            sync_codes_tool = SyncCodesClass(args, gcp_env)
+            sync_codes_tool = CodesManagementClass(args, gcp_env)
             return sync_codes_tool.run()
 
     def _load_code_with_value(self, code_value) -> Code:
@@ -128,7 +128,7 @@ class SyncCodesTest(BaseTestCase):
         module_code = self.assertCodeExists('TestQuestionnaire', 'Test Questionnaire Module', CodeType.MODULE)
         self.assertCodeExists('participant_id', 'Participant ID', CodeType.QUESTION, module_code)
 
-    @mock.patch('rdr_service.tools.tool_libs.sync_codes.logger')
+    @mock.patch('rdr_service.tools.tool_libs.codes_management.logger')
     def test_failure_on_question_code_reuse(self, mock_logger):
         self.data_generator.create_database_code(value='old_code')
 


### PR DESCRIPTION
It's going to help the Survey Operations (Pilot?) team alot to have an updated list of codes that RDR has for surveys. I've added functionality to the code import/sync tool to have it generate a CSV and upload it to Drive.

A part of that work was to break the tool's code into two separate parts so that the export can be done with a service account that has permissions to drive, but not necessarily permissions for connecting to the SQL database.

The diff also looks like the tool is in a brand new file because I've renamed the file from what it was before (sorry about that).