### PR TITLE
[DA-1774] research_directory_search_feature

### DIFF
--- a/rdr_service/api/research_projects_directory_api.py
+++ b/rdr_service/api/research_projects_directory_api.py
@@ -7,7 +7,7 @@ from rdr_service.dao.workbench_dao import WorkbenchWorkspaceDao
 from rdr_service.participant_enums import WorkbenchWorkspaceStatus
 
 DEFAULT_SEQUESTRATION_WINDOWS = 23
-
+MAX_PAGE_SIZE = 2000
 
 class ResearchProjectsDirectoryApi(Resource):
     def __init__(self):
@@ -17,7 +17,16 @@ class ResearchProjectsDirectoryApi(Resource):
     def get(self):
         params = {
             'status': request.args.get('status'),
-            'sequest_hour': request.args.get('sequest_hour')
+            'sequest_hour': request.args.get('sequestHour'),
+            'given_name': request.args.get('givenName'),
+            'family_name': request.args.get('familyName'),
+            'user_source_id': request.args.get('userId'),
+            'user_role': request.args.get('userRole'),
+            'workspace_name_like': request.args.get('workspaceNameLike'),
+            'intend_to_study_like': request.args.get('intendToStudyLike'),
+            'project_purpose': request.args.get('projectPurpose'),
+            'page': request.args.get('page'),
+            'page_size': request.args.get('pageSize')
         }
 
         filters = self.validate_params(params)
@@ -25,14 +34,13 @@ class ResearchProjectsDirectoryApi(Resource):
 
         return results
 
-    def get_filtered_results(self, status, sequest_hour):
+    def get_filtered_results(self, **kwargs):
         """Queries DB, returns results in format consumed by front-end
-        :param status: Workspace status
-        :param sequest_hour: sequestration time window
+        :param kwargs: query parameters
         :return: Filtered results
         """
 
-        return self.workspace_dao.get_workspaces_with_user_detail(status, sequest_hour)
+        return self.workspace_dao.get_workspaces_with_user_detail(**kwargs)
 
     def validate_params(self, params):
         filters = {}
@@ -48,8 +56,52 @@ class ResearchProjectsDirectoryApi(Resource):
             try:
                 filters['sequest_hour'] = int(params['sequest_hour'])
             except TypeError:
-                raise BadRequest(f"Invalid parameter sequest_hour: {params['sequest_hour']}")
+                raise BadRequest(f"Invalid parameter sequestHour: {params['sequest_hour']}")
         else:
             filters['sequest_hour'] = DEFAULT_SEQUESTRATION_WINDOWS
+
+        if params['user_source_id']:
+            try:
+                filters['user_source_id'] = int(params['user_source_id'])
+            except TypeError:
+                raise BadRequest(f"Invalid parameter userId: {params['user_source_id']}")
+
+        if params['user_role']:
+            if params['user_role'] in ['owner', 'member', 'all']:
+                filters['user_role'] = params['user_role']
+            else:
+                raise BadRequest(f"Invalid parameter userRole: {params['user_role']}")
+
+        if params['project_purpose']:
+            params['project_purpose'] = params['project_purpose'].strip().split(',')
+            if set(params['project_purpose']).issubset(['diseaseFocusedResearch', 'methodsDevelopment', 'ancestry',
+                                                        'socialBehavioral', 'populationHealth', 'drugDevelopment',
+                                                        'commercialPurpose', 'educational', 'controlSet']):
+                filters['project_purpose'] = params['project_purpose']
+            else:
+                raise BadRequest(f"Invalid parameter projectPurpose: {params['project_purpose']}")
+
+        if params['page']:
+            try:
+                filters['page'] = int(params['page'])
+            except TypeError:
+                filters['page'] = 1
+        else:
+            filters['page'] = 1
+
+        if params['page_size']:
+            try:
+                filters['page_size'] = int(params['page_size'])
+            except TypeError:
+                filters['page_size'] = MAX_PAGE_SIZE
+        else:
+            filters['page_size'] = MAX_PAGE_SIZE
+
+        filters['given_name'] = params['given_name'].lower() if params['given_name'] else None
+        filters['family_name'] = params['family_name'].lower() if params['family_name'] else None
+        filters['workspace_name_like'] = '%{}%'.format(params['workspace_name_like'].lower()) \
+            if params['workspace_name_like'] else None
+        filters['intend_to_study_like'] = '%{}%'.format(params['intend_to_study_like'].lower()) \
+            if params['intend_to_study_like'] else None
 
         return filters

