### PR TITLE
[DA-1859] Tool and Cloud Task for Calculating Contamination Category

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -245,11 +245,10 @@ class CalculateContaminationCategoryApi(Resource):
                 )
 
                 # Update the contamination category
-                if not self.args.dryrun:
-                    record.GenomicGCValidationMetrics.contaminationCategory = contamination_category
-                    s.merge(record.GenomicGCValidationMetrics)
+                record.GenomicGCValidationMetrics.contaminationCategory = contamination_category
+                s.merge(record.GenomicGCValidationMetrics)
 
-                    logging.warning(f"Updated contamination category for member id: {member_id}")
+                logging.info(f"Updated contamination category for member id: {member_id}")
 
 
 class RebuildGenomicTableRecordsApi(Resource):

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -719,6 +719,9 @@ class GenomicManifestTypes(messages.Enum):
     AW3_ARRAY = 8
     AW3_WGS = 9
     AW2F = 10
+    GEM_A2 = 11
+    AW4_ARRAY = 12
+    AW4_WGS = 13
 
 
 class GenomicContaminationCategory(messages.Enum):

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -643,6 +643,7 @@ class GenomicJob(messages.Enum):
     GENOMIC_MANIFEST_FILE_TRIGGER = 28
     AW2F_MANIFEST = 29
     FEEDBACK_SCAN = 30
+    RECALCULATE_CONTAMINATION_CATEGORY = 31
 
 
 class GenomicWorkflowState(messages.Enum):

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -7,7 +7,8 @@ from sqlalchemy.exc import DBAPIError
 from rdr_service import app_util
 from rdr_service.api.cloud_tasks_api import RebuildParticipantsTaskApi, RebuildCodebookTaskApi, \
     CopyCloudStorageObjectTaskApi, BQRebuildQuestionnaireTaskApi, GenerateBiobankSamplesTaskApi, \
-    RebuildOneParticipantTaskApi, IngestAW1ManifestTaskApi, RebuildGenomicTableRecordsApi, IngestAW2ManifestTaskApi
+    RebuildOneParticipantTaskApi, IngestAW1ManifestTaskApi, RebuildGenomicTableRecordsApi, IngestAW2ManifestTaskApi, \
+    CalculateContaminationCategoryApi
 from rdr_service.services.flask import RESOURCE_PREFIX, TASK_PREFIX, flask_start, flask_stop
 from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging, \
     flask_restful_log_exception_error
@@ -53,6 +54,10 @@ def _build_resource_app():
     # Ingest AW2 manifest
     _api.add_resource(IngestAW2ManifestTaskApi, TASK_PREFIX + "IngestAW2ManifestTaskApi",
                       endpoint="ingest_aw2_manifest_task", methods=["POST"])
+
+    # Calculate Contamination Category
+    _api.add_resource(CalculateContaminationCategoryApi, TASK_PREFIX + "CalculateContaminationCategoryApi",
+                      endpoint="calculate_contamination_category_task", methods=["POST"])
 
     #
     # End Task API endpoints

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1158,7 +1158,6 @@ class BackfillGenomicSetMemberFileProcessedID(GenomicManifestBase):
             # Iterate through each package ID
             for l in csvreader:
                 pkg = l[0]
-                result = 0
 
                 members_for_pkg = self.get_members_aw1_from_package_id(pkg)
 
@@ -1171,9 +1170,6 @@ class BackfillGenomicSetMemberFileProcessedID(GenomicManifestBase):
                         records_updated_count += 1
 
                 _logger.warning(f'{pkg}: updated {records_updated_count}/{record_count_for_pkg}')
-
-                if result == 1:
-                    return 1
 
         return 0
 
