### PR TITLE
Fix logging error in AW1 workflow

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -339,7 +339,6 @@ class GenomicFileIngester:
 
                         else:
                             logging.error(f"Skipping collection tube ID: {collection_tube_id}, "
-                                          f"biobank id: {bid}, "
                                           f"genome type: {genome_type}")
 
                         continue


### PR DESCRIPTION
This PR fixes an error in the AW1 workflow logging code for samples where no Biobank ID is supplied.