### PR TITLE
[PDR-106] Add EHR status fields to PDR/BigQuery participant summary data

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from dateutil import parser, tz
 from dateutil.parser import ParserError
 from sqlalchemy import func, desc, exc
-from sqlalchemy.orm import load_only
 from werkzeug.exceptions import NotFound
 
 from rdr_service import config
@@ -181,12 +180,12 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
 
         """
         # TODO: Workaround for PDR-106 is to pull needed EHR fields from participant_summary. LIMITED USE CASE ONLY
-        # Goal is to eliminate dependencies on participant_summary.  Long term solution may mean creating a
-        # participant_profile table for these outlier fields that are managed outside of the RDR API, and
-        # query that table instead
+        # Goal is to eliminate dependencies on participant_summary, which may go away someday.
+        # Long term solution may mean creating a participant_profile table for these outlier fields that are managed
+        # outside of the RDR API, and query that table instead.
         data = {}
-        ps = ro_session.query(ParticipantSummary) \
-            .options(load_only("ehrReceiptTime", "ehrStatus", "ehrUpdateTime")) \
+        ps = ro_session.query(ParticipantSummary.ehrStatus, ParticipantSummary.ehrReceiptTime,
+                              ParticipantSummary.ehrUpdateTime) \
             .filter(ParticipantSummary.participantId == p_id).first()
 
         if ps and ps.ehrStatus:

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -198,7 +198,7 @@ class BQParticipantSummarySchema(BQSchema):
     enrollment_core_ordered = BQField('enrollment_core_ordered', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     enrollment_core_stored = BQField('enrollment_core_stored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
-    # These EHR fields are being replaced by a direct query from Curation's BigQuery database and need to be removed.
+    # PDR-106: The EHR fields are needed in PDR by PTSC and for consistency should come from RDR vs. Curation BigQuery
     ehr_status = BQField('ehr_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     ehr_status_id = BQField('ehr_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     ehr_receipt = BQField('ehr_receipt', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -63,7 +63,7 @@ class BQPDRParticipantSummarySchema(BQSchema):
     enrollment_core_ordered = BQField('enrollment_core_ordered', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     enrollment_core_stored = BQField('enrollment_core_stored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
-    # These EHR fields are being replaced by a direct query from Curation's BigQuery database and need to be removed.
+    # PDR-106: The EHR fields are needed in PDR by PTSC and for consistency should come from RDR vs. Curation BigQuery
     ehr_status = BQField('ehr_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     ehr_status_id = BQField('ehr_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     ehr_receipt = BQField('ehr_receipt', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)

--- a/rdr_service/offline/bigquery_sync.py
+++ b/rdr_service/offline/bigquery_sync.py
@@ -32,6 +32,53 @@ class BigQueryJobError(BaseException):
 # Only perform BQ/Resource operations in these environments.
 _bq_env = ['localhost', 'pmi-drc-api-test', 'all-of-us-rdr-sandbox', 'all-of-us-rdr-stable', 'all-of-us-rdr-prod']
 
+
+def dispatch_participant_rebuild_tasks(pid_list, batch_size=100):
+    """
+       A utility routine to handle dispatching batched requests for rebuilding participants.  Is also called
+       from other cron job endpoint handlers (e.g., biobank reconciliation and EHR status update jobs)
+    """
+
+    if config.GAE_PROJECT not in _bq_env:
+        logging.warning(f'BigQuery operations not supported in {config.GAE_PROJECT}, skipping.')
+        return
+
+    count = 0
+    batch_count = 0
+    batch = list()
+    task = None if config.GAE_PROJECT == 'localhost' else GCPCloudTask()
+
+    # queue up a batch of participant ids and send them to be rebuilt.
+    for pid in pid_list:
+        batch.append({'pid': pid})
+        count += 1
+
+        if count == batch_size:
+            payload = {'batch': batch}
+
+            if config.GAE_PROJECT == 'localhost':
+                batch_rebuild_participants_task(payload)
+            else:
+                task.execute('rebuild_participants_task', payload=payload, in_seconds=15,
+                             queue='resource-rebuild', quiet=True)
+            batch_count += 1
+            # reset for next batch
+            batch = list()
+            count = 0
+
+    # send last batch if needed.
+    if count:
+        payload = {'batch': batch}
+        batch_count += 1
+        if config.GAE_PROJECT == 'localhost':
+            batch_rebuild_participants_task(payload)
+        else:
+            task.execute('rebuild_participants_task', payload=payload, in_seconds=15,
+                         queue='resource-rebuild', quiet=True)
+
+    logging.info(f'Submitted {batch_count} tasks.')
+
+
 def rebuild_bigquery_handler():
     """
     Cron job handler, setup queued tasks to rebuild bigquery data.