--- a/rdr_service/api/research_projects_directory_api.py
+++ b/rdr_service/api/research_projects_directory_api.py
@@ -9,6 +9,7 @@ from rdr_service.participant_enums import WorkbenchWorkspaceStatus
 DEFAULT_SEQUESTRATION_WINDOWS = 23
 MAX_PAGE_SIZE = 2000
 
+
 class ResearchProjectsDirectoryApi(Resource):
     def __init__(self):
         self.workspace_dao = WorkbenchWorkspaceDao()
@@ -20,10 +21,12 @@ class ResearchProjectsDirectoryApi(Resource):
             'sequest_hour': request.args.get('sequestHour'),
             'given_name': request.args.get('givenName'),
             'family_name': request.args.get('familyName'),
+            'owner_name': request.args.get('ownerName'),
             'user_source_id': request.args.get('userId'),
             'user_role': request.args.get('userRole'),
             'workspace_name_like': request.args.get('workspaceNameLike'),
             'intend_to_study_like': request.args.get('intendToStudyLike'),
+            'workspace_like': request.args.get('workspaceLike'),
             'project_purpose': request.args.get('projectPurpose'),
             'page': request.args.get('page'),
             'page_size': request.args.get('pageSize')
@@ -99,9 +102,13 @@ class ResearchProjectsDirectoryApi(Resource):
 
         filters['given_name'] = params['given_name'].lower() if params['given_name'] else None
         filters['family_name'] = params['family_name'].lower() if params['family_name'] else None
+        filters['owner_name'] = params['owner_name'].lower() if params['owner_name'] else None
+
         filters['workspace_name_like'] = '%{}%'.format(params['workspace_name_like'].lower()) \
             if params['workspace_name_like'] else None
         filters['intend_to_study_like'] = '%{}%'.format(params['intend_to_study_like'].lower()) \
             if params['intend_to_study_like'] else None
+        filters['workspace_like'] = '%{}%'.format(params['workspace_like'].lower()) \
+            if params['workspace_like'] else None
 
         return filters

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -467,7 +467,8 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                     query = query.filter(func.lower(WorkbenchWorkspaceApproved.name).like(workspace_name_like))
 
                 if intend_to_study_like:
-                    query = query.filter(func.lower(WorkbenchWorkspaceApproved.intendToStudy).like(intend_to_study_like))
+                    query = query.filter(func.lower(WorkbenchWorkspaceApproved.intendToStudy)
+                                         .like(intend_to_study_like))
 
             if project_purpose:
                 for purpose in project_purpose:

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -280,7 +280,7 @@ class WorkbenchWorkspaceDao(UpdatableDao):
             return result
 
     def get_workspace_by_workspace_id_with_session(self, session, workspace_id):
-        return session.query(WorkbenchWorkspaceApproved)\
+        return session.query(WorkbenchWorkspaceApproved) \
             .filter(WorkbenchWorkspaceApproved.workspaceSourceId == workspace_id).first()
 
     def remove_workspace_by_workspace_id_with_session(self, session, workspace_id):
@@ -332,15 +332,15 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                                     if affiliation.nonAcademicAffiliation else 'UNSET'
                             }
                 workspace_researcher = {
-                            "userId": researcher.userSourceId,
-                            "creationTime": researcher.creationTime,
-                            "modifiedTime": researcher.modifiedTime,
-                            "givenName": researcher.givenName,
-                            "familyName": researcher.familyName,
-                            "email": researcher.email,
-                            "verifiedInstitutionalAffiliation": verified_institutional_affiliation,
-                            "affiliations": affiliations
-                        }
+                    "userId": researcher.userSourceId,
+                    "creationTime": researcher.creationTime,
+                    "modifiedTime": researcher.modifiedTime,
+                    "givenName": researcher.givenName,
+                    "familyName": researcher.familyName,
+                    "email": researcher.email,
+                    "verifiedInstitutionalAffiliation": verified_institutional_affiliation,
+                    "affiliations": affiliations
+                }
 
                 exist = False
                 for result in results:
@@ -413,7 +413,23 @@ class WorkbenchWorkspaceDao(UpdatableDao):
 
         return results
 
-    def get_workspaces_with_user_detail(self, status, sequest_hour):
+    def get_workspaces_with_user_detail(self, **kwargs):
+        status = kwargs.get('status')
+        sequest_hour = kwargs.get('sequest_hour')
+        given_name = kwargs.get('given_name')
+        family_name = kwargs.get('family_name')
+        user_source_id = kwargs.get('user_source_id')
+        user_role = kwargs.get('user_role')
+        workspace_name_like = kwargs.get('workspace_name_like')
+        intend_to_study_like = kwargs.get('intend_to_study_like')
+        project_purpose = kwargs.get('project_purpose')
+        page = kwargs.get('page')
+        page_size = kwargs.get('page_size')
+        if page and page_size:
+            offset = (page - 1) * page_size
+        if offset < 0:
+            raise BadRequest("invalid parameter: page")
+
         results = []
         now = clock.CLOCK.now()
         sequest_hours_ago = now - timedelta(hours=sequest_hour)
