### PR TITLE
[DA-1783] Renaming dv_order DAO and API classes

### DIFF
--- a/rdr_service/api/mail_kit_order_api.py
+++ b/rdr_service/api/mail_kit_order_api.py
@@ -7,15 +7,15 @@ from werkzeug.exceptions import BadRequest, Conflict, MethodNotAllowed
 from rdr_service.api.base_api import UpdatableApi
 from rdr_service.api_util import PTC, PTC_AND_HEALTHPRO, DV_FHIR_URL
 from rdr_service.app_util import ObjDict, auth_required, get_oauth_id, get_account_origin_id
-from rdr_service.dao.dv_order_dao import DvOrderDao
+from rdr_service.dao.mail_kit_order_dao import MailKitOrderDao
 from rdr_service.fhir_utils import SimpleFhirR4Reader
 from rdr_service.model.utils import from_client_participant_id
 from rdr_service.participant_enums import OrderShipmentTrackingStatus
 
 
-class DvOrderApi(UpdatableApi):
+class MailKitOrderApi(UpdatableApi):
     def __init__(self):
-        super(DvOrderApi, self).__init__(DvOrderDao())
+        super(MailKitOrderApi, self).__init__(MailKitOrderDao())
 
     @staticmethod
     def _lookup_resource_type_method(resource_type_method_map, raw_resource):
@@ -125,7 +125,7 @@ class DvOrderApi(UpdatableApi):
             self.dao.insert_biobank_order(p_id, merged_resource)
             self.dao.insert_mayolink_create_order_history(p_id, merged_resource, resource, response)
 
