### PR TITLE
[DA-1770] Scheduled subset of genomic cron jobs.

### DIFF
--- a/rdr_service/cron_careevo.yaml
+++ b/rdr_service/cron_careevo.yaml
@@ -3,19 +3,20 @@ cron:
 - description: Participant count metrics (Do not manually start)
 - description: Flag ghost participants
 - description: Genomic Pipeline AW0 (Cohort 2) Workflow
-- description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
-- description: Genomic AW1 Workflow (Manual)
-- description: Genomic AW1 Failures Workflow (Manual)
+- description: Genomic Pipeline AW0 (Cohort 3) Workflow
+- description: Genomic Pipeline AW0 (Cohort 1) Workflow
+- description: Genomic AW1 Workflow
+- description: Genomic AW1 Failures Workflow
 - description: Genomic AW1C (CVL) Workflow (Manual)
 - description: Genomic AW1CF (CVL) Failures Workflow (Manual)
 - description: Genomic AW2 Workflow (Manual)
-- description: Genomic GEM A1-A2 Workflow (Manual)
-- description: Genomic GEM A2 Workflow (Manual)
+- description: Genomic GEM A1-A2 Workflow
+- description: Genomic GEM A2 Workflow
 - description: Genomic CVL W1 Workflow (Manual)
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
-- description: Genomic AW3 Workflow (Manual)
-- description: Genomic AW4 Workflow (Manual)
+- description: Genomic AW3 Workflow
+- description: Genomic AW4 Workflow
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport
   schedule: every day 03:00

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -64,25 +64,30 @@ cron:
   schedule: every day 02:45
   timezone: America/New_York
   target: offline
+- description: Genomic Pipeline AW0 (Cohort 1) Workflow
+  url: /offline/GenomicC1AW0Workflow
+  timezone: America/New_York
+  schedule: every monday 07:15
+  target: offline
 - description: Genomic Pipeline AW0 (Cohort 2) Workflow
   url: /offline/GenomicC2AW0Workflow
   schedule: every monday 07:00
   timezone: America/New_York
   target: offline
-- description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
-  url: /offline/GenomicC1AW0Workflow
+- description: Genomic Pipeline AW0 (Cohort 3) Workflow
+  url: /offline/GenomicC3AW0Workflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every monday 06:30
   target: offline
-- description: Genomic AW1 Workflow (Manual)
+- description: Genomic AW1 Workflow
   url: /offline/GenomicGCManifestWorkflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every day 05:45
   target: offline
-- description: Genomic AW1 Failures Workflow (Manual)
+- description: Genomic AW1 Failures Workflow
   url: /offline/GenomicFailuresWorkflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every day 06:00
   target: offline
 - description: Genomic AW1C (CVL) Workflow (Manual)
   url: /offline/GenomicAW1CManifestWorkflow
@@ -99,15 +104,15 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
-- description: Genomic GEM A1-A2 Workflow (Manual)
+- description: Genomic GEM A1-A2 Workflow
   url: /offline/GenomicGemA1A2Workflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every 6 hours
   target: offline
-- description: Genomic GEM A3 Workflow (Manual)
+- description: Genomic GEM A3 Workflow
   url: /offline/GenomicGemA3Workflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every sunday 12:00
   target: offline
 - description: Genomic CVL W1 Workflow (Manual)
   url: /offline/GenomicCvlW1Workflow
@@ -124,13 +129,13 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
-- description: Genomic AW3 Workflow (Manual)
+- description: Genomic AW3 Workflow
   url: /offline/GenomicAW3Workflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every day 06:45
   target: offline
-- description: Genomic AW4 Workflow (Manual)
+- description: Genomic AW4 Workflow
   url: /offline/GenomicAW4Workflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every day 07:45
   target: offline

--- a/rdr_service/cron_ptsc.yaml
+++ b/rdr_service/cron_ptsc.yaml
@@ -3,19 +3,20 @@ cron:
 - description: Participant count metrics (Do not manually start)
 - description: Flag ghost participants
 - description: Genomic Pipeline AW0 (Cohort 2) Workflow
-- description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
-- description: Genomic AW1 Workflow (Manual)
-- description: Genomic AW1 Failures Workflow (Manual)
+- description: Genomic Pipeline AW0 (Cohort 3) Workflow
+- description: Genomic Pipeline AW0 (Cohort 1) Workflow
+- description: Genomic AW1 Workflow
+- description: Genomic AW1 Failures Workflow
 - description: Genomic AW1C (CVL) Workflow (Manual)
 - description: Genomic AW1CF (CVL) Failures Workflow (Manual)
 - description: Genomic AW2 Workflow (Manual)