@@ -425,7 +441,7 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                     .group_by(WorkbenchWorkspaceSnapshot.workspaceSourceId).subquery()
             )
             query = (
-                session.query(WorkbenchWorkspaceApproved, WorkbenchResearcher,
+                session.query(WorkbenchWorkspaceApproved, WorkbenchResearcher, WorkbenchWorkspaceUser.role,
                               snapshot_subquery.c.snapshot_id)
                     .options(joinedload(WorkbenchWorkspaceApproved.workbenchWorkspaceUser),
                              joinedload(WorkbenchResearcher.workbenchInstitutionalAffiliations))
@@ -435,13 +451,24 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                             WorkbenchWorkspaceApproved.workspaceSourceId == snapshot_subquery.c.workspace_source_id,
                             or_(WorkbenchWorkspaceApproved.modified < sequest_hours_ago,
                                 WorkbenchWorkspaceApproved.isReviewed == 1))
+                    .order_by(desc(WorkbenchWorkspaceApproved.modifiedTime))
             )
 
             if status is not None:
                 query = query.filter(WorkbenchWorkspaceApproved.status == status)
 
+            if workspace_name_like:
+                query = query.filter(func.lower(WorkbenchWorkspaceApproved.name).like(workspace_name_like))
+
+            if intend_to_study_like:
+                query = query.filter(func.lower(WorkbenchWorkspaceApproved.intendToStudy).like(intend_to_study_like))
+
+            if project_purpose:
+                for purpose in project_purpose:
+                    query = query.filter(getattr(WorkbenchWorkspaceApproved, purpose) == 1)
+
             items = query.all()
-            for workspace, researcher, snapshot_id in items:
+            for workspace, researcher, role, snapshot_id in items:
                 affiliations = []
                 researcher_has_verified_institution = False
                 workspace_has_verified_institution = False
@@ -471,13 +498,30 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                 user = {
                     'userId': researcher.userSourceId,
                     'userName': researcher.givenName + ' ' + researcher.familyName,
+                    'degree': [str(WorkbenchResearcherDegree(value)) for value in researcher.degree],
                     'affiliations': affiliations
                 }
+                hit_search = False
+                if given_name and given_name in researcher.givenName.lower():
+                    hit_search = True
+                if family_name and family_name in researcher.familyName.lower():
+                    hit_search = True
+                if user_source_id and user_role:
+                    if user_source_id == researcher.userSourceId and role == WorkbenchWorkspaceUserRole('OWNER') \
+                        and user_role == 'owner':
+                        hit_search = True
+                    elif user_source_id == researcher.userSourceId and role != WorkbenchWorkspaceUserRole('OWNER') \
+                        and user_role == 'member':
+                        hit_search = True
+                    elif user_source_id == researcher.userSourceId and user_role == 'all':
+                        hit_search = True
 
                 exist = False
                 for result in results:
                     if result['workspaceId'] == workspace.workspaceSourceId:
                         result['workspaceUsers'].append(user)
+                        if hit_search:
+                            result['hitSearch'] = True
                         if user.get('userId') == owner_user_id:
                             result['workspaceOwner'].append(user)
                         if workspace_has_verified_institution:
@@ -490,6 +534,7 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                 record = {
                     'workspaceId': workspace.workspaceSourceId,
                     'snapshotId': snapshot_id,
+                    'hitSearch': hit_search,
                     'name': workspace.name,
                     'creationTime': workspace.creationTime,
                     'modifiedTime': workspace.modifiedTime,
@@ -541,7 +586,21 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                     }
                 }
                 results.append(record)
-        expected_result = [ws for ws in results if ws.get('hasVerifiedInstitution') is True]
+
+        if given_name or family_name or (user_source_id and user_role):
+            expected_result = [ws for ws in results if ws.get('hitSearch') is True
+                               and ws.get('hasVerifiedInstitution') is True]
+        else:
+            expected_result = [ws for ws in results if ws.get('hasVerifiedInstitution') is True]
+
+        for er in expected_result:
+            er.pop('hitSearch', None)
+
+        if offset >= len(expected_result):
+            expected_result = []
+        else:
+            page_end = offset + page_size if offset + page_size < len(expected_result) else len(expected_result)
+            expected_result = expected_result[offset:page_end]
         metadata_dao = MetadataDao()
         metadata = metadata_dao.get_by_key(WORKBENCH_LAST_SYNC_KEY)
         if metadata:
