### PR TITLE
Some refactoring for the code import process

### DIFF
--- a/rdr_service/offline/codebook_importer.py
+++ b/rdr_service/offline/codebook_importer.py
@@ -1,0 +1,95 @@
+import logging
+import re
+
+from rdr_service.clock import CLOCK
+from rdr_service.model.code import Code, CodeType
+
+CODE_SYSTEM = 'http://terminology.pmi-ops.org/CodeSystem/ppi'
+CODE_TYPES_WITH_OPTIONS = ['radio', 'dropdown', 'checkbox']
+
+
+class CodebookImporter:
+    def __init__(self, dry_run, session, codes_allowed_for_reuse):
+        self.dry_run = dry_run
+        self.session = session
+        self.codes_allowed_for_reuse = codes_allowed_for_reuse
+
+        self.code_reuse_found = False
+        self.module_code = None
+        self.invalid_codes_found = []
+        self.questions_missing_options = []
+
+    def initialize_code(self, value, display, parent=None, code_type=None):
+        new_code = Code(
+            codeType=code_type,
+            value=value,
+            shortValue=value[:50],
+            display=display,
+            system=CODE_SYSTEM,
+            mapped=True,
+            created=CLOCK.now()
+        )
+        existing_code_with_value = self.session.query(Code).filter(
+            Code.value == value,
+            Code.system == CODE_SYSTEM
+        ).one_or_none()
+        if existing_code_with_value:
+            # Answer codes should automatically be allowed to be reused, anything else needs to be explicitly stated
+            if code_type != CodeType.ANSWER and value not in self.codes_allowed_for_reuse:
+                # At this point, it's not an answer code and it wasn't explicitly allowed for reuse
+                # so set up the tool to stop saving and print out the code.
+                # Let the script continue so that any other duplications can be caught.
+                self.code_reuse_found = True
+                logging.error(f'Code "{value}" is already in use')
+            else:
+                # Allows for reused codes to be a child (or parent) of other codes being imported
+                return existing_code_with_value
+        elif self.dry_run:
+            logging.info(f'Found new "{code_type}" type code, value: {value}')
+        elif not self.code_reuse_found and not self.dry_run:
+            # Associating a code with a parent adds it to the session too,
+            # so it should only happen when we intend to save it.
+            # (But the parent here could be empty, so we make sure the code gets to the session)
+            new_code.parent = parent
+            self.session.add(new_code)
+
+        return new_code
+
+    def import_answer_code(self, answer_text, question_code):
+        # There may be multiple commas in the display string, we want to split on the first to get the code
+        code, display = (part.strip() for part in answer_text.split(',', 1))
+        self.initialize_code(code, display, question_code, CodeType.ANSWER)
+
+    @staticmethod
+    def is_code_value_valid(code_value):
+        not_allowed_chars_regex = re.compile(r'[^a-zA-Z0-9_]')  # Regex for any characters that aren't allowed
+        invalid_matches = not_allowed_chars_regex.search(code_value)
+        return invalid_matches is None
+
+    def import_data_dictionary_item(self, code_json):
+        code_value = code_json['field_name']
+        code_description = code_json['field_label']
+
+        if code_value != 'record_id':  # Ignore the code Redcap automatically inserts into each project
+            if not self.is_code_value_valid(code_value):
+                self.invalid_codes_found.append(code_value)
+            else:
+                if code_json['field_type'] == 'descriptive':
+                    # Only catch the first 'descriptive' field we see. That's the module code.
+                    # Descriptive fields other than the first are considered to be readonly, display text.
+                    # So we don't want to save codes for them
+                    if not self.module_code:
+                        new_code = self.initialize_code(code_value, code_description,
+                                                        self.module_code, CodeType.MODULE)
+                        self.module_code = new_code
+                else:
+                    new_code = self.initialize_code(code_value, code_description,
+                                                    self.module_code, CodeType.QUESTION)
+
+                    answers_string = code_json['select_choices_or_calculations']
+                    if answers_string:
+                        for answer_text in answers_string.split('|'):
+                            self.import_answer_code(answer_text.strip(), new_code)
+                    elif code_json['field_type'] in CODE_TYPES_WITH_OPTIONS:
+                        # The answers string was empty, but this is a type we'd expect to have options
+                        self.questions_missing_options.append(code_value)

--- a/rdr_service/offline/codebook_importer.py
+++ b/rdr_service/offline/codebook_importer.py
@@ -1,4 +1,3 @@
-import logging
 import re
 
 from rdr_service.clock import CLOCK
