### PR TITLE
[DA-1744] Reworking A3 manifest to once again include gRoR removal

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -518,9 +518,16 @@ class GenomicSetMemberDao(UpdatableDao):
                     GenomicWorkflowState.A2
                 )) &
                 (
-                    (ParticipantSummary.consentForStudyEnrollment != QuestionnaireStatus.SUBMITTED) &
-                    (ParticipantSummary.consentForStudyEnrollmentAuthored > _date) &
-                    (ParticipantSummary.withdrawalStatus == WithdrawalStatus.NO_USE)
+                    (
+                        (ParticipantSummary.consentForGenomicsROR != QuestionnaireStatus.SUBMITTED) &
+                        (ParticipantSummary.consentForGenomicsRORAuthored > _date)
+                    ) |
+
+                    (
+                        (ParticipantSummary.consentForStudyEnrollment != QuestionnaireStatus.SUBMITTED) &
+                        (ParticipantSummary.consentForStudyEnrollmentAuthored > _date) &
+                        (ParticipantSummary.withdrawalStatus == WithdrawalStatus.NO_USE)
+                    )
                 )
             ).all()
         return members


### PR DESCRIPTION
This PR undoes some of the work from #1978. Color wishes to receive the participants that remove gRoR consent in the A3 manifest.