### PR TITLE
Fix for PDR-166 EHR receipt / Add deceased status (PDR-176)

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -28,6 +28,7 @@ from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_pdr_participant_summary import BQPDRParticipantSummary
 from rdr_service.model.bq_participant_summary import BQParticipantSummarySchema, BQStreetAddressTypeEnum, \
     BQModuleStatusEnum, BQParticipantSummary, COHORT_1_CUTOFF, COHORT_2_CUTOFF, BQConsentCohort
+from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.ehr import ParticipantEhrReceipt
 from rdr_service.model.hpo import HPO
 from rdr_service.model.measurements import PhysicalMeasurements, PhysicalMeasurementsStatus
@@ -39,7 +40,8 @@ from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.questionnaire import QuestionnaireConcept
 from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
-    SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus
+    SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus, DeceasedStatus, \
+    DeceasedReportStatus
 from rdr_service.resource.helpers import DateCollection
 
 
@@ -203,6 +205,22 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         organization = ro_session.query(Organization.externalId). \
             filter(Organization.organizationId == p.organizationId).first()
 
+        # See DeceasedReportDao._update_participant_summary() for the logic for populating
+        # the deceased status details in participant_summary.  DENIED reports are not reflected in
+        # participant_summary, only PENDING and APPROVED.  Also, when records are inserted into the deceased_report
+        # table there is a check to ensure each participant only has one report that is PENDING or APPROVED
+        deceased = ro_session.query(DeceasedReport) \
+            .filter(DeceasedReport.participantId == p_id,
+                    DeceasedReport.status != DeceasedReportStatus.DENIED).one_or_none()
+        if deceased:
+            deceased_status = DeceasedStatus(str(deceased.status))
+            deceased_authored = deceased.reviewed if deceased_status == DeceasedStatus.APPROVED else deceased.authored
+            deceased_date_of_death = deceased.dateOfDeath
+        else:
+            deceased_authored = None
+            deceased_status = DeceasedStatus.UNSET
+            deceased_date_of_death = None
+
         withdrawal_status = WithdrawalStatus(p.withdrawalStatus)
         withdrawal_reason = WithdrawalReason(p.withdrawalReason if p.withdrawalReason else 0)
         suspension_status = SuspensionStatus(p.suspensionStatus)
@@ -250,8 +268,14 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             'is_ghost_id': 1 if p.isGhostId is True else 0,
             'test_participant': 1 if p.isTestParticipant is True else 0,
             'cohort_2_pilot_flag': str(cohort_2_pilot_flag),
-            'cohort_2_pilot_flag_id': int(cohort_2_pilot_flag)
+            'cohort_2_pilot_flag_id': int(cohort_2_pilot_flag),
+            'deceased_status': str(deceased_status),
+            'deceased_status_id':  int(deceased_status),
+            'deceased_authored': deceased_authored,
+            # TODO:  Enable this field definition in the BQ model if it's determined it should be included in PDR
+            'date_of_death': deceased_date_of_death
         }
+
 
         return data
 

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -36,6 +36,7 @@ class BQConsentCohort(Enum):
 COHORT_1_CUTOFF = datetime(2018, 4, 24, 0, 0, 0)
 COHORT_2_CUTOFF = datetime(2020, 4, 21, 4, 0, 0)
 
+
 class BQAddressSchema(BQSchema):
     """
     Represents a street address schema.
@@ -278,6 +279,13 @@ class BQParticipantSummarySchema(BQSchema):
     first_ehr_receipt_time = BQField('first_ehr_receipt_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     latest_ehr_receipt_time = BQField('latest_ehr_receipt_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     ehr_receipts = BQRecordField('ehr_receipts', schema=BQEhrReceiptSchema)
+
+    # PDR-176: Participant Deceased status info
+    deceased_authored = BQField('deceased_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    deceased_status = BQField('deceased_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    deceased_status_id = BQField('deceased_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR
+    # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
 
 
 class BQParticipantSummary(BQTable):

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -169,6 +169,15 @@ class BQPatientStatusSchema(BQSchema):
     site_id = BQField('site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
+class BQEhrReceiptSchema(BQSchema):
+    """
+    Participant EHR Receipt Histories
+    """
+    file_timestamp = BQField('file_timestamp', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    first_seen = BQField('first_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    last_seen = BQField('last_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
+
 class BQParticipantSummarySchema(BQSchema):
     """
     Note: Do not use camelCase for property names. Property names must exactly match BQ
@@ -263,6 +272,12 @@ class BQParticipantSummarySchema(BQSchema):
     cohort_2_pilot_flag = BQField('cohort_2_pilot_flag', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     cohort_2_pilot_flag_id = BQField('cohort_2_pilot_flag_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     biobank_orders = BQRecordField('biobank_orders', schema=BQBiobankOrderSchema)
+    # PDR-166:  Additional EHR status / history information enabled by DA-1781
+    is_ehr_data_available = BQField('is_ehr_data_available', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    was_ehr_data_available = BQField('was_ehr_data_available', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    first_ehr_receipt_time = BQField('first_ehr_receipt_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    latest_ehr_receipt_time = BQField('latest_ehr_receipt_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    ehr_receipts = BQRecordField('ehr_receipts', schema=BQEhrReceiptSchema)
 
 
 class BQParticipantSummary(BQTable):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -152,6 +152,13 @@ class BQPDRParticipantSummarySchema(BQSchema):
     latest_ehr_receipt_time = BQField('latest_ehr_receipt_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     ehr_receipts = BQRecordField('ehr_receipts', schema=BQPDREhrReceiptSchema)
 
+    # PDR-176: Participant deceased status info
+    deceased_authored = BQField('deceased_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    deceased_status = BQField('deceased_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    deceased_status_id = BQField('deceased_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR
+    # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
+
 
 class BQPDRParticipantSummary(BQTable):
     """ PDR Participant Summary BigQuery Table """

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -10,7 +10,7 @@ from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGener
 from rdr_service.dao.bq_pdr_participant_summary_dao import BQPDRParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay
+    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec
 from rdr_service.resource.generators import ParticipantSummaryGenerator
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
 
@@ -56,7 +56,9 @@ def batch_rebuild_participants_task(payload, project_id=None):
             BQPDROverallHealth,
             BQPDREHRConsentPII,
             BQPDRDVEHRSharing,
-            BQPDRCOPEMay
+            BQPDRCOPEMay,
+            BQPDRCOPENov,
+            BQPDRCOPEDec,
         )
         for module in modules:
             mod = module()


### PR DESCRIPTION
The implementation of PDR-166 was missing necessary BQ model updates for adding the EHR receipt fields.  The bq_pdr_participant_summary.py model file was updated but bq_participant_summary.py was missed.

These changes will also include the new RDR participant_summary deceased status fields in the PDR data as well (PDR-176)

Note on date_of_death:  Not confirmed yet if that field is needed in PDR so it's been left out of the BQ pdr_participant schema definition.  But it is part of the generator data builds.  If we do find out it's needed, we can just run migrate-bq on the BigQuery table to recognize that field, rather than needing to do another RDR deploy to add generator changes.

Also fixed up a couple of places in handling the COPE data where some of the work for cope_nov/cope_dec surveys was missing.

