### PR TITLE
[DA-1758] API for PTSC Genomic Outreach Test

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -50,7 +50,7 @@ class GenomicOutreachApi(BaseApi):
         return BadRequest
 
     @auth_required(RDR_AND_PTC)
-    @restrict_to_gae_project(['all-of-us-rdr-sandbox', 'all-of-us-rdr-ptsc-test-1', 'localhost'])
+    @restrict_to_gae_project(['all-of-us-rdr-sandbox', 'all-of-us-rdr-ptsc-1-test', 'localhost'])
     def post(self, p_id, mode=None):
         """
         Generates a genomic test participant from payload

--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -50,7 +50,7 @@ class GenomicOutreachApi(BaseApi):
         return BadRequest
 
     @auth_required(RDR_AND_PTC)
-    @restrict_to_gae_project(['all-of-us-rdr-ptsc-1-test', 'localhost'])
+    @restrict_to_gae_project(['all-of-us-rdr-sandbox', 'all-of-us-rdr-ptsc-1-test', 'localhost'])
     def post(self, p_id, mode=None):
         """
         Generates a genomic test participant from payload
@@ -92,7 +92,7 @@ class GenomicOutreachApi(BaseApi):
             if _pid.startswith("P"):
                 _pid = _pid[1:]
 
-            participant_report_states = self.dao.participant_lookup(_pid)
+            participant_report_states = self.dao.participant_state_lookup(_pid)
 
             if len(participant_report_states) == 0:
                 raise NotFound(f'Participant P{_pid} does not exist in the Genomic system.')

--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -50,7 +50,7 @@ class GenomicOutreachApi(BaseApi):
         return BadRequest
 
     @auth_required(RDR_AND_PTC)
-    @restrict_to_gae_project(['all-of-us-rdr-sandbox', 'all-of-us-rdr-ptsc-1-test', 'localhost'])
+    @restrict_to_gae_project(['all-of-us-rdr-ptsc-1-test', 'localhost'])
     def post(self, p_id, mode=None):
         """
         Generates a genomic test participant from payload

--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -11,6 +11,11 @@ from rdr_service.app_util import auth_required, restrict_to_gae_project
 from rdr_service.dao.genomics_dao import GenomicPiiDao, GenomicOutreachDao
 
 
+ALLOWED_ENVIRONMENTS = ['all-of-us-rdr-sandbox',
+                        'all-of-us-rdr-stable',
+                        'all-of-us-rdr-ptsc-1-test',
+                        'localhost']
+
 class GenomicPiiApi(BaseApi):
     def __init__(self):
         super(GenomicPiiApi, self).__init__(GenomicPiiDao())
@@ -50,7 +55,7 @@ class GenomicOutreachApi(BaseApi):
         return BadRequest
 
     @auth_required(RDR_AND_PTC)
-    @restrict_to_gae_project(['all-of-us-rdr-sandbox', 'all-of-us-rdr-ptsc-1-test', 'localhost'])
+    @restrict_to_gae_project(ALLOWED_ENVIRONMENTS)
     def post(self, p_id, mode=None):
         """
         Generates a genomic test participant from payload

--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -4,9 +4,10 @@ from flask import request
 from werkzeug.exceptions import NotFound, BadRequest
 
 from rdr_service import clock
-from rdr_service.api.base_api import BaseApi
+from rdr_service import config
+from rdr_service.api.base_api import BaseApi, log_api_request
 from rdr_service.api_util import GEM, RDR_AND_PTC, RDR
-from rdr_service.app_util import auth_required
+from rdr_service.app_util import auth_required, restrict_to_gae_project
 from rdr_service.dao.genomics_dao import GenomicPiiDao, GenomicOutreachDao
 
 
@@ -41,11 +42,27 @@ class GenomicOutreachApi(BaseApi):
 
     @auth_required(RDR_AND_PTC)
     def get(self, mode=None):
-        if mode not in ('GEM', 'RHP'):
-            raise BadRequest("GenomicOutreach Mode required to be \"GEM\" or \"RHP\".")
+        self._check_mode(mode)
 
-        if mode == "GEM":
+        if mode.lower() == "gem":
             return self.get_gem_outreach()
+
+        return BadRequest
+
+    @auth_required(RDR_AND_PTC)
+    @restrict_to_gae_project(['all-of-us-rdr-sandbox', 'all-of-us-rdr-ptsc-test-1', 'localhost'])
+    def post(self, p_id, mode=None):
+        """
+        Generates a genomic test participant from payload
+        Overwrites BaseAPI.post()
+        :param p_id:
+        :param mode:
+        :return:
+        """
+        self._check_mode(mode)
+
+        if mode.lower() == "gem":
+            return self.post_gem_outreach(p_id)
 
         return BadRequest
 
@@ -95,3 +112,35 @@ class GenomicOutreachApi(BaseApi):
             return self._make_response(proto_payload)
 
         return BadRequest