-- description: Genomic GEM A1-A2 Workflow (Manual)
-- description: Genomic GEM A2 Workflow (Manual)
+- description: Genomic GEM A1-A2 Workflow
+- description: Genomic GEM A2 Workflow
 - description: Genomic CVL W1 Workflow (Manual)
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
-- description: Genomic AW3 Workflow (Manual)
-- description: Genomic AW4 Workflow (Manual)
+- description: Genomic AW3 Workflow
+- description: Genomic AW4 Workflow
 - description: Daily Biobank sample import and order reconciliation
   url: /offline/BiobankSamplesImport
   schedule: every day 03:00

--- a/rdr_service/cron_sandbox.yaml
+++ b/rdr_service/cron_sandbox.yaml
@@ -5,17 +5,18 @@ cron:
 - description: Participant count metrics (Do not manually start)
 - description: Flag ghost participants
 - description: Genomic Pipeline AW0 (Cohort 2) Workflow
-- description: Genomic Pipeline AW0 (Cohort 1) Workflow (Manual)
-- description: Genomic AW1 Workflow (Manual)
-- description: Genomic AW1 Failures Workflow (Manual)
+- description: Genomic Pipeline AW0 (Cohort 3) Workflow
+- description: Genomic Pipeline AW0 (Cohort 1) Workflow
+- description: Genomic AW1 Workflow
+- description: Genomic AW1 Failures Workflow
 - description: Genomic AW2 Workflow (Manual)
-- description: Genomic GEM A1-A2 Workflow (Manual)
-- description: Genomic GEM A2 Workflow (Manual)
+- description: Genomic GEM A1-A2 Workflow
+- description: Genomic GEM A2 Workflow
 - description: Genomic CVL W1 Workflow (Manual)
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)
-- description: Genomic AW3 Workflow (Manual)
-- description: Genomic AW4 Workflow (Manual)
+- description: Genomic AW3 Workflow
+- description: Genomic AW4 Workflow
 - description: Rotate service account keys older than 3 days
   url: /offline/DeleteOldKeys
   schedule: every day 01:00

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -247,11 +247,6 @@ def genomic_c2_participant_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_c1_participant_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.c1_participant_workflow()
     return '{"success": "true"}'
 
@@ -259,11 +254,6 @@ def genomic_c1_participant_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_gc_manifest_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.genomic_centers_manifest_workflow()
     return '{"success": "true"}'
 
@@ -271,11 +261,6 @@ def genomic_gc_manifest_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_aw1f_failures_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.genomic_centers_aw1f_manifest_workflow()
     genomic_pipeline.genomic_centers_accessioning_failures_workflow()
     return '{"success": "true"}'
@@ -323,11 +308,6 @@ def genomic_data_manifest_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_gem_a1_a2_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.gem_a1_manifest_workflow()
     genomic_pipeline.gem_a2_manifest_workflow()
     return '{"success": "true"}'
@@ -336,11 +316,6 @@ def genomic_gem_a1_a2_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_gem_a3_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.gem_a3_manifest_workflow()
     return '{"success": "true"}'
 
@@ -384,11 +359,6 @@ def genomic_cvl_w3_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_aw3_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.aw3_array_manifest_workflow()
     genomic_pipeline.aw3_wgs_manifest_workflow()
     return '{"success": "true"}'
@@ -397,11 +367,6 @@ def genomic_aw3_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_aw4_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.aw4_array_manifest_workflow()
     genomic_pipeline.aw4_wgs_manifest_workflow()
     return '{"success": "true"}'
@@ -550,7 +515,7 @@ def _build_pipeline_app():
 
     # BEGIN Genomic Pipeline Jobs
     offline_app.add_url_rule(
-        OFFLINE_PREFIX + "GenomicNewParticipantWorkflow",
+        OFFLINE_PREFIX + "GenomicC3AW0Workflow",
         endpoint="genomic_new_participant_workflow",
         view_func=genomic_new_participant_workflow, methods=["GET"]
     )


### PR DESCRIPTION
This PR changes the schedule of the following genomic cron jobs:
- Genomic Pipeline AW0 (Cohort 3) Workflow
- Genomic Pipeline AW0 (Cohort 1) Workflow
- Genomic AW1 Workflow
- Genomic AW1 Failures Workflow
- Genomic GEM A1-A2 Workflow
- Genomic GEM A2 Workflow
- Genomic AW3 Workflow
- Genomic AW4 Workflow

These cron jobs were previously set to never run unless manually triggered. This PR will set them to run at the scheduled time. This is to support the GEM launch, the restarting of biospecimen collection, and the DRC Broad QC workflows.