### PR TITLE
[ROC-703] Accounting for lines missing severity

### DIFF
--- a/rdr_service/services/gcp_logging.py
+++ b/rdr_service/services/gcp_logging.py
@@ -159,7 +159,8 @@ def get_highest_severity_level_from_lines(lines):
     :param lines: List of log records
     """
     if lines:
-        s = sorted([line['severity'] for line in lines], reverse=True)
+        severities_found = [line['severity'] for line in lines if 'severity' in line]
+        s = sorted(severities_found, reverse=True)
         return s[0]
     else:
         return gcp_logging_v2.gapic.enums.LogSeverity(200)

--- a/rdr_service/services/gcp_logging.py
+++ b/rdr_service/services/gcp_logging.py
@@ -161,9 +161,10 @@ def get_highest_severity_level_from_lines(lines):
     if lines:
         severities_found = [line['severity'] for line in lines if line.get('severity', False)]
         s = sorted(severities_found, reverse=True)
-        return s[0]
-    else:
-        return gcp_logging_v2.gapic.enums.LogSeverity(200)
+        if s:
+            return s[0]
+
+    return gcp_logging_v2.gapic.enums.LogSeverity(200)
 
 
 def setup_proto_payload(lines: list, log_status: LogCompletionStatusEnum, **kwargs):

--- a/rdr_service/services/gcp_logging.py
+++ b/rdr_service/services/gcp_logging.py
@@ -159,7 +159,7 @@ def get_highest_severity_level_from_lines(lines):
     :param lines: List of log records
     """
     if lines:
-        severities_found = [line['severity'] for line in lines if 'severity' in line]
+        severities_found = [line['severity'] for line in lines if line.get('severity', False)]
         s = sorted(severities_found, reverse=True)
         return s[0]
     else:

--- a/tests/test_gcp_logging.py
+++ b/tests/test_gcp_logging.py
@@ -39,6 +39,7 @@ class GCPLoggingTest(BaseTestCase):
         lines = [
             {'severity': logging.INFO},
             {'msg': 'This one has no severity'},
+            {'severity': None},
             {'severity': logging.CRITICAL},
             {'severity': logging.ERROR},
         ]

--- a/tests/test_gcp_logging.py
+++ b/tests/test_gcp_logging.py
@@ -46,3 +46,12 @@ class GCPLoggingTest(BaseTestCase):
 
         highest_severity = gcp_logging.get_highest_severity_level_from_lines(lines)
         self.assertEqual(logging.CRITICAL, highest_severity)
+
+    def test_handle_no_severities_when_finding_highest(self):
+        lines = [
+            {'msg': 'This one has no severity'},
+            {'severity': None},
+        ]
+
+        highest_severity = gcp_logging.get_highest_severity_level_from_lines(lines)
+        self.assertEqual(enums.LogSeverity.INFO, highest_severity)

--- a/tests/test_gcp_logging.py
+++ b/tests/test_gcp_logging.py
@@ -34,3 +34,14 @@ class GCPLoggingTest(BaseTestCase):
             _, kwargs = mock_final_log_entry_call.call_args
             logged_severity = kwargs.get('severity')
             self.assertEqual(enums.LogSeverity.ERROR, logged_severity)
+
+    def test_handle_missing_severity_when_finding_highest(self):
+        lines = [
+            {'severity': logging.INFO},
+            {'msg': 'This one has no severity'},
+            {'severity': logging.CRITICAL},
+            {'severity': logging.ERROR},
+        ]
+
+        highest_severity = gcp_logging.get_highest_severity_level_from_lines(lines)
+        self.assertEqual(logging.CRITICAL, highest_severity)


### PR DESCRIPTION
It's possible for `get_highest_severity_level_from_lines` to see log line records that don't specify a severity. In that case this change prevents a crash when publishing logs.