### PR TITLE
[ROC-687] Fixes for data cleaning and header formatting

### DIFF
--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -85,7 +85,7 @@ class CurationExportClass(object):
         # This is needed because gcloud export sql doesn't support column headers and
         # Curation would like them in the file for schema validation (ROC-687)
         sql_string = f"""
-            SELECT {','.join(field_list)}
+            SELECT {','.join(column_names)}
             FROM 
             (
                 (

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -76,12 +76,12 @@ class CurationExportClass(object):
         # https://issuetracker.google.com/issues/64579566
         # NULL characters (\0) can also corrupt the output file, so they're removed.
         # And whitespace was trimmed before so that's moved into the SQL as well
-        # Newlines and souble-quotes are also replace with spaces and single-quotes, respectively
+        # Newlines and double-quotes are also replaced with spaces and single-quotes, respectively
         field_list = [f"TRIM(REPLACE(REPLACE(REPLACE(COALESCE({name}, ''), '\\0', ''), '\n', ' '), '\\\"', '\\\''))"
                       for name in column_names]
 
-        # Unions are unordered, so the headers do not always end up at the top
-        # of the file. The below format forces the headers to the top of the file
+        # Unions are unordered, so the headers do not always end up at the top of the file.
+        # The below format forces the headers to the top of the file
         # This is needed because gcloud export sql doesn't support column headers and
         # Curation would like them in the file for schema validation (ROC-687)
         sql_string = f"""


### PR DESCRIPTION
This PR fixes some errors in the CDM to CSV export process:
- Column headers were appearing in locations other than row 0
- Newline characters in the data were causing the CSV to have incomplete rows
- Double-quote characters in the data would be passed into the CSV, potentially breaking the formatting
