### PR TITLE
[DA-1769] Sync codes for all environments at once

### DIFF
--- a/rdr_service/services/gcp_config.py
+++ b/rdr_service/services/gcp_config.py
@@ -21,7 +21,7 @@ GCP_PROJECTS = [
     "aou-pdr-data-prod"
 ]
 
-GCP_INSTANCES = {
+GCP_INSTANCES = {  # List of RDR's GCP projects mapped to their database instance names
     "all-of-us-rdr-prod": "all-of-us-rdr-prod:us-central1:rdrmaindb",
     "all-of-us-rdr-stable": "all-of-us-rdr-stable:us-central1:rdrmaindb",
     "all-of-us-rdr-staging": "all-of-us-rdr-staging:us-central1:rdrmaindb",
@@ -31,7 +31,6 @@ GCP_INSTANCES = {
     "all-of-us-rdr-ptsc-1-test": "all-of-us-rdr-ptsc-1-test:us-central1:rdrmaindb",
     "all-of-us-rdr-ptsc-2-test": "all-of-us-rdr-ptsc-2-test:us-central1:rdrmaindb",
     "all-of-us-rdr-ptsc-3-test": "all-of-us-rdr-ptsc-3-test:us-central1:rdrmaindb",
-
 }
 
 GCP_REPLICA_INSTANCES = {

--- a/rdr_service/tools/tool_libs/_tool_base.py
+++ b/rdr_service/tools/tool_libs/_tool_base.py
@@ -15,13 +15,17 @@ class ToolBase(object):
         self.tool_cmd = tool_cmd
         self.gcp_env = gcp_env
 
+    @staticmethod
+    def initialize_process_context(tool_cmd, project, account, service_account):
+        return GCPProcessContext(tool_cmd, project, account, service_account)
+
     def run_process(self):
         """
         Responsible for setting up the GCP environment and running the tool's code
         :return: Tool's exit code value
         """
-        with GCPProcessContext(self.tool_cmd, self.args.project,
-                               self.args.account, self.args.service_account) as gcp_env:
+        with self.initialize_process_context(self.tool_cmd, self.args.project,
+                                             self.args.account, self.args.service_account) as gcp_env:
             self.gcp_env = gcp_env
             return self.run()
 
@@ -54,5 +58,5 @@ def cli_run(tool_cmd, tool_desc, tool_class: ToolBase, parser_hook=None, default
         parser_hook(parser)
 
     args = parser.parse_args()
-    process = tool_class(args, tool_cmd)
+    process = tool_class(args, tool_cmd=tool_cmd)
     return process.run_process()

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -209,8 +209,9 @@ class CodesSyncClass(ToolBase):
 
         return response.content
 
-    def write_export_file(self, session):
-        with open(code_export_file_path + self.gcp_env.project, 'w') as output_file:
+    @staticmethod
+    def write_export_file(session):
+        with open(code_export_file_path, 'w') as output_file:
             code_csv_writer = csv.writer(output_file)
             code_csv_writer.writerow([
                 'Code Value',

--- a/tests/tool_tests/test_codes_management.py
+++ b/tests/tool_tests/test_codes_management.py
@@ -64,7 +64,7 @@ class CodesManagementTest(BaseTestCase):
                 mock.patch('rdr_service.tools.tool_libs.codes_management.open'):  # Prevent tests from making real files
             mock_response = mock_requests.post.return_value
             mock_response.status_code = 200
-            mock_response.content = redcap_data_dictionary
+            mock_response.json.return_value = redcap_data_dictionary
 
             mock_csv_writerow = mock_csv.writer.return_value.writerow
 
@@ -88,6 +88,11 @@ class CodesManagementTest(BaseTestCase):
 
     def test_question_and_answer_codes(self):
         self.run_tool([
+            self._get_mock_dictionary_item(
+                'record_id',
+                'Redcap inserts a record_id code into everything, it should be ignored',
+                'text'
+            ),
             self._get_mock_dictionary_item(
                 'participant_id',
                 'Participant ID',


### PR DESCRIPTION
This does a little refactoring to let the CodeSync tool class detect if we want to sync codes for every environment (with the _all project option). If _all is given as the project then the tool connects to all environments and imports the codes from the Redcap project and then exports the codes for Prod to google drive.