@@ -549,7 +608,12 @@ class WorkbenchWorkspaceDao(UpdatableDao):
         else:
             last_sync_date = clock.CLOCK.now()
 
-        return {"last_sync_date": last_sync_date, "data": expected_result}
+        return {
+            "page": page,
+            "pageSize": page_size,
+            "last_sync_date": last_sync_date,
+            "data": expected_result
+        }
 
     def add_approved_workspace_with_session(self, session, workspace_snapshot, is_reviewed=False):
         exist = self.get_workspace_by_workspace_id_with_session(session, workspace_snapshot.workspaceSourceId)
@@ -596,14 +660,14 @@ class WorkbenchWorkspaceHistoryDao(UpdatableDao):
         return obj.id
 
     def get_snapshot_by_id_with_session(self, session, snapshot_id):
-        return session.query(WorkbenchWorkspaceSnapshot)\
-            .options(subqueryload(WorkbenchWorkspaceSnapshot.workbenchWorkspaceUser))\
+        return session.query(WorkbenchWorkspaceSnapshot) \
+            .options(subqueryload(WorkbenchWorkspaceSnapshot.workbenchWorkspaceUser)) \
             .filter(WorkbenchWorkspaceSnapshot.id == snapshot_id).first()
 
     def is_snapshot_exist_with_session(self, session, workspace_id, modified_time):
-        record = session.query(WorkbenchWorkspaceSnapshot)\
+        record = session.query(WorkbenchWorkspaceSnapshot) \
             .filter(WorkbenchWorkspaceSnapshot.workspaceSourceId == workspace_id,
-                    WorkbenchWorkspaceSnapshot.modifiedTime == modified_time)\
+                    WorkbenchWorkspaceSnapshot.modifiedTime == modified_time) \
             .first()
         return True if record else False
 
@@ -827,7 +891,7 @@ class WorkbenchResearcherDao(UpdatableDao):
             session.add(history)
 
     def get_researcher_by_user_id_with_session(self, session, user_id):
-        return session.query(WorkbenchResearcher).filter(WorkbenchResearcher.userSourceId == user_id)\
+        return session.query(WorkbenchResearcher).filter(WorkbenchResearcher.userSourceId == user_id) \
             .order_by(desc(WorkbenchResearcher.created)).first()
 
 
@@ -842,15 +906,15 @@ class WorkbenchResearcherHistoryDao(UpdatableDao):
                 .order_by(desc(WorkbenchResearcherHistory.created)).first()
 
     def is_snapshot_exist_with_session(self, session, user_source_id, modified_time):
-        record = session.query(WorkbenchResearcherHistory)\
+        record = session.query(WorkbenchResearcherHistory) \
             .filter(WorkbenchResearcherHistory.userSourceId == user_source_id,
-                    WorkbenchResearcherHistory.modifiedTime == modified_time)\
+                    WorkbenchResearcherHistory.modifiedTime == modified_time) \
             .first()
         return True if record else False
 
     def get_researcher_history_by_id_with_session(self, researcher_history_id):
         with self.session() as session:
-            return session.query(WorkbenchResearcherHistory)\
+            return session.query(WorkbenchResearcherHistory) \
                 .filter(WorkbenchResearcherHistory.id == researcher_history_id).first()
 
     def get_id(self, obj):
@@ -944,7 +1008,6 @@ class WorkbenchWorkspaceAuditDao(UpdatableDao):
         workspace_snapshot.excludeFromPublicDirectory = True
         workspace_snapshot.isReviewed = True
         self.workspace_dao.remove_workspace_by_workspace_id_with_session(session, workspace_snapshot.workspaceSourceId)
-
 
     def add_approved_workspace_with_session(self, session, workspace_snapshot_id):
         workspace_snapshot = self.workspace_snapshot_dao.get_snapshot_by_id_with_session(session, workspace_snapshot_id)

--- a/tests/api_tests/test_workspace_audit_and_research_directory_api.py
+++ b/tests/api_tests/test_workspace_audit_and_research_directory_api.py
@@ -719,15 +719,26 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         # test search by workspace intendToStudy
         result = self.send_get('researchHub/projectDirectory?intendToStudyLike=string2')
         self.assertEqual(len(result['data']), 1)
