### PR TITLE
[PDR-165] Remove replayed questionnaire responses from PDR data

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -1195,7 +1195,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                     if module == 'GROR' \
                        and data['questionnaire_id'] == _deprecated_gror_consent_questionnaire_id \
                        and qnan.code_name in _deprecated_gror_consent_question_code_names \
-                       and qnan.answer and int(qnan.answer) == 1:
+                       and qnan.answer and qnan.answer == '1':
                         # The deprecated consent question code name (if it has the selected/True value), ends up being
                         # the answer code value for the updated GROR consent question
                         data[_consent_module_question_map['GROR']] = qnan.code_name

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -93,6 +93,13 @@ _consent_answer_status_map = {
     'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE
 }
 
+# See hotfix ticket ROC-447 / backfill ticket ROC-475.  The first GROR consent questionnaire was immediately
+# deprecated and replaced by a revised consent questionnaire.  Early GROR consents (~200) already received
+# were replayed using the revised questionnaire format.  When retrieving GROR module answers, we'll look for
+# deprecated GROR consent questions/answers to map them to the revised consent question/answer format.
+_deprecated_gror_consent_questionnaire_id = 415
+_deprecated_gror_consent_question_code_names = ('CheckDNA_Yes', 'CheckDNA_No', 'CheckDNA_NotSure')
+
 class BQParticipantSummaryGenerator(BigQueryGenerator):
     """
     Generate a Participant Summary BQRecord object
@@ -334,14 +341,18 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         :param ro_session: Readonly DAO session object
         :return: dict
         """
+
         code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
             filter(QuestionnaireResponse.questionnaireId ==
                    QuestionnaireConcept.questionnaireId).label('codeId')
+
+        # Responses are sorted by authored date ascending and then created date descending
+        # This should result in a list where any replays of a response are adjacent (most recently created first)
         query = ro_session.query(
             QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
             QuestionnaireResponse.created, QuestionnaireResponse.language, code_id_query). \
             filter(QuestionnaireResponse.participantId == p_id). \
-            order_by(QuestionnaireResponse.authored)
+            order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
         # sql = self.ro_dao.query_to_text(query)
         results = query.all()
 
@@ -353,18 +364,26 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         consents = list()
         consent_dt = None
 
+
         if results:
+            # Track the last module/consent data dictionaries generated, so we can detect and omit replayed responses
+            last_mod_processed = {}
+            last_consent_processed = {}
             for row in results:
+                consent_added = False
                 module_name = self._lookup_code_value(row.codeId, ro_session)
+                # Start with a default submittal status.  May be updated if this is a consent module with a specific
+                # consent question/answer that determines module submittal status
+                module_status = BQModuleStatusEnum.SUBMITTED
                 module_data = {
                     'mod_module': module_name,
                     'mod_baseline_module': 1 if module_name in self._baseline_modules else 0,  # Boolean field
                     'mod_authored': row.authored,
                     'mod_created': row.created,
                     'mod_language': row.language,
+                    'mod_status': module_status.name,
+                    'mod_status_id': module_status.value
                 }
-                # Default status, may be updated based on consent answer
-                module_status = BQModuleStatusEnum.SUBMITTED
 
                 # check if this is a module with consents.
                 if module_name in _consent_module_question_map:
@@ -393,7 +412,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                         }
                         # Note:  Based on currently available modules when a module has no
                         # associated answer options (like ConsentPII or ProgramUpdate), any submitted response is given
-                        # animplicit ConsentPermission_Yes value.   May need adjusting if there are ever modules where
+                        # an implicit ConsentPermission_Yes value.   May need adjusting if there are ever modules where
                         # that may no longer be true
                         if _consent_module_question_map[module_name] is None:
                             consent['consent'] = module_name
@@ -417,15 +436,24 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                                 # May want to reconsider if this should be something else (UNSET?)
                                 module_status = BQModuleStatusEnum.SUBMITTED
 
