### PR TITLE
[DA-1755] Added 'manifest' to A3 filename.

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2017,7 +2017,7 @@ class ManifestDefinitionProvider:
             job_run_field='gemA3ManifestJobRunId',
             source_data=self._get_source_data_query(GenomicManifestTypes.GEM_A3),
             destination_bucket=f'{self.bucket_name}',
-            output_filename=f'{GENOMIC_GEM_A3_MANIFEST_SUBFOLDER}/AoU_GEM_A3_{now_formatted}.csv',
+            output_filename=f'{GENOMIC_GEM_A3_MANIFEST_SUBFOLDER}/AoU_GEM_A3_manifest_{now_formatted}.csv',
             columns=self._get_manifest_columns(GenomicManifestTypes.GEM_A3),
             signal=self.DEFAULT_SIGNAL,
         )

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1884,7 +1884,7 @@ class GenomicPipelineTest(BaseTestCase):
             "sample_id",
             "date_of_consent_removal",
         )
-        with open_cloud_file(os.path.normpath(f'{bucket_name}/{sub_folder}/AoU_GEM_A3_{out_time}.csv')) as csv_file:
+        with open_cloud_file(os.path.normpath(f'{bucket_name}/{sub_folder}/AoU_GEM_A3_manifest_{out_time}.csv')) as csv_file:
             csv_reader = csv.DictReader(csv_file)
             missing_cols = set(expected_gem_columns) - set(csv_reader.fieldnames)
             self.assertEqual(0, len(missing_cols))
@@ -1900,7 +1900,7 @@ class GenomicPipelineTest(BaseTestCase):
         # Array
         file_record = self.file_processed_dao.get(1)  # remember, GC Metrics is #1
         self.assertEqual(2, file_record.runId)
-        self.assertEqual(f'{sub_folder}/AoU_GEM_A3_{out_time}.csv', file_record.fileName)
+        self.assertEqual(f'{sub_folder}/AoU_GEM_A3_manifest_{out_time}.csv', file_record.fileName)
 
         # Test the job result
         run_obj = self.job_run_dao.get(2)


### PR DESCRIPTION
Color is expecting the file name to match `AoU_GEM_A3_manifest_YYYY-MM-DD-hh-mm-ss.csv`. We are currently missing 'manifest'. This PR adds 'manifest' to the filename.