### PR TITLE
Blocking Questionnaire and QuestionnaireResponses that use unrecognized codes

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -121,10 +121,6 @@ INTERNAL_STATUS_MAIL_SENDER = "internal_status_email_sender"
 INTERNAL_STATUS_MAIL_RECIPIENTS = "internal_status_email_recipients"
 BIOBANK_STATUS_MAIL_RECIPIENTS = "biobank_status_mail_recipients"
 
-# True if we should add codes referenced in questionnaires that
-# aren't in the code book; false if we should reject the questionnaires.
-ADD_QUESTIONNAIRE_CODES_IF_MISSING = "add_questionnaire_codes_if_missing"
-
 REQUIRED_CONFIG_KEYS = [BIOBANK_SAMPLES_BUCKET_NAME]
 
 DAYS_TO_DELETE_KEYS = "days_to_delete_keys"

--- a/rdr_service/dao/code_dao.py
+++ b/rdr_service/dao/code_dao.py
@@ -181,6 +181,8 @@ class CodeDao(CacheAllDao):
                 result_map[(system, value)] = code.codeId
         if len(result_map) == len(code_map):
             return result_map
+
+        missing_codes = []
         with self.session() as session:
             for system, value in list(code_map.keys()):
                 existing_code = result_map.get((system, value))
@@ -190,8 +192,14 @@ class CodeDao(CacheAllDao):
                     if existing_code:
                         result_map[(system, value)] = code.codeId
                     else:
-                        raise BadRequest(f"Couldn't find code: system = {system}, value = {value}")
-        return result_map
+                        missing_codes.append(f'{value} (system: {system})')
+
+        if missing_codes:
+            raise BadRequest(
+                f"The following code values were unrecognized: {', '.join(missing_codes)}"
+            )
+        else:
+            return result_map
 
 
 class CodeHistoryDao(BaseDao):

--- a/rdr_service/dao/questionnaire_dao.py
+++ b/rdr_service/dao/questionnaire_dao.py
@@ -220,6 +220,10 @@ class QuestionnaireDao(UpdatableDao):
                 if question.group:
                     for sub_group in question.group:
                         cls._populate_questions(sub_group, code_map, questions)
+                if question.option:
+                    for option in question.option:
+                        code_map[(option.system, option.code)] = (option.display, CodeType.ANSWER, None)
+
         if group.group:
             for sub_group in group.group:
                 cls._populate_questions(sub_group, code_map, questions)

--- a/rdr_service/dao/questionnaire_dao.py
+++ b/rdr_service/dao/questionnaire_dao.py
@@ -144,9 +144,7 @@ class QuestionnaireDao(UpdatableDao):
         from rdr_service.dao.code_dao import CodeDao
 
         # Get or insert codes, and retrieve their database IDs.
-        #add_codes_if_missing = _add_codes_if_missing()
-        add_codes_if_missing = True  # @TODO: do not hard code this !!!!!!!!!!!!!!!!!!
-        code_id_map = CodeDao().get_or_add_codes(code_map, add_codes_if_missing=add_codes_if_missing)
+        code_id_map = CodeDao().get_internal_id_code_map(code_map)
 
         # Now add the child objects, using the IDs in code_id_map
         cls._add_concepts(q, code_id_map, concepts)
@@ -282,10 +280,3 @@ class QuestionnaireQuestionDao(BaseDao):
         return (
             session.query(QuestionnaireQuestion).filter(QuestionnaireQuestion.questionnaireQuestionId.in_(ids)).all()
         )
-
-def _add_codes_if_missing():
-    # Only import "config" on demand, as it depends on Datastore packages (and
-    # GAE). This code path may not be executed via CLI or test code.
-    import config
-
-    return config.getSetting(config.ADD_QUESTIONNAIRE_CODES_IF_MISSING, False)

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -44,7 +44,6 @@ from rdr_service.code_constants import (
     EHR_CONSENT_EXPIRED_YES,
     PRIMARY_CONSENT_UPDATE_QUESTION_CODE,
     COHORT_1_REVIEW_CONSENT_YES_CODE)
