### PR TITLE
[DA-1782] Genomic Reconciliation And Ingestion Updates

### DIFF
--- a/rdr_service/cron_careevo.yaml
+++ b/rdr_service/cron_careevo.yaml
@@ -9,7 +9,9 @@ cron:
 - description: Genomic AW1 Failures Workflow
 - description: Genomic AW1C (CVL) Workflow (Manual)
 - description: Genomic AW1CF (CVL) Failures Workflow (Manual)
-- description: Genomic AW2 Workflow (Manual)
+- description: Genomic AW2 Workflow
+- description: Genomic Reconciliation Array Data Workflow
+- description: Genomic Reconciliation WGS Data Workflow
 - description: Genomic GEM A1-A2 Workflow
 - description: Genomic GEM A2 Workflow
 - description: Genomic CVL W1 Workflow (Manual)

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -99,10 +99,20 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
-- description: Genomic AW2 Workflow (Manual)
+- description: Genomic AW2 Workflow
   url: /offline/GenomicDataManifestWorkflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every day 05:00
+  target: offline
+- description: Genomic Reconciliation Array Data Workflow (Manual)
+  url: /offline/GenomicArrayReconciliationWorkflow
+  timezone: America/New_York
+  schedule: every day 05:30
+  target: offline
+- description: Genomic Reconciliation WGS Data Workflow (Manual)
+  url: /offline/GenomicWGSReconciliationWorkflow
+  timezone: America/New_York
+  schedule: every day 06:00
   target: offline
 - description: Genomic GEM A1-A2 Workflow
   url: /offline/GenomicGemA1A2Workflow

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -104,12 +104,12 @@ cron:
   timezone: America/New_York
   schedule: every day 05:00
   target: offline
-- description: Genomic Reconciliation Array Data Workflow (Manual)
+- description: Genomic Reconciliation Array Data Workflow
   url: /offline/GenomicArrayReconciliationWorkflow
   timezone: America/New_York
   schedule: every day 05:30
   target: offline
-- description: Genomic Reconciliation WGS Data Workflow (Manual)
+- description: Genomic Reconciliation WGS Data Workflow
   url: /offline/GenomicWGSReconciliationWorkflow
   timezone: America/New_York
   schedule: every day 06:00

--- a/rdr_service/cron_ptsc.yaml
+++ b/rdr_service/cron_ptsc.yaml
@@ -9,7 +9,9 @@ cron:
 - description: Genomic AW1 Failures Workflow
 - description: Genomic AW1C (CVL) Workflow (Manual)
 - description: Genomic AW1CF (CVL) Failures Workflow (Manual)
-- description: Genomic AW2 Workflow (Manual)
+- description: Genomic AW2 Workflow
+- description: Genomic Reconciliation Array Data Workflow
+- description: Genomic Reconciliation WGS Data Workflow
 - description: Genomic GEM A1-A2 Workflow
 - description: Genomic GEM A2 Workflow
 - description: Genomic CVL W1 Workflow (Manual)

--- a/rdr_service/cron_sandbox.yaml
+++ b/rdr_service/cron_sandbox.yaml
@@ -4,19 +4,6 @@ cron:
 - description: Monthly reconciliation report
 - description: Participant count metrics (Do not manually start)
 - description: Flag ghost participants
-- description: Genomic Pipeline AW0 (Cohort 2) Workflow
-- description: Genomic Pipeline AW0 (Cohort 3) Workflow
-- description: Genomic Pipeline AW0 (Cohort 1) Workflow
-- description: Genomic AW1 Workflow
-- description: Genomic AW1 Failures Workflow
-- description: Genomic AW2 Workflow (Manual)
-- description: Genomic GEM A1-A2 Workflow
-- description: Genomic GEM A2 Workflow
-- description: Genomic CVL W1 Workflow (Manual)
-- description: Genomic CVL W2 Workflow (Manual)
-- description: Genomic CVL W3 Workflow (Manual)
-- description: Genomic AW3 Workflow
-- description: Genomic AW4 Workflow
 - description: Rotate service account keys older than 3 days
   url: /offline/DeleteOldKeys
   schedule: every day 01:00

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -542,20 +542,6 @@ class GenomicSetMemberDao(UpdatableDao):
             ).all()
         return members
 
