### PR TITLE
[PDR fix] Fixes for new genomics tables/fields in BQ

### DIFF
--- a/rdr_service/dao/bq_genomics_dao.py
+++ b/rdr_service/dao/bq_genomics_dao.py
@@ -426,7 +426,7 @@ def bq_genomic_manifest_feedback_batch_update(_ids, project_id=None):
     gen = BQGenomicManifestFeedbackSchemaGenerator()
     w_dao = BigQuerySyncDao()
     for _id in _ids:
-        bq_genomic_manifest_file_update(_id, project_id=project_id, gen=gen, w_dao=w_dao)
+        bq_genomic_manifest_feedback_update(_id, project_id=project_id, gen=gen, w_dao=w_dao)
 
 
 class BQGenomicGCValidationMetricsSchemaGenerator(BigQueryGenerator):

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -41,7 +41,7 @@ tool_desc = "Tools for updating resource records in RDR"
 
 
 GENOMIC_DB_TABLES = ('genomic_set', 'genomic_set_member', 'genomic_job_run', 'genomic_gc_validation_metrics',
-                     'genomic_file_processed')
+                     'genomic_file_processed', 'genomic_manifest_file', 'genomic_manifest_feedback')
 
 class ParticipantResourceClass(object):
     def __init__(self, args, gcp_env: GCPEnvConfigObject, pid_list: None):


### PR DESCRIPTION
Fix for what looked like an unmodified cut/paste when generating `genomic_manifest_feedback` PDR data.  It was stamping the `bigquery_sync` records with the wrong table_id (`genomic_manifest_file`), which would trigger BigQuery errors when it tried to insert the data into that target table.

Also updated the resource tool to recognize the new genomics tables.