### PR TITLE
Allowing cron jobs an hour before they get killed

### DIFF
--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -2,7 +2,7 @@
 
 runtime: python37
 service: offline
-entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 600 rdr_service.offline.main:app
+entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 3600 rdr_service.offline.main:app
 # Default AppEngine configuration (B1) has only 128 MB of RAM and 600 MhZ CPU, which makes
 # the metrics pipeline run very slowly. Bumping up to 1 GB of RAM and 2.4 GHz to speed things up.
 # https://cloud.google.com/appengine/docs/standard/


### PR DESCRIPTION
I haven't figured out yet why it doesn't happen at the 10 minute mark, but it's clear from the logs that the Gunicorn worker for updating participant ehr data is getting murdered. This changes the offline timeout from 10 minutes to an hour.