### PR TITLE
Revert "[DA-1784] allow hpo lite access UNSET participants"

### DIFF
--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -8,8 +8,6 @@ from rdr_service.dao.base_dao import _MIN_ID, _MAX_ID
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.hpo import HPO
 from rdr_service.model.participant_summary import ParticipantSummary
-from rdr_service.config import getSettingList, HPO_LITE_AWARDEE
-from rdr_service.code_constants import UNSET
 
 
 class ParticipantSummaryApi(BaseApi):
@@ -42,11 +40,7 @@ class ParticipantSummaryApi(BaseApi):
             if auth_awardee:
                 # make sure request has awardee
                 requested_awardee = request.args.get("awardee")
-                hpo_lite_awardees = getSettingList(HPO_LITE_AWARDEE, default=[])
-                if requested_awardee == UNSET and auth_awardee in hpo_lite_awardees:
-                    # allow hpo lite awardee to access UNSET participants
-                    pass
-                elif requested_awardee != auth_awardee:
+                if requested_awardee != auth_awardee:
                     raise Forbidden
             return super(ParticipantSummaryApi, self)._query("participantId")
 

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -106,7 +106,6 @@ LOCALHOST_DEFAULT_BUCKET_NAME = 'local_bucket'
 BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN = 'biobank_samples_daily_inventory_file_pattern'
 BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN = 'biobank_samples_monthly_inventory_file_pattern'
 COPE_FORM_ID_MAP = 'cope_form_id_map'
-HPO_LITE_AWARDEE = 'hpo_lite_awardee'
 
 # Questionnaire Codes
 DNA_PROGRAM_CONSENT_UPDATE_CODE = 'dna_program_consent_update_code'


### PR DESCRIPTION
Reverts all-of-us/raw-data-repository#2090

We are going to pause on working on it until next sprint. NIH is having further discussions about whether the HPO Lite sites should set UNSET participants or if they should only see the VCU participants at the last minute. We will move this ticket out into next sprint once NIH makes a final decision on how we are to handle these site’s access. 