### PR TITLE
Clearing more metrics cache tables in the tests

### DIFF
--- a/tests/api_tests/test_participant_counts_over_time.py
+++ b/tests/api_tests/test_participant_counts_over_time.py
@@ -101,6 +101,12 @@ class ParticipantCountsOverTimeApiTest(BaseTestCase):
             curr_date = curr_date + datetime.timedelta(days=1)
 
         self.clear_table_after_test('metrics_enrollment_status_cache')
+        self.clear_table_after_test('metrics_gender_cache')
+        self.clear_table_after_test('metrics_age_cache')
+        self.clear_table_after_test('metrics_race_cache')
+        self.clear_table_after_test('metrics_region_cache')
+        self.clear_table_after_test('metrics_lifecycle_cache')
+        self.clear_table_after_test('metrics_language_cache')
 
     def _insert(
         self,


### PR DESCRIPTION
My last PR for changing the algorithm for clearing the database between tests failed on some data already being in the metrics cache tables. This adds the rest of the cache tables to be cleared for the participant count tests.