### PR TITLE
Distinct logs for invalid link ids and unanswered questions

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -166,9 +166,9 @@ class QuestionnaireResponseDao(BaseDao):
                     and link_id.lower() != "ignorethis"
                     and link_id not in link_ids
                 ):
+                    # The link_ids list being checked is a list of questions that have been answered,
+                    #  the list doesn't include valid link_ids that don't have answers
                     if "answer" in section:
-                        # The link_ids list being checked is a list of questions that have been answered,
-                        #  the list doesn't include valid link_ids that don't have answers
                         logging.error(f'Questionnaire response contains invalid link ID "{link_id}"')
                     else:
                         logging.warning(f'Questionnaire response has not answered link ID "{link_id}"')

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -159,14 +159,19 @@ class QuestionnaireResponseDao(BaseDao):
         # once we have a question section, iterate through list of answers.
         if "question" in resource:
             for section in resource["question"]:
-
+                link_id = section.get('linkId', None)
                 # Do not log warning or raise exception when link id is 'ignoreThis' for unit tests.
                 if (
-                    "linkId" in section
-                    and section["linkId"].lower() != "ignorethis"
-                    and section["linkId"] not in link_ids
+                    link_id is not None
+                    and link_id.lower() != "ignorethis"
+                    and link_id not in link_ids
                 ):
-                    logging.error(f"Questionnaire response contains invalid link ID {section['linkId']}.")
+                    if "answer" in section:
+                        # The link_ids list being checked is a list of questions that have been answered,
+                        #  the list doesn't include valid link_ids that don't have answers
+                        logging.error(f'Questionnaire response contains invalid link ID "{link_id}"')
+                    else:
+                        logging.warning(f'Questionnaire response has not answered link ID "{link_id}"')
 
     @staticmethod
     def _imply_street_address_2_from_street_address_1(code_ids):

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -51,7 +51,7 @@ class DataGenerator:
         for field, default in [('version', 1),
                                ('created', datetime.now()),
                                ('lastModified', datetime.now()),
-                               ('resource', 'test')]:
+                               ('resource', '{"version": 1}')]:
             if field not in kwargs:
                 kwargs[field] = default
 
@@ -117,6 +117,10 @@ class DataGenerator:
     def _questionnaire_question(self, **kwargs):
         if 'repeats' not in kwargs:
             kwargs['repeats'] = True
+
+        if 'codeId' not in kwargs:
+            code = self.create_database_code()
+            kwargs['codeId'] = code.codeId
 
         return QuestionnaireQuestion(**kwargs)
 
@@ -280,7 +284,8 @@ class DataGenerator:
         for field, default in [('system', PPI_SYSTEM),
                                ('codeType', 1),
                                ('mapped', False),
-                               ('created', datetime.now())]:
+                               ('created', datetime.now()),
+                               ('value', self.faker.pystr(4, 8))]:
             if field not in kwargs:
                 kwargs[field] = default
 


### PR DESCRIPTION
We're seeing some error logs for 'invalid link IDs' for questions on a questionnaire response that don't have an answer field. They are usually included on the questionnaire, but since they don't have answers they're left out of the link id list that they're validated with.

They may be worth investigating more, but I'm dropping them down to warnings since nothing is particularly wrong with them (even if it is strange that they're in the payload).