### PR TITLE
Fixing dependency issue between app_util and base_api

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -12,7 +12,7 @@ from flask import request
 from werkzeug.exceptions import Forbidden, Unauthorized, GatewayTimeout
 
 from rdr_service import clock, config
-from rdr_service.api.base_api import log_api_request
+from rdr_service.api import base_api
 from rdr_service.config import GAE_PROJECT
 
 _GMT = pytz.timezone("GMT")
@@ -244,7 +244,7 @@ def auth_required(role_whitelist):
     def auth_required_wrapper(func):
         def wrapped(*args, **kwargs):
             appid = GAE_PROJECT
-            request.log_record = log_api_request()
+            request.log_record = base_api.log_api_request()
             # Only enforce HTTPS and auth for external requests; requests made for data generation
             # are allowed through (when enabled).
             acceptable_hosts = ("None", "testbed-test", "testapp", "localhost", "127.0.0.1")
@@ -257,7 +257,7 @@ def auth_required(role_whitelist):
             result = func(*args, **kwargs)
             if request.logged is False:
                 try:
-                    log_api_request(log=request.log_record)
+                    base_api.log_api_request(log=request.log_record)
                 except RuntimeError:
                     # Unittests don't always setup a valid flask request context.
                     pass


### PR DESCRIPTION
This resolves some trouble I'm having with getting the documentation to load from an API class, but I wanted to get it out into a PR of its own so that it doesn't get buried in other changes.

When trying to import the DeceasedReportApi class directly I would get an error with this traceback:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/skaggskd/Projects/VUMC/raw-data-repository/rdr_service/api/deceased_report_api.py", line 4, in <module>
    from rdr_service.api.base_api import BaseApi, UpdatableApi
  File "/Users/skaggskd/Projects/VUMC/raw-data-repository/rdr_service/api/base_api.py", line 10, in <module>
    from rdr_service import app_util
  File "/Users/skaggskd/Projects/VUMC/raw-data-repository/rdr_service/app_util.py", line 15, in <module>
    from rdr_service.api.base_api import log_api_request
ImportError: cannot import name 'log_api_request' from 'rdr_service.api.base_api' (/Users/skaggskd/Projects/VUMC/raw-data-repository/rdr_service/api/base_api.py)
```

The `rdr_service.api.base_api` module imports the `rdr_service.app_util` module. And then the app_util module imports the `log_api_request` function from `rdr_service.api.base_api`, but that function doesn't seem to exist.

The deceased_reports module only imports base_api, but if I import app_util first this error goes away. This is my guess as to what is happening with the error:
1. Referencing `rdr_service.api.base_api` (to import the base classes) starts to read the file and construct the module
1. While constructing the `rdr_service.api.base_api` module from the file, the line to import app_util begins constructing that module from its file
1. The app_util file references the base_api module to attempt to import the `log_api_request` function. But the base_api module isn't fully built and doesn't yet have that function, so then the whole thing fails.

I'm guessing this isn't an issue with other things (like running the server) because app_util gets imported first. And this solution gives a feeling of circular import issues, but unit tests are running smoothly (and it gets me around the import error). So my guess with that is that they each can reference each other as modules since they don't need anything from the other when parsing the file.