### PR TITLE
Additional tables needing to be cleared for metrics tests

### DIFF
--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -99,7 +99,13 @@ class PublicMetricsApiTest(BaseTestCase):
             CalendarDao().insert(calendar_day)
             curr_date = curr_date + datetime.timedelta(days=1)
 
+        self.clear_table_after_test('metrics_enrollment_status_cache')
+        self.clear_table_after_test('metrics_gender_cache')
+        self.clear_table_after_test('metrics_age_cache')
+        self.clear_table_after_test('metrics_race_cache')
+        self.clear_table_after_test('metrics_region_cache')
         self.clear_table_after_test('metrics_lifecycle_cache')
+        self.clear_table_after_test('metrics_language_cache')
 
     def _insert(
         self,


### PR DESCRIPTION
It looks like there's another set of tests where some extra cache tables would need to be explicitly cleared. This PR adds that in to make sure we don't see any intermittent failures because of them.