### PR TITLE
[ROC-788] Rolling up consent module for curation export

### DIFF
--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -4,28 +4,26 @@ from sqlalchemy.dialects.mysql import DECIMAL, TINYINT
 from rdr_service.model.base import Base
 
 
-class QuestionnaireVibrentForms(Base):
-    __tablename__ = 'questionnaire_vibrent_forms'
-    id = Column(BigInteger, autoincrement=True, primary_key=True)
-    questionnaire_id = Column(BigInteger)
-    version = Column(BigInteger)
-    vibrent_form_id = Column(String(200))
-    __table_args__ = (Index('idx_questionnaire_vibrent_forms_qid_version', questionnaire_id, version), )
-
-
-class QuestionnaireResponsesByModule(Base):
-    __tablename__ = 'questionnaire_responses_by_module'
+class QuestionnaireAnswersByModule(Base):
+    __tablename__ = 'questionnaire_answers_by_module'
     id = Column(BigInteger, autoincrement=True, primary_key=True)
     participant_id = Column(BigInteger)
     authored = Column(DateTime)
     created = Column(DateTime)
     survey = Column(String(200))
-    __table_args__ = (Index('idx_questionnaire_responses_by_module_pid_survey', participant_id, survey), )
+    response_id = Column(BigInteger)
+    question_code_id = Column(BigInteger)
+    __table_args__ = (Index(
+        'idx_participant_questionnaire_answers_by_module_and_code',
+        participant_id,
+        survey,
+        question_code_id
+    ), )
 
 
 class SrcClean(Base):
     __tablename__ = 'src_clean'
-    id = Column(BigInteger, autoincrement=True, primary_key=True)  # TODO: make sure this doesn't get to the export
+    id = Column(BigInteger, autoincrement=True, primary_key=True)
     participant_id = Column(BigInteger)
     research_id = Column(BigInteger)
     survey_name = Column(String(200))


### PR DESCRIPTION
Responses for the consent survey need to be rolled up when exporting to curation. Sometimes, after we have a full questionnaire response for the consent survey, we receive responses that will only have one or two answers. Those are sent to update fields like the email address or the phone number. Rather than sending these as the latest response to curation, we should send the latest of all the answers the participant has for that module.

To potentially get the latest answers, a helper table was changed to also capture what questions were being answered in a questionnaire response. When populating the src_clean table with questionnaire data that should just use the latest response, the helper table (QuestionnaireAnswersByModule) is used in the same way as it was previously (seeing if there are any later responses, regardless of what questions are answered) and is joined using a DISTINCT query to get the response data alone.

I've also removed the VibrentForms helper table since QuestionnaireHistory has the external id now.