### PR TITLE
[DA-1788] Update AW0 Cohort 3 Manifest Job

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -77,7 +77,7 @@ cron:
 - description: Genomic Pipeline AW0 (Cohort 3) Workflow
   url: /offline/GenomicC3AW0Workflow
   timezone: America/New_York
-  schedule: every monday 06:30
+  schedule: every day 06:30
   target: offline
 - description: Genomic AW1 Workflow
   url: /offline/GenomicGCManifestWorkflow


### PR DESCRIPTION
This PR makes a tweak to the C3 sample logic and changes the schedule to daily. The sample logic prioritizes 1ED04 samples over 1SAL2. A filter was also added to ensure we are not resending C3 participants unless they are set to IGNORE in the `genomic_set_member` table.