### PR TITLE
Logging HTTPExceptions in offline app

### DIFF
--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -438,6 +438,7 @@ def check_enrollment_status():
 def _build_pipeline_app():
     """Configure and return the app with non-resource pipeline-triggering endpoints."""
     offline_app = Flask(__name__)
+    offline_app.config['TRAP_HTTP_EXCEPTIONS'] = True
 
     offline_app.add_url_rule(
         OFFLINE_PREFIX + "EnrollmentStatusCheck",

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import BadRequest
 from rdr_service import app_util, config
 from rdr_service.api_util import EXPORTER
 from rdr_service.dao.metric_set_dao import AggregateMetricsDao
+from rdr_service.main import _log_request_exception
 from rdr_service.offline import biobank_samples_pipeline, genomic_pipeline, sync_consent_files, update_ehr_status, \
     antibody_study_pipeline
 from rdr_service.offline.base_pipeline import send_failure_alert
@@ -658,7 +659,7 @@ def _build_pipeline_app():
 
     offline_app.register_error_handler(DBAPIError, app_util.handle_database_disconnect)
 
-    got_request_exception.connect(flask_restful_log_exception_error, offline_app)
+    got_request_exception.connect(_log_request_exception, offline_app)
 
     return offline_app
 

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -14,13 +14,14 @@ class OfflineAppTest(BaseTestCase):
 
     def test_offline_http_exceptions_get_logged(self):
         """Make sure HTTPException are logged when thrown"""
+        expected_error_message_text = 'This exception message should appear in the logs'
 
         # Need to raise an HTTPException on a cron call, picking an arbitrary one that is easy to mock
         with mock.patch('rdr_service.offline.main.mark_ghost_participants') as mock_cron_call, \
                 mock.patch('rdr_service.app_util.check_cron', return_value=True),\
-                mock.patch('rdr_service.services.gcp_logging.logging') as mock_logging:
+                mock.patch('rdr_service.main.logging') as mock_logging:
             def throw_exception():
-                raise HTTPException('This exception message should appear in the logs')
+                raise HTTPException(expected_error_message_text)
             mock_cron_call.side_effect = throw_exception
 
             # Call to trigger the exception
@@ -35,4 +36,4 @@ class OfflineAppTest(BaseTestCase):
             self.assertIsNotNone(error_log_call, 'An error log should have been made')
 
             error_message = error_log_call.args[0]
-            self.assertIn('This exception message should appear in the logs', error_message)
+            self.assertIn(expected_error_message_text, error_message)

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -1,0 +1,38 @@
+import mock
+from werkzeug.exceptions import HTTPException
+
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class OfflineAppTest(BaseTestCase):
+    def setUp(self):
+        super(OfflineAppTest, self).setUp()
+
+        from rdr_service.offline.main import app, OFFLINE_PREFIX
+        self.offline_test_client = app.test_client()
+        self.url_prefix = OFFLINE_PREFIX
+
+    def test_offline_http_exceptions_get_logged(self):
+        """Make sure HTTPException are logged when thrown"""
+
+        # Need to raise an HTTPException on a cron call, picking an arbitrary one that is easy to mock
+        with mock.patch('rdr_service.offline.main.mark_ghost_participants') as mock_cron_call, \
+                mock.patch('rdr_service.app_util.check_cron', return_value=True),\
+                mock.patch('rdr_service.services.gcp_logging.logging') as mock_logging:
+            def throw_exception():
+                raise HTTPException('This exception message should appear in the logs')
+            mock_cron_call.side_effect = throw_exception
+
+            # Call to trigger the exception
+            self.send_get(
+                'MarkGhostParticipants',
+                test_client=self.offline_test_client,
+                prefix=self.url_prefix,
+                expected_status=None
+            )
+
+            error_log_call = mock_logging.error.call_args
+            self.assertIsNotNone(error_log_call, 'An error log should have been made')
+
+            error_message = error_log_call.args[0]
+            self.assertIn('This exception message should appear in the logs', error_message)

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -500,6 +500,8 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         expected_status=http.client.OK,
         headers=None,
         expected_response_headers=None,
+        test_client=None,
+        prefix=main.API_PREFIX
     ):
         """Makes a JSON API call against the test client and returns its response data.
 
@@ -509,15 +511,18 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
       request_data: Parsed JSON payload for the request.
       expected_status: What HTTP status to assert, if not 200 (OK).
     """
-        response = self.app.open(
-            main.API_PREFIX + local_path,
+        if test_client is None:
+            test_client = self.app
+        response = test_client.open(
+            prefix + local_path,
             method=method,
             data=json.dumps(request_data) if request_data is not None else None,
             query_string=query_string,
             content_type="application/json",
             headers=headers,
         )
-        self.assertEqual(expected_status, response.status_code, response.data)
+        if expected_status is not None:  # Allow tests the option to have an error without knowing the status code
+            self.assertEqual(expected_status, response.status_code, response.data)
         if expected_response_headers:
             self.assertTrue(
                 set(expected_response_headers.items()).issubset(set(response.headers.items())),


### PR DESCRIPTION
It looks like Flask was sending out HTTPException responses before we had a chance to log them. I'll describe the Flask code below, but (kind of counter-intuitively) we need to set `TRAP_HTTP_EXCEPTIONS` to True in the offline app to be able to have the errors printed out in the logs. I think the default app doesn't have this issue because it's wrapped in flask_restful.

A drawback to this is that any cron job failures because of HTTPExceptions (BadRequest, BadGateway, Forbidden, ...) will all receive the response of 500. But I think that's ok since the only client will be GAE calling cron jobs. And we'll get to see what the status code was (and more importantly the stack trace and error message) in the logs.

In Flask's app.py file, line 1938 defines `full_dispatch_request` which handles requests (https://github.com/pallets/flask/blob/93dd1709d05a1cf0e886df6223377bdab3b077fb/src/flask/app.py#L1938). Requests are handled in a `try` block and line 1952 calls `handle_user_exception` if something happens. That method is defined up on line 1781 (https://github.com/pallets/flask/blob/93dd1709d05a1cf0e886df6223377bdab3b077fb/src/flask/app.py#L1781). At line 1815 it will check to see if it's a type of HTTPException and if it should not trap it. When it doesn't trap it, then it returns from 1816 and sends the response (without giving us a chance to log it).

But if set the config up so that it will trap it, then this continues on to 1821 (as long as it hasn't found an error handler for it). This then re-raises the exception which throws the exception up to where `full_dispatch` is called on line 2447 (https://github.com/pallets/flask/blob/93dd1709d05a1cf0e886df6223377bdab3b077fb/src/flask/app.py#L2447). The exception is caught again there and line 2450 calls `handle_exception`. That method is defined on 1824 (https://github.com/pallets/flask/blob/93dd1709d05a1cf0e886df6223377bdab3b077fb/src/flask/app.py#L1824) and on line 1859 the signal that an exception occurred is sent out. Coincidentally it also logs the exception itself on line 1871.