### PR TITLE
[DA-1798] Modify AW3 manifests

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -147,7 +147,7 @@ cron:
 - description: Genomic AW3 Workflow
   url: /offline/GenomicAW3Workflow
   timezone: America/New_York
-  schedule: every day 06:45
+  schedule: every monday 06:45
   target: offline
 - description: Genomic AW4 Workflow
   url: /offline/GenomicAW4Workflow

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2138,9 +2138,9 @@ class ManifestDefinitionProvider:
                         GenomicGCValidationMetrics.vcfTbiPath,
                         GenomicGCValidationMetrics.vcfMd5Path,
                         Participant.researchId,
-                        GenomicGCValidationMetrics.sexConcordance,
-                        GenomicGCValidationMetrics.contamination,
-                        GenomicGCValidationMetrics.processingStatus,
+                        #GenomicGCValidationMetrics.sexConcordance,
+                        #GenomicGCValidationMetrics.contamination,
+                        #GenomicGCValidationMetrics.processingStatus,
                     ]
                 ).select_from(
                     sqlalchemy.join(
@@ -2193,9 +2193,9 @@ class ManifestDefinitionProvider:
                         GenomicGCValidationMetrics.craiPath,
                         Participant.researchId,
                         GenomicSetMember.sampleId,
-                        GenomicGCValidationMetrics.sexConcordance,
-                        GenomicGCValidationMetrics.contamination,
-                        GenomicGCValidationMetrics.processingStatus,
+                        #GenomicGCValidationMetrics.sexConcordance,
+                        #GenomicGCValidationMetrics.contamination,
+                        #GenomicGCValidationMetrics.processingStatus,
                     ]
                 ).select_from(
                     sqlalchemy.join(
@@ -2411,9 +2411,9 @@ class ManifestDefinitionProvider:
                 "vcf_index_path",
                 "vcf_md5_path",
                 "research_id",
-                "sex_concordance",
-                "contamination",
-                "processing_status",
+                #"sex_concordance",
+                #"contamination",
+                #"processing_status",
             )
 
         elif manifest_type == GenomicManifestTypes.AW3_WGS:
@@ -2433,9 +2433,9 @@ class ManifestDefinitionProvider:
                 "cram_md5_path",
                 "crai_path",
                 "research_id",
-                "sex_concordance",
-                "contamination",
-                "processing_status",
+                #"sex_concordance",
+                #"contamination",
+                #"processing_status",
             )
 
         return columns

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -19,6 +19,7 @@ from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 from rdr_service import clock
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.participant import Participant
+from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_gc_validation_metrics_update, \
     genomic_set_update, genomic_file_processed_update
 from rdr_service.services.jira_utils import JiraTicketHandler
