### PR TITLE
Responding to more than HTTPExceptions

### DIFF
--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -11,7 +11,6 @@ from werkzeug.exceptions import BadRequest
 from rdr_service import app_util, config
 from rdr_service.api_util import EXPORTER
 from rdr_service.dao.metric_set_dao import AggregateMetricsDao
-from rdr_service.main import _log_request_exception
 from rdr_service.offline import biobank_samples_pipeline, genomic_pipeline, sync_consent_files, update_ehr_status, \
     antibody_study_pipeline
 from rdr_service.offline.base_pipeline import send_failure_alert
@@ -27,7 +26,8 @@ from rdr_service.offline.public_metrics_export import LIVE_METRIC_SET_ID, Public
 from rdr_service.offline.sa_key_remove import delete_service_account_keys
 from rdr_service.offline.table_exporter import TableExporter
 from rdr_service.services.flask import OFFLINE_PREFIX, flask_start, flask_stop
-from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging
+from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging,\
+    flask_restful_log_exception_error
 
 
 def _alert_on_exceptions(func):
@@ -688,7 +688,7 @@ def _build_pipeline_app():
 
     offline_app.register_error_handler(DBAPIError, app_util.handle_database_disconnect)
 
-    got_request_exception.connect(_log_request_exception, offline_app)
+    got_request_exception.connect(flask_restful_log_exception_error, offline_app)
 
     return offline_app
 

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -100,6 +100,9 @@ def update_participant_summaries_from_job(job):
             except HTTPException as e:
                 LOG.error(f'HTTP Exception: {e}', exc_info=True)
 
+            except Exception:  # pylint: disable=broad-except
+                LOG.error(f'Exception encountered', exc_info=True)
+
 
 def make_update_organizations_job():
     config_param = config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION


### PR DESCRIPTION
It looks like the UpdateEhrStatusParticipant cron job is still failing and not giving much information. I still haven't found anything definite about what could be happening but I noticed that the measures we put in place previously only worked for anything that was a subclass of HTTPException.

This modifies the checks to account for a broader range of exceptions in case it's something other than an HTTPException. `flask_restful_log_exception_error` logs error messages for more that HTTPExceptions but only logs the stack trace and not the exception message, so I modified the unit test to account for that.