### PR TITLE
[DA-1749] Genomic tools for updating member states, job run results

### DIFF
--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -15,14 +15,16 @@ import csv
 import pytz
 
 from rdr_service import clock, config
-from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_set_update
+from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_set_update, \
+    bq_genomic_job_run_update
 from rdr_service.dao.genomics_dao import GenomicSetMemberDao, GenomicSetDao, GenomicJobRunDao
 from rdr_service.genomic.genomic_job_components import GenomicBiobankSamplesCoupler
 from rdr_service.genomic.genomic_biobank_manifest_handler import (
     create_and_upload_genomic_biobank_manifest_file)
 from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 from rdr_service.model.genomics import GenomicSetMember, GenomicSet
-from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_set_update
+from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_set_update, \
+    genomic_job_run_update
 from rdr_service.services.system_utils import setup_logging, setup_i18n
 from rdr_service.storage import GoogleCloudStorageProvider, LocalFilesystemStorageProvider
 from rdr_service.tools.tool_libs import GCPProcessContext, GCPEnvConfigObject
@@ -635,6 +637,10 @@ class JobRunResult(GenomicManifestBase):
             job_run.runResult = new_result
 
             self.dao.update(job_run)
+
+            # Update run for PDR
+            bq_genomic_job_run_update(job_run.id)
+            genomic_job_run_update(job_run.id)
 
         return 0
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -381,68 +381,6 @@ class GenerateManifestClass(GenomicManifestBase):
             member_dao.update_member_state(member, new_state)
 
 
-class IgnoreStateClass(object):
-    def __init__(self, args, gcp_env: GCPEnvConfigObject):
-        """
-        :param args: command line arguments.
-        :param gcp_env: gcp environment information, see: gcp_initialize().
-        """
-        # Tool_lib attributes
-        self.args = args
-        self.gcp_env = gcp_env
-        self.dao = None
-
-    def run(self):
-        """
-        Main program process
-        :return: Exit code value
-        """
-        _logger.info("Running ignore tool")
-
-        # Validate Aruguments
-        if self.args.csv is None:
-            _logger.error('Argument --csv must be provided.')
-            return 1
-
-        if not os.path.exists(self.args.csv):
-            _logger.error(f'File {self.args.csv} was not found.')
-            return 1
-
-        # Activate the SQL Proxy
-        self.gcp_env.activate_sql_proxy()
-        self.dao = GenomicSetMemberDao()
-
-        # Update gsm IDs from file
-        with open(self.args.csv, encoding='utf-8-sig') as f:
-            lines = f.readlines()
-            for _member_id in lines:
-                _member = self.dao.get(_member_id)
-
-                if _member is None:
-                    _logger.warning(f"Member id {_member_id.rstrip()} does not exist.")
-                    continue
-
-                self.update_genomic_set_member_state(_member)
-
-        return 0
-
-    def update_genomic_set_member_state(self, member):
-        """
-        Sets the member.genomicWorkflowState = IGNORE for member
-        :param member:
-        :return:
-        """
-        member.genomicWorkflowState = GenomicWorkflowState.IGNORE
-
-        with self.dao.session() as session:
-            _logger.info(f"Updating member id {member.id}")
-            session.merge(member)
-
-        # Update state for PDR
-        bq_genomic_set_member_update(member.id, project_id=self.gcp_env.project)
-        genomic_set_member_update(member.id)
-
-
 class ControlSampleClass(GenomicManifestBase):
     def __init__(self, args, gcp_env: GCPEnvConfigObject):
         super(ControlSampleClass, self).__init__(args, gcp_env)
@@ -645,6 +583,79 @@ class JobRunResult(GenomicManifestBase):
         return 0
 
 
