### PR TITLE
[DA-1749] Improvements for AW1 and AW2 workflows

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -794,10 +794,12 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
             # Get existing ID if exists
             existing_metrics_obj = self.get_metrics_by_member_id(gc_metrics_obj.genomicSetMemberId)
             if existing_metrics_obj is not None:
+                logging.info(f'GC Metrics for member ID {gc_metrics_obj.genomicSetMemberId} found.')
                 gc_metrics_obj.id = existing_metrics_obj.id
 
             # Insert or overwrite the object
             with self.session() as session:
+                logging.info(f'Writing GC Metrics for member ID {gc_metrics_obj.genomicSetMemberId}.')
                 updated_metrics_obj = session.merge(gc_metrics_obj)
 
             # Update GC Metrics for PDR

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -777,25 +777,25 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
     def get_id(self, obj):
         return obj.id
 
-    def insert_gc_validation_metrics_batch(self, data_to_insert):
+    def insert_gc_validation_metrics_object(self, data_to_insert):
         """
-        Inserts a batch of GC validation metrics
-        :param data_to_insert: list of dictionary rows to insert
+        Inserts a GC validation metrics object
+        :param data_to_insert: dictionary of row-data from AW2 file to insert
         :return: result code
         """
         try:
-            for row in data_to_insert:
-                gc_metrics_obj = GenomicGCValidationMetrics()
-                for key in self.data_mappings.keys():
-                    try:
-                        gc_metrics_obj.__setattr__(key, row[self.data_mappings[key]])
-                    except KeyError:
-                        gc_metrics_obj.__setattr__(key, None)
-                inserted_metrics_obj = self.insert(gc_metrics_obj)
 
-                # Update GC Metrics for PDR
-                bq_genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
-                genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
+            gc_metrics_obj = GenomicGCValidationMetrics()
+            for key in self.data_mappings.keys():
+                try:
+                    gc_metrics_obj.__setattr__(key, data_to_insert[self.data_mappings[key]])
+                except KeyError:
+                    gc_metrics_obj.__setattr__(key, None)
+            inserted_metrics_obj = self.insert(gc_metrics_obj)
+
+            # Update GC Metrics for PDR
+            bq_genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
+            genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -777,21 +777,23 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
     def get_id(self, obj):
         return obj.id
 
-    def insert_gc_validation_metrics_object(self, data_to_insert):
+    def insert_or_update_gc_validation_metrics(self, data_to_insert):
         """
-        Inserts a GC validation metrics object
+        Insert or updates a GC validation metrics object
         :param data_to_insert: dictionary of row-data from AW2 file to insert
         :return: result code
         """
         try:
-
             gc_metrics_obj = GenomicGCValidationMetrics()
             for key in self.data_mappings.keys():
                 try:
                     gc_metrics_obj.__setattr__(key, data_to_insert[self.data_mappings[key]])
                 except KeyError:
                     gc_metrics_obj.__setattr__(key, None)
-            inserted_metrics_obj = self.insert(gc_metrics_obj)
+
+            # Insert or update the object
+            with self.session() as session:
+                inserted_metrics_obj = session.merge(gc_metrics_obj)
 
             # Update GC Metrics for PDR
             bq_genomic_gc_validation_metrics_update(inserted_metrics_obj.id)

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -791,13 +791,18 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                 except KeyError:
                     gc_metrics_obj.__setattr__(key, None)
 
-            # Insert or update the object
+            # Get existing ID if exists
+            existing_metrics_obj = self.get_metrics_by_member_id(gc_metrics_obj.genomicSetMemberId)
+            if existing_metrics_obj is not None:
+                gc_metrics_obj.id = existing_metrics_obj.id
+
+            # Insert or overwrite the object
             with self.session() as session:
-                inserted_metrics_obj = session.merge(gc_metrics_obj)
+                updated_metrics_obj = session.merge(gc_metrics_obj)
 
             # Update GC Metrics for PDR
