### PR TITLE
Allowing for null values in place of collections when preloading a migration

### DIFF
--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -249,12 +249,12 @@ class BiobankSpecimenDao(BiobankDaoBase):
         specimen_rlims_id = specimen_json['rlimsID']
         self.preloader.register_for_hydration(BiobankSpecimen(rlimsId=specimen_rlims_id))
 
-        if 'attributes' in specimen_json:
+        if specimen_json.get('attributes'):
             attribute_dao = BiobankSpecimenAttributeDao()
             for attribute_json in specimen_json['attributes']:
                 attribute_dao.ready_preloader(self.preloader, attribute_json, specimen_rlims_id)
 
-        if 'aliquots' in specimen_json:
+        if specimen_json.get('aliquots'):
             aliquot_dao = BiobankAliquotDao()
             for aliquot_json in specimen_json['aliquots']:
                 aliquot_dao.ready_preloader(self.preloader, aliquot_json)
@@ -401,12 +401,12 @@ class BiobankAliquotDao(BiobankDaoBase):
     def ready_preloader(self, preloader: ObjectPreloader, aliquot_json):
         preloader.register_for_hydration(BiobankAliquot(rlimsId=aliquot_json['rlimsID']))
 
-        if 'datasets' in aliquot_json:
+        if aliquot_json.get('datasets'):
             dataset_dao = BiobankAliquotDatasetDao()
             for dataset_json in aliquot_json['datasets']:
                 dataset_dao.ready_preloader(preloader, dataset_json)
 
-        if 'aliquots' in aliquot_json:
+        if aliquot_json.get('aliquots'):
             for child_json in aliquot_json['aliquots']:
                 self.ready_preloader(preloader, child_json)
 
@@ -488,7 +488,7 @@ class BiobankAliquotDatasetDao(BiobankDaoBase):
         dataset_rlims_id = dataset_json['rlimsID']
         preloader.register_for_hydration(BiobankAliquotDataset(rlimsId=dataset_rlims_id))
 
-        if 'datasetItems' in dataset_json:
+        if dataset_json.get('datasetItems'):
             item_dao = BiobankAliquotDatasetItemDao()
 
             for dataset_item_json in dataset_json['datasetItems']:

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -245,6 +245,15 @@ class BiobankOrderApiTest(BaseTestCase):
         saved_specimen_client_json = self.retrieve_specimen_json(result['id'])
         self.assertSpecimenJsonMatches(saved_specimen_client_json, payload)
 
+    def test_allow_for_null_collections_on_migration(self):
+        payload = self.get_minimal_specimen_json()
+        payload['attributes'] = None
+        self.send_put(f"Biobank/specimens", request_data=[payload])
+
+        specimen = self.get_specimen_from_dao(rlims_id=payload['rlimsID'])
+        saved_specimen_client_json = self.dao.to_client_json(specimen)
+        self.assertSpecimenJsonMatches(saved_specimen_client_json, payload)
+
     def test_clear_specimen_data(self):
         payload = self.get_minimal_specimen_json()
         self._add_specimen_data_to_payload(payload)


### PR DESCRIPTION
I forgot that the biobank payloads should be able to accept Null in the place of the arrays (like attributes and aliquots). This updates the preloading code to allow for that.