-from rdr_service.config_api import is_config_admin
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao, raise_if_withdrawn
@@ -625,7 +624,7 @@ class QuestionnaireResponseDao(BaseDao):
             if not answers:
                 logging.error("No answers from QuestionnaireResponse JSON. This is harmless but probably an error.")
             # Get or insert codes, and retrieve their database IDs.
-            code_id_map = CodeDao().get_or_add_codes(code_map, add_codes_if_missing=_add_codes_if_missing(client_id))
+            code_id_map = CodeDao().get_internal_id_code_map(code_map)
 
             # Now add the child answers, using the IDs in code_id_map
             self._add_answers(qr, code_id_map, answers)
@@ -753,15 +752,6 @@ class QuestionnaireResponseDao(BaseDao):
             if system_and_code:
                 answer.valueCodeId = code_id_map[system_and_code]
             qr.answers.append(answer)
-
-
-def _add_codes_if_missing(client_id):
-    """Don't add missing codes for questionnaire responses submitted by the config admin
-  (our command line tools.)
-
-  Tests override this to return true.
-  """
-    return not is_config_admin(client_id)
 
 
 def _validate_consent_pdfs(resource):

--- a/rdr_service/tools/import_questionnaires.py
+++ b/rdr_service/tools/import_questionnaires.py
@@ -12,9 +12,6 @@ from rdr_service.main_util import configure_logging, get_parser
 
 
 def main(args):
-    # We should never add codes when importing questionnaires; the codebook should already have
-    # been imported with all the codes questionnaires reference.
-    dao.questionnaire_dao._add_codes_if_missing = lambda: False
     dao.database_factory.DB_CONNECTION_STRING = os.environ["DB_CONNECTION_STRING"]
     files = args.files.split(",")
     questionnaire_dao = QuestionnaireDao()

--- a/tests/api_tests/test_participant_answers.py
+++ b/tests/api_tests/test_participant_answers.py
@@ -49,9 +49,7 @@ class QuestionnaireAnswersApiTest(BaseTestCase):
         ]
         self.send_consent(p_id, email=email, language="en", code_values=code_answers)
 
-        response = self.send_get(self._answers_url(p_id, "OverallHealth"), expected_status=http.client.NOT_FOUND)
-
-        self.assertEqual(response, None)
+        self.send_get(self._answers_url(p_id, "OverallHealth"), expected_status=http.client.NOT_FOUND)
 
     def test_invalid_module(self):
         """
@@ -66,6 +64,4 @@ class QuestionnaireAnswersApiTest(BaseTestCase):
         ]
         self.send_consent(p_id, email=email, language="en", code_values=code_answers)
 
-        response = self.send_get(self._answers_url(p_id, "InvalidModule"), expected_status=http.client.BAD_REQUEST)
-
-        self.assertEqual(response, None)
+        self.send_get(self._answers_url(p_id, "InvalidModule"), expected_status=http.client.BAD_REQUEST)

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -46,11 +46,8 @@ class ParticipantApiTest(BaseTestCase):
         self._ehr_questionnaire_id = None
 
     def test_participant_id_out_of_range(self):
-        response = self.send_get("Participant/P12345678", expected_status=404)
-        self.assertEqual(None, response)
-
-        response = self.send_get("Participant/P1234567890", expected_status=404)
-        self.assertEqual(None, response)
+        self.send_get("Participant/P12345678", expected_status=404)
+        self.send_get("Participant/P1234567890", expected_status=404)
 
     def test_insert(self):
         response = self.send_post("Participant", self.participant)

--- a/tests/api_tests/test_participant_counts_over_time.py
+++ b/tests/api_tests/test_participant_counts_over_time.py
@@ -1272,8 +1272,7 @@ class ParticipantCountsOverTimeApiTest(BaseTestCase):
         """
         qs = "".join(qs.split())  # Remove all whitespace
 
