### PR TITLE
[DA-1850] Pausing Genomics A1 workflow until Jan 5

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -119,11 +119,6 @@ cron:
   timezone: America/New_York
   schedule: every day 06:00
   target: offline
-- description: Genomic GEM A1 Workflow
-  url: /offline/GenomicGemA1Workflow
-  timezone: America/New_York
-  schedule: every tuesday 12:00
-  target: offline
 - description: Genomic GEM A2 Workflow
   url: /offline/GenomicGemA2Workflow
   timezone: America/New_York


### PR DESCRIPTION
The AoU has decided to pause the A1 genomics workflow until after the holiday season. This PR removes the cron entry for the A1 workflow. It will be reversed before January 5th.

The config changes for the cron schedule are already applied to Prod. This is to make sure releases don't add it back in.