### PR TITLE
Fix for code sensitivity and cache miss issues

### DIFF
--- a/rdr_service/dao/questionnaire_dao.py
+++ b/rdr_service/dao/questionnaire_dao.py
@@ -176,7 +176,7 @@ class QuestionnaireDao(UpdatableDao):
                 QuestionnaireConcept(
                     questionnaireId=q.questionnaireId,
                     questionnaireVersion=q.version,
-                    codeId=code_id_map.get((system, code)),
+                    codeId=code_id_map.get(system, code),
                 )
             )
 
@@ -188,7 +188,7 @@ class QuestionnaireDao(UpdatableDao):
                     questionnaireId=q.questionnaireId,
                     questionnaireVersion=q.version,
                     linkId=linkId,
-                    codeId=code_id_map.get((system, code)),
+                    codeId=code_id_map.get(system, code),
                     repeats=repeats if repeats else False,
                 )
             )

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -749,8 +749,9 @@ class QuestionnaireResponseDao(BaseDao):
     @staticmethod
     def _add_answers(qr, code_id_map, answers):
         for answer, system_and_code in answers:
+            system, code = system_and_code
             if system_and_code:
-                answer.valueCodeId = code_id_map[system_and_code]
+                answer.valueCodeId = code_id_map.get(system, code)
             qr.answers.append(answer)
 
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -749,8 +749,8 @@ class QuestionnaireResponseDao(BaseDao):
     @staticmethod
     def _add_answers(qr, code_id_map, answers):
         for answer, system_and_code in answers:
-            system, code = system_and_code
             if system_and_code:
+                system, code = system_and_code
                 answer.valueCodeId = code_id_map.get(system, code)
             qr.answers.append(answer)
 

--- a/tests/dao_tests/test_code_dao.py
+++ b/tests/dao_tests/test_code_dao.py
@@ -1,5 +1,4 @@
 import datetime
-import mock
 
 from werkzeug.exceptions import BadRequest
 


### PR DESCRIPTION
Testing of a survey in Stable revealed an interesting bug in code mapping. The RDR database has an answer-type code with the value `cope_a_289`. A questionnaire response payload was sent with an answer of `COPE_A_289`, but the code recorded a questionaire_response_answer object for the response with the code `COPE_A_33`.

The problem was when building out the system-value to code_id map for the codes used in the response. The cache layer is built to be case-sensitive, so didn't find the code value (since it was looking for it in all-caps, but had it stored in lower case). If it can't find it in the cache, it attempts to look in the database. That look up was case insensitive, so it did find a match. But instead of storing the correct id, it would store the id of the last code that was found in the cache.

Adding the correct code id to the map object would still cause it to not be found in the map, so I also changed the behavior of the code id map so that it would function in a case-insensitive way.

The cache still functions in a case-sensitive way, so any case mismatches for codes will cause a cache miss and retrieve them from the database. But this will correct the bug for now until we have more time to implement a solution to the problem at the cache level.