### PR TITLE
Quick fix for updating PPI Validator with new code validation logic

### DIFF
--- a/rdr_service/api/check_ppi_data_api.py
+++ b/rdr_service/api/check_ppi_data_api.py
@@ -106,7 +106,7 @@ def _get_validation_result(key, codes_to_answers):
             if not question_code:
                 result.add_error(f"Could not find question code {code_string}, skipping answer {answer_string}.")
                 continue
-            if question_code.codeType != CodeType.QUESTION:
+            if question_code.codeType != CodeType.QUESTION and question_code.codeType != CodeType.TOPIC:
                 result.add_error(f"Code {code_string} type is {question_code.codeType}, not QUESTION; skipping.")
                 continue
 

--- a/rdr_service/api/check_ppi_data_api.py
+++ b/rdr_service/api/check_ppi_data_api.py
@@ -96,7 +96,7 @@ def _get_validation_result(key, codes_to_answers):
         return result
     participant_id = summaries[0].participantId
 
-    code_dao = CodeDao()
+    code_dao = CodeDao(use_cache=False)
     qra_dao = QuestionnaireResponseAnswerDao()
     with qra_dao.session() as session:
         for code_string, answer_string in list(codes_to_answers.items()):


### PR DESCRIPTION
Codes can be reused and there is no longer a sense of Topic codes. So this updates the PPI validator to recognize that Topic type codes can be used as questions.

The DAO cache system isn't extensible enough to easily allow for specifying that code values should be compared in a case-insensitive way, so this adds a way for the PPI validator to have the CodeDao skip looking up codes with the cache and go to the database directly (which is an case-insensitive lookup).