-            bq_genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
-            genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
+            bq_genomic_gc_validation_metrics_update(updated_metrics_obj.id)
+            genomic_gc_validation_metrics_update(updated_metrics_obj.id)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -470,10 +470,7 @@ class GenomicFileIngester:
         :param data_to_ingest: stream of data in dict format
         :return result code
         """
-        gc_metrics_batch = []
-
-        # iterate over each row from CSV and
-        # add to insert batch gc metrics record
+        # iterate over each row from CSV and insert into gc metrics table
         for row in data_to_ingest['rows']:
             # change all key names to lower
             row_copy = dict(zip([key.lower().replace(' ', '').replace('_', '')

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -288,7 +288,7 @@ class GenomicFileIngester:
                         # RDR may need to do something with them in the future
 
                     else:
-                        logging.warning(f'Invalid collection tube ID: {collection_tube_id}'
+                        logging.error(f'Invalid collection tube ID: {collection_tube_id}'
                                         f' or genome_type: {genome_type}')
 
                         # Aborting the job if invalid collection tube ID found.
@@ -494,7 +494,9 @@ class GenomicFileIngester:
                 row_copy['member_id'] = member.id
                 self.metrics_dao.insert_gc_validation_metrics_object(row_copy)
             else:
-                logging.warning(f'Sample ID {sample_id} has no corresponding Genomic Set Member.')
+                logging.error(f'Sample ID {sample_id} has no corresponding Genomic Set Member.')
+
+                # Aborting the job if sample ID cannot be found.
                 return GenomicSubProcessResult.ERROR
 
         return GenomicSubProcessResult.SUCCESS

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -290,6 +290,10 @@ class GenomicFileIngester:
                     else:
                         logging.warning(f'Invalid collection tube ID: {collection_tube_id}'
                                         f' or genome_type: {genome_type}')
+
+                        # Aborting the job if invalid collection tube ID found.
+                        return GenomicSubProcessResult.ERROR
+
                     continue
 
                 member.gcSiteId = _site
@@ -491,11 +495,12 @@ class GenomicFileIngester:
             if member is not None:
                 self.member_dao.update_member_state(member, GenomicWorkflowState.AW2)
                 row_copy['member_id'] = member.id
-                gc_metrics_batch.append(row_copy)
+                self.metrics_dao.insert_gc_validation_metrics_object(row_copy)
             else:
                 logging.warning(f'Sample ID {sample_id} has no corresponding Genomic Set Member.')
+                return GenomicSubProcessResult.ERROR
 
-        return self.metrics_dao.insert_gc_validation_metrics_batch(gc_metrics_batch)
+        return GenomicSubProcessResult.SUCCESS
 
     def _ingest_cvl_w2_manifest(self, file_data):
         """

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -494,7 +494,7 @@ class GenomicFileIngester:
                 row_copy['member_id'] = member.id
                 self.metrics_dao.insert_or_update_gc_validation_metrics(row_copy)
             else:
-                logging.error(f'Sample ID {sample_id} has no corresponding Genomic Set Member.')
+                logging.error(f'Sample ID {sample_id} has no corresponding Genomic Set Member in AW1 state.')
 
                 # Aborting the job if sample ID cannot be found.
                 return GenomicSubProcessResult.ERROR

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -492,7 +492,7 @@ class GenomicFileIngester:
             if member is not None:
                 self.member_dao.update_member_state(member, GenomicWorkflowState.AW2)
                 row_copy['member_id'] = member.id
-                self.metrics_dao.insert_gc_validation_metrics_object(row_copy)
+                self.metrics_dao.insert_or_update_gc_validation_metrics(row_copy)
             else:
                 logging.error(f'Sample ID {sample_id} has no corresponding Genomic Set Member.')
 

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -604,7 +604,7 @@ class GenomicPipelineTest(BaseTestCase):
 
     def test_gc_metrics_reconciliation_vs_manifest(self):
         # Create the fake Google Cloud CSV files to ingest
-        self._create_fake_datasets_for_gc_tests(1, arr_override=True, array_participants=[1],
+        self._create_fake_datasets_for_gc_tests(2, arr_override=True, array_participants=[1, 2],
                                                 genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest.csv',

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -256,6 +256,34 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(1)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
+        # Test updated metrics
+        # Setup Test file (reusing test file)
+        updated_aw2_file = test_data.open_genomic_set_file('RDR_AoU_GEN_TestDataManifest.csv')
+        updated_aw2_file = updated_aw2_file.replace('10002', '11002')
+
+        updated_aw2_filename = "RDR_AoU_GEN_TestDataManifest_11192020.csv"
+
+        self._write_cloud_csv(
+            updated_aw2_filename,
+            updated_aw2_file,
+            bucket=bucket_name,
+            folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1]),
+        )
+
+        # Reset members' states back to AW1
+        members = self.member_dao.get_all()
+        for m in members:
+            m.genomicWorkflowState = GenomicWorkflowState.AW1
+            self.member_dao.update(m)
+
+        # run the GC Metrics Ingestion workflow again
+        genomic_pipeline.ingest_genomic_centers_metrics_files()
+
+        gc_metrics = self.metrics_dao.get_all()
+        self.assertEqual(len(gc_metrics), 2)
+        self.assertEqual(gc_metrics[1].limsId, '11002')
+
+
     def _update_test_sample_ids(self):
         # update sample ID (mock AW1 manifest)
         for m in self.member_dao.get_all():


### PR DESCRIPTION
This PR makes the following updates to improve the AW1 and AW2 workflows:
- If a sample ID (AW2) or collection tube ID (AW1) is not found, the job is aborted.
- AW2 workflow no longer uses a batch insert.
- AW2 workflow can now update existing GC metrics.