### PR TITLE
[DA-1756] Add contamination column to AW2 Array ingestion.

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -680,6 +680,7 @@ class GenomicFileValidator:
                 "chipwellbarcode",
                 "callrate",
                 "sexconcordance",
+                "contamination",
                 "processingstatus",
                 "notes",
             ),

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -337,6 +337,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual('10001_R01C01', record.chipwellbarcode)
             self.assertEqual('0.34567890', record.callRate)
             self.assertEqual('True', record.sexConcordance)
+            self.assertEqual('8.67812390', record.contamination)
             self.assertEqual('Pass', record.processingStatus)
             self.assertEqual('This sample passed', record.notes)
 

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,3 +1,3 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Processing Status,Notes
-T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,Pass,This sample passed
-T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,Pass,This sample passed
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Notes
+T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,8.67812390,Pass,This sample passed
+T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Pass,This sample passed


### PR DESCRIPTION
This PR adds the `contamination` column to the AW2 Array ingestion workflow. This column is already being ingested in the Whole Genome Sequencing workflow.