@@ -9,7 +8,7 @@ CODE_TYPES_WITH_OPTIONS = ['radio', 'dropdown', 'checkbox']
 
 
 class CodebookImporter:
-    def __init__(self, dry_run, session, codes_allowed_for_reuse):
+    def __init__(self, dry_run, session, codes_allowed_for_reuse, logger):
         self.dry_run = dry_run
         self.session = session
         self.codes_allowed_for_reuse = codes_allowed_for_reuse
@@ -18,6 +17,8 @@ class CodebookImporter:
         self.module_code = None
         self.invalid_codes_found = []
         self.questions_missing_options = []
+
+        self.logger = logger
 
     def initialize_code(self, value, display, parent=None, code_type=None):
         new_code = Code(
@@ -40,12 +41,12 @@ class CodebookImporter:
                 # so set up the tool to stop saving and print out the code.
                 # Let the script continue so that any other duplications can be caught.
                 self.code_reuse_found = True
-                logging.error(f'Code "{value}" is already in use')
+                self.logger.error(f'Code "{value}" is already in use')
             else:
                 # Allows for reused codes to be a child (or parent) of other codes being imported
                 return existing_code_with_value
         elif self.dry_run:
-            logging.info(f'Found new "{code_type}" type code, value: {value}')
+            self.logger.info(f'Found new "{code_type}" type code, value: {value}')
         elif not self.code_reuse_found and not self.dry_run:
             # Associating a code with a parent adds it to the session too,
             # so it should only happen when we intend to save it.

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -173,7 +173,7 @@ class CodesSyncClass(ToolBase):
             project_api_key = self.parse_values_from_config(self.args.redcap_project)
 
             if not self.args.export_only:
-                code_importer = CodebookImporter(self.args.dry_run, session, self.codes_allowed_for_reuse)
+                code_importer = CodebookImporter(self.args.dry_run, session, self.codes_allowed_for_reuse, logger)
 
                 if not self.args.dry_run:
                     logger.info(f'Importing codes for {self.gcp_env.project}')

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -4,12 +4,10 @@ from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 from oauth2client.service_account import ServiceAccountCredentials
 import os
-import re
-from sqlalchemy.orm.session import Session
 
-from rdr_service.clock import CLOCK
 from rdr_service.services.gcp_utils import gcp_get_iam_service_key_info
 from rdr_service.model.code import Code, CodeType
+from rdr_service.offline.codebook_importer import CodebookImporter
 from rdr_service.services.gcp_config import GCP_INSTANCES
 from rdr_service.services.redcap_client import RedcapClient
 from rdr_service.tools.tool_libs._tool_base import cli_run, logger, ToolBase
@@ -23,7 +21,6 @@ tool_desc = "Manage code import/export process. Syncing codes from the provided 
 REDCAP_PROJECT_KEYS = 'project_api_keys'
 DRIVE_EXPORT_FOLDER_ID = 'drive_export_folder'
 EXPORT_SERVICE_ACCOUNT_NAME = 'code_export_service_account'
-CODE_SYSTEM = 'http://terminology.pmi-ops.org/CodeSystem/ppi'
 
 CODE_EXPORT_NAME_PREFIX = 'codes_'
 
@@ -32,21 +29,6 @@ _now_string = datetime.now().strftime('%Y-%m-%d_%H%M')
 code_export_file_path = f'{CODE_EXPORT_NAME_PREFIX}{_now_string}.csv'
 drive_folder_id = ''
 exporter_service_account_name = ''
-
-CODE_TYPES_WITH_OPTIONS = ['radio', 'dropdown', 'checkbox']
-
-
-class CodeException(Exception):
-    def __init__(self, code_value):
-        self.code_value = code_value
-
-
-class InvalidCodeValue(CodeException):
-    pass
-
-
-class QuestionOptionsMissing(CodeException):
-    pass
 
 
 class CodesExportClass(ToolBase):
@@ -108,9 +90,7 @@ class CodesExportClass(ToolBase):
 
 
 class CodesSyncClass(ToolBase):
-    module_code = None
     codes_allowed_for_reuse = []
-    code_reuse_found = False
 
     def parse_values_from_config(self, redcap_project_name):
         server_config = self.get_server_config()
@@ -145,78 +125,6 @@ class CodesSyncClass(ToolBase):
         else:
             return None
 
-    def initialize_code(self, session: Session, value, display, parent=None, code_type=None):
-        new_code = Code(
-            codeType=code_type,
-            value=value,
-            shortValue=value[:50],
-            display=display,
-            system=CODE_SYSTEM,
-            mapped=True,
-            created=CLOCK.now()
-        )
-        existing_code_with_value = session.query(Code).filter(Code.value == value).one_or_none()
-        if existing_code_with_value:
-            # Answer codes should automatically be allowed to be reused, anything else needs to be explicitly stated
-            if code_type != CodeType.ANSWER and value not in self.codes_allowed_for_reuse:
-                # At this point, it's not an answer code and it wasn't explicitly allowed for reuse
-                # so set up the tool to stop saving and print out the code.
-                # Let the script continue so that any other duplications can be caught.
-                self.code_reuse_found = True
-                logger.error(f'Code "{value}" is already in use')
-            else:
-                # Allows for reused codes to be a child (or parent) of other codes being imported
-                return existing_code_with_value
-        elif self.args.dry_run:
-            logger.info(f'Found new "{code_type}" type code, value: {value}')
-        elif not self.code_reuse_found and not self.args.dry_run:
-            # Associating a code with a parent adds it to the session too,
-            # so it should only happen when we intend to save it.
-            # (But the parent here could be empty, so we make sure the code gets to the session)
-            new_code.parent = parent
-            session.add(new_code)
-
-        return new_code
-
-    def import_answer_code(self, session, answer_text, question_code):
-        # There may be multiple commas in the display string, we want to split on the first to get the code
-        code, display = (part.strip() for part in answer_text.split(',', 1))
-        self.initialize_code(session, code, display, question_code, CodeType.ANSWER)
-
-    @staticmethod
-    def is_code_value_valid(code_value):
-        not_allowed_chars_regex = re.compile(r'[^a-zA-Z0-9_]')  # Regex for any characters that aren't allowed
-        invalid_matches = not_allowed_chars_regex.search(code_value)
-        return invalid_matches is None
-
-    def import_data_dictionary_item(self, session: Session, code_json):
-        code_value = code_json['field_name']
-        code_description = code_json['field_label']
-
-        if code_value != 'record_id':  # Ignore the code Redcap automatically inserts into each project
-            if not self.is_code_value_valid(code_value):
-                raise InvalidCodeValue(code_value)
-            else:
-                if code_json['field_type'] == 'descriptive':
-                    # Only catch the first 'descriptive' field we see. That's the module code.
-                    # Descriptive fields other than the first are considered to be readonly, display text.
-                    # So we don't want to save codes for them
-                    if not self.module_code:
-                        new_code = self.initialize_code(session, code_value, code_description,
-                                                        self.module_code, CodeType.MODULE)
-                        self.module_code = new_code
-                else:
-                    new_code = self.initialize_code(session, code_value, code_description,
-                                                    self.module_code, CodeType.QUESTION)
-
-                    answers_string = code_json['select_choices_or_calculations']
-                    if answers_string:
-                        for answer_text in answers_string.split('|'):
-                            self.import_answer_code(session, answer_text.strip(), new_code)
-                    elif code_json['field_type'] in CODE_TYPES_WITH_OPTIONS:
-                        # The answers string was empty, but this is a type we'd expect to have options
-                        raise QuestionOptionsMissing(code_value)
-
     @staticmethod
     def write_export_file(session):
         with open(code_export_file_path, 'w') as output_file:
@@ -242,6 +150,9 @@ class CodesSyncClass(ToolBase):
                 code_csv_writer.writerow(row_data)
 
     def run_process(self):
+        if self.args.reuse_codes:
+            self.codes_allowed_for_reuse = [code_val.strip() for code_val in self.args.reuse_codes.split(',')]
+
         if self.args.project == '_all':
             for project in GCP_INSTANCES.keys():
                 with self.initialize_process_context(self.tool_cmd, project, self.args.account,
@@ -255,17 +166,15 @@ class CodesSyncClass(ToolBase):
     def run(self, skip_file_export_write=False):
         super(CodesSyncClass, self).run()
         exit_code = 0
-        invalid_codes_found = []
-        questions_missing_options = []
-
-        if self.args.reuse_codes:
-            self.codes_allowed_for_reuse = [code_val.strip() for code_val in self.args.reuse_codes.split(',')]
 
         with self.get_session() as session:
+
             # Get the server config to read Redcap API keys
             project_api_key = self.parse_values_from_config(self.args.redcap_project)
 
             if not self.args.export_only:
+                code_importer = CodebookImporter(self.args.dry_run, session, self.codes_allowed_for_reuse)
+
                 if not self.args.dry_run:
                     logger.info(f'Importing codes for {self.gcp_env.project}')
                 if project_api_key is None:
@@ -276,15 +185,10 @@ class CodesSyncClass(ToolBase):
                 redcap = RedcapClient()
                 dictionary_json = redcap.get_data_dictionary(project_api_key)
                 for item_json in dictionary_json:
-                    try:
-                        self.import_data_dictionary_item(session, item_json)
-                    except InvalidCodeValue as exc:
-                        invalid_codes_found.append(exc.code_value)
-                    except QuestionOptionsMissing as exc:
-                        questions_missing_options.append(exc.code_value)
+                    code_importer.import_data_dictionary_item(item_json)
 
                 # Don't save anything if codes were unintentionally reused
-                if self.code_reuse_found and not self.args.dry_run:
+                if code_importer.code_reuse_found and not self.args.dry_run:
                     logger.error('The above codes were already in the RDR database. '
                                  'Please verify with the team creating questionnaires in Redcap that this '
                                  'was intentional, and then re-run the tool with the "--reuse-codes" argument '
@@ -292,17 +196,17 @@ class CodesSyncClass(ToolBase):
                     exit_code = 1
 
                 # Don't save anything if no module code was found
-                if self.module_code is None:
+                if code_importer.module_code is None:
                     logger.error('No module code found, canceling import')
                     exit_code = 1
 
-                if invalid_codes_found:
-                    code_values_str = ", ".join([f'"{value}"' for value in invalid_codes_found])
+                if code_importer.invalid_codes_found:
+                    code_values_str = ", ".join([f'"{value}"' for value in code_importer.invalid_codes_found])
                     logger.error(f'Invalid code values found: {code_values_str}')
                     exit_code = 1
 
-                if questions_missing_options:
-                    code_values_str = ", ".join([f'"{value}"' for value in questions_missing_options])
+                if code_importer.questions_missing_options:
+                    code_values_str = ", ".join([f'"{value}"' for value in code_importer.questions_missing_options])
                     logger.error(f'The following question codes are missing answer options: {code_values_str}')
                     exit_code = 1
 

--- a/tests/tool_tests/test_codes_management.py
+++ b/tests/tool_tests/test_codes_management.py
@@ -147,7 +147,7 @@ class CodesManagementTest(BaseTestCase):
         module_code = self.assertCodeExists('TestQuestionnaire', 'Test Questionnaire Module', CodeType.MODULE)
         self.assertCodeExists('participant_id', 'Participant ID', CodeType.QUESTION, module_code)
 
-    @mock.patch('rdr_service.offline.codebook_importer.logging')
+    @mock.patch('rdr_service.tools.tool_libs.codes_management.logger')
     def test_failure_on_question_code_reuse(self, mock_logger):
         self.data_generator.create_database_code(value='old_code')
 
@@ -223,7 +223,7 @@ class CodesManagementTest(BaseTestCase):
         self.assertEqual(0, return_val,
                          'Script should successfully exit, allowing for intentional reuse of the question code')
 
-    @mock.patch('rdr_service.offline.codebook_importer.logging')
+    @mock.patch('rdr_service.tools.tool_libs.codes_management.logger')
     def test_dry_run(self, mock_logger):
         self.run_tool([
             self._get_mock_dictionary_item(
@@ -253,7 +253,7 @@ class CodesManagementTest(BaseTestCase):
         mock_logger.info.assert_any_call('Found new "ANSWER" type code, value: A3')
         mock_logger.info.assert_any_call('Found new "ANSWER" type code, value: A4')
 
-    @mock.patch('rdr_service.offline.codebook_importer.logging')
+    @mock.patch('rdr_service.tools.tool_libs.codes_management.logger')
     def test_dry_run_with_reuse_and_errors(self, mock_logger):
         self.data_generator.create_database_code(value='old_code')
         self.data_generator.create_database_code(value='accidental_reuse')


### PR DESCRIPTION
I've run into issues the past few times I've tried to run the code sync tool against all environments at once. It would import them all into the first environment, but then the following ones would silently fail.

This refactor brings some of the state of the process out into a separate class that gets re-initialized for each environment. I think the module code was what was causing the issue (trying to use the module code saved in the first environment as a parent is subsequent environments).

There's a bunch more refactoring and cleaning up I'd like to do, but I think this will atleast get us around the issue I was seeing and would make the tool a bit easier to use.