### PR TITLE
Refactoring how GAE instances restart

### DIFF
--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -830,7 +830,7 @@ def gcp_restart_instances(project, service=None):
     if service is None:
         service_msg = 'all services'
     else:
-        service_msg = f'service {service}'
+        service_msg = f'service "{service}"'
     _logger.debug(f'Restarting instances for project "{project}" and {service_msg}')
 
     # First get instance ID's

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -344,8 +344,7 @@ class DeployAppClass(object):
 
         # Note: self.services will either be a user-provided list from --services arg, or the GCP_SERVICES list from
         # gcp_config.  Need to iterate through each service to make sure appropriate instances get restarted
-        for service in self.services:
-            gcp_restart_instances(self.gcp_env.project, service=service)
+        gcp_restart_instances(self.gcp_env.project)
 
         return 0 if result else 1
 


### PR DESCRIPTION
When retrieving the list of instances, we get all of the instances back along with what service they're for. This refactors how the instances are restarted so we only need to retrieve the list once.

This also changes the default behavior of the `gcp_restart_instances` to delete all instances rather than just the ones in the 'default' service.