### PR TITLE
[PDR-158] Fix module submittal status values in generators

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -110,11 +110,17 @@ HEALTHCARE_ACCESS_MODULE = "HealthcareAccess"
 # A new survey was developed for November 2020
 COPE_MODULE = 'COPE'
 COPE_NOV_MODULE = 'cope_nov'
+GENETIC_ANCESTRY_MODULE = 'GeneticAncestry'
 
 # DVEHR ANSWERS
 DVEHRSHARING_CONSENT_CODE_YES = "DVEHRSharing_Yes"
 DVEHRSHARING_CONSENT_CODE_NO = "DVEHRSharing_No"
 DVEHRSHARING_CONSENT_CODE_NOT_SURE = "DVEHRSharing_NotSure"
+
+# Genetic Ancestry Consent Answers
+GENETIC_ANCESTRY_CONSENT_CODE_YES = "ConsentAncestryTraits_Yes"
+GENETIC_ANCESTRY_CONSENT_CODE_NO = "ConsentAncestryTraits_No"
+GENETIC_ANCESTRY_CONSENT_CODE_NOT_SURE = "ConsentAncestryTraits_NotSure"
 
 
 BIOBANK_TESTS = [

--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -105,6 +105,11 @@ PERSONAL_MEDICAL_HISTORY_MODULE = "PersonalMedicalHistory"
 MEDICATIONS_MODULE = "MedicationsPPI"
 # TODO: UPDATE THIS TO REAL CODEBOOK VALUES WHEN PRESENT
 HEALTHCARE_ACCESS_MODULE = "HealthcareAccess"
+# COVID Experience surveys:
+# The COPE module covers the May/June/July (2020) COPE Survey questionnaires
+# A new survey was developed for November 2020
+COPE_MODULE = 'COPE'
+COPE_NOV_MODULE = 'cope_nov'
 
 # DVEHR ANSWERS
 DVEHRSHARING_CONSENT_CODE_YES = "DVEHRSharing_Yes"

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -50,7 +50,9 @@ _consent_module_question_map = {
     'GROR': 'ResultsConsent_CheckDNA',
     'PrimaryConsentUpdate': 'Reconsent_ReviewConsentAgree',
     'ProgramUpdate': None,
-    'COPE': 'section_participation'
+    'COPE': 'section_participation',
+    'cope_nov': 'section_participation',
+    'GeneticAncestry': 'GeneticAncestry_ConsentAncestryTraits'
 }
 
 # _consent_expired_question_map must contain every module ID from _consent_module_question_map.
@@ -61,7 +63,9 @@ _consent_expired_question_map = {
     'GROR': None,
     'PrimaryConsentUpdate': None,
     'ProgramUpdate': None,
-    'COPE': None
+    'COPE': None,
+    'cope_nov': None,
+    'GeneticAncestry': None
 }
 
 # Possible answer codes for the consent module questions and what submittal status the answers correspond to
@@ -81,7 +85,10 @@ _consent_answer_status_map = {
     # COPE_A_13
     CONSENT_COPE_NO_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     # COPE_A_231
-    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE
+    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    'ConsentAncestryTraits_Yes': BQModuleStatusEnum.SUBMITTED,
+    'ConsentAncestryTraits_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE
 }
 
 class BQParticipantSummaryGenerator(BigQueryGenerator):
@@ -358,7 +365,6 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
 
                 # check if this is a module with consents.
                 if module_name in _consent_module_question_map:
-
                     # Calculate Consent Cohort from ConsentPII authored
                     if consent_dt is None and module_name == 'ConsentPII' and row.authored:
                         consent_dt = row.authored
@@ -403,6 +409,9 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                                 logging.warning(
                                    f'Defaulting {module_name} answer {consent_value} to status SUBMITTED (pid: {p_id}) '
                                 )
+                                # TODO: SUBMITTED is what all module statuses used to default to, so will use the same
+                                # default in cases where there was no known value in the map for the answer code.
+                                # May want to reconsider if this should be something else (UNSET?)
                                 module_status = BQModuleStatusEnum.SUBMITTED
 
                         consents.append(consent)

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -10,9 +10,19 @@ from sqlalchemy import func, desc, exc
 from werkzeug.exceptions import NotFound
 
 from rdr_service import config
-from rdr_service.code_constants import CONSENT_GROR_YES_CODE, CONSENT_PERMISSION_YES_CODE, CONSENT_PERMISSION_NO_CODE, \
-    DVEHR_SHARING_QUESTION_CODE, EHR_CONSENT_QUESTION_CODE, DVEHRSHARING_CONSENT_CODE_YES, GROR_CONSENT_QUESTION_CODE, \
-    EHR_CONSENT_EXPIRED_YES
+from rdr_service.code_constants import (
+    CONSENT_GROR_YES_CODE,
+    CONSENT_PERMISSION_YES_CODE,
+    CONSENT_PERMISSION_NO_CODE,
+    DVEHR_SHARING_QUESTION_CODE,
+    EHR_CONSENT_QUESTION_CODE,
+    DVEHRSHARING_CONSENT_CODE_YES,
+    GROR_CONSENT_QUESTION_CODE,
+    EHR_CONSENT_EXPIRED_YES,
+    CONSENT_COPE_YES_CODE,
+    CONSENT_COPE_NO_CODE,
+    CONSENT_COPE_DEFERRED_CODE
+)
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_pdr_participant_summary import BQPDRParticipantSummary
@@ -39,7 +49,8 @@ _consent_module_question_map = {
     'EHRConsentPII': 'EHRConsentPII_ConsentPermission',
     'GROR': 'ResultsConsent_CheckDNA',
     'PrimaryConsentUpdate': 'Reconsent_ReviewConsentAgree',
-    'ProgramUpdate': None
+    'ProgramUpdate': None,
+    'COPE': 'section_participation'
 }
 
 # _consent_expired_question_map must contain every module ID from _consent_module_question_map.
@@ -49,9 +60,29 @@ _consent_expired_question_map = {
     'EHRConsentPII': 'EHRConsentPII_ConsentExpired',
     'GROR': None,
     'PrimaryConsentUpdate': None,
-    'ProgramUpdate': None
+    'ProgramUpdate': None,
+    'COPE': None
 }
 
+# Possible answer codes for the consent module questions and what submittal status the answers correspond to
+_consent_answer_status_map = {
+    'ConsentPermission_Yes': BQModuleStatusEnum.SUBMITTED,
+    'ConsentPermission_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'DVEHRSharing_Yes': BQModuleStatusEnum.SUBMITTED,
+    'DVEHRSharing_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'DVEHRSharing_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    'CheckDNA_Yes': BQModuleStatusEnum.SUBMITTED,
+    'CheckDNA_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'CheckDNA_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    'ReviewConsentAgree_Yes': BQModuleStatusEnum.SUBMITTED,
+    'ReviewConsentAgree_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    # COPE_A_44
+    CONSENT_COPE_YES_CODE: BQModuleStatusEnum.SUBMITTED,
+    # COPE_A_13
+    CONSENT_COPE_NO_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    # COPE_A_231
+    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE
+}
 
 class BQParticipantSummaryGenerator(BigQueryGenerator):
     """
@@ -315,60 +346,66 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         if results:
             for row in results:
                 module_name = self._lookup_code_value(row.codeId, ro_session)
-                modules.append({
+                module_data = {
                     'mod_module': module_name,
                     'mod_baseline_module': 1 if module_name in self._baseline_modules else 0,  # Boolean field
                     'mod_authored': row.authored,
                     'mod_created': row.created,
                     'mod_language': row.language,
-                    'mod_status': BQModuleStatusEnum.SUBMITTED.name,
-                    'mod_status_id': BQModuleStatusEnum.SUBMITTED.value,
-                })
+                }
+                # Default status, may be updated based on consent answer
+                module_status = BQModuleStatusEnum.SUBMITTED
 
                 # check if this is a module with consents.
-                if module_name not in _consent_module_question_map:
-                    continue
+                if module_name in _consent_module_question_map:
 
-                # Calculate Consent Cohort from ConsentPII authored
-                if consent_dt is None and module_name == 'ConsentPII' and row.authored:
-                    consent_dt = row.authored
-                    if consent_dt < COHORT_1_CUTOFF:
-                        cohort = BQConsentCohort.COHORT_1
-                    elif COHORT_1_CUTOFF <= consent_dt <= COHORT_2_CUTOFF:
-                        cohort = BQConsentCohort.COHORT_2
-                    else:
-                        cohort = BQConsentCohort.COHORT_3
-                    data['consent_cohort'] = cohort.name
-                    data['consent_cohort_id'] = cohort.value
+                    # Calculate Consent Cohort from ConsentPII authored
+                    if consent_dt is None and module_name == 'ConsentPII' and row.authored:
+                        consent_dt = row.authored
+                        if consent_dt < COHORT_1_CUTOFF:
+                            cohort = BQConsentCohort.COHORT_1
+                        elif COHORT_1_CUTOFF <= consent_dt <= COHORT_2_CUTOFF:
+                            cohort = BQConsentCohort.COHORT_2
+                        else:
+                            cohort = BQConsentCohort.COHORT_3
+                        data['consent_cohort'] = cohort.name
+                        data['consent_cohort_id'] = cohort.value
 
-                qnans = self.get_module_answers(self.ro_dao, module_name, p_id, row.questionnaireResponseId)
-                if qnans:
-                    qnan = BQRecord(schema=None, data=qnans)
-                    consent = {
-                        'consent': _consent_module_question_map[module_name],
-                        'consent_id': self._lookup_code_id(_consent_module_question_map[module_name], ro_session),
-                        'consent_date': parser.parse(qnan['authored']).date() if qnan['authored'] else None,
-                        'consent_module': module_name,
-                        'consent_module_authored': row.authored,
-                        'consent_module_created': row.created,
-                    }
-                    # Note:  Based on currently available modules when a module has no
-                    # associated answer options (like ConsentPII or ProgramUpdate), any submitted response is given an
-                    # implicit ConsentPermission_Yes value.   May need adjusting if there are ever modules where that
-                    # may no longer be true
-                    if _consent_module_question_map[module_name] is None:
-                        consent['consent'] = module_name
-                        consent['consent_id'] = self._lookup_code_id(module_name, ro_session)
-                        consent['consent_value'] = 'ConsentPermission_Yes'
-                        consent['consent_value_id'] = self._lookup_code_id('ConsentPermission_Yes', ro_session)
-                    else:
-                        consent['consent_value'] = qnan.get(_consent_module_question_map[module_name], None)
-                        consent['consent_value_id'] = self._lookup_code_id(
-                            qnan.get(_consent_module_question_map[module_name], None), ro_session)
-                        consent['consent_expired'] = \
-                            qnan.get(_consent_expired_question_map[module_name] or 'None', None)
+                    qnans = self.get_module_answers(self.ro_dao, module_name, p_id, row.questionnaireResponseId)
+                    if qnans:
+                        qnan = BQRecord(schema=None, data=qnans)
+                        consent = {
+                            'consent': _consent_module_question_map[module_name],
+                            'consent_id': self._lookup_code_id(_consent_module_question_map[module_name], ro_session),
+                            'consent_date': parser.parse(qnan['authored']).date() if qnan['authored'] else None,
+                            'consent_module': module_name,
+                            'consent_module_authored': row.authored,
+                            'consent_module_created': row.created,
+                        }
+                        # Note:  Based on currently available modules when a module has no
+                        # associated answer options (like ConsentPII or ProgramUpdate), any submitted response is given
+                        # animplicit ConsentPermission_Yes value.   May need adjusting if there are ever modules where
+                        # that may no longer be true
+                        if _consent_module_question_map[module_name] is None:
+                            consent['consent'] = module_name
+                            consent['consent_id'] = self._lookup_code_id(module_name, ro_session)
+                            consent['consent_value'] = 'ConsentPermission_Yes'
+                            consent['consent_value_id'] = self._lookup_code_id('ConsentPermission_Yes', ro_session)
+                        else:
+                            consent_value = qnan.get(_consent_module_question_map[module_name], None)
+                            consent['consent_value'] = consent_value
+                            consent['consent_value_id'] = self._lookup_code_id(consent_value, ro_session)
+                            consent['consent_expired'] = \
+                                qnan.get(_consent_expired_question_map[module_name] or 'None', None)
+                            # Check for a specific submittal status based on the answer value (default to SUBMITTED)
+                            module_status = _consent_answer_status_map.get(consent_value, BQModuleStatusEnum.SUBMITTED)
 
-                    consents.append(consent)
+                        consents.append(consent)
+
+                module_data['mod_status'] = module_status.name
+                module_data['mod_status_id'] = module_status.value
+                modules.append(module_data)
+
 
         if len(modules) > 0:
             # remove any duplicate modules and consents because of replayed responses.

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -398,7 +398,12 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                             consent['consent_expired'] = \
                                 qnan.get(_consent_expired_question_map[module_name] or 'None', None)
                             # Check for a specific submittal status based on the answer value (default to SUBMITTED)
-                            module_status = _consent_answer_status_map.get(consent_value, BQModuleStatusEnum.SUBMITTED)
+                            module_status = _consent_answer_status_map.get(consent_value, None)
+                            if not module_status:
+                                logging.warning(
+                                   f'Defaulting {module_name} answer {consent_value} to status SUBMITTED (pid: {p_id}) '
+                                )
+                                module_status = BQModuleStatusEnum.SUBMITTED
 
                         consents.append(consent)
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -11,9 +11,19 @@ from werkzeug.exceptions import NotFound
 
 from rdr_service import config
 from rdr_service.resource.helpers import DateCollection
-from rdr_service.code_constants import CONSENT_GROR_YES_CODE, CONSENT_PERMISSION_YES_CODE, CONSENT_PERMISSION_NO_CODE,\
-    DVEHR_SHARING_QUESTION_CODE, EHR_CONSENT_QUESTION_CODE, DVEHRSHARING_CONSENT_CODE_YES, GROR_CONSENT_QUESTION_CODE,\
-    EHR_CONSENT_EXPIRED_YES
+from rdr_service.code_constants import (
+    CONSENT_GROR_YES_CODE,
+    CONSENT_PERMISSION_YES_CODE,
+    CONSENT_PERMISSION_NO_CODE,
+    DVEHR_SHARING_QUESTION_CODE,
+    EHR_CONSENT_QUESTION_CODE,
+    DVEHRSHARING_CONSENT_CODE_YES,
+    GROR_CONSENT_QUESTION_CODE,
+    EHR_CONSENT_EXPIRED_YES,
+    CONSENT_COPE_YES_CODE,
+    CONSENT_COPE_NO_CODE,
+    CONSENT_COPE_DEFERRED_CODE
+)
 from rdr_service.dao.resource_dao import ResourceDataDao
 # TODO: Replace BQRecord here with a Resource alternative.
 from rdr_service.model.bq_base import BQRecord
@@ -40,7 +50,8 @@ _consent_module_question_map = {
     'EHRConsentPII': 'EHRConsentPII_ConsentPermission',
     'GROR': 'ResultsConsent_CheckDNA',
     'PrimaryConsentUpdate': 'Reconsent_ReviewConsentAgree',
-    'ProgramUpdate': None
+    'ProgramUpdate': None,
+    'COPE': 'section_participation'
 }
 
 # _consent_expired_question_map must contain every module ID from _consent_module_question_map.
@@ -50,7 +61,28 @@ _consent_expired_question_map = {
     'EHRConsentPII': 'EHRConsentPII_ConsentExpired',
     'GROR': None,
     'PrimaryConsentUpdate': None,
-    'ProgramUpdate': None
+    'ProgramUpdate': None,
+    'COPE': None
+}
+
+# Possible answer codes for the consent module questions and what submittal status the answers correspond to
+_consent_answer_status_map = {
+    'ConsentPermission_Yes': BQModuleStatusEnum.SUBMITTED,
+    'ConsentPermission_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'DVEHRSharing_Yes': BQModuleStatusEnum.SUBMITTED,
+    'DVEHRSharing_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'DVEHRSharing_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    'CheckDNA_Yes': BQModuleStatusEnum.SUBMITTED,
+    'CheckDNA_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'CheckDNA_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    'ReviewConsentAgree_Yes': BQModuleStatusEnum.SUBMITTED,
+    'ReviewConsentAgree_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    # COPE_A_44
+    CONSENT_COPE_YES_CODE: BQModuleStatusEnum.SUBMITTED,
+    # COPE_A_13
+    CONSENT_COPE_NO_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    # COPE_A_231
+    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE
 }
 
 
@@ -319,60 +351,65 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         if results:
             for row in results:
                 module_name = self._lookup_code_value(row.codeId, ro_session)
-                modules.append({
+                module_data = {
                     'module': module_name,
                     'baseline_module': 1 if module_name in self._baseline_modules else 0,  # Boolean field
                     'module_authored': row.authored,
                     'module_created': row.created,
                     'language': row.language,
-                    'status': BQModuleStatusEnum.SUBMITTED.name,
-                    'status_id': BQModuleStatusEnum.SUBMITTED.value,
-                })
+                }
+                # Default status, may be updated based on consent answer
+                module_status = BQModuleStatusEnum.SUBMITTED
 
                 # check if this is a module with consents.
-                if module_name not in _consent_module_question_map:
-                    continue
+                if module_name in _consent_module_question_map:
 
-                # Calculate Consent Cohort from ConsentPII authored
-                if consent_dt is None and module_name == 'ConsentPII' and row.authored:
-                    consent_dt = row.authored
-                    if consent_dt < COHORT_1_CUTOFF:
-                        cohort = BQConsentCohort.COHORT_1
-                    elif COHORT_1_CUTOFF <= consent_dt <= COHORT_2_CUTOFF:
-                        cohort = BQConsentCohort.COHORT_2
-                    else:
-                        cohort = BQConsentCohort.COHORT_3
-                    data['consent_cohort'] = cohort.name
-                    data['consent_cohort_id'] = cohort.value
+                    # Calculate Consent Cohort from ConsentPII authored
+                    if consent_dt is None and module_name == 'ConsentPII' and row.authored:
+                        consent_dt = row.authored
+                        if consent_dt < COHORT_1_CUTOFF:
+                            cohort = BQConsentCohort.COHORT_1
+                        elif COHORT_1_CUTOFF <= consent_dt <= COHORT_2_CUTOFF:
+                            cohort = BQConsentCohort.COHORT_2
+                        else:
+                            cohort = BQConsentCohort.COHORT_3
+                        data['consent_cohort'] = cohort.name
+                        data['consent_cohort_id'] = cohort.value
 
-                qnans = self.get_module_answers(self.ro_dao, module_name, p_id, row.questionnaireResponseId)
-                if qnans:
-                    qnan = BQRecord(schema=None, data=qnans)  # use only most recent questionnaire.
-                    consent = {
-                        'consent': _consent_module_question_map[module_name],
-                        'consent_id': self._lookup_code_id(_consent_module_question_map[module_name], ro_session),
-                        'consent_date': parser.parse(qnan['authored']).date() if qnan['authored'] else None,
-                        'consent_module': module_name,
-                        'consent_module_authored': row.authored,
-                        'consent_module_created': row.created,
-                    }
-                    # Note:  Based on currently available modules when a module has no
-                    # associated answer options (like ConsentPII or ProgramUpdate), any submitted response is given an
-                    # implicit ConsentPermission_Yes value.   May need adjusting if there are ever modules where that
-                    # may no longer be true
-                    if _consent_module_question_map[module_name] is None:
-                        consent['consent'] = module_name
-                        consent['consent_id'] = self._lookup_code_id(module_name, ro_session)
-                        consent['consent_value'] = 'ConsentPermission_Yes'
-                        consent['consent_value_id'] = self._lookup_code_id('ConsentPermission_Yes', ro_session)
-                    else:
-                        consent['consent_value'] = qnan.get(_consent_module_question_map[module_name], None)
-                        consent['consent_value_id'] = self._lookup_code_id(
-                            qnan.get(_consent_module_question_map[module_name], None), ro_session)
-                        consent['consent_expired'] = \
-                            qnan.get(_consent_expired_question_map[module_name] or 'None', None)
+                    qnans = self.get_module_answers(self.ro_dao, module_name, p_id, row.questionnaireResponseId)
+                    if qnans:
+                        qnan = BQRecord(schema=None, data=qnans)  # use only most recent questionnaire.
+                        consent = {
+                            'consent': _consent_module_question_map[module_name],
+                            'consent_id': self._lookup_code_id(_consent_module_question_map[module_name], ro_session),
+                            'consent_date': parser.parse(qnan['authored']).date() if qnan['authored'] else None,
+                            'consent_module': module_name,
+                            'consent_module_authored': row.authored,
+                            'consent_module_created': row.created,
+                        }
+                        # Note:  Based on currently available modules when a module has no
+                        # associated answer options (like ConsentPII or ProgramUpdate), any submitted response is given
+                        # an implicit ConsentPermission_Yes value.   May need adjusting if there are ever modules where
+                        # that may no longer be true
+                        if _consent_module_question_map[module_name] is None:
+                            consent['consent'] = module_name
+                            consent['consent_id'] = self._lookup_code_id(module_name, ro_session)
+                            consent['consent_value'] = 'ConsentPermission_Yes'
+                            consent['consent_value_id'] = self._lookup_code_id('ConsentPermission_Yes', ro_session)
+                        else:
+                            consent_value = qnan.get(_consent_module_question_map[module_name], None)
+                            consent['consent_value'] = consent_value
+                            consent['consent_value_id'] = self._lookup_code_id(consent_value, ro_session)
+                            consent['consent_expired'] = \
+                                qnan.get(_consent_expired_question_map[module_name] or 'None', None)
+                            # Check for a specific submittal status based on the answer value (default to SUBMITTED)
+                            module_status = _consent_answer_status_map.get(consent_value, BQModuleStatusEnum.SUBMITTED)
 
-                    consents.append(consent)
+                        consents.append(consent)
+
+                module_data['status'] = module_status.name
+                module_data['status_id'] = module_status.value
+                modules.append(module_data)
 
         if len(modules) > 0:
             # remove any duplicate modules and consents because of replayed responses.

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -403,7 +403,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                             consent['consent_expired'] = \
                                 qnan.get(_consent_expired_question_map[module_name] or 'None', None)
                             # Check for a specific submittal status based on the answer value (default to SUBMITTED)
-                            module_status = _consent_answer_status_map.get(consent_value, BQModuleStatusEnum.SUBMITTED)
+                            module_status = _consent_answer_status_map.get(consent_value, None)
+                            if not module_status:
+                                logging.warning(
+                                    f'Defaulting {module_name} answer {consent_value} to status SUBMITTED (pid: {p_id})'
+                                )
+                                module_status = BQModuleStatusEnum.SUBMITTED
 
                         consents.append(consent)
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -51,7 +51,9 @@ _consent_module_question_map = {
     'GROR': 'ResultsConsent_CheckDNA',
     'PrimaryConsentUpdate': 'Reconsent_ReviewConsentAgree',
     'ProgramUpdate': None,
-    'COPE': 'section_participation'
+    'COPE': 'section_participation',
+    'cope_nov': 'section_participation',
+    'GeneticAncestry': 'GeneticAncestry_ConsentAncestryTraits'
 }
 
 # _consent_expired_question_map must contain every module ID from _consent_module_question_map.
@@ -62,7 +64,9 @@ _consent_expired_question_map = {
     'GROR': None,
     'PrimaryConsentUpdate': None,
     'ProgramUpdate': None,
-    'COPE': None
+    'COPE': None,
+    'cope_nov': None,
+    'GeneticAncestry': None
 }
 
 # Possible answer codes for the consent module questions and what submittal status the answers correspond to
@@ -82,7 +86,10 @@ _consent_answer_status_map = {
     # COPE_A_13
     CONSENT_COPE_NO_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     # COPE_A_231
-    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE
+    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    'ConsentAncestryTraits_Yes': BQModuleStatusEnum.SUBMITTED,
+    'ConsentAncestryTraits_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE
 }
 
 
@@ -408,6 +415,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                                 logging.warning(
                                     f'Defaulting {module_name} answer {consent_value} to status SUBMITTED (pid: {p_id})'
                                 )
+                                # TODO: SUBMITTED is what all module statuses used to default to, so will use the same
+                                # default in cases where there was no known value in the map for the answer code.
+                                # May want to reconsider if this should be something else (UNSET?)
                                 module_status = BQModuleStatusEnum.SUBMITTED
 
                         consents.append(consent)

--- a/tests/dao_tests/test_bigquery_sync_dao.py
+++ b/tests/dao_tests/test_bigquery_sync_dao.py
@@ -227,7 +227,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
             return module_list
 
         modules = list(filter(lambda x: x['mod_module'] == module_name, module_list))
-        return sorted(modules, key=(lambda d: d['mod_module_authored']))
+        return sorted(modules, key=(lambda d: d['mod_authored']))
 
     def test_registered_participant_gen(self):
         """ Test a BigQuery after initial participant creation """
@@ -370,6 +370,12 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         ps_json = gen.make_bqrecord(self.participant_id)
         self.assertEqual('CORE_PARTICIPANT', ps_json['enrollment_status'])
 
+        # This verifies the module submitted status from the participant generator data for each of the GROR modules
+        gror_modules = self.get_modules_by_name('GROR', ps_json['modules'])
+        self.assertEqual('SUBMITTED', gror_modules[0]['mod_status'])
+        self.assertEqual('SUBMITTED_NO_CONSENT', gror_modules[1]['mod_status'])
+
+
     def test_previous_ehr_and_dv_ehr_reverted(self):
         # Scenario: a participant previously reached core participant status with EHR and DV EHR consent both YES
         # If EHR consent is changed to No, they should remain Core
@@ -397,6 +403,11 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
                                 response_time=datetime(2019, 7, 1))
         ps_json = gen.make_bqrecord(self.participant_id)
         self.assertEqual('CORE_PARTICIPANT', ps_json['enrollment_status'])
+
+        # This verifies the module submitted status from the participant generator data for each of the zrjt modules
+        gror_modules = self.get_modules_by_name('EHRConsentPII', ps_json['modules'])
+        self.assertEqual('SUBMITTED', gror_modules[0]['mod_status'])
+        self.assertEqual('SUBMITTED_NO_CONSENT', gror_modules[1]['mod_status'])
 
     def test_no_on_ehr_overrides_yes_on_dv(self):
         # Scenario: a participant has had DV_EHR yes, but previously had a no on EHR.

--- a/tests/resource_tests/generator_tests/test_participant_enrollment.py
+++ b/tests/resource_tests/generator_tests/test_participant_enrollment.py
@@ -169,6 +169,19 @@ class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin):
 
             self._make_default_biobank_order(self.participant_id)
 
+    @staticmethod
+    def get_modules_by_name(module_name=None, module_list=None):
+        """
+            Extracts module entries from the participant resource generator data modules list
+            Returns a filtered list of entries that match the module name, sorted by authored date
+        """
+        if not (module_name and isinstance(module_list, list)):
+            return module_list
+
+        modules = list(filter(lambda x: x['module'] == module_name, module_list))
+        return sorted(modules, key=(lambda d: d['module_authored']))
+
+
     def test_full_participant_status(self):
         """ Full Participant Test"""
         self._set_up_participant_data()
@@ -223,9 +236,15 @@ class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin):
         ps_data = gen.make_resource(self.participant_id).get_data()
         self.assertEqual('CORE_PARTICIPANT', ps_data['enrollment_status'])
 
-    def test_previous_ehr_unsure_with_dv_yes(self):
-        # Scenario: a participant previously had their EHR consent as UNSURE, but their DV_EHR as YES.
-        # As long as everything else at the same time was right for them to be Core, they should remain Core
+        # This verifies the module submitted status from the participant generator data for each of the GROR modules
+        gror_modules = self.get_modules_by_name('GROR', ps_data['modules'])
+        self.assertEqual('SUBMITTED', gror_modules[0]['status'])
+        self.assertEqual('SUBMITTED_NO_CONSENT', gror_modules[1]['status'])
+
+
+    def test_previous_ehr_and_dv_ehr_reverted(self):
+        # Scenario: a participant previously had their EHR consent YES, and their DV_EHR as YES.
+        # If EHR consent is changed to No, they should remain Core
         self._set_up_participant_data(skip_ehr=True)
 
         gen = ParticipantSummaryGenerator()
@@ -237,7 +256,7 @@ class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin):
 
         # Get Core status through EHR consents
         self._submit_ehrconsent(self.participant_id,
-                                response_code=CONSENT_PERMISSION_NOT_SURE,
+                                response_code=CONSENT_PERMISSION_YES_CODE,
                                 response_time=datetime(2019, 2, 14))
         self._submit_dvehrconsent(self.participant_id, response_time=datetime(2019, 4, 1))
         ps_data = gen.make_resource(self.participant_id).get_data()
@@ -250,6 +269,11 @@ class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin):
                                 response_time=datetime(2019, 7, 1))
         ps_data = gen.make_resource(self.participant_id).get_data()
         self.assertEqual('CORE_PARTICIPANT', ps_data['enrollment_status'])
+
+        # This checks the module submitted status for each of the EHR consent module responses
+        ehr_modules = self.get_modules_by_name('EHRConsentPII', ps_data['modules'])
+        self.assertEqual('SUBMITTED', ehr_modules[0]['status'])
+        self.assertEqual('SUBMITTED_NO_CONSENT', ehr_modules[1]['status'])
 
     def test_no_on_ehr_overrides_yes_on_dv(self):
         # Scenario: a participant has had DV_EHR yes, but previously had a no on EHR.


### PR DESCRIPTION
The main change is to add logic to  `_prep_modules()  `that will look for answers to consent questions in order to determine the appropriate module submittal status.    It used to hardcode any module response that was detected to SUBMITTED.

Some of the tests were updated to check the appropriate submittal statuses were assigned based on the test's consent data setup.

Note that this fix changes the outcome of the generators' enrollment status calculation in cases where we now detect that (for example) an EHR consent 'yes' was not provided.  That may mean fewer scenarios where the generator determines enrollment_status of CORE_PARTICIPANT or FULLY_CONSENTED.  

 I went through the logic for the `test_previous_ehr_unsure_with_dv_yes` test case and determined that:
1. There is no answer code in the code table for ConsentPermission_NotSure (and no current cases where a participant's `consent_for_study_enrollment ` status is SUBMITTED_NOT_SURE).
2.  Given the fix to the _prep_modules() logic, the participant would not reach CORE_PARTICIPANT status based on the existing test setup and trying to use a "not sure" response.

I modified the test (and the test name) to reflect that.  Instead it will use an initial EHR 'yes' consent that is later reverted.