### PR TITLE
[DA-1735] Updates for ETL script and export tool

### DIFF
--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -634,11 +634,11 @@ JOIN ( -- Filter question answers down to the latest we have from each participa
             WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
             ELSE c_inner.value
         END survey
-	FROM rdr.questionnaire_response qr_inner
-	JOIN rdr.questionnaire_response_answer qra_inner
-	    ON qra_inner.questionnaire_response_id = qr_inner.questionnaire_response_id
-	JOIN rdr.questionnaire_question qq_inner
-	    ON qq_inner.questionnaire_question_id = qra_inner.question_id
+    FROM rdr.questionnaire_response qr_inner
+    JOIN rdr.questionnaire_response_answer qra_inner
+        ON qra_inner.questionnaire_response_id = qr_inner.questionnaire_response_id
+    JOIN rdr.questionnaire_question qq_inner
+        ON qq_inner.questionnaire_question_id = qra_inner.question_id
     JOIN rdr.questionnaire_concept qc_inner
         ON qr_inner.questionnaire_id = qc_inner.questionnaire_id
             AND qr_inner.questionnaire_version = qc_inner.questionnaire_version
@@ -649,10 +649,10 @@ JOIN ( -- Filter question answers down to the latest we have from each participa
         FROM questionnaire_history qh
     ) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
         ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
-	GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
-	    WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
-	    ELSE c_inner.value
-	END
+    GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
+        WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
+        ELSE c_inner.value
+    END
 ) latest
     ON latest.participant_id = qr.participant_id
         AND latest.authored = qr.authored

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -615,12 +615,50 @@ JOIN rdr.questionnaire_response_answer qra
     ON  qra.questionnaire_response_id = qr.questionnaire_response_id
 JOIN rdr.questionnaire_question qq
     ON qra.question_id = qq.questionnaire_question_id
+JOIN (
+    SELECT qh.questionnaire_id, qh.version,
+        json_unquote(json_extract(convert(qh.resource using utf8), '$.identifier[0].value')) vibrent_form_id
+    FROM questionnaire_history qh
+) qvf
+    ON qvf.questionnaire_id = qr.questionnaire_id AND qvf.version = qr.questionnaire_version
 JOIN rdr.code co_q
     ON  qq.code_id = co_q.code_id
 LEFT JOIN rdr.code co_a
     ON  qra.value_code_id = co_a.code_id
 LEFT JOIN rdr.code co_b
     ON qc.code_id = co_b.code_id
+JOIN ( -- Filter question answers down to the latest we have from each participant for each question
+    SELECT qr_inner.participant_id, qq_inner.code_id question_code_id, MAX(qr_inner.authored) as authored, CASE
+            WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
+            ELSE c_inner.value
+        END survey
+	FROM rdr.questionnaire_response qr_inner
+	JOIN rdr.questionnaire_response_answer qra_inner
+	    ON qra_inner.questionnaire_response_id = qr_inner.questionnaire_response_id
+	JOIN rdr.questionnaire_question qq_inner
+	    ON qq_inner.questionnaire_question_id = qra_inner.question_id
+    JOIN rdr.questionnaire_concept qc_inner
+        ON qr_inner.questionnaire_id = qc_inner.questionnaire_id
+            AND qr_inner.questionnaire_version = qc_inner.questionnaire_version
+    JOIN rdr.code c_inner on c_inner.code_id = qc_inner.code_id
+	JOIN (
+        SELECT qh.questionnaire_id, qh.version,
+            json_unquote(json_extract(convert(qh.resource using utf8), '$.identifier[0].value')) vibrent_form_id
+        FROM questionnaire_history qh
+	) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
+	    ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
+	GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
+	    WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
+	    ELSE c_inner.value
+	END
+) latest
+    ON latest.participant_id = qr.participant_id
+	    AND latest.authored = qr.authored
+	    AND latest.question_code_id = qq.code_id
+	    AND latest.survey = CASE
+            WHEN co_b.value = 'COPE' THEN qvf.vibrent_form_id
+            ELSE co_b.value
+        END
 WHERE
     pa.withdrawal_status != 2
     AND pa.is_ghost_id IS NOT TRUE

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -601,7 +601,7 @@ SELECT
 FROM rdr.questionnaire_history qh
 ;
 
