### PR TITLE
[DA-1762] Returning unauthorized (401) when token is invalid

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -142,6 +142,9 @@ def get_oauth_id():
 
                 logging.info(f"Oauth failure: {response.content} (status: {response.status_code})")
 
+                if response.status_code in [400, 401]:  # tokeninfo returns 400
+                    raise Unauthorized
+
         sleep(0.25)
         logging.info('Retrying authentication call to Google after failure.')
 

--- a/tests/test_app_util.py
+++ b/tests/test_app_util.py
@@ -286,7 +286,7 @@ class AppUtilTest(BaseTestCase):
         def mock_response(url):
             response = mock.MagicMock()
             if 'userinfo' in url:
-                response.status_code = 401
+                response.status_code = 403
             else:
                 response.status_code = 200
                 response.json.return_value = {'email': 'fallback_response'}

--- a/tests/test_app_util.py
+++ b/tests/test_app_util.py
@@ -323,6 +323,15 @@ class AppUtilTest(BaseTestCase):
         mock_requests.get.assert_called_with('https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=token')
         mock_logging.error.assert_called_with('UserInfo endpoint did not return the email')
 
+    @mock.patch('rdr_service.app_util.GAE_PROJECT', 'totally_the_server')
+    def test_invalid_token(self):
+        """Check that we get an unauthorized error with a bad token"""
+
+        # Need a request context for app_util to get a token from
+        with Flask('test').test_request_context(headers={'Authorization': 'Bearer token123'}),\
+                self.assertRaises(Unauthorized):
+            app_util.get_oauth_id()
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If we get an invalid token response from Google's API (401 for userinfo, 400 for tokeninfo). We should return an Unauthorized status rather than Gateway Timeout.

This still continues the retry loop if we see anything else returned by Google (such as 403 or 500).