### PR TITLE
[DA-1772] Splitting A1-A2 cron job; disable scheduled A1 run for GEM soft launch.

### DIFF
--- a/rdr_service/cron_careevo.yaml
+++ b/rdr_service/cron_careevo.yaml
@@ -12,8 +12,9 @@ cron:
 - description: Genomic AW2 Workflow
 - description: Genomic Reconciliation Array Data Workflow
 - description: Genomic Reconciliation WGS Data Workflow
-- description: Genomic GEM A1-A2 Workflow
+- description: Genomic GEM A1 Workflow
 - description: Genomic GEM A2 Workflow
+- description: Genomic GEM A3 Workflow
 - description: Genomic CVL W1 Workflow (Manual)
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -114,8 +114,13 @@ cron:
   timezone: America/New_York
   schedule: every day 06:00
   target: offline
-- description: Genomic GEM A1-A2 Workflow
-  url: /offline/GenomicGemA1A2Workflow
+- description: Genomic GEM A1 Workflow
+  url: /offline/GenomicGemA1Workflow
+  timezone: America/New_York
+  schedule: 1 of jan 12:00
+  target: offline
+- description: Genomic GEM A2 Workflow
+  url: /offline/GenomicGemA2Workflow
   timezone: America/New_York
   schedule: every 6 hours
   target: offline

--- a/rdr_service/cron_ptsc.yaml
+++ b/rdr_service/cron_ptsc.yaml
@@ -12,8 +12,9 @@ cron:
 - description: Genomic AW2 Workflow
 - description: Genomic Reconciliation Array Data Workflow
 - description: Genomic Reconciliation WGS Data Workflow
-- description: Genomic GEM A1-A2 Workflow
+- description: Genomic GEM A1 Workflow
 - description: Genomic GEM A2 Workflow
+- description: Genomic GEM A3 Workflow
 - description: Genomic CVL W1 Workflow (Manual)
 - description: Genomic CVL W2 Workflow (Manual)
 - description: Genomic CVL W3 Workflow (Manual)

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -314,8 +314,19 @@ def genomic_wgs_data_reconciliation_workflow():
 
 @app_util.auth_required_cron
 @_alert_on_exceptions
-def genomic_gem_a1_a2_workflow():
+def genomic_gem_a1_workflow():
+    """Temporarily running this manually for GEM Soft Launch"""
+    now = datetime.utcnow()
+    if now.day == 0o1 and now.month == 0o1:
+        logging.info("skipping the scheduled run.")
+        return '{"success": "true"}'
     genomic_pipeline.gem_a1_manifest_workflow()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
+def genomic_gem_a2_workflow():
     genomic_pipeline.gem_a2_manifest_workflow()
     return '{"success": "true"}'
 
@@ -572,9 +583,14 @@ def _build_pipeline_app():
         view_func=genomic_wgs_data_reconciliation_workflow, methods=["GET"]
     )
     offline_app.add_url_rule(
-        OFFLINE_PREFIX + "GenomicGemA1A2Workflow",
-        endpoint="genomic_gem_a1_a2_workflow",
-        view_func=genomic_gem_a1_a2_workflow, methods=["GET"]
+        OFFLINE_PREFIX + "GenomicGemA1Workflow",
+        endpoint="genomic_gem_a1_workflow",
+        view_func=genomic_gem_a1_workflow, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicGemA2Workflow",
+        endpoint="genomic_gem_a2_workflow",
+        view_func=genomic_gem_a2_workflow, methods=["GET"]
     )
     offline_app.add_url_rule(
         OFFLINE_PREFIX + "GenomicGemA3Workflow",


### PR DESCRIPTION
This PR splits the GEM A1-A2 cron job into separate jobs for each GEM manifest. The PR also disables the GEM A1 cron job schedule so that it won't run automatically during the GEM soft launch. The A2 job should still be running every 6 hours. It will only process samples if new files exist.