+
+    def post_gem_outreach(self, p_id):
+        """
+        Creates the genomic participant
+        :return: response
+        """
+        resource = request.get_json(force=True)
+
+        # Create GenomicSetMember with report state
+        model = self.dao.from_client_json(resource, participant_id=p_id, mode='gem')
+        m = self._do_insert(model)
+
+        response_data = {
+                            'date': m.genomicWorkflowStateModifiedTime,
+                            'data': [
+                                (m.participantId, m.genomicWorkflowState),
+                            ]
+                        }
+
+        # Log to requests_log
+        log_api_request(log=request.log_record)
+
+        return self._make_response(response_data)
+
+    @staticmethod
+    def _check_mode(mode):
+        """
+        Checks that the mode in the endpoint is valid
+        :param mode: "GEM" or "RHP"
+        """
+        if mode.lower() not in config.GENOMIC_API_MODES:
+            raise BadRequest(f"GenomicOutreach Mode required to be one of {config.GENOMIC_API_MODES}.")

--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -284,6 +284,30 @@ def auth_required(role_whitelist):
     return auth_required_wrapper
 
 
+def restrict_to_gae_project(allowed_project_list):
+    """
+    A decorator for restricting access of a method
+    to a particular Google App Engine Project
+    :param project_list: list of GAE ids, i.e. 'all-of-us-rdr-stable', etc.
+    :return: function result or Forbidden
+    """
+    def restriction_function_wrapper(func):
+        def inner(*args, **kwargs):
+            app_id = GAE_PROJECT
+
+            # Check app_id against the registered environments
+            if app_id in allowed_project_list:
+                result = func(*args, **kwargs)
+            else:
+                raise Forbidden(f'This operation is forbidden on {app_id}')
+
+            return result
+
+        return inner
+
+    return restriction_function_wrapper
+
+
 def get_validated_user_info():
     """Returns a valid (user email, user info), or raises Unauthorized or Forbidden."""
     user_email = get_oauth_id()

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -97,6 +97,7 @@ READTHEDOCS_CREDS = "readthedocs_creds"
 SENDGRID_KEY = "sendgrid_key"
 SENDGRID_FROM_EMAIL = "no-reply@pmi-ops.org"
 MAYOLINK_ENDPOINT = "mayolink_endpoint"
+GENOMIC_API_MODES = ('gem', 'rhp')
 CONFIG_BUCKET = "all-of-us-rdr-sequestered-config-test"
 EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT = "ehr_status_bigquery_view_participant"
 EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION = "ehr_status_bigquery_view_organization"

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -305,8 +305,9 @@ api.add_resource(GenomicPiiApi,
 
 api.add_resource(GenomicOutreachApi,
                  API_PREFIX + "GenomicOutreach/<string:mode>",
+                 API_PREFIX + "GenomicOutreach/<string:mode>/Participant/<participant_id:p_id>",
                  endpoint='genomic.outreach',
-                 methods=['GET'])
+                 methods=['GET', 'POST'])
 
 api.add_resource(
     DeceasedReportApi,

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -314,3 +314,15 @@ class GenomicOutreachApiTest(GenomicApiTestBase):
         self.assertEqual(expected_response, resp)
         self.assertEqual(GenomicWorkflowState.GEM_RPT_PENDING_DELETE, member.genomicWorkflowState)
 
+    def test_genomic_test_participant_not_found(self):
+        # P2001 doesn't exist in participant
+        local_path = f"GenomicOutreach/GEM/Participant/P2001"
+
+        # Test Payload for participant report status
+        payload = {
+            "status": "pending_delete",
+            "date": "2020-09-13T20:52:12+00:00"
+        }
+
+        self.send_post(local_path, request_data=payload, expected_status=404)
+

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -284,3 +284,33 @@ class GenomicOutreachApiTest(GenomicApiTestBase):
         fake_now = clock.CLOCK.now().replace(microsecond=0)
         with clock.FakeClock(fake_now):
             self.send_get("GenomicOutreach/GEM?participant_id=P13", expected_status=404)
+
+    def test_genomic_test_participant_created(self):
+        p = self._make_participant()
+
+        self._make_summary(p)
+
+        local_path = f"GenomicOutreach/GEM/Participant/P{p.participantId}"
+
+        # Test Payload for participant report status
+        payload = {
+            "status": "pending_delete",
+            "date": "2020-09-13T20:52:12+00:00"
+        }
+
+        expected_response = {
+            "participant_report_statuses": [
+                {
+                    "participant_id": "P2",
+                    "report_status": "pending_delete"
+                }
+            ],
+            "timestamp": "2020-09-13T20:52:12+00:00"
+        }
+
+        resp = self.send_post(local_path, request_data=payload)
+        member = self.member_dao.get(2)
+
+        self.assertEqual(expected_response, resp)
+        self.assertEqual(GenomicWorkflowState.GEM_RPT_PENDING_DELETE, member.genomicWorkflowState)
+


### PR DESCRIPTION
This PR creates a new API endpoint for the Genomic Outreach API. The API allows PTSC to create `genomic_set_member` records from existing test participants. The records are specifically for the Genomic Outreach API, and therefore are mostly empty records except for the `genonic_worflow_state` and `genomic_workflow_state_modified_time` for purposes of regression testing the GEM report state API. This test participant API endpoint is only accessible on certain lower environments: stable & ptsc-test-1.