### PR TITLE
[DA-1846] Adding genomic fields to PDR code

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -9,13 +9,15 @@ from rdr_service.app_util import task_auth_required
 from rdr_service.dao.bq_code_dao import rebuild_bq_codebook_task
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_batch_update, bq_genomic_set_member_batch_update, \
     bq_genomic_job_run_batch_update, bq_genomic_gc_validation_metrics_batch_update, \
-    bq_genomic_file_processed_batch_update
+    bq_genomic_file_processed_batch_update, bq_genomic_manifest_file_batch_update, \
+    bq_genomic_manifest_feedback_batch_update
 from rdr_service.dao.bq_participant_summary_dao import bq_participant_summary_update_task
 from rdr_service.dao.bq_questionnaire_dao import bq_questionnaire_update_task
 from rdr_service.offline.sync_consent_files import cloudstorage_copy_objects_task
 from rdr_service.resource.generators.code import rebuild_codebook_resources_task
 from rdr_service.resource.generators.genomics import genomic_set_batch_update, genomic_set_member_batch_update, \
-    genomic_job_run_batch_update, genomic_gc_validation_metrics_batch_update, genomic_file_processed_batch_update
+    genomic_job_run_batch_update, genomic_gc_validation_metrics_batch_update, genomic_file_processed_batch_update, \
+    genomic_manifest_file_batch_update, genomic_manifest_feedback_batch_update
 from rdr_service.resource.generators.participant import participant_summary_update_resource_task
 from rdr_service.resource.tasks import batch_rebuild_participants_task
 
@@ -175,6 +177,12 @@ class RebuildGenomicTableRecordsApi(Resource):
         elif table == 'genomic_gc_validation_metrics':
             bq_genomic_gc_validation_metrics_batch_update(batch)
             genomic_gc_validation_metrics_batch_update(batch)
+        elif table == 'genomic_manifest_file':
+            bq_genomic_manifest_file_batch_update(batch)
+            genomic_manifest_file_batch_update(batch)
+        elif table == 'genomic_manifest_feedback':
+            bq_genomic_manifest_feedback_batch_update(batch)
+            genomic_manifest_feedback_batch_update(batch)
 
         logging.info(f'Rebuild complete.')
 

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -11,7 +11,8 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from rdr_service import clock, config
 from rdr_service.dao.base_dao import UpdatableDao, BaseDao
