### PR TITLE
Genomic Tools - run genotyping reconciliation process

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -493,6 +493,10 @@ class GenomicSetMemberDao(UpdatableDao):
             logging.error(f'Error updating member id: {member.id}.')
             return GenomicSubProcessResult.ERROR
 
+        except Exception as e:  # pylint: disable=broad-except
+            logging.error(e)
+            return GenomicSubProcessResult.ERROR
+
     def update_member_state(self, member, new_state):
         """
         Sets the member's state to a new state
@@ -888,7 +892,10 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                 )
                 .filter(
                     GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
-                    GenomicGCValidationMetrics.ignoreFlag != 1,
+                    GenomicSetMember.genomeType == config.GENOME_TYPE_ARRAY,
+                    GenomicGCValidationMetrics.genomicFileProcessedId != None,
+                    ((GenomicGCValidationMetrics.ignoreFlag != 1) |
+                     (GenomicGCValidationMetrics.ignoreFlag is not None)),
                     (GenomicGCValidationMetrics.idatRedReceived == 0) |
                     (GenomicGCValidationMetrics.idatGreenReceived == 0) |
                     (GenomicGCValidationMetrics.idatRedMd5Received == 0) |
@@ -916,7 +923,10 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                 )
                 .filter(
                     GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
-                    GenomicGCValidationMetrics.ignoreFlag != 1,
+                    GenomicSetMember.genomeType == config.GENOME_TYPE_WGS,
+                    GenomicGCValidationMetrics.genomicFileProcessedId != None,
+                    ((GenomicGCValidationMetrics.ignoreFlag != 1) | (
+                            GenomicGCValidationMetrics.ignoreFlag is not None)),
                     (GenomicGCValidationMetrics.hfVcfReceived == 0) |
                     (GenomicGCValidationMetrics.hfVcfTbiReceived == 0) |
                     (GenomicGCValidationMetrics.hfVcfMd5Received == 0) |

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1290,6 +1290,7 @@ class GenomicReconciler:
         return 1 if len(filenames) > 0 else 0
 
     def _get_full_filename(self, bucket_name, filename):
+        # Use the storage provider if it was set by tool
         if self.storage_provider:
             files = self.storage_provider.list(bucket_name, prefix=None)
         else:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1026,7 +1026,7 @@ class GenomicFileMover:
 
 class GenomicReconciler:
     """ This component handles reconciliation between genomic datasets """
-    def __init__(self, run_id, job_id, archive_folder=None, file_mover=None, bucket_name=None):
+    def __init__(self, run_id, job_id, archive_folder=None, file_mover=None, bucket_name=None, storage_provider=None):
 
         self.run_id = run_id
         self.job_id = job_id
@@ -1041,6 +1041,7 @@ class GenomicReconciler:
 
         # Other components
         self.file_mover = file_mover
+        self.storage_provider = storage_provider
 
         # Data files and names will be different
         # file types are defined as
@@ -1125,7 +1126,9 @@ class GenomicReconciler:
 
             # Update Job Run ID on member
             self.member_dao.update_member_job_run_id(member, self.run_id, 'reconcileMetricsSequencingJobRunId')
-            self.member_dao.update_member_state(member, next_state)
+
+            if next_state is not None and next_state != member.genomicWorkflowState:
+                self.member_dao.update_member_state(member, next_state)
 
         # Make a roc ticket for missing data files
         if len(total_missing_data) > 0:
@@ -1287,7 +1290,10 @@ class GenomicReconciler:
         return 1 if len(filenames) > 0 else 0
 
     def _get_full_filename(self, bucket_name, filename):
-        files = list_blobs('/' + bucket_name)
+        if self.storage_provider:
+            files = self.storage_provider.list(bucket_name, prefix=None)
+        else:
+            files = list_blobs('/' + bucket_name)
         filenames = [f.name for f in files if f.name.lower().endswith(filename.lower())]
         return filenames[0] if len(filenames) > 0 else 0
 
@@ -2483,7 +2489,11 @@ class GenomicAlertHandler:
     ROC_BOARD_ID = "ROC"
 
     def __init__(self):
-        self._jira_handler = JiraTicketHandler()
+        self.alert_envs = ["all-of-us-rdr-prod", "all-of-us-rdr-stable"]
+        if GAE_PROJECT in self.alert_envs:
+            self._jira_handler = JiraTicketHandler()
+        else:
+            self._jira_handler = None
 
     def make_genomic_alert(self, summary: str, description: str):
         """
