### PR TITLE
Allowing for potential string values for cohort group

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -434,13 +434,12 @@ class QuestionnaireResponseDao(BaseDao):
                             # storing in the Enum column
                             cohort_numbers = ParticipantCohort.numbers()
                             if cohort_group not in cohort_numbers:
-                                raise BadRequest(f'Unable to accept {cohort_group} as a cohort, '
-                                                 f'currently only taking {cohort_numbers}')
+                                raise ValueError
                             else:
                                 participant_summary.consentCohort = answer.valueString
                                 something_changed = True
                         except ValueError:
-                            raise BadRequest(f'Invalid value given for cohort group: received "{answer.valueString}"')
+                            logging.error(f'Invalid value given for cohort group: received "{answer.valueString}"')
 
 
 


### PR DESCRIPTION
We recently learned that it may be possible to receive strings for cohort group at some point in the future. This is to fix my assumption that we should only expect numbers. Instead we'll make an error log and fall back on the date algorithm if we get something we're not expecting. This isn't ideal, but it's easier than cleaning up after rejecting the consent responses. 