### PR TITLE
[DA-1824] AW0 manifest modifications

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -77,7 +77,7 @@ cron:
 - description: Genomic Pipeline AW0 (Cohort 3) Workflow
   url: /offline/GenomicC3AW0Workflow
   timezone: America/New_York
-  schedule: every day 06:30
+  schedule: every wednesday 06:30
   target: offline
 - description: Genomic AW1 Workflow
   url: /offline/GenomicGCManifestWorkflow

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1986,14 +1986,6 @@ class GenomicBiobankSamplesCoupler:
                 and ssed.test in ("1ED04", "1ED10")
                 and ssed.status < 13
             ORDER BY oeds.collected DESC
-                and ed04.collected = (
-                    SELECT MAX(os.collected)
-                    FROM biobank_ordered_sample os
-                        JOIN biobank_order o ON o.biobank_order_id = os.order_id
-                    WHERE os.test = "1ED04"
-                        AND o.participant_id = :pid_param
-                    GROUP BY o.participant_id
-                )
             """
 
         params = {

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1645,8 +1645,7 @@ class GenomicBiobankSamplesCoupler:
                                                                 bid=_bid)
 
             # Determine which sample ID to use
-            sample_data = self._determine_best_sample(blood=blood_sample_data,
-                                                      saliva=saliva_sample_data)
+            sample_data = self._determine_best_sample(blood_sample_data, saliva_sample_data)
 
             # update the sample id, collected site, and biobank order
             if sample_data is not None:
@@ -1700,7 +1699,9 @@ class GenomicBiobankSamplesCoupler:
           END AS gror_consent,
           CASE
               WHEN native.participant_id IS NULL THEN 1 ELSE 0
-          END AS valid_ai_an
+          END AS valid_ai_an,
+          ss.status,
+          ss.test
         FROM
             biobank_stored_sample ss
             JOIN participant p ON ss.biobank_id = p.biobank_id
@@ -1718,20 +1719,7 @@ class GenomicBiobankSamplesCoupler:
                     AND m.genomic_workflow_state <> :ignore_param
             LEFT JOIN biobank_mail_kit_order mk ON mk.participant_id = p.participant_id
         WHERE TRUE
-            AND (
-                    CASE WHEN (
-                            ps.sample_status_1ed04 = :sample_status_param
-                            AND ss.test = "1ED04" 
-                            AND ss.status < 13
-                            ) THEN ss.test = "1ED04"
-                        WHEN (
-                            ps.sample_status_1sal2 = :sample_status_param
-                            AND ss.test = "1SAL2" 
-                            AND ss.status < 13
-                            ) THEN ss.test = "1SAL2"
-                        ELSE ss.test = "1ED04"
-                    END
-                )
+            AND ss.test in ('1ED04', '1ED10', '1SAL2')
             AND ss.rdr_created > :from_date_param
             AND ps.consent_cohort = :cohort_3_param
             AND m.id IS NULL
@@ -1749,7 +1737,54 @@ class GenomicBiobankSamplesCoupler:
         }
         with self.samples_dao.session() as session:
             result = session.execute(_new_samples_sql, params).fetchall()
-        return list(zip(*result))
+
+        result = self._prioritize_samples_by_participant(result)
+        return list(zip(*result))[:-2]  # Slicing to remove the last two columns retrieved for prioritization
+
+    def _prioritize_samples_by_participant(self, sample_results):
+        preferred_samples = {}
+
+        for sample in sample_results:
+            preferred_sample = sample
+
+            previously_found_sample = preferred_samples.get(sample.participant_id, None)
+            if previously_found_sample is not None:
+                preferred_sample = self._determine_best_sample(previously_found_sample, sample)
+
+            preferred_samples[sample.participant_id] = preferred_sample
+
+        return list(preferred_samples.values())
+
+    @staticmethod
+    def _determine_best_sample(sample_one, sample_two):
+        if sample_one is None:
+            return sample_two
+        if sample_two is None:
+            return sample_one
+
+        # Return the usable sample (status less than NOT_RECEIVED) if one is usable and the other isn't
+        if sample_one.status < int(SampleStatus.SAMPLE_NOT_RECEIVED) <= sample_two.status:
+            return sample_one
+        elif sample_two.status < int(SampleStatus.SAMPLE_NOT_RECEIVED) <= sample_two.status:
+            return sample_two
+        elif sample_one.status >= int(SampleStatus.SAMPLE_NOT_RECEIVED) \
+                and sample_two.status >= int(SampleStatus.SAMPLE_NOT_RECEIVED):
+            return None
+
+        # Both are usable
+        # Return the sample by the priority of the code: 1ED04, then 1ED10, and 1SAL2 last
+        test_codes_by_preference = ['1ED04', '1ED10', '1SAL2']  # most desirable first
+        samples_by_code = {}
+        for sample in [sample_one, sample_two]:
+            samples_by_code[sample.test] = sample
+
+        for test_code in test_codes_by_preference:
+            if samples_by_code.get(test_code):
+                return samples_by_code[test_code]
+
+        logging.error(f'Should have been able to select between '
+                      f'{sample_one.biobank_stored_sample_id} and {sample_two.biobank_stored_sample_id}')
+
 
     def _get_new_c2_participants(self, from_date):
         """