@@ -42,7 +89,6 @@ def rebuild_bigquery_handler():
         return
 
     batch_size = 100
-
     ro_dao = BigQuerySyncDao(backup=True)
     with ro_dao.session() as ro_session:
         total_rows = ro_session.query(func.count(Participant.participantId)).first()[0]
@@ -50,43 +96,8 @@ def rebuild_bigquery_handler():
         logging.info('Calculated {0} tasks from {1} records with a batch size of {2}.'.
                      format(count, total_rows, batch_size))
 
-        participants = ro_session.query(Participant.participantId).all()
-
-        count = 0
-        batch_count = 0
-        batch = list()
-        task = None if config.GAE_PROJECT == 'localhost' else GCPCloudTask()
-
-        # queue up a batch of participant ids and send them to be rebuilt.
-        for p in participants:
-
-            batch.append({'pid': p.participantId})
-            count += 1
-
-            if count == batch_size:
-                payload = {'batch': batch}
-
-                if config.GAE_PROJECT == 'localhost':
-                    batch_rebuild_participants_task(payload)
-                else:
-                    task.execute('rebuild_participants_task', payload=payload, in_seconds=15,
-                                        queue='resource-rebuild', quiet=True)
-                batch_count += 1
-                # reset for next batch
-                batch = list()
-                count = 0
-
-        # send last batch if needed.
-        if count:
-            payload = {'batch': batch}
-            batch_count += 1
-            if config.GAE_PROJECT == 'localhost':
-                batch_rebuild_participants_task(payload)
-            else:
-                task.execute('rebuild_participants_task', payload=payload, in_seconds=15,
-                                    queue='resource-rebuild', quiet=True)
-
-        logging.info(f'Submitted {batch_count} tasks.')
+        pids = [row.participantId for row in ro_session.query(Participant.participantId).all()]
+        dispatch_participant_rebuild_tasks(pids, batch_size=batch_size)
 
     #
     # Process tables that don't need to be broken up into smaller tasks.
@@ -111,8 +122,6 @@ def daily_rebuild_bigquery_handler():
         logging.warning(f'BigQuery operations not supported in {config.GAE_PROJECT}, skipping.')
         return
 
-    batch_size = 100
-
     ro_dao = BigQuerySyncDao(backup=True)
     with ro_dao.session() as ro_session:
         # Find all BQ records where enrollment status or withdrawn statuses are different.
@@ -128,42 +137,8 @@ def daily_rebuild_bigquery_handler():
         if not participants:
             logging.info(f'No participants found to rebuild.')
             return
-
-        count = 0
-        batch_count = 0
-        batch = list()
-        task = None if config.GAE_PROJECT == 'localhost' else GCPCloudTask()
-
-        # queue up a batch of participant ids and send them to be rebuilt.
-        for p in participants:
-
-            batch.append({'pid': p.participantId})
-            count += 1
-
-            if count == batch_size:
-                payload = {'batch': batch}
-
-                if config.GAE_PROJECT == 'localhost':
-                    batch_rebuild_participants_task(payload)
-                else:
-                    task.execute('rebuild_participants_task', payload=payload, in_seconds=15,
-                                        queue='resource-rebuild', quiet=True)
-                batch_count += 1
-                # reset for next batch
-                batch = list()
-                count = 0
-
-        # send last batch if needed.
-        if count:
-            payload = {'batch': batch}
-            batch_count += 1
-            if config.GAE_PROJECT == 'localhost':
-                batch_rebuild_participants_task(payload)
-            else:
-                task.execute('rebuild_participants_task', payload=payload, in_seconds=15,
-                                    queue='resource-rebuild', quiet=True)
-
-        logging.info(f'Submitted {batch_count} tasks.')
+        pid_list = [p.participantId for p in participants]
+        dispatch_participant_rebuild_tasks(pid_list, batch_size=100)
 
 
 def insert_batch_into_bq(bq, project_id, dataset, table, batch, dryrun=False):

