### PR TITLE
Refactored to only insert gc metrics once; no update.

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -784,9 +784,9 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
     def get_id(self, obj):
         return obj.id
 
-    def insert_or_update_gc_validation_metrics(self, data_to_insert):
+    def insert_gc_validation_metrics(self, data_to_insert):
         """
-        Insert or updates a GC validation metrics object
+        Insert a GC validation metrics object
         :param data_to_insert: dictionary of row-data from AW2 file to insert
         :return: result code
         """
@@ -798,20 +798,12 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                 except KeyError:
                     gc_metrics_obj.__setattr__(key, None)
 
-            # Get existing ID if exists
-            existing_metrics_obj = self.get_metrics_by_member_id(gc_metrics_obj.genomicSetMemberId)
-            if existing_metrics_obj is not None:
-                logging.info(f'GC Metrics for member ID {gc_metrics_obj.genomicSetMemberId} found.')
-                gc_metrics_obj.id = existing_metrics_obj.id
-
-            # Insert or overwrite the object
-            with self.session() as session:
-                logging.info(f'Writing GC Metrics for member ID {gc_metrics_obj.genomicSetMemberId}.')
-                updated_metrics_obj = session.merge(gc_metrics_obj)
+            logging.info(f'Inserting GC Metrics for member ID {gc_metrics_obj.genomicSetMemberId}.')
+            inserted_metrics_obj = self.insert(gc_metrics_obj)
 
             # Update GC Metrics for PDR
-            bq_genomic_gc_validation_metrics_update(updated_metrics_obj.id)
-            genomic_gc_validation_metrics_update(updated_metrics_obj.id)
+            bq_genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
+            genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -492,7 +492,17 @@ class GenomicFileIngester:
             if member is not None:
                 self.member_dao.update_member_state(member, GenomicWorkflowState.AW2)
                 row_copy['member_id'] = member.id
-                self.metrics_dao.insert_or_update_gc_validation_metrics(row_copy)
+
+                # check whether metrics object exists for that member
+                existing_metrics_obj = self.metrics_dao.get_metrics_by_member_id(member.id)
+                if existing_metrics_obj is None:
+                    self.metrics_dao.insert_gc_validation_metrics(row_copy)
+
+                else:
+                    logging.info(f"Found existing metrics object for member ID {member.id}")
+                    # TODO: skipping update to metrics for now.
+                    continue
+
             else:
                 logging.error(f'Sample ID {sample_id} has no corresponding Genomic Set Member in AW1 state.')
 

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -256,10 +256,10 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(1)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-        # Test updated metrics
+        # Test Inserted metrics are not re-inserted
         # Setup Test file (reusing test file)
         updated_aw2_file = test_data.open_genomic_set_file('RDR_AoU_GEN_TestDataManifest.csv')
-        updated_aw2_file = updated_aw2_file.replace('10002', '11002')
+        #updated_aw2_file = updated_aw2_file.replace('10002', '11002')
 
         updated_aw2_filename = "RDR_AoU_GEN_TestDataManifest_11192020.csv"
 
@@ -280,10 +280,13 @@ class GenomicPipelineTest(BaseTestCase):
         genomic_pipeline.ingest_genomic_centers_metrics_files()
 
         gc_metrics = self.metrics_dao.get_all()
+        # Test that the insert is skipped
         self.assertEqual(len(gc_metrics), 2)
-        for m in gc_metrics:
-            if m.genomicSetMemberId == 2:
-                self.assertEqual(m.limsId, '11002')
+        # TODO: Removing the update functionality for now.
+        #  When rerunning AW2, previously inserted metrics will be skipped
+        # for m in gc_metrics:
+        #     if m.genomicSetMemberId == 2:
+        #         self.assertEqual(m.limsId, '11002')
 
 
     def _update_test_sample_ids(self):


### PR DESCRIPTION
This PR refactors the genomic AW2 workflow to skip inserting GC metrics for genomic set members that already have metrics. This is to fix an insert/update operation that was inconsistently failing unit tests. 