### PR TITLE
Removing warnings about unanswered questions

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -172,8 +172,6 @@ class QuestionnaireResponseDao(BaseDao):
                     #  the list doesn't include valid link_ids that don't have answers
                     if "answer" in section:
                         logging.error(f'Questionnaire response contains invalid link ID "{link_id}"')
-                    else:
-                        logging.warning(f'Questionnaire response has not answered link ID "{link_id}"')
 
     @staticmethod
     def _imply_street_address_2_from_street_address_1(code_ids):

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -25,7 +25,7 @@ from rdr_service.participant_enums import QuestionnaireDefinitionStatus, Questio
     ParticipantCohort, ParticipantCohortPilotFlag
 
 from tests.test_data import data_path
-from tests.helpers.unittest_base import BaseTestCase, QUESTIONNAIRE_NONE_ANSWER
+from tests.helpers.unittest_base import BaseTestCase
 from rdr_service.concepts import Concept
 
 TIME_1 = datetime.datetime(2016, 1, 1)
@@ -1175,15 +1175,13 @@ class QuestionnaireResponseApiTest(BaseTestCase):
             participant_id,
             questionnaire.questionnaireId,
             string_answers=[
-                ('invalid_link', 'This is an answer to a question that is not in the questionnaire'),
-                ('not_answered', QUESTIONNAIRE_NONE_ANSWER)
+                ('invalid_link', 'This is an answer to a question that is not in the questionnaire')
             ]
         )
         self.send_post(f'Participant/{participant_id}/QuestionnaireResponse', questionnaire_response_json)
 
         # Make sure logs have been called for each issue
         mock_logging.error.assert_any_call('Questionnaire response contains invalid link ID "invalid_link"')
-        mock_logging.warning.assert_any_call('Questionnaire response has not answered link ID "not_answered"')
 
 def _add_code_answer(code_answers, link_id, code):
     if code:


### PR DESCRIPTION
Since there is the possibility of branching logic in a questionnaire we don't have a way of knowing which questions should have been answered. So this PR removes the warning given when the code finds that a question wasn't answered.