### PR TITLE
[ROC-794] Using latest questionnaire response received for curation export when authored matches

### DIFF
--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -18,6 +18,7 @@ class QuestionnaireResponsesByModule(Base):
     id = Column(BigInteger, autoincrement=True, primary_key=True)
     participant_id = Column(BigInteger)
     authored = Column(DateTime)
+    created = Column(DateTime)
     survey = Column(String(200))
     __table_args__ = (Index('idx_questionnaire_responses_by_module_pid_survey', participant_id, survey), )
 

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -224,6 +224,7 @@ class CurationExportClass(ToolBase):
         column_map = {
             QuestionnaireResponsesByModule.participant_id: QuestionnaireResponse.participantId,
             QuestionnaireResponsesByModule.authored: QuestionnaireResponse.authored,
+            QuestionnaireResponsesByModule.created: QuestionnaireResponse.created,
             QuestionnaireResponsesByModule.survey: case(
                 [(Code.value == 'COPE', QuestionnaireVibrentForms.vibrent_form_id)],
                 else_=Code.value
@@ -339,7 +340,11 @@ class CurationExportClass(ToolBase):
                     [(module_code.value == 'COPE', QuestionnaireVibrentForms.vibrent_form_id)],
                     else_=module_code.value
                 ),
-                QuestionnaireResponsesByModule.authored > QuestionnaireResponse.authored
+                case(  # If the authored date for the responses match, then join based on the created date instead
+                    [(QuestionnaireResponsesByModule.authored == QuestionnaireResponse.authored,
+                      QuestionnaireResponsesByModule.created > QuestionnaireResponse.created)],
+                    else_=(QuestionnaireResponsesByModule.authored > QuestionnaireResponse.authored)
+                )
             )
         ).filter(
             Participant.withdrawalStatus != WithdrawalStatus.NO_USE,

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import mock
 
+from rdr_service.etl.model.src_clean import SrcClean
 from rdr_service.model.participant import Participant
 from rdr_service.tools.tool_libs.curation import CurationExportClass
 from tests.helpers.unittest_base import BaseTestCase
@@ -17,36 +18,44 @@ class CurationEtlTest(BaseTestCase):
         module_code = self.data_generator.create_database_code(value='src_clean_test')
         question_code = self.data_generator.create_database_code(value='q_1')
 
-        questionnaire = self.data_generator.create_database_questionnaire_history(
+        self.questionnaire = self.data_generator.create_database_questionnaire_history(
             resource='''{
                         "identifier": [
                             {"value": "form_id_1"}
                         ]
                     }'''
         )
-        questionnaire_question = self.data_generator.create_database_questionnaire_question(
-            questionnaireId=questionnaire.questionnaireId,
-            questionnaireVersion=questionnaire.version,
+        self.data_generator.create_database_questionnaire_question(
+            questionnaireId=self.questionnaire.questionnaireId,
+            questionnaireVersion=self.questionnaire.version,
             codeId=question_code.codeId
         )
 
         self.data_generator.create_database_questionnaire_concept(
-            questionnaireId=questionnaire.questionnaireId,
-            questionnaireVersion=questionnaire.version,
+            questionnaireId=self.questionnaire.questionnaireId,
+            questionnaireVersion=self.questionnaire.version,
             codeId=module_code.codeId
         )
 
+        self.questionnaire_response = self.setup_questionnaire_response(self.participant, self.questionnaire)
+
+    def setup_questionnaire_response(self, participant, questionnaire, authored=datetime(2020, 3, 15),
+                                     created=datetime(2020, 3, 15)):
         questionnaire_response = self.data_generator.create_database_questionnaire_response(
-            participantId=self.participant.participantId,
+            participantId=participant.participantId,
             questionnaireId=questionnaire.questionnaireId,
             questionnaireVersion=questionnaire.version,
-            authored=datetime.now()
+            authored=authored,
+            created=created
         )
-        self.data_generator.create_database_questionnaire_response_answer(
-            questionnaireResponseId=questionnaire_response.questionnaireResponseId,
-            questionId=questionnaire_question.questionnaireQuestionId,
-            valueString='test answer'
-        )
+        for question in questionnaire.questions:
+            self.data_generator.create_database_questionnaire_response_answer(
+                questionnaireResponseId=questionnaire_response.questionnaireResponseId,
+                questionId=question.questionnaireQuestionId,
+                valueString='test answer'
+            )
+
+        return questionnaire_response
 
     @staticmethod
     def run_tool():
@@ -68,3 +77,50 @@ class CurationEtlTest(BaseTestCase):
 
         # This will time out if the tool tries to take an exclusive lock on the participant
         self.run_tool()
+
+    def _src_clean_record_found_for_response(self, questionnaire_response_id):
+        response_record = self.session.query(SrcClean).filter(
+            SrcClean.questionnaire_response_id == questionnaire_response_id
+        ).one_or_none()
+        return response_record is not None
+
+    def test_latest_questionnaire_response_used(self):
+        """The latest questionnaire response received for a module should be used"""
+        # Note: this only applies to modules that shouldn't roll up answers (ConsentPII should be rolled up)
+
+        # Create a questionnaire response that would be used instead of the default for the test suite
+        later_response = self.setup_questionnaire_response(
+            self.participant,
+            self.questionnaire,
+            authored=datetime(2020, 5, 10),
+            created=datetime(2020, 5, 10)
+        )
+
+        # Check that the later response is used and that the previous response doesn't make it into the src_clean table
+        self.run_tool()
+        self.assertTrue(
+            self._src_clean_record_found_for_response(later_response.questionnaireResponseId),
+            'A src_clean record should be created for the later response'
+        )
+        self.assertFalse(
+            self._src_clean_record_found_for_response(self.questionnaire_response.questionnaireResponseId),
+            'A src_clean record should not be created for the earlier response'
+        )
+
+        # Check that two responses with the same authored date uses the latest one received (latest created date)
+        latest_received_response = self.setup_questionnaire_response(
+            self.participant,
+            self.questionnaire,
+            authored=later_response.authored,
+            created=datetime(2020, 8, 1)
+        )
+        self.run_tool()
+        self.assertTrue(
+            self._src_clean_record_found_for_response(latest_received_response.questionnaireResponseId)
+        )
+        self.assertFalse(
+            self._src_clean_record_found_for_response(later_response.questionnaireResponseId)
+        )
+        self.assertFalse(
+            self._src_clean_record_found_for_response(self.questionnaire_response.questionnaireResponseId)
+        )


### PR DESCRIPTION
If a questionnaire response structure is corrected and replayed (like for the GROR) we would have two questionnaire responses for the same module that have the same authored date. So the code was sending both of them to the curation export when it should have only sent one. These changes are to use the created date in place of the authored date if the authored dates match.