### PR TITLE
Adding auth decorator for attribute deletion

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -178,6 +178,7 @@ class BiobankSpecimenAttributeApi(BiobankSpecimenTargetedUpdateBase):
             attribute_dao.update_with_session(session, attribute)
 
     @staticmethod
+    @auth_required(BIOBANK)
     def delete(rlims_id, attribute_name):
         attribute_dao = BiobankSpecimenAttributeDao()
         attribute_dao.delete(rlims_id, attribute_name)


### PR DESCRIPTION
I missed adding the auth check for the code that delete biobank specimen attributes.