### PR TITLE
[DA-1817] Fix Genomic ROC Ticket alerts

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -883,9 +883,10 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                 .all()
             )
 
-    def get_with_missing_gen_files(self):
+    def get_with_missing_gen_files(self, _date):
         """
         Retrieves all gc metrics with missing genotyping files
+        :param: _date: last run time
         :return: list of returned GenomicGCValidationMetrics objects
         """
         with self.session() as session:
@@ -899,6 +900,8 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                     GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
                     GenomicSetMember.genomeType == config.GENOME_TYPE_ARRAY,
                     GenomicGCValidationMetrics.genomicFileProcessedId != None,
+                    sqlalchemy.func.lower(GenomicGCValidationMetrics.processingStatus) == "pass",
+                    GenomicGCValidationMetrics.modified > _date,
                     ((GenomicGCValidationMetrics.ignoreFlag != 1) |
                      (GenomicGCValidationMetrics.ignoreFlag is not None)),
                     (GenomicGCValidationMetrics.idatRedReceived == 0) |
@@ -912,9 +915,10 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                 .all()
             )
 
-    def get_with_missing_seq_files(self):
+    def get_with_missing_seq_files(self, _date):
         """
         Retrieves all gc metrics with missing sequencing files
+        :param: _date: last run time
         :return: list of returned GenomicGCValidationMetrics objects
         """
         with self.session() as session:
@@ -930,6 +934,8 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
                     GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
                     GenomicSetMember.genomeType == config.GENOME_TYPE_WGS,
                     GenomicGCValidationMetrics.genomicFileProcessedId != None,
+                    sqlalchemy.func.lower(GenomicGCValidationMetrics.processingStatus) == "pass",
+                    GenomicGCValidationMetrics.modified > _date,
                     ((GenomicGCValidationMetrics.ignoreFlag != 1) | (
                             GenomicGCValidationMetrics.ignoreFlag is not None)),
                     (GenomicGCValidationMetrics.hfVcfReceived == 0) |

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1146,7 +1146,7 @@ class GenomicReconciler:
         """ The main method for the AW2 manifest vs. array data reconciliation
         :return: result code
         """
-        metrics = self.metrics_dao.get_with_missing_gen_files()
+        metrics = self.metrics_dao.get_with_missing_gen_files(self.controller.last_run_time)
 
         total_missing_data = []
 
@@ -1211,7 +1211,7 @@ class GenomicReconciler:
         """ The main method for the AW2 manifest vs. sequencing data reconciliation
         :return: result code
         """
-        metrics = self.metrics_dao.get_with_missing_seq_files()
+        metrics = self.metrics_dao.get_with_missing_seq_files(self.controller.last_run_time)
 
         # TODO: Update filnames when clarified
         external_ids = "LocalID_InternalRevisionNumber"

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -709,10 +709,10 @@ class GenomicPipelineTest(BaseTestCase):
         mock_alert_handler.make_genomic_alert.return_value = 1
 
         # Create the fake ingested data
-        self._create_fake_datasets_for_gc_tests(2, arr_override=True, array_participants=[1,2],
+        self._create_fake_datasets_for_gc_tests(3, arr_override=True, array_participants=[1, 2, 3],
                                                 genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
-        self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest.csv',
+        self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifestWithFailure.csv',
                                          bucket_name,
                                          folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1]))
 
@@ -801,9 +801,9 @@ class GenomicPipelineTest(BaseTestCase):
         mock_alert_handler.make_genomic_alert.return_value = 1
 
         # Create the fake ingested data
-        self._create_fake_datasets_for_gc_tests(2, genomic_workflow_state=GenomicWorkflowState.AW1)
+        self._create_fake_datasets_for_gc_tests(3, genomic_workflow_state=GenomicWorkflowState.AW1)
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
-        self._create_ingestion_test_file('RDR_AoU_SEQ_TestDataManifest.csv',
+        self._create_ingestion_test_file('RDR_AoU_SEQ_TestDataManifestWithFailure.csv',
                                          bucket_name,
                                          folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[0]))
 

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifestWithFailure.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifestWithFailure.csv
@@ -1,0 +1,4 @@
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Notes
+T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,8.67812390,Pass,This sample passed
+T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Pass,This sample passed
+T3,1003,T3_1993,10003,10003_R01C02,0.3456789012,True,0.1345,Abandoned,Bad sample

--- a/tests/test-data/RDR_AoU_SEQ_TestDataManifestWithFailure.csv
+++ b/tests/test-data/RDR_AoU_SEQ_TestDataManifestWithFailure.csv
@@ -1,0 +1,3 @@
+Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,AoU HDR Coverage,Contamination,Sex Concordance,Sex Ploidy,Aligned Q30 Bases,Array Concordance,Processing Status,Notes
+T2,1002,2_1992,10002,2,2,2,3,True,XY,1000000000004,True,Pass,This sample passed
+T3,1003,3_1993,10003,2,2,2,3,True,XY,1000000000004,True,Abandoned,This sample was abandoned


### PR DESCRIPTION
This PR adds date and processing status filters to data file reconciliation queries. This will prevents the same alert from being sent on multiple occasions unless the underlying record is modified. This also prevents alerts for records that do not have a processing status of `pass.`