### PR TITLE
EhrStatus generator fix for NOT_PRESENT

### DIFF
--- a/doc/api_workflows/field_reference/enumerated_fields.rst
+++ b/doc/api_workflows/field_reference/enumerated_fields.rst
@@ -70,7 +70,6 @@ enrollmentStatus
 
 ehrStatus
 ------------------------------------------------------------
-  * UNSET
   * NOT_PRESENT
   * PRESENT
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -189,14 +189,18 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                               ParticipantSummary.ehrUpdateTime) \
             .filter(ParticipantSummary.participantId == p_id).first()
 
-        if ps and ps.ehrStatus:
-            ehr_status = EhrStatus(ps.ehrStatus)
+        if not ps:
+            logging.debug(f'No participant_summary record found for {p_id}')
+        else:
+            # SqlAlchemy may return None for our zero-based NOT_PRESENT EhrStatus Enum, so map None to NOT_PRESENT
+            # See rdr_service.model.utils Enum decorator class
+            ehr_status = EhrStatus.NOT_PRESENT if ps.ehrStatus is None else ps.ehrStatus
             data = {
                 'ehr_status': str(ehr_status),
                 'ehr_status_id': int(ehr_status),
                 'ehr_receipt': ps.ehrReceiptTime,
                 'ehr_update': ps.ehrUpdateTime
-            }
+             }
 
         return data
 

--- a/tests/resource_tests/generator_tests/test_participant_enrollment.py
+++ b/tests/resource_tests/generator_tests/test_participant_enrollment.py
@@ -177,6 +177,9 @@ class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin):
         self.assertEqual(ps_data['pm'][0]['finalized_site'], 'hpo-site-monroeville')
         self.assertEqual(ps_data['pm'][0]['status'], 'COMPLETED')
         self.assertEqual(ps_data['enrollment_status'], 'CORE_PARTICIPANT')
+        self.assertEqual(ps_data['ehr_status'], 'NOT_PRESENT')
+        self.assertIsNone(ps_data['ehr_receipt'])
+        self.assertIsNone(ps_data['ehr_update'])
 
     def test_cohort_3_without_gror(self):
         self._set_up_participant_data(fake_time=datetime(2020, 6, 1))


### PR DESCRIPTION
This fixes an issue where EhrStatus NOT_PRESENT information was getting left out of the PDR because of how SQLAlchemy may map zero-based Enum values to None.

Upgraded some existing unit tests to verify the generator data.