### PR TITLE
[DA-1815] Sending contact information for suspended or deceased participants

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -33,7 +33,6 @@ from rdr_service.model.participant_summary import (
     ParticipantGenderAnswers,
     ParticipantRaceAnswers,
     ParticipantSummary,
-    SUSPENDED_OR_DECEASED_PARTICIPANT_FIELDS,
     WITHDRAWN_PARTICIPANT_FIELDS,
     WITHDRAWN_PARTICIPANT_VISIBILITY_TIME,
     RETENTION_WINDOW
@@ -781,16 +780,6 @@ class ParticipantSummaryDao(UpdatableDao):
             or model.withdrawalTime < clock.CLOCK.now() - WITHDRAWN_PARTICIPANT_VISIBILITY_TIME
         ):
             result = {k: result.get(k) for k in WITHDRAWN_PARTICIPANT_FIELDS}
-
-        elif (
-            (model.withdrawalStatus != WithdrawalStatus.NO_USE and model.suspensionStatus == SuspensionStatus.NO_CONTACT
-             and model.suspensionTime < clock.CLOCK.now() - WITHDRAWN_PARTICIPANT_VISIBILITY_TIME)
-            or
-            (model.deceasedStatus == DeceasedStatus.APPROVED and
-             model.deceasedAuthored < clock.CLOCK.now() - WITHDRAWN_PARTICIPANT_VISIBILITY_TIME)
-        ):
-            for i in SUSPENDED_OR_DECEASED_PARTICIPANT_FIELDS:
-                result[i] = UNSET
 
         result["participantId"] = to_client_participant_id(model.participantId)
         biobank_id = result.get("biobankId")

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -69,11 +69,6 @@ WITHDRAWN_PARTICIPANT_VISIBILITY_TIME = datetime.timedelta(days=2)
 
 RETENTION_WINDOW = datetime.timedelta(days=547)
 
-# suspended or deceased participants don't allow contact but can still use samples. These fields
-# will not be returned when queried on suspended participant.
-SUSPENDED_OR_DECEASED_PARTICIPANT_FIELDS = ["zipCode", "city", "streetAddress", "streetAddress2", "phoneNumber",
-                                            "loginPhoneNumber", "email"]
-
 # SQL Conditional for participant's retention eligibility computed column (1 = NOT_ELIGIBLE, 2 = ELIGIBLE)
 _COMPUTE_RETENTION_ELIGIBLE_SQL = """
     CASE WHEN

--- a/tests/api_tests/test_deceased_report_api.py
+++ b/tests/api_tests/test_deceased_report_api.py
@@ -588,8 +588,10 @@ class DeceasedReportApiTest(DeceasedReportTestBase):
         self.assertEqual(1, self.session.query(ApiUser).count())
 
     def test_participant_summary_fields_redacted(self):
+        """Should still see contact information, but contact method should be updated for deceased participants"""
+
         participant = self.data_generator.create_database_participant()
-        self.data_generator.create_database_participant_summary(
+        summary_obj = self.data_generator.create_database_participant_summary(
             participant=participant,
             phoneNumber='123-456-7890',
             loginPhoneNumber='1-800-555-5555',
@@ -610,8 +612,16 @@ class DeceasedReportApiTest(DeceasedReportTestBase):
                          "Test is built assuming an APPROVED report would be created")
 
         summary_response = self.send_get(f'Participant/P{participant_id}/Summary')
-        for field in ['phoneNumber', 'loginPhoneNumber', 'email', 'streetAddress', 'streetAddress2', 'city', 'zipCode']:
-            self.assertEqual('UNSET', summary_response[field])
+        for field_name, value in [
+            ('phoneNumber', summary_obj.phoneNumber),
+            ('loginPhoneNumber', summary_obj.loginPhoneNumber),
+            ('email', summary_obj.email),
+            ('streetAddress', summary_obj.streetAddress),
+            ('streetAddress2', summary_obj.streetAddress2),
+            ('city', summary_obj.city),
+            ('zipCode', summary_obj.zipCode)
+        ]:
+            self.assertEqual(value, summary_response[field_name])
         self.assertEqual('NO_CONTACT', summary_response['recontactMethod'])
 
     def test_participant_summary_redact_time_window(self):


### PR DESCRIPTION
We need to update the current logic to not remove contact information fields for deactivated (suspended) or deceased participants so that participant matching algorithms can include these participants as well.