-                        consents.append(consent)
+                        module_data['mod_status'] = module_status.name
+                        module_data['mod_status_id'] = module_status.value
 
-                module_data['mod_status'] = module_status.name
-                module_data['mod_status_id'] = module_status.value
-                modules.append(module_data)
+                        # Compare against the last consent response processed to filter replays/duplicates
+                        if not self.is_replay(last_consent_processed, consent, created_key='consent_module_created'):
+                            consents.append(consent)
+                            consent_added = True
+
+                        last_consent_processed = consent.copy()
+
+                # consent_added == True means we already know it wasn't a replayed consent
+                if consent_added or not self.is_replay(last_mod_processed, module_data, created_key='mod_created'):
+                    modules.append(module_data)
+
+                last_mod_processed = module_data.copy()
 
 
         if len(modules) > 0:
-            # remove any duplicate modules and consents because of replayed responses.
             data['modules'] = [dict(t) for t in {tuple(d.items()) for d in modules}]
             if len(consents) > 0:
                 data['consents'] = [dict(t) for t in {tuple(d.items()) for d in consents}]
@@ -1139,6 +1167,23 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 return None
 
             # Query the answers for all responses found.
+            # Note on special logic for GROR module:  the original GROR consent questionnaire was quickly replaced by
+            # a revised questionnaire with a different consent question/answer structure.  GROR consents (~200)
+            # that came in for the old/deprecated questionnaire_id were resent by PTSC using the new questionnaire_id
+            # (See ROC-447/ROC-475)
+            #
+            # When processing a deprecated GROR response, add a key/value pair to the data
+            # simulating what the consent answer would look like in the revised consent.  E.g., if the
+            # deprecated GROR consent response had these question codes/boolean answer values (only one will be True/1):
+            #   'CheckDNA_Yes': '0',
+            #   'CheckDNA_No': '1',
+            #   'CheckDNA_NotSure': '0'
+            # ... then this key/value pair will be added to simulate the revised GROR consent question code/answer code:
+            #    'ResultsConsent_CheckDNA': 'CheckDNA_No'
+            #
+            # This way the answers returned can have the same logic applied to them by _prep_modules(), for all GROR
+            # consents.  This is intended to help resolve some mismatch issues between RDR and PDR GROR data
+
             for row in results:
                 # Save parent record field values into data dict.
                 data = ro_dao.to_dict(row, result_proxy=results)
@@ -1146,6 +1191,15 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 # Save answers into data dict.
                 for qnan in qnans:
                     data[qnan.code_name] = qnan.answer
+                    # Special handling of GROR deprecated responses
+                    if module == 'GROR' \
+                       and data['questionnaire_id'] == _deprecated_gror_consent_questionnaire_id \
+                       and qnan.code_name in _deprecated_gror_consent_question_code_names \
+                       and qnan.answer and int(qnan.answer) == 1:
+                        # The deprecated consent question code name (if it has the selected/True value), ends up being
+                        # the answer code value for the updated GROR consent question
+                        data[_consent_module_question_map['GROR']] = qnan.code_name
+
                 # Insert data dict into answers list.
                 answers[row.questionnaire_response_id] = data
 
@@ -1157,6 +1211,40 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 break
 
         return data if data else None
