### PR TITLE
[PDR-149] Preserve RDR genomics tables primary key id values in BQ

### DIFF
--- a/rdr_service/dao/bq_genomics_dao.py
+++ b/rdr_service/dao/bq_genomics_dao.py
@@ -34,6 +34,8 @@ class BQGenomicSetGenerator(BigQueryGenerator):
             row = ro_session.execute(text('select * from genomic_set where id = :id'), {'id': _id}).first()
             data = ro_dao.to_dict(row)
 
+            # PDR-149:  Preserve id values from RDR
+            data['orig_id'] = data['id']
             data['orig_created'] = data['created']
             data['orig_modified'] = data['modified']
             data['created'] = data['modified'] = datetime.utcnow()
@@ -79,6 +81,8 @@ class BQGenomicSetMemberSchemaGenerator(BigQueryGenerator):
             row = ro_session.execute(text('select * from genomic_set_member where id = :id'), {'id': _id}).first()
             data = ro_dao.to_dict(row)
 
+            # PDR-149:  Preserve id values from RDR
+            data['orig_id'] = data['id']
             data['orig_created'] = data['created']
             data['orig_modified'] = data['modified']
 
@@ -131,6 +135,9 @@ class BQGenomicJobRunSchemaGenerator(BigQueryGenerator):
             row = ro_session.execute(text('select * from genomic_job_run where id = :id'), {'id': _id}).first()
             data = ro_dao.to_dict(row)
 
+            # PDR-149:  Preserve id values from RDR
+            data['orig_id'] = data['id']
+
             # Populate Enum fields.
             # column data is in 'job_id', instead of 'job' for this one.
             if data['job_id']:
@@ -181,7 +188,8 @@ class BQGenomicGCValidationMetricsSchemaGenerator(BigQueryGenerator):
             row = ro_session.execute(text('select * from genomic_gc_validation_metrics where id = :id'),
                                      {'id': _id}).first()
             data = ro_dao.to_dict(row)
-
+            # PDR-149:  Preserve id values from RDR
+            data['orig_id'] = data['id']
             data['orig_created'] = data['created']
             data['orig_modified'] = data['modified']
 

--- a/rdr_service/model/bq_genomics.py
+++ b/rdr_service/model/bq_genomics.py
@@ -29,6 +29,8 @@ class BQGenomicSetSchema(BQSchema):
     id = BQField('id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
     created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
     modified = BQField('modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    # PDR-149:  Need to preserve the RDR table id values
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     genomic_set_name = BQField('genomic_set_name', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
@@ -65,6 +67,8 @@ class BQGenomicSetMemberSchema(BQSchema):
     id = BQField('id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
     created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
     modified = BQField('modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    # PDR-149:  Need to preserve the RDR table id values
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     genomic_set_id = BQField('genomic_set_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
@@ -177,6 +181,8 @@ class BQGenomicJobRunSchema(BQSchema):
     id = BQField('id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
     created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
     modified = BQField('modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    # PDR-149:  Need to preserve RDR table id values
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     job = BQField('job', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE, fld_enum=GenomicJobEnum)
     job_id = BQField('job_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE, fld_enum=GenomicJobEnum)
     start_time = BQField('start_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
@@ -214,6 +220,8 @@ class BQGenomicGCValidationMetricsSchema(BQSchema):
     id = BQField('id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
     created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
     modified = BQField('modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    # PDR-149:  Need to preserve RDR table id values
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     genomic_set_member_id = BQField('genomic_set_member_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)

--- a/rdr_service/resource/generators/genomics.py
+++ b/rdr_service/resource/generators/genomics.py
@@ -117,7 +117,7 @@ class GenomicJobRunSchemaGenerator(generators.BaseGenerator):
         with ro_dao.session() as ro_session:
             row = ro_session.execute(text('select * from genomic_job_run where id = :id'), {'id': _pk}).first()
             data = ro_dao.to_dict(row)
-
+            data['orig_id'] = data['id']
             # Populate Enum fields.
             # column data is in 'job_id', instead of 'job' for this one.
             if data['job_id']:

--- a/rdr_service/resource/generators/genomics.py
+++ b/rdr_service/resource/generators/genomics.py
@@ -117,7 +117,6 @@ class GenomicJobRunSchemaGenerator(generators.BaseGenerator):
         with ro_dao.session() as ro_session:
             row = ro_session.execute(text('select * from genomic_job_run where id = :id'), {'id': _pk}).first()
             data = ro_dao.to_dict(row)
-            data['orig_id'] = data['id']
             # Populate Enum fields.
             # column data is in 'job_id', instead of 'job' for this one.
             if data['job_id']:


### PR DESCRIPTION
This pulls over the auto-incremented primary key 'id' values from the RDR genomics tables and keeps them as the 'orig_id' column value in the BigQuery genomics tables.

Note:  Since these are new PDR tables and not heavily used yet, I intentionally reordered the columns by grouping the orig_id with the orig_created and orig_modified fields, for schema readability.  This means wiping the tables in BQ to rebuild them because the column order changed.   Verified analytics team is not currently using the data while waiting on this fix.  

Ran through a bq migration and resource rebuild for the genomics tables on sandbox.  Seeded the genomics_gc_validation_metrics table in sandbox RDR so it would be synced and would allow testing of the PDR query posted in PDR-149 