### PR TITLE
BQ/PDR schema and tool fixes related to DA-1790, DA-1792

### DIFF
--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -31,6 +31,7 @@ BQ_TABLES = [
     ('rdr_service.model.bq_genomics', 'BQGenomicSetMember'),
     ('rdr_service.model.bq_genomics', 'BQGenomicJobRun'),
     ('rdr_service.model.bq_genomics', 'BQGenomicGCValidationMetrics'),
+    ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessed')
 ]
 
 BQ_VIEWS = [
@@ -79,4 +80,5 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_genomics', 'BQGenomicSetMemberView'),
     ('rdr_service.model.bq_genomics', 'BQGenomicJobRunView'),
     ('rdr_service.model.bq_genomics', 'BQGenomicGCValidationMetricsView'),
+    ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessedView')
 ]

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -38,7 +38,8 @@ tool_cmd = "resource"
 tool_desc = "Tools for updating resource records in RDR"
 
 
-GENOMIC_DB_TABLES = ('genomic_set', 'genomic_set_member', 'genomic_job_run', 'genomic_gc_validation_metrics')
+GENOMIC_DB_TABLES = ('genomic_set', 'genomic_set_member', 'genomic_job_run', 'genomic_gc_validation_metrics',
+                     'genomic_file_processed')
 
 class ParticipantResourceClass(object):
     def __init__(self, args, gcp_env: GCPEnvConfigObject):
@@ -70,7 +71,8 @@ class ParticipantResourceClass(object):
                 BQPDROverallHealth,
                 BQPDREHRConsentPII,
                 BQPDRDVEHRSharing,
-                BQPDRCOPEMay
+                BQPDRCOPEMay,
+                BQPDRCOPENov,
             )
             for module in modules:
                 mod = module()

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -21,7 +21,7 @@ from rdr_service.dao.bq_genomics_dao import bq_genomic_set_update, bq_genomic_se
     bq_genomic_job_run_update, bq_genomic_gc_validation_metrics_update, bq_genomic_file_processed_update
 from rdr_service.dao.resource_dao import ResourceDataDao
 from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay
+    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov
 from rdr_service.model.participant import Participant
 from rdr_service.offline.bigquery_sync import batch_rebuild_participants_task
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
@@ -72,7 +72,7 @@ class ParticipantResourceClass(object):
                 BQPDREHRConsentPII,
                 BQPDRDVEHRSharing,
                 BQPDRCOPEMay,
-                BQPDRCOPENov,
+                BQPDRCOPENov
             )
             for module in modules:
                 mod = module()


### PR DESCRIPTION
Missed a necessary update to the model when adding new BQPDR tables/views when I reviewed DA-1790 PR #2041 

Also fixed up the resource tool to include changes to support content from DA-1790 and DA-1792 (fall COPE module)

Tested against sandbox environment:
1.  Ran migrate-bq to add genomic_file_processed,v_genomic_file_processed objects to BQ dataset
2. Ran migrate-bq to delete pdr__mod_cope_oct,v_pdr_mod_cope_oct and then add pdr_mod_cope_nov,v_pdr_mod_cope_nov to BQ
3. Ran `resource genomic --all-ids --genomic-table genomic_file_processed` (and then ran the BigQuery sync cron job) and verified new genomic data was synced to new BQ table on sandbox