+
+    @staticmethod
+    def is_replay(prev_data_dict, data_dict, created_key=None):
+        """
+        Compares two module or consent data dictionaries to identify replayed responses
+        Replayed/resent responses are usually the result of trying to resolve a data issue, and are basically
+        duplicate QuestionnaireResponse payloads except for differing creation timestamps
+
+        :param prev_data_dict: data dictionary to compare
+        :param data_dict: data dictionary to compare
+        :param created_key:  Dict key for the created timestamp value
+        :return:  Boolean, True if the dictionaries match on everything except the created timestamp value
+        """
+        # Confirm both data dictionaries are populated
+        if not bool(prev_data_dict) or not bool(data_dict):
+            return False
+
+        # Validate we're comparing "like" dictionaries, with a valid created timestamp key name
+        prev_data_dict_keys = sorted(list(prev_data_dict.keys()))
+        data_dict_keys = sorted(list(data_dict.keys()))
+        if prev_data_dict_keys != data_dict_keys:
+            return False
+        if not (created_key and created_key in data_dict_keys):
+            return False
+
+        # Content must match on everything but created timestamp value
+        for key in data_dict.keys():
+            if key == created_key:
+                continue
+            if data_dict[key] != prev_data_dict[key]:
+                return False
+
+        return True
+
 
 
 def rebuild_bq_participant(p_id, ps_bqgen=None, pdr_bqgen=None, project_id=None, patch_data=None):
@@ -1187,6 +1275,7 @@ def rebuild_bq_participant(p_id, ps_bqgen=None, pdr_bqgen=None, project_id=None,
     pdr_bqr = pdr_bqgen.make_bqrecord(p_id, ps_bqr=ps_bqr)
 
     w_dao = BigQuerySyncDao()
+
 
     with w_dao.session() as w_session:
         # save the participant summary record if this is a full rebuild.

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -373,7 +373,6 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             for row in results:
                 consent_added = False
                 module_name = self._lookup_code_value(row.codeId, ro_session)
-                module_name = self._lookup_code_value(row.codeId, ro_session)
                 # Start with a default submittal status.  May be updated if this is a consent module with a specific
                 # consent question/answer that determines module submittal status
                 module_status = BQModuleStatusEnum.SUBMITTED
@@ -386,12 +385,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     'status': module_status.name,
                     'status_id': module_status.value
                 }
-                # Default status, may be updated based on consent answer
-                module_status = BQModuleStatusEnum.SUBMITTED
 
                 # check if this is a module with consents.
                 if module_name in _consent_module_question_map:
-
                     # Calculate Consent Cohort from ConsentPII authored
                     if consent_dt is None and module_name == 'ConsentPII' and row.authored:
                         consent_dt = row.authored

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -92,6 +92,12 @@ _consent_answer_status_map = {
     'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE
 }
 
+# See hotfix ticket ROC-447 / backfill ticket ROC-475.  The first GROR consent questionnaire was immediately
+# deprecated and replaced by a revised consent questionnaire.  Early GROR consents (~200) already received
+# were replayed using the revised questionnaire format.  When retrieving GROR module answers, we'll look for
+# deprecated GROR consent questions/answers to map them to the revised consent question/answer format.
+_deprecated_gror_consent_questionnaire_id = 415
+_deprecated_gror_consent_question_code_names = ('CheckDNA_Yes', 'CheckDNA_No', 'CheckDNA_NotSure')
 
 class ParticipantSummaryGenerator(generators.BaseGenerator):
     """
@@ -337,14 +343,18 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :param ro_session: Readonly DAO session object
         :return: dict
         """
+
         code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
             filter(QuestionnaireResponse.questionnaireId ==
                    QuestionnaireConcept.questionnaireId).label('codeId')
+
+        # Responses are sorted by authored date ascending and then created date descending
+        # This should result in a list where any replays of a response are adjacent (most recently created first)
         query = ro_session.query(
             QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
             QuestionnaireResponse.created, QuestionnaireResponse.language, code_id_query). \
             filter(QuestionnaireResponse.participantId == p_id). \
-            order_by(QuestionnaireResponse.authored)
+            order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
         # sql = self.ro_dao.query_to_text(query)
         results = query.all()
 
@@ -357,14 +367,24 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         consent_dt = None
 
         if results:
+            # Track the last module/consent data dictionaries generated, so we can detect and omit replayed responses
+            last_mod_processed = {}
+            last_consent_processed = {}
             for row in results:
+                consent_added = False
                 module_name = self._lookup_code_value(row.codeId, ro_session)
