### PR TITLE
[ROC-711] Split EHR Status cron job; catching exceptions on BQ rebuild.

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -9,8 +9,13 @@ cron:
   schedule: 1 of month 00:30
   timezone: America/New_York
   target: offline
-- description: Update EHR Status from curation data
-  url: /offline/UpdateEhrStatus
+- description: Update EHR Status for Organizations from curation data
+  url: /offline/UpdateEhrStatusOrganization
+  schedule: every day 01:00
+  timezone: America/New_York
+  target: offline
+- description: Update EHR Status for Participants from curation data
+  url: /offline/UpdateEhrStatusParticipant
   schedule: every day 00:00
   timezone: America/New_York
   target: offline

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -225,8 +225,15 @@ def run_va_sync_consent_files():
 
 @app_util.auth_required_cron
 @_alert_on_exceptions
-def update_ehr_status_cron():
-    update_ehr_status.update_ehr_status()
+def update_ehr_status_organization():
+    update_ehr_status.update_ehr_status_organization()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
+def update_ehr_status_participant():
+    update_ehr_status.update_ehr_status_participant()
     return '{"success": "true"}'
 
 
@@ -527,7 +534,14 @@ def _build_pipeline_app():
     )
 
     offline_app.add_url_rule(
-        OFFLINE_PREFIX + "UpdateEhrStatus", endpoint="update_ehr_status", view_func=update_ehr_status_cron,
+        OFFLINE_PREFIX + "UpdateEhrStatusOrganization",
+        endpoint="update_ehr_status_organization", view_func=update_ehr_status_organization,
+        methods=["GET"]
+    )
+
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "UpdateEhrStatusParticipant",
+        endpoint="update_ehr_status_participant", view_func=update_ehr_status_participant,
         methods=["GET"]
     )
 

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -92,13 +92,13 @@ def update_participant_summaries_from_job(job):
                 dispatch_participant_rebuild_tasks(patch_data, batch_size=batch_size)
 
             except BadGateway as e:
-                LOG.error(f'Bad Gateway: {e}')
+                LOG.error(f'Bad Gateway: {e}', exc_info=True)
 
             except InternalServerError as e:
-                LOG.error(f'Internal Server Error: {e}')
+                LOG.error(f'Internal Server Error: {e}', exc_info=True)
 
             except HTTPException as e:
-                LOG.error(f'HTTP Exception: {e}')
+                LOG.error(f'HTTP Exception: {e}', exc_info=True)
 
 
 def make_update_organizations_job():

--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -143,7 +143,8 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
         mock_organization_job.return_value = None
 
         with FakeClock(datetime.datetime(2019, 1, 1)):
-            update_ehr_status.update_ehr_status()
+            update_ehr_status.update_ehr_status_participant()
+            update_ehr_status.update_ehr_status_organization()
 
         self.assertFalse(mock_update_summaries.called)
         self.assertFalse(mock_update_organizations.called)
@@ -155,12 +156,14 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
         mock_organization_job.return_value.__iter__.return_value = []
         gen = ParticipantSummaryGenerator()
         with FakeClock(datetime.datetime(2019, 1, 1)):
-            update_ehr_status.update_ehr_status()
+            update_ehr_status.update_ehr_status_participant()
+            update_ehr_status.update_ehr_status_organization()
 
         mock_summary_job.return_value.__iter__.return_value = [[self.EhrUpdatePidRow(11), self.EhrUpdatePidRow(12)]]
         mock_organization_job.return_value.__iter__.return_value = []
         with FakeClock(datetime.datetime(2019, 1, 2)):
-            update_ehr_status.update_ehr_status()
+            update_ehr_status.update_ehr_status_participant()
+            update_ehr_status.update_ehr_status_organization()
 
         summary = self.summary_dao.get(11)
         self.assertEqual(summary.ehrStatus, EhrStatus.PRESENT)
@@ -195,7 +198,8 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
             ]
         ]
         with FakeClock(datetime.datetime(2019, 1, 1)):
-            update_ehr_status.update_ehr_status()
+            update_ehr_status.update_ehr_status_participant()
+            update_ehr_status.update_ehr_status_organization()
 
         foo_a_receipts = self.ehr_receipt_dao.get_by_organization_id(self.org_foo_a.organizationId)
         self.assertEqual(len(foo_a_receipts), 1)
@@ -219,7 +223,8 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
             ]
         ]
         with FakeClock(datetime.datetime(2019, 1, 2)):
-            update_ehr_status.update_ehr_status()
+            update_ehr_status.update_ehr_status_participant()
+            update_ehr_status.update_ehr_status_organization()
 
         foo_a_receipts = self.ehr_receipt_dao.get_by_organization_id(self.org_foo_a.organizationId)
         self.assertEqual(len(foo_a_receipts), 2)
@@ -246,7 +251,8 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
             ]
         ]
         with FakeClock(datetime.datetime(2019, 1, 1)):
-            update_ehr_status.update_ehr_status()
+            update_ehr_status.update_ehr_status_participant()
+            update_ehr_status.update_ehr_status_organization()
 
         foo_a_receipts = self.ehr_receipt_dao.get_all()
         self.assertEqual(len(foo_a_receipts), 0)


### PR DESCRIPTION
This PR splits the UpdateEhrStatus cron job into two separate jobs:
1. UpdateEhrStatusOrganization
  - This updates the Organizations receipt time in the `ehr_receipt` table.
2. UpdateEhrStatusParticipant
  - This updates the participants' `ehr_receipt_time` in the `participant_summary` table

UpdateEhrStatusParticipant was also updated to catch exceptions during the BQ rebuild call for debugging the 502 failures we are seeing during the nightly run.