@@ -2492,7 +2502,7 @@ class GenomicAlertHandler:
         :param summary: the 'title' of the ticket
         :param description: the 'body' of the ticket
         """
-        if GAE_PROJECT in ["all-of-us-rdr-prod", "all-of-us-rdr-stable"]:
+        if self._jira_handler is not None:
             ticket = self._jira_handler.create_ticket(summary, description,
                                                       board_id=self.ROC_BOARD_ID)
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -44,6 +44,7 @@ class GenomicJobController:
                  sub_folder_tuple=None,
                  archive_folder_name=None,
                  bucket_name_list=None,
+                 storage_provider=None,
                  ):
 
         self.job_id = job_id
@@ -67,6 +68,7 @@ class GenomicJobController:
         self.reconciler = None
         self.biobank_coupler = None
         self.manifest_compiler = None
+        self.storage_provider = storage_provider
 
     def __enter__(self):
         logging.info(f'Beginning {self.job_id.name} workflow')
@@ -116,7 +118,7 @@ class GenomicJobController:
         """
         Reconciles the metrics to genotyping files using reconciler component
         """
-        self.reconciler = GenomicReconciler(self.job_run.id, self.job_id)
+        self.reconciler = GenomicReconciler(self.job_run.id, self.job_id, storage_provider=self.storage_provider)
         try:
             self.job_result = self.reconciler.reconcile_metrics_to_genotyping_data()
         except RuntimeError:

--- a/rdr_service/genomic/genomic_state_handler.py
+++ b/rdr_service/genomic/genomic_state_handler.py
@@ -71,6 +71,20 @@ class AW2State(GenomicStateBase):
             return GenomicWorkflowState.GEM_READY
 
 
+class AW2MissingState(GenomicStateBase):
+    """State representing the AW2 Missing Data state"""
+
+    def transition_function(self, signal):
+        if signal == 'missing':
+            return GenomicWorkflowState.AW2_MISSING
+
+        elif signal == 'cvl-ready':
+            return GenomicWorkflowState.CVL_READY
+
+        elif signal == 'gem-ready':
+            return GenomicWorkflowState.GEM_READY
+
+
 class GEMReadyState(GenomicStateBase):
     """State representing the GEM_READY state"""
     def transition_function(self, signal):
@@ -194,6 +208,7 @@ class GenomicStateHandler:
         GenomicWorkflowState.AW0: AW0State(),
         GenomicWorkflowState.AW1: AW1State(),
         GenomicWorkflowState.AW2: AW2State(),
+        GenomicWorkflowState.AW2_MISSING: AW2MissingState(),
         GenomicWorkflowState.CVL_READY: CVLReadyState(),
         GenomicWorkflowState.W1: W1State(),
         GenomicWorkflowState.W2: W2State(),

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -162,12 +162,12 @@ def reconcile_metrics_vs_manifest():
         controller.run_reconciliation_to_manifest()
 
 
-def reconcile_metrics_vs_genotyping_data():
+def reconcile_metrics_vs_genotyping_data(provider=None):
     """
     Entrypoint for GC Metrics File reconciliation
     Genotyping Files (Array) vs Listed in Manifest.
     """
-    with GenomicJobController(GenomicJob.RECONCILE_GENOTYPING_DATA) as controller:
+    with GenomicJobController(GenomicJob.RECONCILE_GENOTYPING_DATA, storage_provider=provider) as controller:
         controller.run_reconciliation_to_genotyping_data()
 
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -488,8 +488,8 @@ class ManualSampleClass(GenomicManifestBase):
                     session.flush()
 
                     # Update state for PDR
-                    #bq_genomic_set_update(inserted_set.id, project_id=self.gcp_env.project)
-                    #genomic_set_update(inserted_set.id)
+                    bq_genomic_set_update(inserted_set.id, project_id=self.gcp_env.project)
+                    genomic_set_update(inserted_set.id)
 
                     for line in csvreader:
                         _pid = line[0]
@@ -518,8 +518,8 @@ class ManualSampleClass(GenomicManifestBase):
                             inserted_member = session.merge(member_to_insert)
                             session.flush()
 
-                            #bq_genomic_set_member_update(inserted_member.id, project_id=self.gcp_env.project)
-                            #genomic_set_member_update(inserted_member.id)
+                            bq_genomic_set_member_update(inserted_member.id, project_id=self.gcp_env.project)
+                            genomic_set_member_update(inserted_member.id)
 
                     session.commit()
 

--- a/rdr_service/tools/tool_libs/tools.bash
+++ b/rdr_service/tools/tool_libs/tools.bash
@@ -139,7 +139,7 @@ _python()
             ;;
         genomic)
             # These are options specific to this tool.
-            local toolopts="resend generate-manifest control-sample manual-sample job-run-result member-state update-gc-metrics"
+            local toolopts="resend generate-manifest control-sample manual-sample job-run-result member-state update-gc-metrics process-runner"
             COMPREPLY=( $(compgen -W "${stdopts} ${toolopts}" -- ${cur}) )
             return 0
             ;;
@@ -207,6 +207,16 @@ _python()
             # genomic update-gc-metrics command
             if echo ${COMP_WORDS[@]} | grep -w "genomic" > /dev/null; then
               local toolopts="--help --csv --dryrun"
+              COMPREPLY=( $(compgen -W "${toolopts}" -- ${cur}) )
+            else
+              COMPREPLY=( $(compgen -W "${stdopts}" -- ${cur}) )
+            fi
+            return 0
+            ;;
+          process-runner)
+            # genomic update-gc-metrics command
+            if echo ${COMP_WORDS[@]} | grep -w "genomic" > /dev/null; then
+              local toolopts="--help --job --file --dryrun"
               COMPREPLY=( $(compgen -W "${toolopts}" -- ${cur}) )
             else
               COMPREPLY=( $(compgen -W "${stdopts}" -- ${cur}) )


### PR DESCRIPTION
This PR creates a new genomic tool `process-runner` that can run genomic workflows. The tool currently supports running one workflow: the AW2 Array Data Reconciliation workflow. The automated cron job that runs this process on Prod is currently failing. This tool will allow developers to run the process manually using local code.  A subsequent PR will follow to further update the reconciliation workflow and fix the issues causing the failures.
Background: The AW2 ingestion process creates the `genomic_gc_validation_metrics` record, and the AW2 Array Data Reconciliation process that this tool runs checks the data buckets for expected data files and updates the gc metrics object if those files are found.