-        # test search by given/family name
+        # test search by generalized parameter workspaceLike
+        result = self.send_get('researchHub/projectDirectory?workspaceLike=str')
+        self.assertEqual(len(result['data']), 2)
+        result = self.send_get('researchHub/projectDirectory?workspaceLike=string2')
+        self.assertEqual(len(result['data']), 1)
+        # test parameter "workspaceLike" will overwrite "intendToStudyLike"
+        result = self.send_get('researchHub/projectDirectory?workspaceLike=str&intendToStudyLike=string2')
+        self.assertEqual(len(result['data']), 2)
+        # test search by owner given/family name
         result = self.send_get('researchHub/projectDirectory?givenName=givenname1')
         self.assertEqual(len(result['data']), 1)
         result = self.send_get('researchHub/projectDirectory?givenName=givenname2')
-        self.assertEqual(len(result['data']), 2)
+        self.assertEqual(len(result['data']), 1)
         result = self.send_get('researchHub/projectDirectory?familyName=familyname1')
         self.assertEqual(len(result['data']), 1)
         result = self.send_get('researchHub/projectDirectory?familyName=familyname2')
-        self.assertEqual(len(result['data']), 2)
+        self.assertEqual(len(result['data']), 1)
+        # test search by owner full name
+        result = self.send_get('researchHub/projectDirectory?ownerName=nname1%20fami')
+        self.assertEqual(len(result['data']), 1)
         # test search by user id
         result = self.send_get('researchHub/projectDirectory?userId=1&userRole=owner')
         self.assertEqual(len(result['data']), 1)
@@ -1117,7 +1128,6 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         result = self.send_get('workbench/audit/workspace/snapshots?snapshot_id=1')
         self.assertEqual(len(result), 1)
 
