### PR TITLE
[PDR fix] Remove nested biobank data from BQPDRParticipantSummaryView

### DIFF
--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -170,7 +170,8 @@ class BQPDRParticipantSummaryView(BQView):
             'modules',
             'consents',
             'biospec',
-            'patient_statuses'
+            'patient_statuses',
+            'biobank_orders'
         ])
     )
 
@@ -194,7 +195,8 @@ class BQPDRParticipantSummaryAllView(BQPDRParticipantSummaryView):
             'modules',
             'consents',
             'biospec',
-            'patient_statuses'
+            'patient_statuses',
+            'biobank_orders'
         ])
     )
 


### PR DESCRIPTION
This was inadvertently omitted from PR #2050.   The nested biobank data that became part of the BQPDRParticipantSummary schema should not be included in the BQPDRParticpantSummary(All)Views schemas.  

It is available in flattened form in the BQPDRParticipantBiobankOrderView and BQPDRParticpantBiobankSampleView schemas which were added in PR #2050.  

This change only affects the migrate-bq tool.   The corrected BQ schema migrations were already applied to prod and the lower environments when 1.82.2 was deployed.