-        response = super(DvOrderApi, self).put(
+        response = super(MailKitOrderApi, self).put(
             bo_id, participant_id=p_id, skip_etag=True, resource=merged_resource
         )
         response[2]["Location"] = "/rdr/v1/SupplyDelivery/{}".format(bo_id)
@@ -141,7 +141,7 @@ class DvOrderApi(UpdatableApi):
         patient = fhir_resource.contained.get(resourceType="Patient")
         pid = patient.identifier.get(system=DV_FHIR_URL + "participantId").value
         p_id = from_client_participant_id(pid)
-        response = super(DvOrderApi, self).post(participant_id=p_id)
+        response = super(MailKitOrderApi, self).post(participant_id=p_id)
         order_id = fhir_resource.identifier.get(system=DV_FHIR_URL + "orderId").value
         response[2]["Location"] = "/rdr/v1/SupplyRequest/{}".format(order_id)
         response[2]['auth_user'] = resource['auth_user']
@@ -163,7 +163,7 @@ class DvOrderApi(UpdatableApi):
         obj = ObjDict(pk)
         id_ = self.dao.get_id(obj)[0]
 
-        return super(DvOrderApi, self).get(id_=id_, participant_id=p_id)
+        return super(MailKitOrderApi, self).get(id_=id_, participant_id=p_id)
 
     @auth_required(PTC)
     def put(self, bo_id=None):  # pylint: disable=unused-argument
@@ -196,7 +196,7 @@ class DvOrderApi(UpdatableApi):
 
         if not p_id:
             raise BadRequest("Request must include participant id")
-        response = super(DvOrderApi, self).put(bo_id, participant_id=p_id, skip_etag=True)
+        response = super(MailKitOrderApi, self).put(bo_id, participant_id=p_id, skip_etag=True)
 
         return response
 
@@ -270,7 +270,7 @@ class DvOrderApi(UpdatableApi):
             self.dao.insert_biobank_order(p_id, merged_resource)
             self.dao.insert_mayolink_create_order_history(p_id, merged_resource, resource, response)
 
-        response = super(DvOrderApi, self).put(
+        response = super(MailKitOrderApi, self).put(
             bo_id, participant_id=p_id, skip_etag=True, resource=merged_resource
         )
         return response
@@ -298,6 +298,6 @@ def merge_dicts(dict_a, dict_b):
 
 
 def _make_response(self, obj):
-    result = super(DvOrderApi, self)._make_response(obj)
-    etag = super(DvOrderApi, self)._make_etag(obj.version)
+    result = super(MailKitOrderApi, self)._make_response(obj)
+    etag = super(MailKitOrderApi, self)._make_etag(obj.version)
     return result, 201, {"ETag": etag}

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -37,10 +37,10 @@ _UTC = pytz.utc
 _US_CENTRAL = pytz.timezone("US/Central")
 
 
-class DvOrderDao(UpdatableDao):
+class MailKitOrderDao(UpdatableDao):
     def __init__(self):
         self.code_dao = CodeDao()
-        super(DvOrderDao, self).__init__(BiobankMailKitOrder)
+        super(MailKitOrderDao, self).__init__(BiobankMailKitOrder)
         # used for testing
         self.biobank_address = {
             "city": "Rochester",

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -23,7 +23,7 @@ from rdr_service.api.biobank_specimen_api import BiobankSpecimenApi, BiobankSpec
 from rdr_service.api.check_ppi_data_api import check_ppi_data
 from rdr_service.api.data_gen_api import DataGenApi, SpecDataGenApi
 from rdr_service.api.deceased_report_api import DeceasedReportApi, DeceasedReportReviewApi
-from rdr_service.api.dv_order_api import DvOrderApi
+from rdr_service.api.mail_kit_order_api import MailKitOrderApi
 from rdr_service.api.genomic_api import GenomicPiiApi, GenomicOutreachApi
 from rdr_service.api.import_codebook_api import import_codebook
 from rdr_service.api.metric_sets_api import MetricSetsApi
@@ -203,12 +203,12 @@ api.add_resource(
 )
 
 api.add_resource(
-    DvOrderApi,
+    MailKitOrderApi,
     API_PREFIX + "SupplyRequest/<string:bo_id>",
     API_PREFIX + "SupplyRequest",
     API_PREFIX + "SupplyDelivery",
     API_PREFIX + "SupplyDelivery/<string:bo_id>",
-    endpoint="participant.dv_order",
+    endpoint="participant.mail_kit_order",  # previously dv_order
     methods=["POST", "GET", "PUT"],
 )
 

--- a/tests/api_tests/test_mail_kit_order_api.py
+++ b/tests/api_tests/test_mail_kit_order_api.py
@@ -3,7 +3,7 @@ import http.client
 import mock
 
 from rdr_service.dao.code_dao import CodeDao
-from rdr_service.dao.dv_order_dao import DvOrderDao
+from rdr_service.dao.mail_kit_order_dao import MailKitOrderDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
@@ -26,12 +26,12 @@ from tests.test_data import load_biobank_order_json
 from rdr_service.model.utils import to_client_participant_id
 
 
-class DvOrderApiTestBase(BaseTestCase):
+class MailKitOrderApiTestBase(BaseTestCase):
     mayolink_response = None
 
     def setUp(self, with_data=True):
         super().setUp(with_data=with_data)
-        self.dv_order_dao = DvOrderDao()
+        self.mail_kit_order_dao = MailKitOrderDao()
         self.hpo_dao = HPODao()
         self.participant_dao = ParticipantDao()
         self.summary_dao = ParticipantSummaryDao()
@@ -44,7 +44,7 @@ class DvOrderApiTestBase(BaseTestCase):
         self.summary_dao.insert(self.summary)
 
         mayolinkapi_patcher = mock.patch(
-            "rdr_service.dao.dv_order_dao.MayoLinkApi", **{"return_value.post.return_value": self.mayolink_response}
+            "rdr_service.dao.mail_kit_order_dao.MayoLinkApi", **{"return_value.post.return_value": self.mayolink_response}
         )
         mayolinkapi_patcher.start()
         self.addCleanup(mayolinkapi_patcher.stop)
@@ -53,11 +53,11 @@ class DvOrderApiTestBase(BaseTestCase):
         return load_test_data_json(filename)
 
     def get_orders(self):
-        with self.dv_order_dao.session() as session:
+        with self.mail_kit_order_dao.session() as session:
             return list(session.query(BiobankMailKitOrder))
 
 
-class DvOrderApiTestPostSupplyRequest(DvOrderApiTestBase):
+class MailKitOrderApiTestPostSupplyRequest(MailKitOrderApiTestBase):
     def test_order_created(self):
         self.assertEqual(0, len(self.get_orders()))
         response = self.send_post(
@@ -70,7 +70,7 @@ class DvOrderApiTestPostSupplyRequest(DvOrderApiTestBase):
         self.assertEqual(1, len(orders))
 
 
-class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
+class MailKitOrderApiTestPutSupplyRequest(MailKitOrderApiTestBase):
     mayolink_response = {
         "orders": {
             "order": {
@@ -150,7 +150,7 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
             self.assertEqual(i.biobankStatus, "Queued")
             self.assertEqual(i.biobankTrackingId, "PAT-123-456")
 
-        with self.dv_order_dao.session() as session:
+        with self.mail_kit_order_dao.session() as session:
             # there should be three identifier records in the BiobankOrderIdentifier table
             identifiers = session.query(BiobankOrderIdentifier).all()
             self.assertEqual(5, len(identifiers))
@@ -211,7 +211,7 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
                 )
 
                 # Compare the results in the DB with the system identifiers defined above
-                with self.dv_order_dao.session() as session:
+                with self.mail_kit_order_dao.session() as session:
                     test_order_id = self.mayolink_response['orders']['order']['number']
                     identifiers = session.query(BiobankOrderIdentifier).filter_by(
                         biobankOrderId=test_order_id
@@ -235,7 +235,7 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
         """DB clean-up to avoid duplicate key errors"""
         test_order_id = self.mayolink_response['orders']['order']['number']
 
-        with self.dv_order_dao.session() as session:
+        with self.mail_kit_order_dao.session() as session:
 
             identifier_history = session.query(BiobankOrderIdentifierHistory).filter_by(
                 biobankOrderId=test_order_id
@@ -267,7 +267,7 @@ class DvOrderApiTestPutSupplyRequest(DvOrderApiTestBase):
             for bb_order in bb_orders:
                 session.delete(bb_order)
 
-class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
+class MailKitOrderApiTestPostSupplyDelivery(MailKitOrderApiTestBase):
     mayolink_response = {
         "orders": {
             "order": {
@@ -303,7 +303,7 @@ class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
         orders = self.get_orders()
         self.assertEqual(1, len(orders))
 
-    @mock.patch("rdr_service.dao.dv_order_dao.get_code_id")
+    @mock.patch("rdr_service.dao.mail_kit_order_dao.get_code_id")
     def test_biobank_address_received(self, patched_code_id):
         patched_code_id.return_value = 1
 
@@ -322,7 +322,7 @@ class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
         )
 
         request = self.get_payload("dv_order_api_put_supply_delivery.json")
-        biobank_address = self.dv_order_dao.biobank_address
+        biobank_address = self.mail_kit_order_dao.biobank_address
         request["contained"][0]["address"] = biobank_address
 
         location_id = response.location.rsplit("/", 1)[-1]
@@ -345,7 +345,7 @@ class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
             self.assertEqual(i.id, int(1))
             self.assertEqual(i.order_id, int(999999))
 
-    @mock.patch("rdr_service.dao.dv_order_dao.get_code_id")
+    @mock.patch("rdr_service.dao.mail_kit_order_dao.get_code_id")
     def test_biobank_address_received_alt_json(self, patched_code_id):
         patched_code_id.return_value = 1
 
@@ -364,7 +364,7 @@ class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
         )
 
         request = self.get_payload("dv_order_api_put_supply_delivery.json")
-        biobank_address = self.dv_order_dao.biobank_address
+        biobank_address = self.mail_kit_order_dao.biobank_address
         request["contained"][0]["address"] = biobank_address
 
         location_id = response.location.rsplit("/", 1)[-1]
@@ -383,7 +383,7 @@ class DvOrderApiTestPostSupplyDelivery(DvOrderApiTestBase):
             self.assertEqual(i.order_id, int(999999))
 
 
-class DvOrderApiTestPutSupplyDelivery(DvOrderApiTestBase):
+class MailKitOrderApiTestPutSupplyDelivery(MailKitOrderApiTestBase):
     mayolink_response = {
         "orders": {
             "order": {

--- a/tests/api_tests/test_patient_status.py
+++ b/tests/api_tests/test_patient_status.py
@@ -10,7 +10,7 @@ from rdr_service.model.participant import Participant
 from tests.helpers.unittest_base import BaseTestCase
 
 
-class DvOrderApiTestBase(BaseTestCase):
+class PatientStatusApiTestBase(BaseTestCase):
     mayolink_response = None
 
     def setUp(self):

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -12,7 +12,7 @@ from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderIdentifier, BiobankOrderedSample
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.biobank_mail_kit_order import BiobankMailKitOrder
-from rdr_service.dao.dv_order_dao import DvOrderDao
+from rdr_service.dao.mail_kit_order_dao import MailKitOrderDao
 from rdr_service.model.code import CodeType
 from rdr_service.model.config_utils import to_client_biobank_id
 from rdr_service.model.participant import Participant
@@ -223,7 +223,7 @@ class MySqlReconciliationTest(BaseTestCase):
             mayo_create_time
         )
 
-        dv_dao = DvOrderDao()
+        dv_dao = MailKitOrderDao()
         dv_order_obj = BiobankMailKitOrder(
             participantId=participant_obj.participantId,
             version=1,

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -11,7 +11,7 @@ from rdr_service.api_util import (
     parse_date,
     get_code_id,
 )
-from rdr_service.dao.dv_order_dao import DvOrderDao
+from rdr_service.dao.mail_kit_order_dao import MailKitOrderDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.biobank_mail_kit_order import BiobankMailKitOrder
@@ -26,7 +26,8 @@ from tests.helpers.unittest_base import BaseTestCase
 
 from collections import namedtuple
 
-class DvOrderDaoTestBase(BaseTestCase):
+
+class MailKitOrderDaoTestBase(BaseTestCase):
     def setUp(self):
         super().setUp()
 
@@ -34,7 +35,7 @@ class DvOrderDaoTestBase(BaseTestCase):
         self.put_delivery = load_test_data_json("dv_order_api_put_supply_delivery.json")
         self.post_request = load_test_data_json("dv_order_api_post_supply_request.json")
         self.put_request = load_test_data_json("dv_order_api_put_supply_request.json")
-        self.dao = DvOrderDao()
+        self.dao = MailKitOrderDao()
 
         self.code_dao = CodeDao()
         self.participant_dao = ParticipantDao()
@@ -58,7 +59,7 @@ class DvOrderDaoTestBase(BaseTestCase):
         }
 
         mayolinkapi_patcher = mock.patch(
-            "rdr_service.dao.dv_order_dao.MayoLinkApi", **{"return_value.post.return_value": self.mayolink_response}
+            "rdr_service.dao.mail_kit_order_dao.MayoLinkApi", **{"return_value.post.return_value": self.mayolink_response}
         )
         mayolinkapi_patcher.start()
         self.addCleanup(mayolinkapi_patcher.stop)
@@ -144,7 +145,7 @@ class DvOrderDaoTestBase(BaseTestCase):
             self.make_supply_posts(test_case)
             run_db_test(expected_data)
 
-    @mock.patch("rdr_service.dao.dv_order_dao.MayoLinkApi")
+    @mock.patch("rdr_service.dao.mail_kit_order_dao.MayoLinkApi")
     def test_service_unavailable(self, mocked_api):
         # pylint: disable=unused-argument
         def raises(*args):


### PR DESCRIPTION
This continues renaming dv_order things with the DvOrderDao and Api classes (along with their test classes). I left some dv_order naming in the tests alone, since they're still technically making DV orders (I'll add some non-dv-order test cases in the final PR).