### PR TITLE
Only logging if msg exists in BQ Questionnaires

### DIFF
--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -78,8 +78,9 @@ class _BQModuleSchema(BQSchema):
                 # Verify field name meets BigQuery requirements.
                 name = row['value']
                 is_valid, msg = self.field_name_is_valid(name)
-                if not is_valid and msg:
-                    logging.warning(msg)
+                if not is_valid:
+                    if msg:
+                        logging.warning(msg)
                     continue
 
                 if name in self._excluded_fields:
@@ -129,7 +130,8 @@ class _BQModuleSchema(BQSchema):
                 # Verify field name meets BigQuery requirements.
                 is_valid, msg = self.field_name_is_valid(name)
                 if not is_valid:
-                    logging.warning(msg)
+                    if msg:
+                        logging.warning(msg)
                     continue
 
                 # flag duplicate fields.

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -26,8 +26,7 @@ from rdr_service.offline.public_metrics_export import LIVE_METRIC_SET_ID, Public
 from rdr_service.offline.sa_key_remove import delete_service_account_keys
 from rdr_service.offline.table_exporter import TableExporter
 from rdr_service.services.flask import OFFLINE_PREFIX, flask_start, flask_stop
-from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging, \
-    flask_restful_log_exception_error
+from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging
 
 
 def _alert_on_exceptions(func):


### PR DESCRIPTION
There are some warning logs that are showing up empty. I think they could be resulting from logging None in BQ Questionnaires.

This also adds a change I had missed in an earlier PR to fix a lint error with offline/main.