### PR TITLE
[DA-1453] GCP logging of exception information and checking biobank ids

### DIFF
--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -1,5 +1,6 @@
 from rdr_service.api_util import format_json_date
 from rdr_service.model.config_utils import from_client_biobank_id, to_client_biobank_id
+from rdr_service.model.participant import Participant
 from rdr_service.api_util import parse_date
 from rdr_service.dao.base_dao import UpdatableDao
 from rdr_service.model.biobank_order import BiobankSpecimen, BiobankSpecimenAttribute, BiobankAliquot,\
@@ -205,6 +206,20 @@ class BiobankSpecimenDao(BiobankDaoBase):
             return order.id
         else:
             return None
+
+    @staticmethod
+    def _check_participant_exists(session, biobank_id):
+        participant_query = session.query(Participant).filter(Participant.biobankId == biobank_id)
+        if not session.query(participant_query.exists()).scalar():
+            raise BadRequest(f'Biobank id {to_client_biobank_id(biobank_id)} does not exist')
+
+    def insert_with_session(self, session, obj: BiobankSpecimen):
+        self._check_participant_exists(session, obj.biobankId)
+        return super(BiobankSpecimenDao, self).insert_with_session(session, obj)
+
+    def update_with_session(self, session, obj: BiobankSpecimen):
+        self._check_participant_exists(session, obj.biobankId)
+        return super(BiobankSpecimenDao, self).update_with_session(session, obj)
 
 
 class BiobankSpecimenAttributeDao(BiobankDaoBase):

--- a/rdr_service/services/gcp_logging.py
+++ b/rdr_service/services/gcp_logging.py
@@ -1,4 +1,5 @@
 import collections
+import io
 import json
 import logging
 import os
@@ -128,6 +129,19 @@ def setup_log_line(record: logging.LogRecord, resource=None, method=None):
 
     message = message.replace('$$method$$', method if method else '')
     message = message.replace('$$resource$$', resource if resource else '/')
+
+    if record.exc_info:
+        # this block was pulled from python logging's built in log formatting
+        # todo: maybe we want to be using that instead? (to be able to pick up on other features)
+        sio = io.StringIO()
+        etype, value, tb = record.exc_info
+        traceback.print_exception(etype, value, tb, None, sio)
+        result_str = sio.getvalue()
+        sio.close()
+        if result_str[-1:] != "\n":
+            result_str = result_str + "\n"
+
+        message = result_str + message
 
     log_line = {
         "logMessage": message,


### PR DESCRIPTION
Testing with the migration endpoint ran into server errors with specimen that referred to biobank ids we didn't already have. This adds a check to make sure that a biobank id exists in the database.

I've also added some code to the GCP log handler so that we can use the `exc_info` argument when creating log records. 