### PR TITLE
[DA-1860] Genomic tool for backfilling AW1 file processed IDs

### DIFF
--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -719,6 +719,9 @@ class GenomicManifestTypes(messages.Enum):
     AW3_ARRAY = 8
     AW3_WGS = 9
     AW2F = 10
+    GEM_A2 = 11
+    AW4_ARRAY = 12
+    AW4_WGS = 13
 
 
 class GenomicContaminationCategory(messages.Enum):

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1158,7 +1158,6 @@ class BackfillGenomicSetMemberFileProcessedID(GenomicManifestBase):
             # Iterate through each package ID
             for l in csvreader:
                 pkg = l[0]
-                result = 0
 
                 members_for_pkg = self.get_members_aw1_from_package_id(pkg)
 
@@ -1171,9 +1170,6 @@ class BackfillGenomicSetMemberFileProcessedID(GenomicManifestBase):
                         records_updated_count += 1
 
                 _logger.warning(f'{pkg}: updated {records_updated_count}/{record_count_for_pkg}')
-
-                if result == 1:
-                    return 1
 
         return 0
 
@@ -1192,7 +1188,7 @@ class BackfillGenomicSetMemberFileProcessedID(GenomicManifestBase):
                 , max(f.id) as aw1_id
             FROM genomic_set_member m
                 JOIN genomic_manifest_file mf ON (
-                        # Strip only Package from file path
+                        # Return only Package from file path
                         SUBSTRING(
                         SUBSTRING_INDEX(
                         SUBSTRING_INDEX(mf.file_path, "_", -1),
@@ -1313,7 +1309,7 @@ def run():
     collection_tube_parser.add_argument("--sample-override", help="for testing",
                                         default=False, action="store_true")  # noqa
 
-    # Backfill tool for genomic_set_member.*_file_processed_ID
+    # Backfill tool for genomic_set_member.aw1_file_processed_ID
     backfill_file_processed_id_parser = subparser.add_parser("file-processed-id-backfill")
     backfill_file_processed_id_parser.add_argument("--csv", help="A CSV file with the package_ids to backfill",
                                         default=None, required=True)

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1235,6 +1235,7 @@ def run():
     parser.add_argument("--project", help="gcp project name", default="localhost")  # noqa
     parser.add_argument("--account", help="pmi-ops account", default=None)  # noqa
     parser.add_argument("--service-account", help="gcp iam service account", default=None)  # noqa
+    parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     subparser = parser.add_subparsers(help='genomic utilities', dest='util')
 
@@ -1258,24 +1259,20 @@ def run():
     member_state_parser = subparser.add_parser("member-state")
     member_state_parser.add_argument("--csv", help="csv file with genomic_set_member.id, state",
                                      default=None, required=True)  # noqa
-    member_state_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     # Create GenomicSetMembers for provided control sample IDs (provided by Biobank)
     control_sample_parser = subparser.add_parser("control-sample")
     control_sample_parser.add_argument("--csv", help="csv file with control sample ids", default=None)  # noqa
-    control_sample_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     # Create Arbitrary GenomicSetMembers for manually provided PID and sample IDs
     manual_sample_parser = subparser.add_parser("manual-sample")
     manual_sample_parser.add_argument("--csv", help="csv file with manual sample ids",
                                        default=None, required=True)  # noqa
-    manual_sample_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     # Update GenomicGCValidationMetrics from CSV
     gc_metrics_parser = subparser.add_parser("update-gc-metrics")
     gc_metrics_parser.add_argument("--csv", help="csv file with genomic_cv_validation_metrics.id, additional fields",
                                      default=None, required=True)  # noqa
-    gc_metrics_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     # Update Job Run ID to result
     job_run_parser = subparser.add_parser("job-run-result")
@@ -1285,7 +1282,6 @@ def run():
                                       default=None, required=True)  # noqa
     job_run_parser.add_argument("--message", help="genomic_job_run.result_message to update to (optional)",
                                       default=None, required=False)  # noqa
-    job_run_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     # Process Runner
     process_runner_parser = subparser.add_parser("process-runner")
@@ -1295,17 +1291,11 @@ def run():
                                        default=None, required=False)
     process_runner_parser.add_argument("--csv", help="A file specifying multiple manifests to process",
                                        default=None, required=False)
-    process_runner_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
-
-    # Backfill GenomicFileProcessed UploadDate
-    upload_date_parser = subparser.add_parser("backfill-upload-date")
-    upload_date_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
 
     # Collection tube
     collection_tube_parser = subparser.add_parser("collection-tube")
     collection_tube_parser.add_argument("--file", help="A CSV file with collection-tube, biobank_id",
                                         default=None, required=False)
-    collection_tube_parser.add_argument("--dryrun", help="for testing", default=False, action="store_true")  # noqa
     collection_tube_parser.add_argument("--sample-override", help="for testing",
                                         default=False, action="store_true")  # noqa
 
@@ -1313,8 +1303,6 @@ def run():
     backfill_file_processed_id_parser = subparser.add_parser("file-processed-id-backfill")
     backfill_file_processed_id_parser.add_argument("--csv", help="A CSV file with the package_ids to backfill",
                                         default=None, required=True)
-    backfill_file_processed_id_parser.add_argument("--dryrun",
-                                                   help="for testing", default=False, action="store_true")  # noqa
 
     args = parser.parse_args()
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1292,6 +1292,9 @@ def run():
     process_runner_parser.add_argument("--csv", help="A file specifying multiple manifests to process",
                                        default=None, required=False)
 
+    # Backfill GenomicFileProcessed UploadDate
+    upload_date_parser = subparser.add_parser("backfill-upload-date")  # pylint: disable=unused-variable
+
     # Collection tube
     collection_tube_parser = subparser.add_parser("collection-tube")
     collection_tube_parser.add_argument("--file", help="A CSV file with collection-tube, biobank_id",


### PR DESCRIPTION
This PR creates a tool to back fill `genomic_set_member.aw1_file_processed_id` from a provided list of package IDs. AW1 files are matched to a `genomic_set_member` record from the `genomic_set_member.package_id` field and the package id string in the AW1 file name.
Additionally, more `GenomicManifestType` enum entries were added for previously missing manifest types.