@@ -2125,7 +2126,7 @@ class ManifestDefinitionProvider:
                 sqlalchemy.select(
                     [
                         GenomicGCValidationMetrics.chipwellbarcode,
-                        GenomicSetMember.biobankId,
+                        sqlalchemy.func.concat(get_biobank_id_prefix(), GenomicSetMember.biobankId),
                         GenomicSetMember.sampleId,
                         GenomicSetMember.sexAtBirth,
                         GenomicSetMember.gcSiteId,
@@ -2137,6 +2138,9 @@ class ManifestDefinitionProvider:
                         GenomicGCValidationMetrics.vcfTbiPath,
                         GenomicGCValidationMetrics.vcfMd5Path,
                         Participant.researchId,
+                        GenomicGCValidationMetrics.sexConcordance,
+                        GenomicGCValidationMetrics.contamination,
+                        GenomicGCValidationMetrics.processingStatus,
                     ]
                 ).select_from(
                     sqlalchemy.join(
@@ -2173,20 +2177,25 @@ class ManifestDefinitionProvider:
                     [
                         GenomicSetMember.biobankId,
                         GenomicSetMember.sampleId,
-                        sqlalchemy.func.concat(GenomicSetMember.biobankId, '_', GenomicSetMember.sampleId),
+                        sqlalchemy.func.concat(get_biobank_id_prefix(),
+                                               GenomicSetMember.biobankId, '_',
+                                               GenomicSetMember.sampleId),
                         GenomicSetMember.sexAtBirth,
                         GenomicSetMember.gcSiteId,
                         GenomicGCValidationMetrics.hfVcfPath,
                         GenomicGCValidationMetrics.hfVcfTbiPath,
-                        #GenomicGCValidationMetrics.hfVcfMd5Path,
+                        GenomicGCValidationMetrics.hfVcfMd5Path,
                         GenomicGCValidationMetrics.rawVcfPath,
                         GenomicGCValidationMetrics.rawVcfTbiPath,
-                        #GenomicGCValidationMetrics.rawVcfMd5Path,
+                        GenomicGCValidationMetrics.rawVcfMd5Path,
                         GenomicGCValidationMetrics.cramPath,
                         GenomicGCValidationMetrics.cramMd5Path,
                         GenomicGCValidationMetrics.craiPath,
                         Participant.researchId,
                         GenomicSetMember.sampleId,
+                        GenomicGCValidationMetrics.sexConcordance,
+                        GenomicGCValidationMetrics.contamination,
+                        GenomicGCValidationMetrics.processingStatus,
                     ]
                 ).select_from(
                     sqlalchemy.join(
@@ -2402,6 +2411,9 @@ class ManifestDefinitionProvider:
                 "vcf_index_path",
                 "vcf_md5_path",
                 "research_id",
+                "sex_concordance",
+                "contamination",
+                "processing_status",
             )
 
         elif manifest_type == GenomicManifestTypes.AW3_WGS:
@@ -2413,12 +2425,17 @@ class ManifestDefinitionProvider:
                 "site_id",
                 "vcf_hf_path",
                 "vcf_hf_index_path",
+                "vcf_hf_md5_path",
                 "vcf_raw_path",
                 "vcf_raw_index_path",
+                "vcf_raw_md5_path",
                 "cram_path",
                 "cram_md5_path",
                 "crai_path",
-                "research_id"
+                "research_id",
+                "sex_concordance",
+                "contamination",
+                "processing_status",
             )
 
         return columns

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -34,6 +34,7 @@ from rdr_service.model.biobank_order import (
     BiobankOrderIdentifier,
     BiobankOrderedSample
 )
+from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.genomics import (
     GenomicSet,
@@ -2275,7 +2276,10 @@ class GenomicPipelineTest(BaseTestCase):
             "green_idat_md5_path",
             "vcf_path",
             "vcf_index_path",
-            "research_id"
+            "research_id",
+            "sex_concordance",
+            "contamination",
+            "processing_status",
         )
 
         bucket_name = config.getSetting(config.DRC_BROAD_BUCKET_NAME)
@@ -2289,7 +2293,7 @@ class GenomicPipelineTest(BaseTestCase):
             rows = list(csv_reader)
 
             self.assertEqual(2, len(rows))
-            self.assertEqual(member.biobankId, int(rows[1]['biobank_id']))
+            self.assertEqual(f"{get_biobank_id_prefix()}{member.biobankId}", rows[1]['biobank_id'])
             self.assertEqual(member.sampleId, rows[1]['sample_id'])
             self.assertEqual(member.sexAtBirth, rows[1]['sex_at_birth'])
             self.assertEqual(member.gcSiteId, rows[1]['site_id'])
@@ -2304,6 +2308,11 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(metric.vcfPath, rows[1]['vcf_path'])
             self.assertEqual(metric.vcfTbiPath, rows[1]['vcf_index_path'])
             self.assertEqual(metric.vcfMd5Path, rows[1]['vcf_md5_path'])
+
+            # Test processing status columns
+            self.assertEqual(metric.sexConcordance, rows[1]['sex_concordance'])
+            self.assertEqual(metric.contamination, rows[1]['contamination'])
+            self.assertEqual(metric.processingStatus, rows[1]['processing_status'])
 
             # Test run record is success
             run_obj = self.job_run_dao.get(4)
@@ -2373,14 +2382,17 @@ class GenomicPipelineTest(BaseTestCase):
             "site_id",
             "vcf_hf_path",
             "vcf_hf_index_path",
-            # "vcf_hf_md5_path",
+            "vcf_hf_md5_path",
             "vcf_raw_path",
             "vcf_raw_index_path",
-            # "vcf_raw_md5_path",
+            "vcf_raw_md5_path",
             "cram_path",
             "cram_md5_path",
             "crai_path",
-            "research_id"
+            "research_id",
+            "sex_concordance",
+            "contamination",
+            "processing_status",
         )
 
         bucket_name = config.getSetting(config.DRC_BROAD_BUCKET_NAME)