-        response = self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
-        self.assertEqual(response, None)
+        self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
 
     def test_url_parameter_validation_for_stratifications(self):
         # Ensure requests invalid stratifications are marked BAD REQUEST
@@ -1286,8 +1285,7 @@ class ParticipantCountsOverTimeApiTest(BaseTestCase):
           """
         qs = "".join(qs.split())  # Remove all whitespace
 
-        response = self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
-        self.assertEqual(response, None)
+        self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
 
     def test_url_parameter_validation_for_awardee(self):
         # Ensure requests invalid awardee are marked BAD REQUEST
@@ -1301,8 +1299,7 @@ class ParticipantCountsOverTimeApiTest(BaseTestCase):
             """
         qs = "".join(qs.split())  # Remove all whitespace
 
-        response = self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
-        self.assertEqual(response, None)
+        self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
 
     def test_url_parameter_validation_for_enrollment_status(self):
         # Ensure requests invalid enrollment status are marked BAD REQUEST
@@ -1316,8 +1313,7 @@ class ParticipantCountsOverTimeApiTest(BaseTestCase):
             """
         qs = "".join(qs.split())  # Remove all whitespace
 
-        response = self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
-        self.assertEqual(response, None)
+        self.send_get("ParticipantCountsOverTime", query_string=qs, expected_status=http.client.BAD_REQUEST)
 
     # Add tests for more invalida parameters, e.g.:
     # * starting or ending halfway through the data

--- a/tests/api_tests/test_participant_counts_over_time.py
+++ b/tests/api_tests/test_participant_counts_over_time.py
@@ -11937,7 +11937,7 @@ class ParticipantCountsOverTimeApiTest(BaseTestCase):
             code = kwargs.get(link_id)
             answers["string_answers"].append((link_id, code))
 
-        response_data = QuestionnaireTestMixin.make_questionnaire_response_json(participant_id, questionnaire_id, **answers)
+        response_data = self.make_questionnaire_response_json(participant_id, questionnaire_id, **answers)
 
         with FakeClock(time):
             url = "Participant/%s/QuestionnaireResponse" % participant_id

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -42,7 +42,7 @@ from rdr_service.participant_enums import (
     TEST_HPO_NAME,
     make_primary_provider_link_for_name,
 )
-from tests.helpers.unittest_base import BaseTestCase, QuestionnaireTestMixin
+from tests.helpers.unittest_base import BaseTestCase
 from tests.helpers.mysql_helper_data import PITT_HPO_ID
 
 TIME_1 = datetime.datetime(2017, 12, 31)
@@ -2589,7 +2589,7 @@ class PublicMetricsApiTest(BaseTestCase):
             code = kwargs.get(link_id)
             answers["string_answers"].append((link_id, code))
 
-        response_data = QuestionnaireTestMixin.make_questionnaire_response_json(participant_id, questionnaire_id, **answers)
+        response_data = self.make_questionnaire_response_json(participant_id, questionnaire_id, **answers)
 
         with FakeClock(time):
             url = "Participant/%s/QuestionnaireResponse" % participant_id

--- a/tests/api_tests/test_questionnaire_api.py
+++ b/tests/api_tests/test_questionnaire_api.py
@@ -1,7 +1,7 @@
 import http.client
 import json
 
-from rdr_service.code_constants import PPI_EXTRA_SYSTEM
+from rdr_service.code_constants import PPI_EXTRA_SYSTEM, PPI_SYSTEM
 from rdr_service.dao.code_dao import CodeDao
 from tests.test_data import data_path
 from tests.helpers.unittest_base import BaseTestCase
@@ -112,4 +112,43 @@ class QuestionnaireApiTest(BaseTestCase):
 
         # Ensure we didn't create codes in the extra system
         self.assertIsNone(CodeDao().get_code(PPI_EXTRA_SYSTEM, 'IgnoreThis'))
+
+    def test_questionnaire_payload_cannot_create_new_codes(self):
+        response = self.send_post('Questionnaire', {
+            "group": {
+                "concept": [
+                    {
+                        "system": PPI_SYSTEM,
+                        "code": 'new_module_code'
+                    }
+                ],
+                "question": [
+                    {
+                        "linkId": "test",
+                        "concept": [
+                            {
+                                "code": "new_question_code",
+                                "system": PPI_SYSTEM
+                            }
+                        ],
+                        "option": [
+                            {
+                                "code": "new_answer_code",
+                                "system": PPI_SYSTEM
+                            }
+                        ]
+                    }
+                ]
+            },
+            "status": "published",
+            "version": "V1"
+        }, expected_status=400)
+
+        self.assertEqual(
+            "The following code values were unrecognized: "
+            "new_module_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi), "
+            "new_question_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi), "
+            "new_answer_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi)",
+            response.json['message']
+        )
 

--- a/tests/api_tests/test_questionnaire_api.py
+++ b/tests/api_tests/test_questionnaire_api.py
@@ -14,6 +14,8 @@ class QuestionnaireApiTest(BaseTestCase):
         for json_file in questionnaire_files:
             with open(data_path(json_file)) as f:
                 questionnaire = json.load(f)
+
+            self._save_codes(questionnaire)
             response = self.send_post("Questionnaire", questionnaire)
             questionnaire_id = response["id"]
             del response["id"]
@@ -23,12 +25,10 @@ class QuestionnaireApiTest(BaseTestCase):
             del response["id"]
             self.assertJsonResponseMatches(questionnaire, response)
 
-        # Ensure we didn't create codes in the extra system
-        self.assertIsNone(CodeDao().get_code(PPI_EXTRA_SYSTEM, "IgnoreThis"))
-
     def insert_questionnaire(self):
         with open(data_path("questionnaire1.json")) as f:
             questionnaire = json.load(f)
+            self._save_codes(questionnaire)
             return self.send_post("Questionnaire", questionnaire, expected_response_headers={'ETag': 'W/"aaa"'})
 
     def test_update_before_insert(self):
@@ -48,6 +48,7 @@ class QuestionnaireApiTest(BaseTestCase):
 
         with open(data_path("questionnaire2.json")) as f2:
             questionnaire2 = json.load(f2)
+            self._save_codes(questionnaire2)
             self.send_put(
                 "Questionnaire/%s" % response["id"],
                 questionnaire2,
@@ -98,6 +99,7 @@ class QuestionnaireApiTest(BaseTestCase):
     def test_insert_with_version(self):
         with open(data_path('questionnaire5_with_version.json')) as f:
             questionnaire = json.load(f)
+        self._save_codes(questionnaire)
         response = self.send_post('Questionnaire', questionnaire)
         questionnaire_id = response['id']
         del response['id']

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -1060,6 +1060,25 @@ class QuestionnaireResponseApiTest(BaseTestCase):
         user_info['example@example.com']['clientId'] = original_user_client_id
         config.override_setting(config.USER_INFO, user_info)
 
+    def test_response_payload_cannot_create_new_codes(self):
+        q_id = self.create_questionnaire("questionnaire1.json")
+        p_id = self.create_participant()
+        self.send_consent(p_id)
+
+        resource = self.make_questionnaire_response_json(
+            p_id,
+            q_id,
+            code_answers=[('2.3.2', Concept(PPI_SYSTEM, 'new_answer_code'))],
+            create_codes=False
+        )
+        response = self.send_post(self.questionnaire_response_url(p_id), resource, expected_status=400)
+
+        self.assertEqual(
+            'The following code values were unrecognized: '
+            'new_answer_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi)',
+            response.json['message']
+        )
+
 
 def _add_code_answer(code_answers, link_id, code):
     if code:

--- a/tests/dao_tests/test_questionnaire_dao.py
+++ b/tests/dao_tests/test_questionnaire_dao.py
@@ -1,10 +1,9 @@
 import datetime
 
 from sqlalchemy.exc import IntegrityError
-from werkzeug.exceptions import BadRequest, NotFound, PreconditionFailed
+from werkzeug.exceptions import NotFound, PreconditionFailed
 
 from rdr_service.clock import FakeClock
-from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.questionnaire_dao import (
     QuestionnaireConceptDao,
@@ -208,44 +207,3 @@ class QuestionnaireDaoTest(BaseTestCase):
         })
 
         self.assertEqual('FORM_1A', model.externalId)
-
-    def test_questionnaire_payload_cannot_create_new_codes(self):
-        with self.assertRaises(BadRequest) as context:
-            self.dao.from_client_json({
-                "group": {
-                    "concept": [
-                        {
-                            "system": PPI_SYSTEM,
-                            "code": 'new_module_code'
-                        }
-                    ],
-                    "question": [
-                        {
-                            "linkId": "test",
-                            "concept": [
-                                {
-                                    "code": "new_question_code",
-                                    "system": PPI_SYSTEM
-                                }
-                            ],
-                            "option": [
-                                {
-                                    "code": "new_answer_code",
-                                    "system": PPI_SYSTEM
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "status": "published",
-                "version": "V1"
-            })
-
-        exception = context.exception
-        self.assertEqual(
-            "The following code values were unrecognized: "
-            "new_module_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi), "
-            "new_question_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi), "
-            "new_answer_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi)",
-            exception.description
-        )

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -10,7 +10,6 @@ from rdr_service.clock import FakeClock
 from rdr_service.code_constants import GENDER_IDENTITY_QUESTION_CODE, PMI_SKIP_CODE, PPI_SYSTEM, THE_BASICS_PPI_MODULE,\
     CONSENT_COPE_YES_CODE, CONSENT_COPE_NO_CODE, CONSENT_COPE_DEFERRED_CODE, PRIMARY_CONSENT_UPDATE_QUESTION_CODE,\
     COHORT_1_REVIEW_CONSENT_YES_CODE, COHORT_1_REVIEW_CONSENT_NO_CODE
-from rdr_service.concepts import Concept
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
@@ -882,28 +881,6 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
         resource = self.make_questionnaire_response_json(p_id, q_id, string_answers=string_answers)
         with self.assertRaises(BadRequest):
             qr = self.questionnaire_response_dao.from_client_json(resource, participant_id=int(p_id[1:]))
-
-    def test_response_payload_cannot_create_new_codes(self):
-        self.insert_codes()
-        q_id = self.create_questionnaire("questionnaire1.json")
-        p_id = self.create_participant()
-        self.send_consent(p_id)
-
-        resource = self.make_questionnaire_response_json(
-            p_id,
-            q_id,
-            code_answers=[('2.3.2', Concept(PPI_SYSTEM, 'new_answer_code'))],
-            create_codes=False
-        )
-        with self.assertRaises(BadRequest) as context:
-            self.questionnaire_response_dao.from_client_json(resource, participant_id=int(p_id[1:]))
-
-        exception = context.exception
-        self.assertEqual(
-            'The following code values were unrecognized: '
-            'new_answer_code (system: http://terminology.pmi-ops.org/CodeSystem/ppi)',
-            exception.description
-        )
 
     def test_get_after_withdrawal_fails(self):
         self.insert_codes()

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -110,6 +110,7 @@ class QuestionnaireTestMixin:
         uri_answers=None,
         language=None,
         authored=None,
+        create_codes=True
     ):
         if isinstance(participant_id, int):
             participant_id = f'P{participant_id}'
@@ -123,7 +124,8 @@ class QuestionnaireTestMixin:
                         "answer": [{"valueCoding": {"code": code.code, "system": code.system}}],
                     }
                 )
-                self.create_code_if_needed(code.code, CodeType.ANSWER, code.system)
+                if create_codes:
+                    self.create_code_if_needed(code.code, CodeType.ANSWER, code.system)
 
         def add_question_result(question_data, answer_value, answer_structure):
             result = {"linkId": question_data}

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -524,9 +524,8 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
             )
         if expected_status == http.client.OK:
             return json.loads(response.data)
-        if expected_status == http.client.CREATED:
-            return response
-        return None
+
+        return response
 
     def send_consent(self, participant_id, email=None, language=None, code_values=None, string_answers=None,
                      extra_string_values=[], authored=None, expected_status=200):

--- a/tests/resource_tests/generator_tests/test_participant_enrollment.py
+++ b/tests/resource_tests/generator_tests/test_participant_enrollment.py
@@ -5,6 +5,7 @@ from rdr_service import clock
 from rdr_service.code_constants import *
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
+from rdr_service.model.code import CodeType
 from rdr_service.model.hpo import HPO
 from rdr_service.model.measurements import PhysicalMeasurements
 from rdr_service.model.site import Site
@@ -63,6 +64,7 @@ class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin):
 
         code_answers = list()
         code_answers.append(self.make_code_answer('ehrConsent', response_code))
+        self.create_code_if_needed(response_code, CodeType.ANSWER)
 
         qr = self.make_questionnaire_response_json(self.participant_id, self.qn_ehrconsent_id,
                                                    code_answers=code_answers)
@@ -129,6 +131,7 @@ class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin):
 
         code_answers = list()
         code_answers.append(self.make_code_answer('genomic_consent', consent_response))
+        self.create_code_if_needed(consent_response, CodeType.ANSWER)
 
         qr = self.make_questionnaire_response_json(self.participant_id, self.qn_gror_id, code_answers=code_answers)
         with clock.FakeClock(response_time or self.TIME_1):

--- a/tests/test-data/questionnaire1.json
+++ b/tests/test-data/questionnaire1.json
@@ -32,11 +32,13 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Yes"
+                    "display": "Yes",
+                    "system":"sys"
                   },
                   {
                     "code": "2",
-                    "display": "No"
+                    "display": "No",
+                    "system": "sys"
                   }
                 ]
               }
@@ -52,11 +54,13 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Male"
+                    "display": "Male",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "Female"
+                    "display": "Female",
+                    "system": "sys"
                   }
                 ]
               },
@@ -77,15 +81,18 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Married"
+                    "display": "Married",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "Option 2"
+                    "display": "Option 2",
+                    "system": "sys"
                   },
                   {
                     "code": "3",
-                    "display": "Divorced"
+                    "display": "Divorced",
+                    "system": "sys"
                   }
                 ]
               }
@@ -101,11 +108,13 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Yes"
+                    "display": "Yes",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "No"
+                    "display": "No",
+                    "system": "sys"
                   }
                 ]
               },
@@ -113,14 +122,22 @@
                 "linkId": "2.3.2",
                 "text": "Do you drink alcohol",
                 "type": "choice",
+                "concept": [
+                  {
+                    "system": "sys",
+                    "code": "alcohol_consumption"
+                  }
+                ],
                 "option": [
                   {
                     "code": "1",
-                    "display": "Yes"
+                    "display": "Yes",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "No"
+                    "display": "No",
+                    "system": "sys"
                   }
                 ]
               }

--- a/tests/test-data/questionnaire2.json
+++ b/tests/test-data/questionnaire2.json
@@ -1,1 +1,261 @@
-{"resourceType":"Questionnaire","status":"published","date":"2016-08-25T06:31:35-04:00","version": "bbb","publisher":"admin","group":{"linkId":"root","title":"email address","text":"keep me logged in keep me logged in","required":true,"repeats":false,"group":[{"linkId":"1","group":[{"linkId":"1.1","question":[{"linkId":"1.1.1","type":"text","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"GIVE SUPPORT\n"},{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"es"}],"text":"DAR APOYO"}]}]},{"linkId":"1.1.2","type":"integer","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"great! let's continue"},{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"es"}],"text":"!bien! Continuemos"}]}]},{"linkId":"1.1.3","type":"choice","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"Camera Roll Camera Roll Camera Roll \n\n","option":[{"code":"1","display":"pick a pic!\n"},{"code":"2","display":"pick a pic!\n"}]}]}]},{"linkId":"1.1.4","type":"date","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"just create a password:\n"}]}]}]},{"linkId":"1.2","question":[{"linkId":"1.2.1","type":"text","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"hint text"}]}]},{"linkId":"1.2.2","type":"integer","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"Please Specify Value Here"}]}]},{"linkId":"1.2.3","type":"choice","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"Pick your answer from the following choices","option":[{"code":"1","display":"Option 1"},{"code":"2","display":"Option 2"}]}]}]},{"linkId":"1.2.4","type":"date","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"Please Select A Date"}]}]},{"linkId":"1.2.5","text":"Label","type":"boolean"},{"linkId":"1.2.6","type":"choice","group":[{"question":[{"extension":[{"url":"http://hl7.org/fhir/StructureDefinition/iso21090-ST-language","valueCode":"en"}],"text":"Select your answer","option":[{"code":"1","display":"Option 1"},{"code":"2","display":"Option 2"}]}]}]}]}]}]}}
+{
+  "resourceType": "Questionnaire",
+  "status": "published",
+  "date": "2016-08-25T06:31:35-04:00",
+  "version": "bbb",
+  "publisher": "admin",
+  "group": {
+    "linkId": "root",
+    "title": "email address",
+    "text": "keep me logged in keep me logged in",
+    "required": true,
+    "repeats": false,
+    "group": [
+      {
+        "linkId": "1",
+        "group": [
+          {
+            "linkId": "1.1",
+            "question": [
+              {
+                "linkId": "1.1.1",
+                "type": "text",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "GIVE SUPPORT\n"
+                      },
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "es"
+                          }
+                        ],
+                        "text": "DAR APOYO"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "1.1.2",
+                "type": "integer",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "great! let's continue"
+                      },
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "es"
+                          }
+                        ],
+                        "text": "!bien! Continuemos"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "1.1.3",
+                "type": "choice",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "Camera Roll Camera Roll Camera Roll \n\n",
+                        "option": [
+                          {
+                            "code": "1",
+                            "display": "pick a pic!\n",
+                            "system": "sys"
+                          },
+                          {
+                            "code": "2",
+                            "display": "pick a pic!\n",
+                            "system": "sys"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "1.1.4",
+                "type": "date",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "just create a password:\n"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "linkId": "1.2",
+            "question": [
+              {
+                "linkId": "1.2.1",
+                "type": "text",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "hint text"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "1.2.2",
+                "type": "integer",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "Please Specify Value Here"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "1.2.3",
+                "type": "choice",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "Pick your answer from the following choices",
+                        "option": [
+                          {
+                            "code": "1",
+                            "display": "Option 1",
+                            "system": "sys"
+                          },
+                          {
+                            "code": "2",
+                            "display": "Option 2",
+                            "system": "sys"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "1.2.4",
+                "type": "date",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "Please Select A Date"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "linkId": "1.2.5",
+                "text": "Label",
+                "type": "boolean"
+              },
+              {
+                "linkId": "1.2.6",
+                "type": "choice",
+                "group": [
+                  {
+                    "question": [
+                      {
+                        "extension": [
+                          {
+                            "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ST-language",
+                            "valueCode": "en"
+                          }
+                        ],
+                        "text": "Select your answer",
+                        "option": [
+                          {
+                            "code": "1",
+                            "display": "Option 1",
+                            "system": "sys"
+                          },
+                          {
+                            "code": "2",
+                            "display": "Option 2",
+                            "system": "sys"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test-data/questionnaire5_with_version.json
+++ b/tests/test-data/questionnaire5_with_version.json
@@ -33,11 +33,13 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Yes"
+                    "display": "Yes",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "No"
+                    "display": "No",
+                    "system": "sys"
                   }
                 ]
               }
@@ -53,11 +55,13 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Male"
+                    "display": "Male",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "Female"
+                    "display": "Female",
+                    "system": "sys"
                   }
                 ]
               },
@@ -78,15 +82,18 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Married"
+                    "display": "Married",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "Option 2"
+                    "display": "Option 2",
+                    "system": "sys"
                   },
                   {
                     "code": "3",
-                    "display": "Divorced"
+                    "display": "Divorced",
+                    "system": "sys"
                   }
                 ]
               }
@@ -102,11 +109,13 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Yes"
+                    "display": "Yes",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "No"
+                    "display": "No",
+                    "system": "sys"
                   }
                 ]
               },
@@ -117,11 +126,13 @@
                 "option": [
                   {
                     "code": "1",
-                    "display": "Yes"
+                    "display": "Yes",
+                    "system": "sys"
                   },
                   {
                     "code": "2",
-                    "display": "No"
+                    "display": "No",
+                    "system": "sys"
                   }
                 ]
               }

--- a/tests/test-data/questionnaire_demographics.json
+++ b/tests/test-data/questionnaire_demographics.json
@@ -20,10 +20,6 @@
       {
         "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
         "code": "TheBasics"
-      },
-      {
-        "system": "http://terminology.pmi-ops.org/CodeSystem/ppi-extra",
-        "code": "IgnoreThis"
       }],
       "group":[
          {

--- a/tests/test-data/questionnaire_demographics.json
+++ b/tests/test-data/questionnaire_demographics.json
@@ -45,31 +45,38 @@
                         "option":[
                            {
                               "code":"American Indian or Alaskan Native",
-                              "display":"American Indian or Alaskan Native"
+                              "display":"American Indian or Alaskan Native",
+                              "system": "sys"
                            },
                            {
                               "code":"Asian",
-                              "display":"Asian"
+                              "display":"Asian",
+                              "system": "sys"
                            },
                            {
                               "code":"Black or African American",
-                              "display":"Black or African American"
+                              "display":"Black or African American",
+                              "system": "sys"
                            },
                            {
                               "code":"Native Hawaiian or Pacific Islander",
-                              "display":"Native Hawaiian or Pacific Islander"
+                              "display":"Native Hawaiian or Pacific Islander",
+                              "system": "sys"
                            },
                            {
                               "code":"White",
-                              "display":"White"
+                              "display":"White",
+                              "system": "sys"
                            },
                            {
                               "code":"Other",
-                              "display":"Other"
+                              "display":"Other",
+                              "system": "sys"
                            },
                            {
                               "code":"Prefer not to answer",
-                              "display":"Prefer not to answer"
+                              "display":"Prefer not to answer",
+                              "system": "sys"
                            }
                         ]
                      },
@@ -80,15 +87,18 @@
                         "option":[
                            {
                               "code":"1",
-                              "display":"Answer Choice 1"
+                              "display":"Answer Choice 1",
+                              "system": "sys"
                            },
                            {
                               "code":"2",
-                              "display":"Option 2"
+                              "display":"Option 2",
+                              "system": "sys"
                            },
                            {
                               "code":"3",
-                              "display":"Option 3"
+                              "display":"Option 3",
+                              "system": "sys"
                            }
                         ]
                      },


### PR DESCRIPTION
This changes the CodeDao to keep questionnaires and responses from creating new codes in the database, giving a 400 error with a message detailing what codes were unrecognized.

The QuestionnaireResponseDao and QuestionnaireDao both used lists of codes gathered from their payloads, but previously only the QuestionnaireResponseDao evaluated the answer codes. I've added block to the QuestionnaireDao so it maps answer option codes as well. That way if any answer codes in invalid on the questionnaire we can catch them when the Questionnaire is created, rather than later when we see them in a response.