### PR TITLE
[DA-1783] MIGRATION - Removing unique constraints from mail-kit history table

### DIFF
--- a/rdr_service/alembic/versions/8cc481fa7390_starting_dv_order_table_rename.py
+++ b/rdr_service/alembic/versions/8cc481fa7390_starting_dv_order_table_rename.py
@@ -101,6 +101,10 @@ def upgrade_rdr():
     """)
 
     add_table_history_table('biobank_mail_kit_order', op)
+    # History table is created from copy of existing table, so dropping constraints
+    op.drop_constraint('uidx_partic_id_order_id', 'biobank_mail_kit_order_history', type_="unique")
+    op.drop_constraint('biobank_order_id', 'biobank_mail_kit_order_history', type_="unique")
+
     history_table_columns = f'{column_names}, revision_action, revision_id, revision_dt'
     op.execute(f"""
         INSERT INTO biobank_mail_kit_order_history ({history_table_columns})


### PR DESCRIPTION
This fixes a problem that PR #2063 had when deploying to the Test environment. The dv_order table has unique constraints that don't work in the history table. It looks like the history table in Prod only has the PRIMARY constraint, so I've added lines to the migration file to remove the constraints before transferring the data. The migration failed on Test and hasn't run in any other environments, so I think we should be safe to make changes to it now.