### PR TITLE
[DA-1453] Always altering disposed fields when setting status and vice versa

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -111,13 +111,13 @@ class BiobankTargetedUpdateBase(BiobankApiBase):
 
 class BiobankStatusApiMixin:
     def update_model(self, model, resource, session):
-        self.dao.read_client_status(resource, model, clear_disposal_fields=True)
+        self.dao.read_client_status(resource, model)
         self.dao.update_with_session(session, model)
 
 
 class BiobankDisposalApiMixin:
     def update_model(self, model, resource, session):
-        self.dao.read_client_disposal(resource, model, set_status=True)
+        self.dao.read_client_disposal(resource, model)
         self.dao.update_with_session(session, model)
 
 

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -38,7 +38,7 @@ class BiobankDaoBase(UpdatableDao):
         return disposal_status
 
     @staticmethod
-    def read_client_status(status_source, model, clear_disposal_fields=False):
+    def read_client_status(status_source, model):
         for status_field_name, parser in [('status', None),
                                           ('freezeThawCount', None),
                                           ('location', None),
@@ -48,20 +48,18 @@ class BiobankDaoBase(UpdatableDao):
                                           ('processingCompleteDate', BiobankDaoBase.parse_nullable_date)]:
             BiobankDaoBase.map_optional_json_field_to_object(status_source, model, status_field_name, parser=parser)
 
-        if clear_disposal_fields:
-            model.disposalDate = None
-            model.disposalReason = ''
+        model.disposalDate = None
+        model.disposalReason = ''
 
     @staticmethod
-    def read_client_disposal(status_source, model, set_status=False):
+    def read_client_disposal(status_source, model):
         for disposal_client_field_name, disposal_model_field_name, parser in\
                 [('reason', 'disposalReason', None),
                  ('disposalDate', None, BiobankSpecimenDao.parse_nullable_date)]:
             BiobankDaoBase.map_optional_json_field_to_object(status_source, model, disposal_client_field_name,
                                                              disposal_model_field_name, parser=parser)
 
-        if set_status:
-            model.status = 'Disposed'
+        model.status = 'Disposed'
 
     @staticmethod
     def map_optional_json_field_to_object(json, obj, json_field_name, object_field_name=None, parser=None):

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -48,8 +48,9 @@ class BiobankDaoBase(UpdatableDao):
                                           ('processingCompleteDate', BiobankDaoBase.parse_nullable_date)]:
             BiobankDaoBase.map_optional_json_field_to_object(status_source, model, status_field_name, parser=parser)
 
-        model.disposalDate = None
-        model.disposalReason = ''
+        if model.status and model.status.lower() != 'disposed':
+            model.disposalDate = None
+            model.disposalReason = ''
 
     @staticmethod
     def read_client_disposal(status_source, model):
@@ -59,7 +60,8 @@ class BiobankDaoBase(UpdatableDao):
             BiobankDaoBase.map_optional_json_field_to_object(status_source, model, disposal_client_field_name,
                                                              disposal_model_field_name, parser=parser)
 
-        model.status = 'Disposed'
+        if model.disposalDate or model.disposalReason:
+            model.status = 'Disposed'
 
     @staticmethod
     def map_optional_json_field_to_object(json, obj, json_field_name, object_field_name=None, parser=None):

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -197,7 +197,7 @@ class BiobankOrderApiTest(BaseTestCase):
             'cohortID': 'cohort id',
             'sampleType': 'sample',
             'status': {
-                'status': 'good',
+                'status': 'Disposed',
                 'freezeThawCount': 1,
                 'location': 'Greendale',
                 'quantity': '1',
@@ -408,7 +408,7 @@ class BiobankOrderApiTest(BaseTestCase):
                 "rlimsID": "other",
                 "sampleType": "test",
                 "status": {
-                    "status": "frozen",
+                    "status": "Disposed",
                     "freezeThawCount": 3,
                     "location": "biobank",
                     "quantity": "5",
@@ -850,7 +850,7 @@ class BiobankOrderApiTest(BaseTestCase):
         self.put_specimen(payload)
 
         # Set a new status
-        payload['status'] = 'updated'
+        payload['status'] = {'status': 'In Circulation'}
         del payload['disposalStatus']
         self.put_specimen(payload)
 


### PR DESCRIPTION
There are endpoints specifically for setting disposed and status fields on a sample (aliquot or parent specimen), and discussions around them led to clearing disposal fields when a status is set, and setting the status to "Disposed" when setting the disposal fields. Biobank would like that behavior to apply to the primary endpoints used for generally creating or updating the samples too.

Additionally, there's a chance that they will send us a non-disposed status with empty disposal fields. In that case we should leave the status alone. And just in case they send a 'Disposed' status again on its own, I have the API leaving the disposal fields alone.