-    def get_null_field_members(self, field):
-        """
-        Get the genomic set members with a null value for a field
-        useful for reconciliation processes.
-        :param field: field to lookup null
-        :return: GenomicSetMember list
-        """
-        with self.session() as session:
-            members = session.query(GenomicSetMember).filter(
-                getattr(GenomicSetMember, field) == None,
-                GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE
-            ).all()
-        return members
-
     def get_unconsented_gror_since_date(self, _date):
         """
         Get the genomic set members with GROR updated to No Consent since date

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -91,13 +91,16 @@ class GenomicFileIngester:
                  bucket=None,
                  archive_folder=None,
                  sub_folder=None,
-                 _controller=None):
+                 _controller=None,
+                 target_file=None):
 
         self.controller = _controller
         self.job_id = job_id
         self.job_run_id = job_run_id
         self.file_obj = None
         self.file_queue = deque()
+
+        self.target_file = target_file
 
         self.bucket_name = bucket
         self.archive_folder_name = archive_folder
@@ -116,7 +119,13 @@ class GenomicFileIngester:
         Creates the list of files to be ingested in this run.
         Ordering is currently arbitrary;
         """
-        files = self._get_uningested_file_names_from_bucket()
+        # Check Target file is set.
+        # It will not be set in cron job, but will be set by tool when run manually
+        if self.target_file is not None:
+            files = [self.target_file]
+        else:
+            files = self._get_uningested_file_names_from_bucket()
+
         if files == GenomicSubProcessResult.NO_FILES:
             return files
         else:
@@ -457,17 +466,24 @@ class GenomicFileIngester:
                 'Opening CSV file from queue {}: {}.'
                 .format(path.split('/')[1], filename)
             )
-            data_to_ingest = {'rows': []}
-            with open_cloud_file(path) as csv_file:
-                csv_reader = csv.DictReader(csv_file, delimiter=",")
-                data_to_ingest['fieldnames'] = csv_reader.fieldnames
-                for row in csv_reader:
-                    data_to_ingest['rows'].append(row)
-            return data_to_ingest
+            if self.controller.storage_provider:
+                with self.controller.storage_provider.open(path, 'r') as csv_file:
+                    return self._read_data_to_ingest(csv_file)
+            else:
+                with open_cloud_file(path) as csv_file:
+                    return self._read_data_to_ingest(csv_file)
 
         except FileNotFoundError:
             logging.error(f"File path '{path}' not found")
             return GenomicSubProcessResult.ERROR
+
+    def _read_data_to_ingest(self, csv_file):
+        data_to_ingest = {'rows': []}
+        csv_reader = csv.DictReader(csv_file, delimiter=",")
+        data_to_ingest['fieldnames'] = csv_reader.fieldnames
+        for row in csv_reader:
+            data_to_ingest['rows'].append(row)
+        return data_to_ingest
 
     def _process_gc_metrics_data_for_insert(self, data_to_ingest):
         """ Since input files vary in column names,

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1064,23 +1064,6 @@ class GenomicReconciler:
                                       ("cramMd5Received", ".cram.md5sum", "cramMd5Path"),
                                       ("craiReceived", ".crai", "craiPath"))
 
-    def reconcile_metrics_to_manifest(self):
-        """ The main method for the metrics vs. manifest reconciliation """
-        try:
-
-            unreconciled_members = self.member_dao.get_null_field_members('reconcileMetricsBBManifestJobRunId')
-            results = []
-            for member in unreconciled_members:
-                results.append(
-                    self.member_dao.update_member_job_run_id(
-                        member, self.run_id, 'reconcileMetricsBBManifestJobRunId')
-                )
-            return GenomicSubProcessResult.SUCCESS \
-                if GenomicSubProcessResult.ERROR not in results \
-                else GenomicSubProcessResult.ERROR
-        except RuntimeError:
-            return GenomicSubProcessResult.ERROR
-
     def reconcile_metrics_to_genotyping_data(self):
         """ The main method for the AW2 manifest vs. array data reconciliation
         :return: result code

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -187,6 +187,21 @@ class GenomicJobController:
         except RuntimeError:
             self.job_result = GenomicSubProcessResult.ERROR
 
