### PR TITLE
Explicitly releasing deceased report locks

### DIFF
--- a/rdr_service/model/database.py
+++ b/rdr_service/model/database.py
@@ -96,6 +96,8 @@ class Database(object):
             sess.commit()
         except Exception:
             sess.rollback()
+            # TODO: rolling back the session here might be preventing us from recording request_logs
+            #  when within the context (such as when inserting with a session in the DAOs)
             raise
         finally:
             sess.close()


### PR DESCRIPTION
The logs are showing that deceased report requests are erring out when trying to create multiple deceased reports for the same participant. That's how they should function, but the error they're returning doesn't look right.

When a named lock is taken by a transaction, the lock is supposed to be implicitly released when the transaction ends. So when two requests try to take the same lock one should get it and release it when done, then the next should get it and then see that the report is already there. So I wouldn't expect any scenarios when an attempt to obtain a lock times out.

In atleast one instance we see a request arrive to create a deceased report, then a second or two later the same request is made. The first request completes successfully, but the second request is unable to obtain the lock and fails on the timeout. It seems as if the locks aren't being released in the way I would expect. So this explicitly releases the lock when the updates to the database are complete.

I also found that attempting to return an error when within a session context seems to keep the request_log record from being created. I'm not sure yet how to handle that, but I made a note about it.