@@ -1930,34 +1965,27 @@ class GenomicBiobankSamplesCoupler:
 
     def _get_usable_blood_sample(self, pid, bid):
         """
-        Select 1ED04 based on max collected date and 1ED04
+        Select 1ED04 or 1ED10 based on max collected date
         :param pid: participant_id
         :param bid: biobank_id
         :return: tuple(blood_collected date, blood sample, blood site, blood order)
         """
         _samples_sql = """
-            # Max 1ED04 Sample
-            SELECT ed04.collected AS blood_collected
-                , ssed.biobank_stored_sample_id AS blood_sample
+            # Latest 1ED04 or 1ED10 Sample
+            SELECT ssed.biobank_stored_sample_id AS blood_sample
                 , oed.collected_site_id AS blood_site
                 , oed.biobank_order_id AS blood_order
+                , ssed.test, ssed.status
             FROM biobank_stored_sample ssed
                 JOIN biobank_order_identifier edid ON edid.value = ssed.biobank_order_identifier
                 JOIN biobank_order oed ON oed.biobank_order_id = edid.biobank_order_id
-                JOIN biobank_ordered_sample ed04 ON oed.biobank_order_id = ed04.order_id
-                    AND ed04.test = "1ED04"
+                JOIN biobank_ordered_sample oeds ON oed.biobank_order_id = oeds.order_id
+                    AND ssed.test = oeds.test
             WHERE TRUE
                 and ssed.biobank_id = :bid_param
-                and ssed.test = "1ED04"
+                and ssed.test in ("1ED04", "1ED10")
                 and ssed.status < 13
-                and ed04.collected = (
-                    SELECT MAX(os.collected)
-                    FROM biobank_ordered_sample os
-                        JOIN biobank_order o ON o.biobank_order_id = os.order_id
-                    WHERE os.test = "1ED04"
-                        AND o.participant_id = :pid_param
-                    GROUP BY o.participant_id
-                )              
+            ORDER BY oeds.collected DESC
             """
 
         params = {
@@ -1979,10 +2007,10 @@ class GenomicBiobankSamplesCoupler:
         """
         _samples_sql = """
             # Max 1SAL2 Sample
-            select sal2.collected AS saliva_collected
-                , sssal.biobank_stored_sample_id AS saliva_sample
+            select sssal.biobank_stored_sample_id AS saliva_sample
                 , osal.collected_site_id AS saliva_site
                 , osal.biobank_order_id AS saliva_order
+                , sssal.test, sssal.status
             FROM biobank_order osal
                 JOIN biobank_order_identifier salid ON osal.biobank_order_id = salid.biobank_order_id
                 JOIN biobank_ordered_sample sal2 ON osal.biobank_order_id = sal2.order_id
@@ -2011,33 +2039,6 @@ class GenomicBiobankSamplesCoupler:
             result = session.execute(_samples_sql, params).first()
 
         return result
-
-    def _determine_best_sample(self, blood, saliva):
-        """
-        Determines which sample to use based on:
-        latest collection date, Blood over Saliva
-        :param blood:
-        :param saliva:
-        :return: tuple of sample to use (sample_id to use, collected_site_ID, biobank_order_id)
-        """
-        if blood is None:
-            if saliva is None:
-                # If both None, return None
-                return None
-
-            # if only blood is none, return saliva
-            return saliva[1:]
-
-        # if only saliva is None, return blood
-        if saliva is None:
-            return blood[1:]
-
-        # if both samples, return latest or blood if same date
-        if blood[0] >= saliva[0]:
-            return blood[1:]
-
-        else:
-            return saliva[1:]
 
     def _create_new_genomic_set(self):
         """Inserts a new genomic set for this run"""

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -891,6 +891,7 @@ class GenomicPipelineTest(BaseTestCase):
             self._make_summary(p, sexId=intersex_code if bid == 100004 else female_code,
                                consentForStudyEnrollment=0 if bid == 100006 else 1,
                                sampleStatus1ED04=0,
+                               sampleStatus1ED10=1 if bid == 100003 else 0,
                                sampleStatus1SAL2=0 if bid == 100005 else 1,
                                samplesToIsolateDNA=0,
                                race=Race.HISPANIC_LATINO_OR_SPANISH,
@@ -935,6 +936,17 @@ class GenomicPipelineTest(BaseTestCase):
                 insert_dtm = fake_datetime_old
             with clock.FakeClock(insert_dtm):
                 self._make_stored_sample(**sample_args)
+
+            # Make a 1ED10 test for 100003 (in addition to the 1SAL2 test for that participant)
+            if bid == 100003:
+                self._make_stored_sample(
+                    test='1ED10',
+                    confirmed=fake_datetime_new,
+                    created=fake_datetime_old,
+                    biobankId=bid,
+                    biobankOrderIdentifier=test_identifier.value,
+                    biobankStoredSampleId='003_1ED10',
+                )
 
             # Make Mail Kit NY participant
             if bid == 100008:
@@ -990,7 +1002,7 @@ class GenomicPipelineTest(BaseTestCase):
             if member.biobankId == 100003:
                 # 100003 : Included, Valid
                 self.assertEqual(0, member.nyFlag)
-                self.assertEqual('100003', member.collectionTubeId)
+                self.assertEqual('003_1ED10', member.collectionTubeId)
                 self.assertEqual('F', member.sexAtBirth)
                 self.assertEqual(GenomicSetMemberStatus.VALID, member.validationStatus)
                 self.assertEqual('N', member.ai_an)
@@ -1073,7 +1085,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual("aou_wgs", rows[1][ExpectedCsvColumns.GENOME_TYPE])
 
             self.assertEqual("T100003", rows[2][ExpectedCsvColumns.BIOBANK_ID])
-            self.assertEqual(100003, int(rows[2][ExpectedCsvColumns.SAMPLE_ID]))
+            self.assertEqual('003_1ED10', rows[2][ExpectedCsvColumns.SAMPLE_ID])
             self.assertEqual("F", rows[2][ExpectedCsvColumns.SEX_AT_BIRTH])
             self.assertEqual("N", rows[2][ExpectedCsvColumns.NY_FLAG])
             self.assertEqual("Y", rows[2][ExpectedCsvColumns.VALIDATION_PASSED])
@@ -1081,7 +1093,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual("aou_array", rows[2][ExpectedCsvColumns.GENOME_TYPE])
 
             self.assertEqual("T100003", rows[3][ExpectedCsvColumns.BIOBANK_ID])
-            self.assertEqual(100003, int(rows[3][ExpectedCsvColumns.SAMPLE_ID]))
+            self.assertEqual('003_1ED10', rows[3][ExpectedCsvColumns.SAMPLE_ID])
             self.assertEqual("F", rows[3][ExpectedCsvColumns.SEX_AT_BIRTH])
             self.assertEqual("N", rows[3][ExpectedCsvColumns.NY_FLAG])
             self.assertEqual("Y", rows[3][ExpectedCsvColumns.VALIDATION_PASSED])
@@ -1434,12 +1446,11 @@ class GenomicPipelineTest(BaseTestCase):
 
             insert_dtm = fake_datetime_new
 
-            # Testing sample business logic (prioritize newer collected samples then 1ED04)
             col_date_1 = datetime.datetime(2018, 6, 30, 0, 0, 0, 0)
             col_date_2 = datetime.datetime(2019, 6, 30, 0, 0, 0, 0)
 
             if bid == 100001:
-                # SAL2 newer than ED04 -> Use SAL2
+                # ED04 with bad status and SAL2 -> Use SAL2
                 sample_1 = self._make_ordered_sample(_test="1ED04", _collected=col_date_1)
                 sample_2 = self._make_ordered_sample(_test="1SAL2", _collected=col_date_2)
 
@@ -1468,6 +1479,7 @@ class GenomicPipelineTest(BaseTestCase):
                     'biobankId': bid,
                     'biobankOrderIdentifier': test_identifier.value,
                     'biobankStoredSampleId': 10000101,
+                    'status': SampleStatus.SAMPLE_NOT_RECEIVED
                 }
 
                 sample_args2 = {
@@ -1477,6 +1489,7 @@ class GenomicPipelineTest(BaseTestCase):
                     'biobankId': bid,
                     'biobankOrderIdentifier': test_identifier2.value,
                     'biobankStoredSampleId': 10000102,
+                    'status': SampleStatus.RECEIVED
                 }
 
                 with clock.FakeClock(insert_dtm):
@@ -1484,8 +1497,8 @@ class GenomicPipelineTest(BaseTestCase):
                     self._make_stored_sample(**sample_args2)
 
             elif bid == 100002:
-                # ED04 and SAL2 same collected date -> Use ED04
-                sample_1 = self._make_ordered_sample(_test="1ED04", _collected=col_date_1)
+                # ED10 and SAL2 -> Use ED10
+                sample_1 = self._make_ordered_sample(_test="1ED10", _collected=col_date_1)
                 sample_2 = self._make_ordered_sample(_test="1SAL2", _collected=col_date_1)
 
                 test_identifier2 = BiobankOrderIdentifier(
@@ -1507,7 +1520,7 @@ class GenomicPipelineTest(BaseTestCase):
                 insert_dtm = fake_datetime_old
 
                 sample_args1 = {
-                    'test': '1ED04',
+                    'test': '1ED10',
                     'confirmed': fake_datetime_new,
                     'created': fake_datetime_old,
                     'biobankId': bid,


### PR DESCRIPTION
This updates the AW0 cron job for cohort 3 to run every Wednesday. And updates the workflow for each cohort to prioritize samples in the following order: 1ED04, 1ED10, and 1SAL2. So if a participant has an 1ED10 sample and a 1SAL2, the 1ED10 would be used in the workflow and the 1SAL2 would be left out.