--- a/rdr_service/offline/bigquery_sync.py
+++ b/rdr_service/offline/bigquery_sync.py
@@ -37,6 +37,8 @@ def dispatch_participant_rebuild_tasks(pid_list, batch_size=100):
     """
        A utility routine to handle dispatching batched requests for rebuilding participants.  Is also called
        from other cron job endpoint handlers (e.g., biobank reconciliation and EHR status update jobs)
+       :param pid_list:  List of participant_id values to rebuild
+       :param batch_size:  Size of the batch of participant IDs to include in the rebuild task payload
     """
 
     if config.GAE_PROJECT not in _bq_env:

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 from rdr_service import clock, config
 from rdr_service.app_util import datetime_as_naive_utc
@@ -6,6 +7,7 @@ from rdr_service.cloud_utils import bigquery
 from rdr_service.dao.ehr_dao import EhrReceiptDao
 from rdr_service.dao.organization_dao import OrganizationDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.offline.bigquery_sync import dispatch_participant_rebuild_tasks
 
 LOG = logging.getLogger(__name__)
 
@@ -48,11 +50,19 @@ def update_particiant_summaries():
 def update_participant_summaries_from_job(job):
     summary_dao = ParticipantSummaryDao()
     now = clock.CLOCK.now()
+    batch_size = 100
     for i, page in enumerate(job):
         LOG.info("Processing page {} of results...".format(i))
         parameter_sets = [{"pid": row.person_id, "receipt_time": now} for row in page]
         query_result = summary_dao.bulk_update_ehr_status(parameter_sets)
-        LOG.info("Affected {} rows.".format(query_result.rowcount))
+        total_rows = query_result.rowcount
+        LOG.info("Affected {} rows.".format(total_rows))
+        if total_rows > 0:
+            count = int(math.ceil(float(total_rows) / float(batch_size)))
+            LOG.info('UpdateEhrStatus: calculated {0} participant rebuild tasks from {1} records and batch size of {2}'.
+                         format(count, total_rows, batch_size))
+            pids = [param['pid'] for param in parameter_sets]
+            dispatch_participant_rebuild_tasks(pids, batch_size=batch_size)
 
 
 def make_update_organizations_job():

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from dateutil import parser, tz
 from dateutil.parser import ParserError
 from sqlalchemy import func, desc, exc
-from sqlalchemy.orm import load_only
 from werkzeug.exceptions import NotFound
 
 from rdr_service import config
@@ -186,9 +185,10 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # Long term solution may mean creating a participant_profile table for these outlier fields that are managed
         # outside of the RDR API, and query that table instead.
         data = {}
-        ps = ro_session.query(ParticipantSummary) \
-            .options(load_only("ehrReceiptTime", "ehrStatus", "ehrUpdateTime")) \
+        ps = ro_session.query(ParticipantSummary.ehrStatus, ParticipantSummary.ehrReceiptTime,
+                              ParticipantSummary.ehrUpdateTime) \
             .filter(ParticipantSummary.participantId == p_id).first()
+
         if ps and ps.ehrStatus:
             ehr_status = EhrStatus(ps.ehrStatus)
             data = {


### PR DESCRIPTION
This adds the logic to populate fields that were already in the BQ pdr_participant schema, but were not being populated.  It's not ideal to have to pull the information out of the RDR participant_summary table, but it's the only source we have right now and PTSC needs this EHR status data in PDR.  This is an initial workaround to get us going until we have an alternate solution that is not dependent on RDR participant_summary.

The UpdateEhrStatus daily cron job will now kick off PDR/BigQuery rebuild requests for the affected participants from that day's job.

Some minor refactoring to move some code that handles batching the rebuild cloud task requests into its own utility method, as it was being replicated again for the UpdateEhrStatus cron job and was already used in a few other places.