+class UpdateGenomicMembersState(GenomicManifestBase):
+    """Class update a genomic_set_member to a particular state."""
+    def __init__(self, args, gcp_env: GCPEnvConfigObject):
+        super(UpdateGenomicMembersState, self).__init__(args, gcp_env)
+        self.valid_genomic_states = GenomicWorkflowState.names()
+
+    def run(self):
+        """
+        Main program process
+        :return: Exit code value
+        """
+
+        _logger.info("Running Genomic State tool")
+        if self.args.dryrun:
+            _logger.info("Running in dryrun mode. No actual updates to data.")
+
+        # Validate Aruguments
+        if not os.path.exists(self.args.csv):
+            _logger.error(f'File {self.args.csv} was not found.')
+            return 1
+
+        # Activate the SQL Proxy
+        self.gcp_env.activate_sql_proxy()
+        self.dao = GenomicSetMemberDao()
+
+        # Update gsm IDs from file
+        with open(self.args.csv, encoding='utf-8-sig') as f:
+            csvreader = csv.reader(f, delimiter=",")
+
+            for line in csvreader:
+                _member_id = line[0]
+                _provided_state = line[1]
+
+                # Check that supplied state is valid
+                if _provided_state not in self.valid_genomic_states:
+                    _logger.error(f'Invalid genomic. must be one of {self.valid_genomic_states}')
+                    return 1
+
+                new_state = GenomicWorkflowState.lookup_by_name(_provided_state)
+
+                # lookup member
+                member = self.dao.get(_member_id)
+
+                if member is None:
+                    _logger.error(f"Member id {_member_id.rstrip()} does not exist.")
+                    return 1
+
+                self.update_genomic_set_member_state(member, new_state)
+
+        return 0
+
+    def update_genomic_set_member_state(self, member, state):
+        """
+        Sets the member.genomicWorkflowState = state
+        :param member:
+        :param state:
+        :return:
+        """
+
+        with self.dao.session() as session:
+            _logger.warning(f"Updating member id {member.id}")
+            _logger.warning(f"    {member.genomicWorkflowState} -> {state}")
+
+            if not self.args.dryrun:
+                member.genomicWorkflowState = state
+                member.genomicWorkflowStateModifiedTime = self.nowts
+                session.merge(member)
+
+        # Update state for PDR
+        bq_genomic_set_member_update(member.id, project_id=self.gcp_env.project)
+        genomic_set_member_update(member.id)
+
+
 def run():
     # Set global debug value and setup application logging.
     setup_logging(
@@ -678,9 +689,11 @@ def run():
     new_manifest_parser.add_argument("--manifest", help=new_manifest_help, default=None)  # noqa
     new_manifest_parser.add_argument("--cohort", help="Cohort [1, 2, 3]", default=None)  # noqa
 
-    # Set GenomicWorkflowState to IGNORE for provided member IDs
-    ignore_state_parser = subparser.add_parser("ignore-state")
-    ignore_state_parser.add_argument("--csv", help="csv file with genomic_set_member ids", default=None)  # noqa
+    # Set GenomicWorkflowState to provided state for provided member IDs
+    member_state_parser = subparser.add_parser("member-state")
+    member_state_parser.add_argument("--csv", help="csv file with genomic_set_member.id, state",
+                                     default=None, required=True)  # noqa
+    member_state_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     # Create GenomicSetMembers for provided control sample IDs (provided by Biobank)
     control_sample_parser = subparser.add_parser("control-sample")
@@ -714,8 +727,8 @@ def run():
             process = GenerateManifestClass(args, gcp_env)
             exit_code = process.run()
 
-        elif args.util == 'ignore-state':
-            process = IgnoreStateClass(args, gcp_env)
+        elif args.util == 'member-state':
+            process = UpdateGenomicMembersState(args, gcp_env)
             exit_code = process.run()
 
         elif args.util == 'control-sample':

--- a/rdr_service/tools/tool_libs/tools.bash
+++ b/rdr_service/tools/tool_libs/tools.bash
@@ -139,7 +139,7 @@ _python()
             ;;
         genomic)
             # These are options specific to this tool.
-            local toolopts="resend generate-manifest control-sample manual-sample"
+            local toolopts="resend generate-manifest control-sample manual-sample job-run-result"
             COMPREPLY=( $(compgen -W "${stdopts} ${toolopts}" -- ${cur}) )
             return 0
             ;;
@@ -177,6 +177,16 @@ _python()
             # genomic generate-manifest command
             if echo ${COMP_WORDS[@]} | grep -w "genomic" > /dev/null; then
               local toolopts="--help --csv --dryrun"
+              COMPREPLY=( $(compgen -W "${toolopts}" -- ${cur}) )
+            else
+              COMPREPLY=( $(compgen -W "${stdopts}" -- ${cur}) )
+            fi
+            return 0
+            ;;
+          job-run-result)
+            # genomic job-run-result command
+            if echo ${COMP_WORDS[@]} | grep -w "genomic" > /dev/null; then
+              local toolopts="--help --id --result --message --dryrun"
               COMPREPLY=( $(compgen -W "${toolopts}" -- ${cur}) )
             else
               COMPREPLY=( $(compgen -W "${stdopts}" -- ${cur}) )

--- a/rdr_service/tools/tool_libs/tools.bash
+++ b/rdr_service/tools/tool_libs/tools.bash
@@ -139,7 +139,7 @@ _python()
             ;;
         genomic)
             # These are options specific to this tool.
-            local toolopts="resend generate-manifest control-sample manual-sample job-run-result"
+            local toolopts="resend generate-manifest control-sample manual-sample job-run-result member-state"
             COMPREPLY=( $(compgen -W "${stdopts} ${toolopts}" -- ${cur}) )
             return 0
             ;;
@@ -187,6 +187,16 @@ _python()
             # genomic job-run-result command
             if echo ${COMP_WORDS[@]} | grep -w "genomic" > /dev/null; then
               local toolopts="--help --id --result --message --dryrun"
+              COMPREPLY=( $(compgen -W "${toolopts}" -- ${cur}) )
+            else
+              COMPREPLY=( $(compgen -W "${stdopts}" -- ${cur}) )
+            fi
+            return 0
+            ;;
+          member-state)
+            # genomic generate-manifest command
+            if echo ${COMP_WORDS[@]} | grep -w "genomic" > /dev/null; then
+              local toolopts="--help --csv --dryrun"
               COMPREPLY=( $(compgen -W "${toolopts}" -- ${cur}) )
             else
               COMPREPLY=( $(compgen -W "${stdopts}" -- ${cur}) )


### PR DESCRIPTION
This PR implements 2 genomics tools:

1. Job Run Tool
  - This tool updates the job run result. This allows jobs to be rerun and pick up old files.
2. Member State Tool
  - This tool updates `genomic_set_member.genomic_workflow_state` to arbitrary values. 

This PR also removes the Ignore State tool, since that functionality is contained within the new Member State tool.