### PR TITLE
Fix for test time comparison

### DIFF
--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -178,19 +178,8 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
 
         # The first_seen and last_seen fields are set with mysql's NOW function,
         #   so check that the time is close to what is expected
-
-        # mysql isn't storing the microseconds
-        first_seen = first_seen.replace(microsecond=0)
-        last_seen = last_seen.replace(microsecond=0)
-
-        self.assertLessEqual(first_seen, record.firstSeen,
-                             "The record found has a firstSeen time earlier than expected")
-        self.assertGreaterEqual(1, (record.firstSeen - first_seen).seconds,
-                                "The record found has a firstSeen time much later than expected")
-        self.assertLessEqual(last_seen, record.lastSeen,
-                             "The record found has a lastSeen time earlier than expected")
-        self.assertGreaterEqual(1, (record.lastSeen - last_seen).seconds,
-                                "The record found has a lastSeen time much later than expected")
+        self.assertAlmostEquals(first_seen, record.firstSeen, delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEquals(last_seen, record.lastSeen, delta=datetime.timedelta(seconds=1))
 
         # Check generated data.
         gen = ParticipantSummaryGenerator()
@@ -199,12 +188,15 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
 
         # Look for a matching dict entry in the ps_data['ehr_receipts'] list, since it may also contain other entries
         # depending on the test construction
-        generated_ehr_receipt = {
-            'file_timestamp': file_timestamp,
-            'first_seen': first_seen,
-            'last_seen': last_seen
-        }
-        self.assertIn(generated_ehr_receipt, ps_data['ehr_receipts'])
+        def ehr_receipt_matches_expected(generated_ehr_receipt):
+            first_seen_timedelta = generated_ehr_receipt['first_seen'] - first_seen
+            last_seen_timedelta = generated_ehr_receipt['last_seen'] - last_seen
+            return all([
+                generated_ehr_receipt['file_timestamp'] == file_timestamp,
+                first_seen_timedelta <= datetime.timedelta(seconds=1),
+                last_seen_timedelta <= datetime.timedelta(seconds=1)
+            ])
+        self.assertTrue(any([ehr_receipt_matches_expected(ehr_receipt) for ehr_receipt in ps_data['ehr_receipts']]))
 
     @mock.patch("rdr_service.offline.update_ehr_status.make_update_participant_summaries_job")
     def test_updates_participant_summaries(self, mock_summary_job):


### PR DESCRIPTION
The first_seen and last_seen columns for participant ehr receipts are set with `NOW()` in Mysql so there isn't a very reliable way to make sure the database has the same time as what the test is expecting. This popped up in a recent CI run of the unit tests. This PR updates the EHR tests to make sure the first_seen and last_seen times are close enough when looking at the generated PDR data and refactors how it was compared with the rdr database to make it more concise.