+                module_name = self._lookup_code_value(row.codeId, ro_session)
+                # Start with a default submittal status.  May be updated if this is a consent module with a specific
+                # consent question/answer that determines module submittal status
+                module_status = BQModuleStatusEnum.SUBMITTED
                 module_data = {
                     'module': module_name,
                     'baseline_module': 1 if module_name in self._baseline_modules else 0,  # Boolean field
                     'module_authored': row.authored,
                     'module_created': row.created,
                     'language': row.language,
+                    'status': module_status.name,
+                    'status_id': module_status.value
                 }
                 # Default status, may be updated based on consent answer
                 module_status = BQModuleStatusEnum.SUBMITTED
@@ -421,11 +441,23 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                                 # May want to reconsider if this should be something else (UNSET?)
                                 module_status = BQModuleStatusEnum.SUBMITTED
 
-                        consents.append(consent)
+                        module_data['status'] = module_status.name
+                        module_data['status_id'] = module_status.value
 
-                module_data['status'] = module_status.name
-                module_data['status_id'] = module_status.value
-                modules.append(module_data)
+                        # Compare against the last consent response processed to filter replays/duplicates
+                        if not self.is_replay(last_consent_processed, consent, created_key='consent_module_created'):
+                            consents.append(consent)
+                            consent_added = True
+
+                        last_consent_processed = consent.copy()
+
+                # consent_added == True means we already know it wasn't a replayed consent
+                if consent_added or not self.is_replay(last_mod_processed, module_data,
+                                                        created_key='module_created'):
+                    modules.append(module_data)
+
+                last_mod_processed = module_data.copy()
+
 
         if len(modules) > 0:
             # remove any duplicate modules and consents because of replayed responses.
@@ -1161,6 +1193,39 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 break
 
         return data if data else None
+
+    @staticmethod
+    def is_replay(prev_data_dict, data_dict, created_key=None):
+        """
+        Compares two module or consent data dictionaries to identify replayed responses
+        Replayed/resent responses are usually the result of trying to resolve a data issue, and are basically
+        duplicate QuestionnaireResponse payloads except for differing creation timestamps
+
+        :param prev_data_dict: data dictionary to compare
+        :param data_dict: data dictionary to compare
+        :param created_key:  Dict key for the created timestamp value
+        :return:  Boolean, True if the dictionaries match on everything except the created timestamp value
+        """
+        # Confirm both data dictionaries are populated
+        if not bool(prev_data_dict) or not bool(data_dict):
+            return False
+
+        # Validate we're comparing "like" dictionaries, with a valid created timestamp key name
+        prev_data_dict_keys = sorted(list(prev_data_dict.keys()))
+        data_dict_keys = sorted(list(data_dict.keys()))
+        if prev_data_dict_keys != data_dict_keys:
+            return False
+        if not (created_key and created_key in data_dict_keys):
+            return False
+
+        # Content must match on everything but created timestamp value
+        for key in data_dict.keys():
+            if key == created_key:
+                continue
+            if data_dict[key] != prev_data_dict[key]:
+                return False
+
+        return True
 
 
 def rebuild_participant_summary_resource(p_id, res_gen=None, patch_data=None):


### PR DESCRIPTION
Had some significant "duplication" in PDR module/consent data due to some known replay events, such as PTSC replaying ~65K GROR consents because of missing electronic signatures in the associated PDF files.

Additionally, found a prior replay event from April (ROC-447/ROC-475) where PTSC deprecated the original GROR consent questionnaire;  the updated version had a different consent question/answer structure.  So the replays were mapped to the new questionnaire ID structure, but still had the same authored date as the original response for the deprecated questionnaire ID.  Added some special case code for deprecated GROR responses that will allow them to still be recognized as "replays"/duplicates of the updated response, despite the structural differences.

The PDR generator code that assembles the lists of module/consent summaries will look for responses that match on everything except creation date, and only include the most recently created.