### PR TITLE
[ROC-657] Treating NULL as UNSET when finding sample status time for participant summary

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -149,7 +149,7 @@ _SAMPLE_SQL = """,
                      WHERE bss.biobank_id = ps.biobank_id
                        AND bss.test = %(sample_param_ref)s)
               ELSE (SELECT MAX(confirmed) from biobank_stored_sample bss
-                     WHERE bss.biobank_id = ps.biobank_id and bss.status < :disposed_bad
+                     WHERE bss.biobank_id = ps.biobank_id and (bss.status < :disposed_bad or bss.status is null)
                        AND bss.test = %(sample_param_ref)s)
               END
           ELSE NULL END

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -346,6 +346,10 @@ class DataGenerator:
         if 'biobankStoredSampleId' not in kwargs:
             kwargs['biobankStoredSampleId'] = self.unique_biobank_stored_sample_id()
 
+        for field, default in [('biobankOrderIdentifier', self.faker.pystr())]:
+            if field not in kwargs:
+                kwargs[field] = default
+
         return BiobankStoredSample(**kwargs)
 
     def create_database_log_position(self, **kwargs):


### PR DESCRIPTION
There are some store samples in the database that have a status of Null and it's affecting how the sample_status_..._time gets set (some of them are Null, which is in turn affecting retention eligible times). I haven't found a way for a stored sample's status column to become Null in the database, so this might be an artifact of an old change and some samples that got missed by a backfill.

I've updated the query for the sample_status_time column to treat Nulls as UNSET (so they'll be picked up by the ELSE of the case statement).