### PR TITLE
[DA-1795] Update A1 Manifest site ID to UPPERCASE; add PDR generators to genomic file tool

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2271,7 +2271,7 @@ class ManifestDefinitionProvider:
                                            sqlalchemy.sql.expression.literal("no")),
                         ParticipantSummary.consentForGenomicsRORAuthored,
                         GenomicGCValidationMetrics.chipwellbarcode,
-                        GenomicSetMember.gcSiteId,
+                        sqlalchemy.func.upper(GenomicSetMember.gcSiteId),
                     ]
                 ).select_from(
                     sqlalchemy.join(

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -16,7 +16,7 @@ import pytz
 
 from rdr_service import clock, config
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_set_update, \
-    bq_genomic_job_run_update, bq_genomic_gc_validation_metrics_update
+    bq_genomic_job_run_update, bq_genomic_gc_validation_metrics_update, bq_genomic_file_processed_update
 from rdr_service.dao.genomics_dao import GenomicSetMemberDao, GenomicSetDao, GenomicJobRunDao, \
     GenomicGCValidationMetricsDao, GenomicFileProcessedDao
 from rdr_service.genomic.genomic_job_components import GenomicBiobankSamplesCoupler
@@ -27,7 +27,7 @@ from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 from rdr_service.model.genomics import GenomicSetMember, GenomicSet, GenomicGCValidationMetrics, GenomicFileProcessed
 from rdr_service.offline.genomic_pipeline import reconcile_metrics_vs_genotyping_data
 from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_set_update, \
-    genomic_job_run_update, genomic_gc_validation_metrics_update
+    genomic_job_run_update, genomic_gc_validation_metrics_update, genomic_file_processed_update
 from rdr_service.services.system_utils import setup_logging, setup_i18n
 from rdr_service.storage import GoogleCloudStorageProvider, LocalFilesystemStorageProvider
 from rdr_service.tools.tool_libs import GCPProcessContext, GCPEnvConfigObject
@@ -859,6 +859,10 @@ class FileUploadDateClass(GenomicManifestBase):
                     # Set upload_date
                     file.uploadDate = _blob.updated
                     self.dao.update(file)
+
+                    # For BQ/PDR
+                    bq_genomic_file_processed_update(file.id, project_id=self.gcp_env.project)
+                    genomic_file_processed_update(file.id)
 
                     counter += 1
 

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1789,7 +1789,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual("yes", rows[0]['consent_for_ror'])
             self.assertEqual(test_member_1.consentForGenomicsRORAuthored, parse(rows[0]['date_of_consent_for_ror']))
             self.assertEqual(test_member_1.chipwellbarcode, rows[0]['chipwellbarcode'])
-            self.assertEqual(test_member_1.gcSiteId, rows[0]['genome_center'])
+            self.assertEqual('JH', rows[0]['genome_center'])
 
         # Array
         file_record = self.file_processed_dao.get(2)  # remember, GC Metrics is #1


### PR DESCRIPTION
This PR updates the site ID column of the A1 manifest to be uppercase. An unrelated change was made to the genomic file processed back fill tool as well to add the PDR generators.