-
     def test_hide_workspace_without_verified_institution_from_RH(self):
         # create researchers
         researchers_json = [
@@ -1382,4 +1392,3 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
 
         result = self.send_get('researchHub/projectDirectory')
         self.assertEqual(len(result['data']), 2)
-

--- a/tests/api_tests/test_workspace_audit_and_research_directory_api.py
+++ b/tests/api_tests/test_workspace_audit_and_research_directory_api.py
@@ -26,6 +26,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                 "ethnicity": "HISPANIC",
                 "gender": ["MAN"],
                 "race": ["AIAN"],
+                "degree": ["PHD", "MPH"],
                 "sexAtBirth": ["FEMALE"],
                 "sexualOrientation": "BISEXUAL",
                 "affiliations": [
@@ -58,6 +59,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                 "sexualOrientation": "BISEXUAL",
                 "gender": ["MAN", "WOMAN"],
                 "race": ["AIAN", "WHITE"],
+                "degree": ["PHD", "MPH"],
                 "affiliations": [
                     {
                         "institution": "institution2",
@@ -188,12 +190,14 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        'creationTime': '2019-11-25T17:43:41.085000',
                        'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'ACTIVE',
                        'workspaceUsers': [
-                           {'userId': 0, 'userName': 'given name 1 family name 1', 'affiliations': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
                                 'nonAcademicAffiliation': 'INDUSTRY'},
                                {'institution': 'display name', 'role': 'verified institution role 1',
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}]},
-                           {'userId': 1, 'userName': 'given name 2 family name 2', 'affiliations': [
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution2', 'role': 'institution role 2', 'isVerified': None,
                                 'nonAcademicAffiliation': 'UNSET'},
                                {'institution': 'institution22', 'role': 'institution role 22', 'isVerified': None,
@@ -203,6 +207,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                            ]}
                        ],
                        'workspaceOwner': [{'userId': 1, 'userName': 'given name 2 family name 2',
+                                           'degree': ['PHD', 'MPH'],
                                            'affiliations': [{'institution': 'institution2',
                                                              'role': 'institution role 2',
                                                              'isVerified': None,
@@ -244,13 +249,15 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        'creationTime': '2019-11-25T17:43:41.085000',
                        'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'INACTIVE',
                        'workspaceUsers': [
-                           {'userId': 0, 'userName': 'given name 1 family name 1', 'affiliations': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
                                 'nonAcademicAffiliation': 'INDUSTRY'},
                                {'institution': 'display name', 'role': 'verified institution role 1',
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
                            ]},
-                           {'userId': 1, 'userName': 'given name 2 family name 2', 'affiliations': [
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution2', 'role': 'institution role 2', 'isVerified': None,
                                 'nonAcademicAffiliation': 'UNSET'},
                                {'institution': 'institution22', 'role': 'institution role 22', 'isVerified': None,
@@ -260,6 +267,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                            ]}
                        ],
                        'workspaceOwner': [{'userId': 0, 'userName': 'given name 1 family name 1',
+                                           'degree': ['PHD', 'MPH'],
                                            'affiliations': [{'institution': 'institution1',
                                                              'role': 'institution role 1',
                                                              'isVerified': None,
@@ -327,13 +335,15 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        'creationTime': '2019-11-25T17:43:41.085000',
                        'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'ACTIVE',
                        'workspaceUsers': [
-                           {'userId': 0, 'userName': 'given name 1 family name 1', 'affiliations': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
                                 'nonAcademicAffiliation': 'INDUSTRY'},
                                {'institution': 'display name', 'role': 'verified institution role 1',
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
                            ]},
-                           {'userId': 1, 'userName': 'given name 2 family name 2', 'affiliations': [
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution2', 'role': 'institution role 2', 'isVerified': None,
                                 'nonAcademicAffiliation': 'UNSET'},
                                {'institution': 'institution22', 'role': 'institution role 22', 'isVerified': None,
@@ -343,6 +353,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                            ]}
                        ],
                        'workspaceOwner': [{'userId': 1, 'userName': 'given name 2 family name 2',
+                                           'degree': ['PHD', 'MPH'],
                                            'affiliations': [{'institution': 'institution2',
                                                              'role': 'institution role 2',
                                                              'isVerified': None,
@@ -388,13 +399,15 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        'creationTime': '2019-11-25T17:43:41.085000',
                        'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'ACTIVE',
                        'workspaceUsers': [
-                           {'userId': 0, 'userName': 'given name 1 family name 1', 'affiliations': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
                                 'nonAcademicAffiliation': 'INDUSTRY'},
                                {'institution': 'display name', 'role': 'verified institution role 1',
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
                            ]},
-                           {'userId': 1, 'userName': 'given name 2 family name 2', 'affiliations': [
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution2', 'role': 'institution role 2', 'isVerified': None,
                                 'nonAcademicAffiliation': 'UNSET'},
                                {'institution': 'institution22', 'role': 'institution role 22', 'isVerified': None,
@@ -404,6 +417,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                            ]}
                        ],
                        'workspaceOwner': [{'userId': 1, 'userName': 'given name 2 family name 2',
+                                           'degree': ['PHD', 'MPH'],
                                            'affiliations': [{'institution': 'institution2',
                                                              'role': 'institution role 2',
                                                              'isVerified': None,
@@ -468,13 +482,15 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        'creationTime': '2019-11-25T17:43:41.085000',
                        'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'INACTIVE',
                        'workspaceUsers': [
-                           {'userId': 0, 'userName': 'given name 1 family name 1', 'affiliations': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
                                 'nonAcademicAffiliation': 'INDUSTRY'},
                                {'institution': 'display name', 'role': 'verified institution role 1',
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
                            ]},
-                           {'userId': 1, 'userName': 'given name 2 family name 2', 'affiliations': [
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution2', 'role': 'institution role 2', 'isVerified': None,
                                 'nonAcademicAffiliation': 'UNSET'},
                                {'institution': 'institution22', 'role': 'institution role 22', 'isVerified': None,
@@ -484,6 +500,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                            ]}
                        ],
                        'workspaceOwner': [{'userId': 0, 'userName': 'given name 1 family name 1',
+                                           'degree': ['PHD', 'MPH'],
                                            'affiliations': [{'institution': 'institution1',
                                                              'role': 'institution role 1',
                                                              'isVerified': None,
@@ -517,6 +534,216 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        }
                        },
                       result['data'])
+
+    def test_get_research_projects_directory_search_and_filter(self):
+        # create researchers
+        researchers_json = [
+            {
+                "userId": 0,
+                "creationTime": "2019-11-26T21:21:13.056Z",
+                "modifiedTime": "2019-11-26T21:21:13.056Z",
+                "givenName": "givenname1",
+                "familyName": "familyname1",
+                "streetAddress1": "string",
+                "streetAddress2": "string",
+                "city": "string",
+                "state": "string",
+                "zipCode": "string",
+                "country": "string",
+                "ethnicity": "HISPANIC",
+                "gender": ["MAN"],
+                "race": ["AIAN"],
+                "degree": ["PHD", "MPH"],
+                "sexAtBirth": ["FEMALE"],
+                "sexualOrientation": "BISEXUAL",
+                "affiliations": [
+                    {
+                        "institution": "institution1",
+                        "role": "institution role 1",
+                        "nonAcademicAffiliation": "INDUSTRY"
+                    }
+                ],
+                "verifiedInstitutionalAffiliation": {
+                    "institutionDisplayName": "display name",
+                    "institutionShortName": "verified institution",
+                    "institutionalRole": "verified institution role 1",
+                    "nonAcademicAffiliation": "INDUSTRY"
+                }
+            },
+            {
+                "userId": 1,
+                "creationTime": "2019-11-27T21:21:13.056Z",
+                "modifiedTime": "2019-11-27T21:21:13.056Z",
+                "givenName": "givenname2",
+                "familyName": "familyname2",
+                "streetAddress1": "string2",
+                "streetAddress2": "string2",
+                "city": "string2",
+                "state": "string2",
+                "zipCode": "string2",
+                "country": "string2",
+                "ethnicity": "HISPANIC",
+                "sexualOrientation": "BISEXUAL",
+                "gender": ["MAN", "WOMAN"],
+                "race": ["AIAN", "WHITE"],
+                "degree": ["PHD", "MPH"],
+                "affiliations": [
+                    {
+                        "institution": "institution2",
+                        "role": "institution role 2"
+                    },
+                    {
+                        "institution": "institution22",
+                        "role": "institution role 22",
+                        "nonAcademicAffiliation": "INDUSTRY"
+                    }
+                ],
+                "verifiedInstitutionalAffiliation": {
+                    "institutionShortName": "verified institution",
+                    "institutionalRole": "verified institution role 1",
+                    "nonAcademicAffiliation": "INDUSTRY"
+                }
+            }
+        ]
+        self.send_post('workbench/directory/researchers', request_data=researchers_json)
+
+        # create workspace
+        request_json = [
+            {
+                "workspaceId": 0,
+                "name": "workspace name str Search test",
+                "creationTime": "2019-11-25T17:43:41.085Z",
+                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "status": "ACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 1,
+                        "role": "OWNER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "creator": {
+                    "userId": 1,
+                    "givenName": "aaa",
+                    "familyName": "bbb"
+                },
+                "excludeFromPublicDirectory": False,
+                "ethicalLegalSocialImplications": True,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "disease focused research name str",
+                "otherPurposeDetails": "other purpose details str",
+                "methodsDevelopment": True,
+                "controlSet": True,
+                "ancestry": True,
+                "socialBehavioral": False,
+                "populationHealth": True,
+                "drugDevelopment": True,
+                "commercialPurpose": True,
+                "educational": True,
+                "otherPurpose": True,
+                "scientificApproaches": 'reasonForInvestigation string',
+                "intendToStudy": 'intendToStudy string',
+                "findingsFromStudy": 'findingsFromStudy string',
+                "focusOnUnderrepresentedPopulations": True,
+                "workspaceDemographic": {
+                    "raceEthnicity": ['AIAN', 'MENA'],
+                    "age": ['AGE_0_11', 'AGE_65_74'],
+                    "sexAtBirth": "UNSET",
+                    "genderIdentity": "OTHER_THAN_MAN_WOMAN",
+                    "sexualOrientation": "OTHER_THAN_STRAIGHT",
+                    "geography": "RURAL",
+                    "disabilityStatus": "DISABILITY",
+                    "accessToCare": "NOT_EASILY_ACCESS_CARE",
+                    "educationLevel": "LESS_THAN_HIGH_SCHOOL",
+                    "incomeLevel": "BELOW_FEDERAL_POVERTY_LEVEL_200_PERCENT",
+                    "others": "string"
+                }
+            },
+            {
+                "workspaceId": 1,
+                "name": "workspace name str 2",
+                "creationTime": "2019-11-25T17:43:41.085Z",
+                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "status": "INACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 0,
+                        "role": "OWNER",
+                        "status": "ACTIVE"
+                    },
+                    {
+                        "userId": 1,
+                        "role": "READER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "creator": {
+                    "userId": 0,
+                    "givenName": "aaa",
+                    "familyName": "bbb"
+                },
+                "excludeFromPublicDirectory": False,
+                "ethicalLegalSocialImplications": False,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "disease focused research name str 2",
+                "otherPurposeDetails": "other purpose details str 2",
+                "methodsDevelopment": False,
+                "controlSet": False,
+                "ancestry": False,
+                "socialBehavioral": False,
+                "populationHealth": False,
+                "drugDevelopment": False,
+                "commercialPurpose": False,
+                "educational": False,
+                "otherPurpose": False,
+                "scientificApproaches": 'reasonForInvestigation string2',
+                "intendToStudy": 'intendToStudy string2',
+                "findingsFromStudy": 'findingsFromStudy string2'
+            }
+        ]
+        now = clock.CLOCK.now()
+        sequest_hours_ago = now - timedelta(hours=24)
+        with FakeClock(sequest_hours_ago):
+            self.send_post('workbench/directory/workspaces', request_data=request_json)
+        result = self.send_get('researchHub/projectDirectory')
+        self.assertEqual(len(result['data']), 2)
+        # test search by project purpose
+        result = self.send_get('researchHub/projectDirectory?projectPurpose=controlSet')
+        self.assertEqual(len(result['data']), 1)
+        # test search by multiple project purpose
+        result = self.send_get('researchHub/projectDirectory?projectPurpose=controlSet,socialBehavioral')
+        self.assertEqual(len(result['data']), 0)
+        # test search by workspace name
+        result = self.send_get('researchHub/projectDirectory?workspaceNameLike=Search%20test')
+        self.assertEqual(len(result['data']), 1)
+        # test search by workspace intendToStudy
+        result = self.send_get('researchHub/projectDirectory?intendToStudyLike=string2')
+        self.assertEqual(len(result['data']), 1)
+        # test search by given/family name
+        result = self.send_get('researchHub/projectDirectory?givenName=givenname1')
+        self.assertEqual(len(result['data']), 1)
+        result = self.send_get('researchHub/projectDirectory?givenName=givenname2')
+        self.assertEqual(len(result['data']), 2)
+        result = self.send_get('researchHub/projectDirectory?familyName=familyname1')
+        self.assertEqual(len(result['data']), 1)
+        result = self.send_get('researchHub/projectDirectory?familyName=familyname2')
+        self.assertEqual(len(result['data']), 2)
+        # test search by user id
+        result = self.send_get('researchHub/projectDirectory?userId=1&userRole=owner')
+        self.assertEqual(len(result['data']), 1)
+        result = self.send_get('researchHub/projectDirectory?userId=1&userRole=member')
+        self.assertEqual(len(result['data']), 1)
+        result = self.send_get('researchHub/projectDirectory?userId=1&userRole=all')
+        self.assertEqual(len(result['data']), 2)
+        # test page and page size
+        result = self.send_get('researchHub/projectDirectory?page=1&pageSize=1')
+        self.assertEqual(len(result['data']), 1)
+        result = self.send_get('researchHub/projectDirectory?page=2&pageSize=1')
+        self.assertEqual(len(result['data']), 1)
+        result = self.send_get('researchHub/projectDirectory?page=3&pageSize=1')
+        self.assertEqual(len(result['data']), 0)
+        result = self.send_get('researchHub/projectDirectory?page=1&pageSize=2')
+        self.assertEqual(len(result['data']), 2)
 
     def test_get_research_projects_directory_less_than_23_hours(self):
         # create researchers
@@ -910,6 +1137,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                 "gender": ["MAN"],
                 "race": ["AIAN"],
                 "sexAtBirth": ["FEMALE"],
+                "degree": ["PHD", "MPH"],
                 "sexualOrientation": "BISEXUAL",
                 "affiliations": [
                     {
@@ -940,6 +1168,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                 "sexualOrientation": "BISEXUAL",
                 "gender": ["MAN", "WOMAN"],
                 "race": ["AIAN", "WHITE"],
+                "degree": ["PHD", "MPH"],
                 "affiliations": [
                     {
                         "institution": "institution2",
@@ -1065,18 +1294,21 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        'creationTime': '2019-11-25T17:43:41.085000',
                        'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'INACTIVE',
                        'workspaceUsers': [
-                           {'userId': 0, 'userName': 'given name 1 family name 1', 'affiliations': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
                                 'nonAcademicAffiliation': 'INDUSTRY'},
                            {'institution': 'verified institution', 'role': 'verified institution role 1',
                             'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}]},
-                           {'userId': 1, 'userName': 'given name 2 family name 2', 'affiliations': [
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
                                {'institution': 'institution2', 'role': 'institution role 2', 'isVerified': None,
                                 'nonAcademicAffiliation': 'UNSET'},
                                {'institution': 'institution22', 'role': 'institution role 22', 'isVerified': None,
                                 'nonAcademicAffiliation': 'INDUSTRY'}]}
                        ],
                        'workspaceOwner': [{'userId': 0, 'userName': 'given name 1 family name 1',
+                                           'degree': ['PHD', 'MPH'],
                                            'affiliations': [{'institution': 'institution1',
                                                              'role': 'institution role 1',
                                                              'isVerified': None,


### PR DESCRIPTION
1. Search workspaces by workspace owner
2. Search workspaces using “LIKE”-based queries on workspace name and intendToStudy
3. Filter workspace results by project purpose (ie, diseaseFocusedResearch, methodsDevelopment, ancestry, socialBehavioral, populationHealth, drugDevelopment, commercialPurpose, educational, and controlSet)
4. Include second tier data for when raceEthnicity and/or age are set to TRUE (these fall under the workspaceDemographic data)
5. Update API to paginate results
6. Return research credentials/degrees with workspace member/owner data, if available