@@ -2394,7 +2406,8 @@ class GenomicPipelineTest(BaseTestCase):
             rows = list(csv_reader)
 
             self.assertEqual(1, len(rows))
-            self.assertEqual(f'{member.biobankId}_{member.sampleId}', rows[0]['biobankidsampleid'])
+            self.assertEqual(f'{get_biobank_id_prefix()}{member.biobankId}_{member.sampleId}',
+                             rows[0]['biobankidsampleid'])
             self.assertEqual(member.sexAtBirth, rows[0]['sex_at_birth'])
             self.assertEqual(member.gcSiteId, rows[0]['site_id'])
             self.assertEqual(1000002, int(rows[0]['research_id']))
@@ -2410,6 +2423,11 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(metric.cramPath, rows[0]["cram_path"])
             self.assertEqual(metric.cramMd5Path, rows[0]["cram_md5_path"])
             self.assertEqual(metric.craiPath, rows[0]["crai_path"])
+
+            # Test processing status columns
+            self.assertEqual(metric.sexConcordance, rows[0]['sex_concordance'])
+            self.assertEqual(metric.contamination, rows[0]['contamination'])
+            self.assertEqual(metric.processingStatus, rows[0]['processing_status'])
 
             # Test run record is success
             run_obj = self.job_run_dao.get(4)

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -2277,9 +2277,9 @@ class GenomicPipelineTest(BaseTestCase):
             "vcf_path",
             "vcf_index_path",
             "research_id",
-            "sex_concordance",
-            "contamination",
-            "processing_status",
+            # "sex_concordance",
+            # "contamination",
+            # "processing_status",
         )
 
         bucket_name = config.getSetting(config.DRC_BROAD_BUCKET_NAME)
@@ -2310,9 +2310,10 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(metric.vcfMd5Path, rows[1]['vcf_md5_path'])
 
             # Test processing status columns
-            self.assertEqual(metric.sexConcordance, rows[1]['sex_concordance'])
-            self.assertEqual(metric.contamination, rows[1]['contamination'])
-            self.assertEqual(metric.processingStatus, rows[1]['processing_status'])
+            # TODO: Column reqs not finalized yet
+            # self.assertEqual(metric.sexConcordance, rows[1]['sex_concordance'])
+            # self.assertEqual(metric.contamination, rows[1]['contamination'])
+            # self.assertEqual(metric.processingStatus, rows[1]['processing_status'])
 
             # Test run record is success
             run_obj = self.job_run_dao.get(4)
@@ -2390,9 +2391,9 @@ class GenomicPipelineTest(BaseTestCase):
             "cram_md5_path",
             "crai_path",
             "research_id",
-            "sex_concordance",
-            "contamination",
-            "processing_status",
+            # "sex_concordance",
+            # "contamination",
+            # "processing_status",
         )
 
         bucket_name = config.getSetting(config.DRC_BROAD_BUCKET_NAME)
@@ -2425,9 +2426,10 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(metric.craiPath, rows[0]["crai_path"])
 
             # Test processing status columns
-            self.assertEqual(metric.sexConcordance, rows[0]['sex_concordance'])
-            self.assertEqual(metric.contamination, rows[0]['contamination'])
-            self.assertEqual(metric.processingStatus, rows[0]['processing_status'])
+            # TODO: Column reqs not finalized yet
+            # self.assertEqual(metric.sexConcordance, rows[0]['sex_concordance'])
+            # self.assertEqual(metric.contamination, rows[0]['contamination'])
+            # self.assertEqual(metric.processingStatus, rows[0]['processing_status'])
 
             # Test run record is success
             run_obj = self.job_run_dao.get(4)


### PR DESCRIPTION
This PR includes the following updates:
- Switch AW3 job schedule from daily to weekly
- Add Biobank prefix to `biobank_id`
- Add md5 path columns to WGS

There are addition columns that will be added to the AW3 manifest, but these are pending discussions with DRC Broad. These are left in this PR but commented out.