### PR TITLE
[PDR-122] Add biobank order/stored sample data to BQ PDR generators

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -146,7 +146,3 @@ GENOME_TYPE = ["aou_array", "aou_wgs"]
 # Source of a created participant
 ORIGINATING_SOURCES = ['vibrent', 'careevolution', 'example']
 
-# For handling biobank stored samples without a corresponding biobank order id during RDR to PDR rebuilds
-# See: https://precisionmedicineinitiative.atlassian.net/browse/DA-812 and
-# https://precisionmedicineinitiative.atlassian.net/browse/PDR-89
-UNKNOWN_BIOBANK_ORDER_ID = 'unknown_biobank_order_id'

--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -51,6 +51,8 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRConsentView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRBioSpecView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRPatientStatuesView'),
+    ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantBiobankOrderView'),
+    ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantBiobankSampleView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRConsentPIIView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRTheBasicsView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRLifestyleView'),

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -262,6 +262,7 @@ class BQParticipantSummarySchema(BQSchema):
 
     cohort_2_pilot_flag = BQField('cohort_2_pilot_flag', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     cohort_2_pilot_flag_id = BQField('cohort_2_pilot_flag_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    biobank_orders = BQRecordField('biobank_orders', schema=BQBiobankOrderSchema)
 
 
 class BQParticipantSummary(BQTable):

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -13,7 +13,7 @@ from rdr_service import config
 from rdr_service.resource.helpers import DateCollection
 from rdr_service.code_constants import CONSENT_GROR_YES_CODE, CONSENT_PERMISSION_YES_CODE, CONSENT_PERMISSION_NO_CODE,\
     DVEHR_SHARING_QUESTION_CODE, EHR_CONSENT_QUESTION_CODE, DVEHRSHARING_CONSENT_CODE_YES, GROR_CONSENT_QUESTION_CODE,\
-    EHR_CONSENT_EXPIRED_YES, UNKNOWN_BIOBANK_ORDER_ID
+    EHR_CONSENT_EXPIRED_YES
 from rdr_service.dao.resource_dao import ResourceDataDao
 # TODO: Replace BQRecord here with a Resource alternative.
 from rdr_service.model.bq_base import BQRecord
@@ -617,7 +617,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             samples = [s for s in cursor]
             if len(samples):
                 orders.append({'tests_ordered': 0, 'tests_stored': len(samples),
-                    'biobank_order_id': UNKNOWN_BIOBANK_ORDER_ID, 'samples': list()})
+                    'biobank_order_id': 'UNSET', 'samples': list()})
                 for row in samples:
                     orders[-1]['samples'].append(_make_stored_sample_dict_from_row(row, has_order=False))
 
@@ -998,13 +998,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         if 'biobank_orders' in summary:
             for order in summary['biobank_orders']:
-                if order['biobank_order_id'] != UNKNOWN_BIOBANK_ORDER_ID \
+                if order['biobank_order_id'] != 'UNSET' \
                    and ['status_id'] != int(BiobankOrderStatus.CANCELLED) and 'samples' in order:
                     for sample in order['samples']:
                         if 'finalized' in sample and sample['finalized'] and \
                             isinstance(sample['finalized'], datetime.datetime):
                             dates.append(datetime_to_date(sample['finalized']))
-
         dates = list(set(dates))  # de-dup list
         data['distinct_visits'] = len(dates)
         return data

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -525,6 +525,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                         where bss2.biobank_order_identifier = boi.`value`) as tests_stored
              from biobank_order bo left outer join biobank_order_identifier boi on bo.biobank_order_id = boi.biobank_order_id
              where boi.`system` = 'https://www.pmi-ops.org' and bo.participant_id = :pid
+                   and boi.`value` in (select bss.biobank_order_identifier from biobank_stored_sample bss)
              order by bo.created desc;
          """
 

--- a/rdr_service/tools/tool_libs/bq_migrate.py
+++ b/rdr_service/tools/tool_libs/bq_migrate.py
@@ -230,6 +230,10 @@ class BQMigration(object):
         if not self.args.delete and not self.gcp_env.activate_sql_proxy():
             return 1
 
+        migrate_all = self.args.names.lower() == 'all'
+        if not migrate_all:
+            migrate_list = self.args.names.lower().split(",")
+
         # TODO: Validate dataset name exists in BigQuery
         # Loop through table schemas
         for path, var_name in BQ_TABLES:
@@ -239,7 +243,7 @@ class BQMigration(object):
             ls_obj = bq_table.get_schema()
 
             # See if we need to skip this table
-            if self.args.names.lower() != 'all' and bq_table.get_name().lower() not in self.args.names.lower():
+            if not migrate_all and bq_table.get_name().lower() not in migrate_list:
                 continue
 
             if self.args.show_schemas:
@@ -293,7 +297,7 @@ class BQMigration(object):
             view_id = bq_view.get_name()
 
             # See if we need to skip this view
-            if self.args.names.lower() != 'all' and view_id.lower() not in self.args.names.lower():
+            if not migrate_all and view_id.lower() not in migrate_list:
                 continue
 
             bq_table = bq_view.get_table()


### PR DESCRIPTION

The biobank data added is based on what was already being generated by the `_prep_biobank_info()` method in the generators, but was not included in the participant resource JSON data until now (see discussion in PDR-122).

The `_biobank_orders_sql` query defined/executed in the `_prep_biobank_info()` method was corrected to eliminate multiple result rows for the same `biobank_order_id`, in cases where the same order id value appeared multiple times in the `biobank_order_identifier` table.    **NOTE:  Please review the other unchanged queries in  `_prep_biobank_info()` to confirm my visual check that no other queries needed related changes.**   

For stored samples that have no associated biobank order, setting the biobank_order_id to 'UNSET' (instead of the previously used nonstandard string value).  None/NULL was not used because of possible side effects on other places in the generator/pid rebuild path that might use the `bbo_biobank_order_id` key from the resource data and expect a string value.

The `migrate-bq` tool fix resolves an issue where if BQ table/view names are substrings of what the user specified with the --names option, the tool might "match" the wrong table/view when testing for` in self.args.names.lower()`