--- Setup for being able to filter question answers down to the latest we have from each participant for each question
+-- Setup for being able to filter questionnaire responses to the latest we have from each participant for each survey
 INSERT INTO cdm.questionnaire_responses_by_module
 SELECT qr.participant_id, qr.authored as authored, CASE
         WHEN c.value = 'COPE' THEN qvf.vibrent_form_id

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -642,22 +642,22 @@ JOIN ( -- Filter question answers down to the latest we have from each participa
     JOIN rdr.questionnaire_concept qc_inner
         ON qr_inner.questionnaire_id = qc_inner.questionnaire_id
             AND qr_inner.questionnaire_version = qc_inner.questionnaire_version
-    JOIN rdr.code c_inner on c_inner.code_id = qc_inner.code_id
-	JOIN (
+    JOIN rdr.code c_inner ON c_inner.code_id = qc_inner.code_id
+    JOIN (
         SELECT qh.questionnaire_id, qh.version,
             json_unquote(json_extract(convert(qh.resource using utf8), '$.identifier[0].value')) vibrent_form_id
         FROM questionnaire_history qh
-	) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
-	    ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
+    ) qvf_inner -- Need to distinguish by vibrent_form_id for the COPE surveys
+        ON qvf_inner.questionnaire_id = qr_inner.questionnaire_id AND qvf_inner.version = qr_inner.questionnaire_version
 	GROUP BY qr_inner.participant_id, qq_inner.code_id, CASE
 	    WHEN c_inner.value = 'COPE' THEN qvf_inner.vibrent_form_id
 	    ELSE c_inner.value
 	END
 ) latest
     ON latest.participant_id = qr.participant_id
-	    AND latest.authored = qr.authored
-	    AND latest.question_code_id = qq.code_id
-	    AND latest.survey = CASE
+        AND latest.authored = qr.authored
+        AND latest.question_code_id = qq.code_id
+        AND latest.survey = CASE
             WHEN co_b.value = 'COPE' THEN qvf.vibrent_form_id
             ELSE co_b.value
         END

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -537,7 +537,8 @@ DROP TABLE IF EXISTS cdm.questionnaire_vibrent_forms;
 CREATE TABLE cdm.questionnaire_vibrent_forms (
     questionnaire_id            bigint,
     version                     bigint,
-    vibrent_form_id             varchar(1024)
+    vibrent_form_id             varchar(1024),
+    INDEX vibrent_form_index    (questionnaire_id, version)
 );
 
 INSERT INTO cdm.questionnaire_vibrent_forms
@@ -557,7 +558,8 @@ CREATE TABLE cdm.questionnaire_latest_answers (
     participant_id              bigint,
     question_code_id            bigint,
     authored                    datetime,
-    survey                      varchar(1024)
+    survey                      varchar(1024),
+    INDEX latest_asnswers_index (participant_id, question_code_id, authored, survey)
 );
 
 -- -------------------------------------------------------------------

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -532,6 +532,8 @@ CREATE TABLE cdm.dose_era
 -- -----------------------------------------------
 -- questionnaire_vibrent_forms
 -- -----------------------------------------------