+    def ingest_specific_aw1_manifest(self, filename):
+        """
+        Uses GenomicFileIngester to ingest specific Genomic Manifest files (AW1).
+        """
+        try:
+            self.ingester = GenomicFileIngester(job_id=self.job_id,
+                                                job_run_id=self.job_run.id,
+                                                bucket=self.bucket_name,
+                                                target_file=filename,
+                                                _controller=self)
+
+            self.job_result = self.ingester.generate_file_queue_and_do_ingestion()
+        except RuntimeError:
+            self.job_result = GenomicSubProcessResult.ERROR
+
     def run_aw1f_manifest_workflow(self):
         """
         Ingests the BB to GC failure manifest (AW1F)

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -103,17 +103,6 @@ class GenomicJobController:
         except RuntimeError:
             self.job_result = GenomicSubProcessResult.ERROR
 
-    def run_reconciliation_to_manifest(self):
-        """
-        Reconciles the metrics to manifest using reconciler component
-        :return: result code for job run
-        """
-        self.reconciler = GenomicReconciler(self.job_run.id, self.job_id)
-        try:
-            self.job_result = self.reconciler.reconcile_metrics_to_manifest()
-        except RuntimeError:
-            self.job_result = GenomicSubProcessResult.ERROR
-
     def run_reconciliation_to_genotyping_data(self):
         """
         Reconciles the metrics to genotyping files using reconciler component

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -153,15 +153,6 @@ def ingest_genomic_centers_metrics_files():
         controller.ingest_gc_metrics()
 
 