@@ -1192,7 +1188,7 @@ class BackfillGenomicSetMemberFileProcessedID(GenomicManifestBase):
                 , max(f.id) as aw1_id
             FROM genomic_set_member m
                 JOIN genomic_manifest_file mf ON (
-                        # Strip only Package from file path
+                        # Return only Package from file path
                         SUBSTRING(
                         SUBSTRING_INDEX(
                         SUBSTRING_INDEX(mf.file_path, "_", -1),
@@ -1313,7 +1309,7 @@ def run():
     collection_tube_parser.add_argument("--sample-override", help="for testing",
                                         default=False, action="store_true")  # noqa
 
-    # Backfill tool for genomic_set_member.*_file_processed_ID
+    # Backfill tool for genomic_set_member.aw1_file_processed_ID
     backfill_file_processed_id_parser = subparser.add_parser("file-processed-id-backfill")
     backfill_file_processed_id_parser.add_argument("--csv", help="A CSV file with the package_ids to backfill",
                                         default=None, required=True)

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1289,7 +1289,13 @@ class CalculateContaminationCategoryClass(GenomicManifestBase):
                 if count == batch_size:
                     data = {"member_ids": batch}
 
-                    _task.execute('/resource/task/CalculateContaminationCategoryApi', payload=data, queue=task_queue)
+                    if self.args.dryrun:
+                        _logger.info("In Dryrun mode, skip submitting cloud task.")
+                    else:
+                        _task.execute('calculate_contamination_category_task',
+                                      payload=data,
+                                      queue=task_queue,
+                                      project_id=self.gcp_env.project)
 
                     batch_count += 1
                     _logger.info(f'Task created for batch {batch_count}')
@@ -1302,7 +1308,10 @@ class CalculateContaminationCategoryClass(GenomicManifestBase):
             if count > 0:
                 batch_count += 1
                 data = {"member_ids": batch}
-                _task.execute('/resource/task/CalculateContaminationCategoryApi', payload=data, queue=task_queue)
+                _task.execute('calculate_contamination_category_task',
+                              payload=data,
+                              queue=task_queue,
+                              project_id=self.gcp_env.project)
 
             _logger.info(f'Submitted {batch_count} tasks.')
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1274,14 +1274,18 @@ class CalculateContaminationCategoryClass(GenomicManifestBase):
         if _task is not None:
             task_queue = 'resource-tasks'
 
-            batch_size = 1
+            batch_size = 100
+
+            # Get total number of batches
             batch_total = math.ceil(len(self.member_ids) / batch_size)
             _logger.info(f'Found {batch_total} member_id batches of size {batch_size}.')
 
+            # Setup counts
             count = 0
             batch_count = 0
             batch = list()
 
+            # Add members to batch and submit cloud tasks
             for mid in self.member_ids:
                 batch.append(mid)
                 count += 1
@@ -1304,7 +1308,7 @@ class CalculateContaminationCategoryClass(GenomicManifestBase):
                     batch.clear()
                     count = 0
 
-            # Send remainder
+            # Submit remainder in last batch
             if count > 0:
                 batch_count += 1
                 data = {"member_ids": batch}
@@ -1441,8 +1445,6 @@ def run():
     contamination_category_parser.add_argument("--cloud-task",
                                                help="Use a cloud task",
                                                default=False, action="store_true")  # noqa
-    contamination_category_parser.add_argument("--dryrun",
-                                                   help="for testing", default=False, action="store_true")  # noqa
 
     args = parser.parse_args()
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1281,23 +1281,24 @@ class CalculateContaminationCategoryClass(GenomicManifestBase):
             with self.dao.session() as s:
                 record = s.query(GenomicSetMember, GenomicGCValidationMetrics).filter(
                     GenomicSetMember.id == mid,
-                ).join(GenomicGCValidationMetrics).filter(
-                    GenomicGCValidationMetrics.ignoreFlag == 0,
+                    GenomicSetMember.collectionTubeId != None,
+                    GenomicGCValidationMetrics.genomicSetMemberId == mid
                 ).one_or_none()
 
-                # calculate new contamination category
-                contamination_category = genomic_ingester.calculate_contamination_category(
-                    record.GenomicSetMember.collectionTubeId,
-                    float(record.GenomicGCValidationMetrics.contamination),
-                    record.GenomicSetMember
-                    )
+                if record is not None:
+                    # calculate new contamination category
+                    contamination_category = genomic_ingester.calculate_contamination_category(
+                        record.GenomicSetMember.collectionTubeId,
+                        float(record.GenomicGCValidationMetrics.contamination),
+                        record.GenomicSetMember
+                        )
 
-                # Update the contamination category
-                if not self.args.dryrun:
-                    record.GenomicGCValidationMetrics.contaminationCategory = contamination_category
-                    s.merge(record.GenomicGCValidationMetrics)
+                    # Update the contamination category
+                    if not self.args.dryrun:
+                        record.GenomicGCValidationMetrics.contaminationCategory = contamination_category
+                        s.merge(record.GenomicGCValidationMetrics)
 
-                    _logger.warning(f"Updated contamination category for member id: {mid}")
+                        _logger.warning(f"Updated contamination category for member id: {mid}")
 
 
 def run():


### PR DESCRIPTION
This PR implements a tool to update `gc_validation_metrics` with `contamination_category` based on the latest AW2 contamination number and current GROR consent. The tool can be ran locally or can be pushed to a cloud task queue. To support the usage of cloud tasks, a new cloud task class and endpoint was created: `CalculateContaminationCategoryApi` and `calculate_contamination_category_task`, respectively.