### PR TITLE
Simplifying and reusing code that temporarily sets values in the config

### DIFF
--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import datetime
 import http.client
 from mock import patch
@@ -91,27 +92,16 @@ class ParticipantSummaryApiTest(BaseTestCase):
     def setUp(self):
         super().setUp()
         self.hpo_dao = HPODao()
-        self.original_user_roles = None
         # Needed by test_switch_to_test_account
         self.hpo_dao.insert(
             HPO(hpoId=TEST_HPO_ID, name=TEST_HPO_NAME, displayName="Test", organizationType=OrganizationType.UNSET)
         )
 
-    def tearDown(self):
-        if self.original_user_roles is not None:
-            self.overwrite_test_user_awardee(None, self.original_user_roles, save_current=False)
-
-        super(ParticipantSummaryApiTest, self).tearDown()
-
-    def overwrite_test_user_awardee(self, awardee, roles, save_current=True):
-        user_info = config.getSettingJson(config.USER_INFO)
-
-        if save_current:
-            # Save what was there so we can set it back in the tearDown
-            self.original_user_roles = user_info['example@example.com']['roles']
-        user_info['example@example.com']['roles'] = roles
-        user_info['example@example.com']['awardee'] = awardee
-        config.override_setting(config.USER_INFO, user_info)
+    def overwrite_test_user_awardee(self, awardee, roles):
+        new_user_info = deepcopy(config.getSettingJson(config.USER_INFO))
+        new_user_info['example@example.com']['roles'] = roles
+        new_user_info['example@example.com']['awardee'] = awardee
+        self.temporarily_override_config_setting(config.USER_INFO, new_user_info)
 
     def create_demographics_questionnaire(self):
         """Uses the demographics test data questionnaire.  Returns the questionnaire id"""


### PR DESCRIPTION
There are a couple of places that we override the config data and then reset it at the end of the test. I moved the boilerplate for that into the unit test base class so reusing it elsewhere is easier in the future. Changing how to know when to reset the value makes using it a little simpler and cleaner too.