-from rdr_service.dao.bq_genomics_dao import bq_genomic_gc_validation_metrics_update, bq_genomic_set_member_update
+from rdr_service.dao.bq_genomics_dao import bq_genomic_gc_validation_metrics_update, bq_genomic_set_member_update, \
+    bq_genomic_manifest_feedback_update
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.genomics import (
     GenomicSet,
@@ -32,7 +33,8 @@ from rdr_service.participant_enums import (
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.query import FieldFilter, Operator, OrderBy, Query
-from rdr_service.resource.generators.genomics import genomic_gc_validation_metrics_update, genomic_set_member_update
+from rdr_service.resource.generators.genomics import genomic_gc_validation_metrics_update, genomic_set_member_update, \
+    genomic_manifest_feedback_update
 
 
 class GenomicSetDao(UpdatableDao):
@@ -866,7 +868,7 @@ class GenomicGCValidationMetricsDao(UpdatableDao):
             inserted_metrics_obj = self.insert(gc_metrics_obj)
 
             # Update GC Metrics for PDR
-            bq_genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
+            bq_genomic_gc_validation_metrics_update(inserted_metrics_obj.id, )
             genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
 
             return GenomicSubProcessResult.SUCCESS
@@ -1235,6 +1237,9 @@ class GenomicManifestFeedbackDao(BaseDao):
 
             with self.session() as session:
                 session.merge(fb)
+
+            bq_genomic_manifest_feedback_update(fb.id)
+            genomic_manifest_feedback_update(fb.id)
         else:
             raise ValueError(f'No feedback record for manifest id {manifest_id}')
 

--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -33,7 +33,8 @@ BQ_TABLES = [
     ('rdr_service.model.bq_genomics', 'BQGenomicSetMember'),
     ('rdr_service.model.bq_genomics', 'BQGenomicJobRun'),
     ('rdr_service.model.bq_genomics', 'BQGenomicGCValidationMetrics'),
-    ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessed')
+    ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessed'),
+    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFile')
 ]
 
 BQ_VIEWS = [
@@ -87,5 +88,6 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_genomics', 'BQGenomicSetMemberView'),
     ('rdr_service.model.bq_genomics', 'BQGenomicJobRunView'),
     ('rdr_service.model.bq_genomics', 'BQGenomicGCValidationMetricsView'),
-    ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessedView')
+    ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessedView'),
+    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFileView')
 ]

--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -34,7 +34,8 @@ BQ_TABLES = [
     ('rdr_service.model.bq_genomics', 'BQGenomicJobRun'),
     ('rdr_service.model.bq_genomics', 'BQGenomicGCValidationMetrics'),
     ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessed'),
-    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFile')
+    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFile'),
+    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFeedback')
 ]
 
 BQ_VIEWS = [
@@ -89,5 +90,6 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_genomics', 'BQGenomicJobRunView'),
     ('rdr_service.model.bq_genomics', 'BQGenomicGCValidationMetricsView'),
     ('rdr_service.model.bq_genomics', 'BQGenomicFileProcessedView'),
-    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFileView')
+    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFileView'),
+    ('rdr_service.model.bq_genomics', 'BQGenomicManifestFeedbackView')
 ]

--- a/rdr_service/model/bq_genomics.py
+++ b/rdr_service/model/bq_genomics.py
@@ -169,7 +169,7 @@ class BQGenomicSetMemberSchema(BQSchema):
     fingerprint_path = BQField('fingerprint_path', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     aw1_file_processed_id = BQField('aw1_file_processed_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     aw2_file_processed_id = BQField('aw2_file_processed_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-    aw3_file_processed_id = BQField('aw3_file_processed_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    aw2f_file_processed_id = BQField('aw2f_file_processed_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     dev_note = BQField('dev_note', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
 
 

--- a/rdr_service/model/bq_genomics.py
+++ b/rdr_service/model/bq_genomics.py
@@ -13,7 +13,9 @@ from rdr_service.participant_enums import (
     GenomicSubProcessResult as _GenomicSubProcessResult,
     GenomicJob as _GenomicJob,
     GenomicWorkflowState as _GenomicWorkflowState,
-    GenomicQcStatus as _GenomicQcStatus
+    GenomicQcStatus as _GenomicQcStatus,
+    GenomicContaminationCategory as _GenomicContaminationCategory,
+    GenomicManifestTypes as _GenomicManifestTypes
 )
 
 # Convert weird participant_enums to standard python enums.
@@ -25,6 +27,8 @@ GenomicSubProcessResultEnum = Enum('GenomicSubProcessResultEnum', _GenomicSubPro
 GenomicJobEnum = Enum('GenomicJobEnum', _GenomicJob.to_dict())
 GenomicWorkflowStateEnum = Enum('GenomicWorkflowStateEnum', _GenomicWorkflowState.to_dict())
 GenomicQcStatusEnum = Enum('GenomicQcStatusEnum', _GenomicQcStatus.to_dict())
+GenomicContaminationCategoryEnum = Enum('GenomicContaminationCategoryEnum', _GenomicContaminationCategory.to_dict())
+GenomicManifestTypesEnum = Enum('GenomicManifestTypesEnum', _GenomicManifestTypes.to_dict())
 
 
 class BQGenomicSetSchema(BQSchema):
@@ -125,6 +129,8 @@ class BQGenomicSetMemberSchema(BQSchema):
     gem_pass = BQField('gem_pass', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     gem_a3_manifest_job_run_id = BQField('gem_a3_manifest_job_run_id', BQFieldTypeEnum.INTEGER,
                                          BQFieldModeEnum.NULLABLE)
+    aw3_manifest_job_run_id = BQField('aw3_manifest_job_run_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    aw4_manifest_job_run_id = BQField('aw4_manifest_job_run_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     cvl_aw1c_manifest_job_run_id = BQField('cvl_aw1c_manifest_job_run_id', BQFieldTypeEnum.INTEGER,
                                            BQFieldModeEnum.NULLABLE)
     cvl_aw1cf_manifest_job_run_id = BQField('cvl_aw1cf_manifest_job_run_id', BQFieldTypeEnum.INTEGER,
@@ -161,6 +167,9 @@ class BQGenomicSetMemberSchema(BQSchema):
     qc_status_id = BQField('qc_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
                            fld_enum=GenomicQcStatusEnum)
     fingerprint_path = BQField('fingerprint_path', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    aw1_file_processed_id = BQField('aw1_file_processed_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    aw2_file_processed_id = BQField('aw2_file_processed_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    aw3_file_processed_id = BQField('aw3_file_processed_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     dev_note = BQField('dev_note', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
 
 
@@ -233,6 +242,7 @@ class BQGenomicFileProcessedSchema(BQSchema):
     file_result = BQField('file_result', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE,
                           fld_enum=GenomicSubProcessResultEnum)
     upload_date = BQField('upload_date', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    genomic_manifest_file_id = BQField('genomic_manifest_file_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQGenomicFileProcessed(BQTable):
@@ -246,6 +256,68 @@ class BQGenomicFileProcessedView(BQView):
     __viewdescr__ = 'Genomic File Processed View'
     __pk_id__ = 'id'
     __table__ = BQGenomicFileProcessed
+
+
+class BQGenomicManifestFileSchema(BQSchema):
+    id = BQField('id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    modified = BQField('modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+
+    # RDR fields
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    upload_date = BQField('upload_date', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    manifest_type_id = BQField('manifest_type_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
+                               fld_enum=GenomicManifestTypesEnum)
+    manifest_type = BQField('manifest_type', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE,
+                            fld_enum=GenomicManifestTypesEnum)
+    file_path = BQField('file_path', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    bucket_name = BQField('bucket_name', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    record_count = BQField('record_count', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    rdr_processing_complete = BQField('rdr_processing_complete', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    rdr_processing_complete_date = BQField('rdr_processing_complete_date', BQFieldTypeEnum.DATETIME,
+                                           BQFieldModeEnum.NULLABLE)
+    ignore = BQField('ignore', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+
+
+class BQGenomicManifestFile(BQTable):
+    """  BigQuery Table """
+    __tablename__ = 'genomic_manifest_file'
+    __schema__ = BQGenomicManifestFileSchema
+
+
+class BQGenomicManifestFileView(BQView):
+    __viewname__ = 'v_genomic_manifest_file'
+    __viewdescr__ = 'Genomic Manifest File View'
+    __pk_id__ = 'id'
+    __table__ = BQGenomicManifestFile
+
+
+class BQGenomicManifestFeedbackSchema(BQSchema):
+    id = BQField('id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    created = BQField('created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    modified = BQField('modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+
+    # RDR fields
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    input_manifest_file_id = BQField('input_manifest_file_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    feedback_manifest_file_id = BQField('feedback_manifest_file_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    feedback_record_count = BQField('feedback_record_count', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    feedback_complete = BQField('feedback_complete', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    feedback_complete_date = BQField('feedback_complete_date', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    ignore = BQField('ignore', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+
+
+class BQGenomicManifestFeedback(BQTable):
+    """  BigQuery Table """
+    __tablename__ = 'genomic_manifest_feedback'
+    __schema__ = BQGenomicManifestFeedbackSchema
+
+
+class BQGenomicManifestFeedbackView(BQView):
+    __viewname__ = 'v_genomic_manifest_feedback'
+    __viewdescr__ = 'Genomic Manifest Feedback View'
+    __pk_id__ = 'id'
+    __table__ = BQGenomicManifestFeedback
 
 
 class BQGenomicGCValidationMetricsSchema(BQSchema):
@@ -306,6 +378,9 @@ class BQGenomicGCValidationMetricsSchema(BQSchema):
     vcf_tbi_received = BQField('vcf_tbi_received', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     ignore_flag = BQField('ignore_flag', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     dev_note = BQField('dev_note', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    contamination_category = BQField('contamination_category', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    contamination_category_id = BQField('contamination_category_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
+                                        fld_enum=GenomicContaminationCategoryEnum)
 
 
 class BQGenomicGCValidationMetrics(BQTable):

--- a/rdr_service/resource/constants.py
+++ b/rdr_service/resource/constants.py
@@ -34,6 +34,8 @@ class SchemaID(IntEnum):
     genomic_job_run = 3020
     genomic_gc_validation_metrics = 3030
     genomic_file_processed = 3040
+    genomic_manifest_file = 3050
+    genomic_manifest_feedback = 3060
 
     # Workbench
     workbench_researcher = 4000

--- a/rdr_service/resource/generators/genomics.py
+++ b/rdr_service/resource/generators/genomics.py
@@ -13,7 +13,9 @@ from rdr_service.participant_enums import (
     GenomicSubProcessResult as GenomicSubProcessResultEnum,
     GenomicJob as GenomicJobEnum,
     GenomicWorkflowState as GenomicWorkflowStateEnum,
-    GenomicQcStatus as GenomicQcStatusEnum)
+    GenomicQcStatus as GenomicQcStatusEnum,
+    GenomicManifestTypes as GenomicManifestTypesEnum,
+    GenomicContaminationCategory as GenomicContaminationCategoryEnum)
 from rdr_service.resource import generators, schemas
 
 
@@ -254,6 +256,108 @@ def genomic_file_processed_batch_update(_pk_ids):
         genomic_file_processed_update(_pk, gen=gen, w_dao=w_dao)
 
 
+class GenomicManifestFileSchemaGenerator(generators.BaseGenerator):
+    """
+    Generate a GenomicManifestFile resource object
+    """
+    ro_dao = None
+
+    def make_resource(self, _pk, backup=False):
+        """
+        Build a resource object from the given primary key id.
+        :param _pk: Primary key value from rdr table.
+        :param backup: if True, get from backup database instead of Primary.
+        :return: resource object
+        """
+        if not self.ro_dao:
+            self.ro_dao = ResourceDataDao(backup=backup)
+
+        with self.ro_dao.session() as ro_session:
+            row = ro_session.execute(text('select * from genomic_manifest_file where id = :id'), {'id': _pk}).first()
+            data = self.ro_dao.to_dict(row)
+            # Populate Enum fields.
+            if data['manifest_type_id']:
+                enum = GenomicManifestTypesEnum(data['manifest_type_id'])
+                data['manifest_type'] = str(enum)
+                data['manifest_type_id_id'] = int(enum)
+
+            return generators.ResourceRecordSet(schemas.GenomicManifestFileSchema, data)
+
+
+def genomic_manifest_file_update(_pk, gen=None, w_dao=None):
+    """
+    Generate GenomicManifestFile record.
+    :param _pk: Primary Key
+    :param gen: GenomicManifestFileSchemaGenerator object
+    :param w_dao: Writable DAO object.
+    """
+    if not gen:
+        gen = GenomicManifestFileSchemaGenerator()
+    res = gen.make_resource(_pk)
+    res.save(w_dao=w_dao)
+
+
+def genomic_manifest_file_batch_update(_pk_ids):
+    """
+    Generate a batch of ids.
+    :param _pk_ids: list of pk ids.
+    """
+    gen = GenomicManifestFileSchemaGenerator()
+    w_dao = ResourceDataDao()
+    for _pk in _pk_ids:
+        genomic_manifest_file_update(_pk, gen=gen, w_dao=w_dao)
+
+
+class GenomicManifestFeedbackSchemaGenerator(generators.BaseGenerator):
+    """
+    Generate a GenomicManifestFeedback resource object
+    """
+    ro_dao = None
+
+    def make_resource(self, _pk, backup=False):
+        """
+        Build a resource object from the given primary key id.
+        :param _pk: Primary key value from rdr table.
+        :param backup: if True, get from backup database instead of Primary.
+        :return: resource object
+        """
+        if not self.ro_dao:
+            self.ro_dao = ResourceDataDao(backup=backup)
+
+        with self.ro_dao.session() as ro_session:
+            row = ro_session.execute(
+                text('select * from genomic_manifest_feedback where id = :id'),
+                {'id': _pk}
+            ).first()
+            data = self.ro_dao.to_dict(row)
+
+            return generators.ResourceRecordSet(schemas.GenomicManifestFeedbackSchema, data)
+
+
+def genomic_manifest_feedback_update(_pk, gen=None, w_dao=None):
+    """
+    Generate GenomicManifestFeedback record.
+    :param _pk: Primary Key
+    :param gen: GenomicManifestFeedbackSchemaGenerator object
+    :param w_dao: Writable DAO object.
+    """
+    if not gen:
+        gen = GenomicManifestFeedbackSchemaGenerator()
+    res = gen.make_resource(_pk)
+    res.save(w_dao=w_dao)
+
+
+def genomic_manifest_feedback_batch_update(_pk_ids):
+    """
+    Generate a batch of ids.
+    :param _pk_ids: list of pk ids.
+    """
+    gen = GenomicManifestFeedbackSchemaGenerator()
+    w_dao = ResourceDataDao()
+    for _pk in _pk_ids:
+        genomic_manifest_feedback_update(_pk, gen=gen, w_dao=w_dao)
+
+
 class GenomicGCValidationMetricsSchemaGenerator(generators.BaseGenerator):
     """
     Generate a GenomicGCValidationMetrics resource object
@@ -274,6 +378,12 @@ class GenomicGCValidationMetricsSchemaGenerator(generators.BaseGenerator):
             row = ro_session.execute(text('select * from genomic_gc_validation_metrics where id = :id'),
                                      {'id': _pk}).first()
             data = self.ro_dao.to_dict(row)
+
+            # Populate Enum fields.
+            if data['contamination_category']:
+                enum = GenomicContaminationCategoryEnum(data['contamination_category'])
+                data['contamination_category'] = str(enum)
+                data['contamination_category_id'] = int(enum)
 
             return generators.ResourceRecordSet(schemas.GenomicGCValidationMetricsSchema, data)
 

--- a/rdr_service/resource/schemas/__init__.py
+++ b/rdr_service/resource/schemas/__init__.py
@@ -12,7 +12,8 @@ from .workbench_workspace import WorkbenchWorkspaceSchema, WorkbenchWorkspaceUse
 from .covid_antibody_study import BiobankCovidAntibodySampleSchema, QuestCovidAntibodyTestResultSchema, \
     QuestCovidAntibodyTestSchema
 from .genomics import GenomicSetSchema, GenomicSetMemberSchema, GenomicJobRunSchema, \
-    GenomicGCValidationMetricsSchema, GenomicFileProcessedSchema
+    GenomicGCValidationMetricsSchema, GenomicFileProcessedSchema, GenomicManifestFileSchema, \
+    GenomicManifestFeedbackSchema
 
 __all__ = [
     'ParticipantSchema',
@@ -32,4 +33,6 @@ __all__ = [
     'GenomicJobRunSchema',
     'GenomicGCValidationMetricsSchema',
     'GenomicFileProcessedSchema',
+    'GenomicManifestFileSchema',
+    'GenomicManifestFeedbackSchema'
 ]

--- a/rdr_service/resource/schemas/genomics.py
+++ b/rdr_service/resource/schemas/genomics.py
@@ -114,7 +114,7 @@ class GenomicSetMemberSchema(Schema):
     dev_note = fields.String(validate=validate.Length(max=255))
     aw1_file_processed_id = fields.Int32()
     aw2_file_processed_id = fields.Int32()
-    aw3_file_processed_id = fields.Int32()
+    aw2f_file_processed_id = fields.Int32()
 
     class Meta:
         schema_id = SchemaID.genomic_set_member

--- a/rdr_service/resource/schemas/genomics.py
+++ b/rdr_service/resource/schemas/genomics.py
@@ -15,7 +15,9 @@ from rdr_service.participant_enums import (
     GenomicSubProcessResult,
     GenomicJob,
     GenomicWorkflowState,
-    GenomicQcStatus
+    GenomicQcStatus,
+    GenomicContaminationCategory,
+    GenomicManifestTypes
 )
 
 
@@ -87,6 +89,8 @@ class GenomicSetMemberSchema(Schema):
     gem_a2_manifest_job_run_id = fields.Int32()
     gem_pass = fields.String(validate=validate.Length(max=10))
     gem_a3_manifest_job_run_id = fields.Int32()
+    aw3_manifest_job_run_id = fields.Int32()
+    aw4_manifest_job_run_id = fields.Int32()
     cvl_aw1c_manifest_job_run_id = fields.Int32()
     cvl_aw1cf_manifest_job_run_id = fields.Int32()
     cvl_w1_manifest_job_run_id = fields.Int32()
@@ -108,6 +112,9 @@ class GenomicSetMemberSchema(Schema):
     qc_status_id = fields.EnumInteger(enum=GenomicQcStatus)
     fingerprint_path = fields.String(validate=validate.Length(max=255))
     dev_note = fields.String(validate=validate.Length(max=255))
+    aw1_file_processed_id = fields.Int32()
+    aw2_file_processed_id = fields.Int32()
+    aw3_file_processed_id = fields.Int32()
 
     class Meta:
         schema_id = SchemaID.genomic_set_member
@@ -148,10 +155,50 @@ class GenomicFileProcessedSchema(Schema):
     file_result = fields.EnumString(enum=GenomicSubProcessResult)
     file_result_id = fields.EnumInteger(enum=GenomicSubProcessResult)
     upload_date = fields.DateTime()
+    genomic_manifest_file_id = fields.Int32()
 
     class Meta:
         schema_id = SchemaID.genomic_file_processed
         resource_uri = 'GenomicFileProcessed'
+        resource_pk_field = 'id'
+
+
+class GenomicManifestFileSchema(Schema):
+
+    id = fields.Int32()
+    created = fields.DateTime()
+    modified = fields.DateTime()
+    upload_date = fields.DateTime()
+    manifest_type = fields.EnumString(enum=GenomicManifestTypes)
+    manifest_type_id = fields.EnumInteger(enum=GenomicManifestTypes)
+    file_path = fields.String(validate=validate.Length(max=255))
+    bucket_name = fields.String(validate=validate.Length(max=128))
+    record_count = fields.Int32()
+    rdr_processing_complete = fields.Int16()
+    rdr_processing_complete_date = fields.DateTime()
+    ignore = fields.Int16()
+
+    class Meta:
+        schema_id = SchemaID.genomic_manifest_file
+        resource_uri = 'GenomicManifestFile'
+        resource_pk_field = 'id'
+
+
+class GenomicManifestFeedbackSchema(Schema):
+
+    id = fields.Int32()
+    created = fields.DateTime()
+    modified = fields.DateTime()
+    input_manifest_file_id = fields.Int32()
+    feedback_manifest_file_id = fields.Int32()
+    feedback_record_count = fields.Int32()
+    feedback_complete = fields.Int16()
+    feedback_complete_date = fields.DateTime()
+    ignore = fields.Int16()
+
+    class Meta:
+        schema_id = SchemaID.genomic_manifest_feedback
+        resource_uri = 'GenomicManifestFeedback'
         resource_pk_field = 'id'
 
 
@@ -210,6 +257,8 @@ class GenomicGCValidationMetricsSchema(Schema):
     vcf_tbi_received = fields.Int16()
     ignore_flag = fields.Int16()
     dev_note = fields.String(validate=validate.Length(max=255))
+    contamination_category = fields.EnumString(enum=GenomicContaminationCategory)
+    contamination_category_id = fields.EnumInteger(enum=GenomicContaminationCategory)
 
     class Meta:
         schema_id = SchemaID.genomic_gc_validation_metrics

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -18,7 +18,8 @@ from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao
 from rdr_service.dao.bq_participant_summary_dao import rebuild_bq_participant
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_update, bq_genomic_set_member_update, \
-    bq_genomic_job_run_update, bq_genomic_gc_validation_metrics_update, bq_genomic_file_processed_update
+    bq_genomic_job_run_update, bq_genomic_gc_validation_metrics_update, bq_genomic_file_processed_update, \
+    bq_genomic_manifest_file_update, bq_genomic_manifest_feedback_update
 from rdr_service.dao.resource_dao import ResourceDataDao
 from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
     BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEJan
@@ -26,7 +27,8 @@ from rdr_service.model.participant import Participant
 from rdr_service.offline.bigquery_sync import batch_rebuild_participants_task
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
 from rdr_service.resource.generators.genomics import genomic_set_update, genomic_set_member_update, \
-    genomic_job_run_update, genomic_gc_validation_metrics_update, genomic_file_processed_update
+    genomic_job_run_update, genomic_gc_validation_metrics_update, genomic_file_processed_update, \
+    genomic_manifest_file_update, genomic_manifest_feedback_update
 from rdr_service.services.system_utils import setup_logging, setup_i18n, print_progress_bar
 from rdr_service.tools.tool_libs import GCPProcessContext, GCPEnvConfigObject
 
@@ -271,6 +273,12 @@ class GenomicResourceClass(object):
             elif table == 'genomic_file_processed':
                 bq_genomic_file_processed_update(_id, project_id=self.gcp_env.project)
                 genomic_file_processed_update(_id)
+            elif table == 'genomic_manifest_file':
+                bq_genomic_manifest_file_update(_id, project_id=self.gcp_env.project)
+                genomic_manifest_file_update(_id)
+            elif table == 'genomic_manifest_feedback':
+                bq_genomic_manifest_feedback_update(_id, project_id=self.gcp_env.project)
+                genomic_manifest_feedback_update(_id)
             elif table == 'genomic_gc_validation_metrics':
                 bq_genomic_gc_validation_metrics_update(_id, project_id=self.gcp_env.project)
                 genomic_gc_validation_metrics_update(_id)


### PR DESCRIPTION
This adds the following fields from genomics to the existing schemas in PDR:
- genomic_file_processed: genomic_manifest_file_id
- genomic_set_member: aw1_file_processed_id, aw2_file_processed_id, aw2f_file_processed_id, aw3_manifest_job_run_id, and aw4_manifest_job_run_id
- genomic_gc_validation_metrics: contamination_category

It also adds the genomic_manifest_file and genomic_manifest_feedback tables with the calls to update them.