### PR TITLE
Setting up DELETE method on specimen attributes

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -1,13 +1,13 @@
 from flask import request
 import logging
+from werkzeug.exceptions import BadRequest, NotFound
+from sqlalchemy.orm.exc import NoResultFound
 
 from rdr_service.api.base_api import UpdatableApi, log_api_request
 from rdr_service.api_util import BIOBANK
 from rdr_service.app_util import auth_required
 from rdr_service.dao.biobank_specimen_dao import BiobankSpecimenDao, BiobankSpecimenAttributeDao, BiobankAliquotDao,\
     BiobankAliquotDatasetDao
-from werkzeug.exceptions import BadRequest, NotFound
-from sqlalchemy.orm.exc import NoResultFound
 
 
 class BiobankApiBase(UpdatableApi):
@@ -176,6 +176,12 @@ class BiobankSpecimenAttributeApi(BiobankSpecimenTargetedUpdateBase):
             attribute_dao.insert_with_session(session, attribute)
         else:
             attribute_dao.update_with_session(session, attribute)
+
+    @staticmethod
+    def delete(rlims_id, attribute_name):
+        attribute_dao = BiobankSpecimenAttributeDao()
+        attribute_dao.delete(rlims_id, attribute_name)
+        return 200
 
 
 class BiobankSpecimenAliquotApi(BiobankSpecimenTargetedUpdateBase):

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -348,6 +348,13 @@ class BiobankSpecimenAttributeDao(BiobankDaoBase):
         else:
             return None
 
+    def delete(self, specimen_rlims_id, attribute_name):
+        with self.session() as session:
+            session.query(BiobankSpecimenAttribute).filter(
+                BiobankSpecimenAttribute.specimen_rlims_id == specimen_rlims_id,
+                BiobankSpecimenAttribute.name == attribute_name
+            ).delete()
+
 
 class BiobankAliquotDao(BiobankDaoBase):
 

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -238,7 +238,7 @@ api.add_resource(
     BiobankSpecimenAttributeApi,
     API_PREFIX + "Biobank/specimens/<string:rlims_id>/attributes/<string:attribute_name>",
     endpoint="biobank.parent_attribute",
-    methods=["PUT"],
+    methods=["PUT", "DELETE"],
     )
 
 api.add_resource(

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -958,6 +958,27 @@ class BiobankOrderApiTest(BaseTestCase):
         attribute = specimen['attributes'][0]
         self.assertEqual('updated', attribute['value'])
 
+    def test_attribute_deletion(self):
+        payload = self.get_minimal_specimen_json()
+        payload['attributes'] = [
+            {
+                'name': 'attr_one',
+                'value': '1'
+            },
+            {
+                'name': 'attr_two',
+                'value': 'two'
+            }
+        ]
+        initial_result = self.put_specimen(payload)
+
+        self.send_delete(f"Biobank/specimens/sabrina/attributes/attr_one")
+
+        specimen = self.retrieve_specimen_json(initial_result['id'])
+        self.assertEqual(1, len(specimen['attributes']), 'Should only have one attribute after the delete request')
+        attribute = specimen['attributes'][0]
+        self.assertEqual('attr_two', attribute['name'])
+
     def test_parent_attribute_not_found(self):
         self.send_put(f"Biobank/specimens/sabrina/attributes/attr1", {
             'disposalDate': TIME_1.isoformat()

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -524,6 +524,9 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
     def send_put(self, *args, **kwargs):
         return self.send_request("PUT", *args, **kwargs)
 
+    def send_delete(self, *args, **kwargs):
+        return self.send_request("DELETE", *args, **kwargs)
+
     def send_patch(self, *args, **kwargs):
         return self.send_request("PATCH", *args, **kwargs)
 


### PR DESCRIPTION
The Biobank team is testing the API and discovered that there needs to be a way to remove individual attributes from a specimen (without sending a list of all the valid attributes to the API). This sets up a DELETE method for the attributes endpoint that allows for deleting the attributes.