-def reconcile_metrics_vs_manifest():
-    """
-    Entrypoint for GC Metrics File reconciliation
-    against Manifest subprocess of genomic_pipeline.
-    """
-    with GenomicJobController(GenomicJob.RECONCILE_MANIFEST) as controller:
-        controller.run_reconciliation_to_manifest()
-
-
 def reconcile_metrics_vs_genotyping_data(provider=None):
     """
     Entrypoint for GC Metrics File reconciliation

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -294,14 +294,21 @@ def aw1cf_failures_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_data_manifest_workflow():
-    """Temporarily running this manually for E2E Testing"""
-    now = datetime.utcnow()
-    if now.day == 0o1 and now.month == 0o1:
-        logging.info("skipping the scheduled run.")
-        return '{"success": "true"}'
     genomic_pipeline.ingest_genomic_centers_metrics_files()
-    genomic_pipeline.reconcile_metrics_vs_manifest()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
+def genomic_array_data_reconciliation_workflow():
     genomic_pipeline.reconcile_metrics_vs_genotyping_data()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
+def genomic_wgs_data_reconciliation_workflow():
+    genomic_pipeline.reconcile_metrics_vs_sequencing_data()
     return '{"success": "true"}'
 
 
@@ -553,6 +560,16 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicDataManifestWorkflow",
         endpoint="genomic_data_manifest_workflow",
         view_func=genomic_data_manifest_workflow, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicArrayReconciliationWorkflow",
+        endpoint="genomic_array_data_reconciliation_workflow",
+        view_func=genomic_array_data_reconciliation_workflow, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicWGSReconciliationWorkflow",
+        endpoint="genomic_wgs_data_reconciliation_workflow",
+        view_func=genomic_wgs_data_reconciliation_workflow, methods=["GET"]
     )
     offline_app.add_url_rule(
         OFFLINE_PREFIX + "GenomicGemA1A2Workflow",

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -637,33 +637,6 @@ class GenomicPipelineTest(BaseTestCase):
             codeType=CodeType.ANSWER, mapped=True)
         return self.code_dao.insert(code_to_insert).codeId
 
-    def test_gc_metrics_reconciliation_vs_manifest(self):
-        # Create the fake Google Cloud CSV files to ingest
-        self._create_fake_datasets_for_gc_tests(2, arr_override=True, array_participants=[1, 2],
-                                                genomic_workflow_state=GenomicWorkflowState.AW1)
-        bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
-        self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest.csv',
-                                         bucket_name,
-                                         folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1]))
-
-        self._update_test_sample_ids()
-
-        # Run the GC Metrics Ingestion workflow
-        genomic_pipeline.ingest_genomic_centers_metrics_files()  # run_id = 1
-
-        # Run the GC Metrics Reconciliation
-        genomic_pipeline.reconcile_metrics_vs_manifest()  # run_id = 2
-        test_set_member = self.member_dao.get(1)
-        gc_metric_record = self.metrics_dao.get(1)
-
-        # Test the gc_metrics were updated with reconciliation data
-        self.assertEqual(test_set_member.id, gc_metric_record.genomicSetMemberId)
-        self.assertEqual(2, test_set_member.reconcileMetricsBBManifestJobRunId)
-
-        run_obj = self.job_run_dao.get(2)
-
-        self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
-
     @mock.patch('rdr_service.genomic.genomic_job_components.GenomicAlertHandler')
     def test_gc_metrics_reconciliation_vs_genotyping_data(self, patched_handler):
         mock_alert_handler = patched_handler.return_value
@@ -1689,14 +1662,13 @@ class GenomicPipelineTest(BaseTestCase):
         for f in sequencing_test_files:
             self._write_cloud_csv(f, 'attagc', bucket=bucket_name)
 
-        genomic_pipeline.reconcile_metrics_vs_manifest()  # run_id = 3
-        genomic_pipeline.reconcile_metrics_vs_genotyping_data()  # run_id = 4
+        genomic_pipeline.reconcile_metrics_vs_genotyping_data()  # run_id = 3
 
         # finally run the manifest workflow
         bucket_name = config.getSetting(config.GENOMIC_GEM_BUCKET_NAME)
         a1_time = datetime.datetime(2020, 4, 1, 0, 0, 0, 0)
         with clock.FakeClock(a1_time):
-            genomic_pipeline.gem_a1_manifest_workflow()  # run_id = 5
+            genomic_pipeline.gem_a1_manifest_workflow()  # run_id = 4
         a1f = a1_time.strftime("%Y-%m-%d-%H-%M-%S")
         # Test Genomic Set Member updated with GEM Array Manifest job run
         with self.member_dao.session() as member_session:
@@ -1718,7 +1690,7 @@ class GenomicPipelineTest(BaseTestCase):
                 GenomicSetMember.id == 1
             ).one()
 
-        self.assertEqual(5, test_member_1.gemA1ManifestJobRunId)
+        self.assertEqual(4, test_member_1.gemA1ManifestJobRunId)
         self.assertEqual(GenomicWorkflowState.A1, test_member_1.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -1748,7 +1720,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Array
         file_record = self.file_processed_dao.get(2)  # remember, GC Metrics is #1
-        self.assertEqual(5, file_record.runId)
+        self.assertEqual(4, file_record.runId)
         self.assertEqual(f'{sub_folder}/AoU_GEM_A1_manifest_{a1f}.csv', file_record.fileName)
 
         # Test the job result
@@ -1944,20 +1916,19 @@ class GenomicPipelineTest(BaseTestCase):
         for f in sequencing_test_files:
             self._write_cloud_csv(f, 'attagc', bucket=bucket_name)
 
-        genomic_pipeline.reconcile_metrics_vs_manifest()  # run_id = 3
-        genomic_pipeline.reconcile_metrics_vs_sequencing_data()  # run_id = 4
+        genomic_pipeline.reconcile_metrics_vs_sequencing_data()  # run_id = 3
 
         # Run the W1 manifest workflow
         fake_dt = datetime.datetime(2020, 4, 3, 0, 0, 0, 0)
 
         with clock.FakeClock(fake_dt):
-            genomic_pipeline.create_cvl_w1_manifest()  # run_id 5
+            genomic_pipeline.create_cvl_w1_manifest()  # run_id 4
 
         w1_dtf = fake_dt.strftime("%Y-%m-%d-%H-%M-%S")
 
         # Test member was updated
         member = self.member_dao.get(2)
-        self.assertEqual(5, member.cvlW1ManifestJobRunId)
+        self.assertEqual(4, member.cvlW1ManifestJobRunId)
         self.assertEqual(GenomicWorkflowState.W1, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -1990,10 +1961,10 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test file processed is recorded
         file_record = self.file_processed_dao.get(2)  # remember, GC Metrics is #1
-        self.assertEqual(5, file_record.runId)
+        self.assertEqual(4, file_record.runId)
         self.assertEqual(f'{sub_folder}/AoU_CVL_Manifest_{w1_dtf}.csv', file_record.fileName)
 
-        run_obj = self.job_run_dao.get(5)
+        run_obj = self.job_run_dao.get(4)
 
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
@@ -2162,21 +2133,20 @@ class GenomicPipelineTest(BaseTestCase):
         for f in sequencing_test_files:
             self._write_cloud_csv(f, 'attagc', bucket=bucket_name)
 
-        genomic_pipeline.reconcile_metrics_vs_manifest()  # run_id = 3
-        genomic_pipeline.reconcile_metrics_vs_genotyping_data()  # run_id = 4
+        genomic_pipeline.reconcile_metrics_vs_genotyping_data()  # run_id = 3
 
         # finally run the AW3 manifest workflow
         fake_dt = datetime.datetime(2020, 8, 3, 0, 0, 0, 0)
 
         with clock.FakeClock(fake_dt):
-            genomic_pipeline.aw3_array_manifest_workflow()  # run_id = 5
+            genomic_pipeline.aw3_array_manifest_workflow()  # run_id = 4
 
         aw3_dtf = fake_dt.strftime("%Y-%m-%d-%H-%M-%S")
 
         # Test member was updated
         member = self.member_dao.get(2)
 
-        self.assertEqual(5, member.aw3ManifestJobRunID)
+        self.assertEqual(4, member.aw3ManifestJobRunID)
         self.assertEqual(GenomicWorkflowState.GEM_READY, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -2223,7 +2193,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(metric.vcfMd5Path, rows[1]['vcf_md5_path'])
 
             # Test run record is success
-            run_obj = self.job_run_dao.get(5)
+            run_obj = self.job_run_dao.get(4)
 
             self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
@@ -2265,21 +2235,20 @@ class GenomicPipelineTest(BaseTestCase):
         for f in sequencing_test_files:
             self._write_cloud_csv(f, 'attagc', bucket=bucket_name)
 
-        genomic_pipeline.reconcile_metrics_vs_manifest()  # run_id = 3
-        genomic_pipeline.reconcile_metrics_vs_sequencing_data()  # run_id = 4
+        genomic_pipeline.reconcile_metrics_vs_sequencing_data()  # run_id = 3
 
         # finally run the AW3 manifest workflow
         fake_dt = datetime.datetime(2020, 8, 3, 0, 0, 0, 0)
 
         with clock.FakeClock(fake_dt):
-            genomic_pipeline.aw3_wgs_manifest_workflow()  # run_id = 5
+            genomic_pipeline.aw3_wgs_manifest_workflow()  # run_id = 4
 
         aw3_dtf = fake_dt.strftime("%Y-%m-%d-%H-%M-%S")
 
         # Test member was updated
         member = self.member_dao.get(2)
 
-        self.assertEqual(5, member.aw3ManifestJobRunID)
+        self.assertEqual(4, member.aw3ManifestJobRunID)
         self.assertEqual(GenomicWorkflowState.CVL_READY, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -2330,7 +2299,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(metric.craiPath, rows[0]["crai_path"])
 
             # Test run record is success
-            run_obj = self.job_run_dao.get(5)
+            run_obj = self.job_run_dao.get(4)
 
             self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 


### PR DESCRIPTION
This PR includes implements a new branch of the `genomic process-runner` tool to ingest specified AW1 manifests. Additionally, this PR includes changes to the genomic data reconciliation processes. 

- The AW2 ingestion, array data reconciliation, and wgs data reconciliation workflows were split into 3 cron jobs.
- The AW2 to AW1 manifest reconciliation workflow is not needed anymore and therefore was removed. The reconciliation is implied during the AW2 ingestion since the job arborts on missing genomic set member records.
- Unit tests were updated since the previous workflow is no longer running.
- The `GenomicFileIngester` component class was updated with a new method, `ingest_specific_aw1_manifest`, to facilitate the update to the genomic `process-runner` tool for the AW1 ingestion.
- Minor refactors were needed to read cloud files using the correct `storage_provider` from within a `GenomicJobController` context called from the local tools. 