+-- TODO: soon external ids will be available in Prod,
+--  this table can be removed when they are
 DROP TABLE IF EXISTS cdm.questionnaire_vibrent_forms;
 
 CREATE TABLE cdm.questionnaire_vibrent_forms (
@@ -542,16 +544,16 @@ CREATE TABLE cdm.questionnaire_vibrent_forms (
 );
 
 -- -----------------------------------------------
--- questionnaire_latest_answers
+-- questionnaire_answers_by_code
 -- -----------------------------------------------
-DROP TABLE IF EXISTS cdm.questionnaire_latest_answers;
+DROP TABLE IF EXISTS cdm.questionnaire_answers_by_code;
 
-CREATE TABLE cdm.questionnaire_latest_answers (
+CREATE TABLE cdm.questionnaire_answers_by_code (
     participant_id              bigint,
     question_code_id            bigint,
     authored                    datetime,
     survey                      varchar(200),
-    INDEX latest_asnswers_index (participant_id, question_code_id, authored, survey)
+    INDEX answers_by_code_index (participant_id, question_code_id, survey)
 );
 
 -- -------------------------------------------------------------------
@@ -601,8 +603,8 @@ FROM rdr.questionnaire_history qh
 ;
 
 -- Setup for being able to filter question answers down to the latest we have from each participant for each question
-INSERT INTO cdm.questionnaire_latest_answers
-SELECT qr.participant_id, qq.code_id question_code_id, MAX(qr.authored) as authored, CASE
+INSERT INTO cdm.questionnaire_answers_by_code
+SELECT qr.participant_id, qq.code_id question_code_id, qr.authored as authored, CASE
         WHEN c.value = 'COPE' THEN qvf.vibrent_form_id
         ELSE c.value
     END survey
@@ -617,10 +619,6 @@ JOIN rdr.questionnaire_concept qc
 JOIN rdr.code c ON c.code_id = qc.code_id
 JOIN cdm.questionnaire_vibrent_forms qvf -- Need to distinguish by vibrent_form_id for the COPE surveys
     ON qvf.questionnaire_id = qr.questionnaire_id AND qvf.version = qr.questionnaire_version
-GROUP BY qr.participant_id, qq.code_id, CASE
-    WHEN c.value = 'COPE' THEN qvf.vibrent_form_id
-    ELSE c.value
-END
 ;
 
 INSERT INTO cdm.src_clean
@@ -681,14 +679,14 @@ LEFT JOIN rdr.code co_a
     ON  qra.value_code_id = co_a.code_id
 LEFT JOIN rdr.code co_b
     ON qc.code_id = co_b.code_id
-JOIN cdm.questionnaire_latest_answers latest
-    ON latest.participant_id = qr.participant_id
-        AND latest.authored = qr.authored
-        AND latest.question_code_id = qq.code_id
-        AND latest.survey = CASE
+LEFT JOIN cdm.questionnaire_answers_by_code later_answer
+    ON later_answer.participant_id = qr.participant_id
+        AND later_answer.question_code_id = qq.code_id
+        AND later_answer.survey = CASE
             WHEN co_b.value = 'COPE' THEN qvf.vibrent_form_id
             ELSE co_b.value
         END
+        AND later_answer.authored > qr.authored
 WHERE
     pa.withdrawal_status != 2
     AND pa.is_ghost_id IS NOT TRUE
@@ -704,6 +702,7 @@ WHERE
         OR qra.value_datetime IS NOT NULL
         OR qra.value_string IS NOT NULL
     )
+    AND later_answer.participant_id IS NULL  -- Make sure the response doesn't have anything authored later
 ;
 
 -- Reset ISOLATION level to previous setting (assuming here that it was MySql's default)

--- a/rdr_service/etl/etl.sql
+++ b/rdr_service/etl/etl.sql
@@ -572,7 +572,9 @@ SELECT
     pa.participant_id               AS participant_id,
     pa.research_id                  AS research_id,
     co_b.value                      AS survey_name,
-    qr.created                      AS date_of_survey,
+    COALESCE(
+        qr.authored,
+        qr.created)                 AS date_of_survey,
     co_q.short_value                AS question_ppi_code,
     qq.code_id                      AS question_code_id,
     co_a.short_value                AS value_ppi_code,


### PR DESCRIPTION
This adds some functionality to the ETL script for removing duplicate answers from the results and using authored date rather than created date when available. For removing duplicate answer we create a helper table that has all authored dates for a participant's response to a question code. Duplicate answers are removed from the src_clean table by joining it to the response table and finding if there are any responses that are later: if there aren't then it's included in the results, if there are then it's left out. The COPE surveys all use the same module code, so to account for them I look for later answers by question code ids and external id's instead. The ETL script is also updated with a fix for setting the transaction isolation level. Without specifying SESSION, it was leaving the isolation level unmodified and locking the questionnaire response and answer records when performing the "insert into ... select ..." query.

I've also updated the `curation` tool so that we can use the `gcloud sql export csv` utility. This essentially instructs the Google Platform to store the results of a SQL query in a bucket. Using that will let us avoid having to export the tables to our computers and upload them manually.