### PR TITLE
[ROC-796] Generating reconciliation reports only if the samples import was successful

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -9,11 +9,6 @@ cron:
   schedule: every day 01:30
   timezone: America/New_York
   target: offline
-- description: Daily reconciliation report
-  url: /offline/DailyReconciliationReport
-  schedule: every day 03:00
-  timezone: America/New_York
-  target: offline
 - description: Monthly reconciliation report
   url: /offline/MonthlyReconciliationReport
   schedule: 1 of month 05:00

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -1,6 +1,6 @@
 cron:
 - description: Daily Biobank sample import and order reconciliation
-  url: /offline/BiobankSamplesImport
+  url: /offline/BiobankSamplesPipeline
   schedule: every day 02:30
   timezone: America/New_York
   target: offline

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -107,29 +107,19 @@ def recalculate_public_metrics():
 
 
 @app_util.auth_required_cron
-#@_alert_on_exceptions
-def import_biobank_samples():
+def biobank_samples_pipeline():
     # Note that crons always have a 10 minute deadline instead of the normal 60s; additionally our
     # offline service uses basic scaling with has no deadline.
     logging.info("Starting samples import.")
-    written, _ = biobank_samples_pipeline.upsert_from_latest_csv()
+    written, timestamp = biobank_samples_pipeline.upsert_from_latest_csv()
     logging.info("Import complete %(written)d, generating report.", written)
-    return json.dumps({"written": written})
 
-
-@app_util.auth_required_cron
-#@_alert_on_exceptions
-def biobank_daily_reconciliation_report():
-    # TODO: setup to only run after import_biobank_samples completion instead of 1hr after start.
-    sample_file_path, sample_file, timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info(monthly=False)
-    logging.info(f"Generating reconciliation report from {sample_file_path}, {sample_file}")
     # iterate new list and write reports
     biobank_samples_pipeline.write_reconciliation_report(timestamp)
     logging.info("Generated reconciliation report.")
     return '{"success": "true"}'
 
 @app_util.auth_required_cron
-#@_alert_on_exceptions
 def biobank_monthly_reconciliation_report():
     # make sure this cron job is executed after import_biobank_samples
     sample_file_path, sample_file, timestamp = biobank_samples_pipeline.get_last_biobank_sample_file_info(monthly=True)
@@ -488,18 +478,12 @@ def _build_pipeline_app():
     )
 
     offline_app.add_url_rule(
-        OFFLINE_PREFIX + "BiobankSamplesImport",
-        endpoint="biobankSamplesImport",
-        view_func=import_biobank_samples,
+        OFFLINE_PREFIX + "BiobankSamplesPipeline",
+        endpoint="biobankSamplesPipeline",
+        view_func=biobank_samples_pipeline,
         methods=["GET"],
     )
 
-    offline_app.add_url_rule(
-        OFFLINE_PREFIX + "DailyReconciliationReport",
-        endpoint="dailyReconciliationReport",
-        view_func=biobank_daily_reconciliation_report,
-        methods=["GET"],
-    )
     offline_app.add_url_rule(
         OFFLINE_PREFIX + "MonthlyReconciliationReport",
         endpoint="monthlyReconciliationReport",

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -107,7 +107,7 @@ def recalculate_public_metrics():
 
 
 @app_util.auth_required_cron
-def biobank_samples_pipeline():
+def run_biobank_samples_pipeline():
     # Note that crons always have a 10 minute deadline instead of the normal 60s; additionally our
     # offline service uses basic scaling with has no deadline.
     logging.info("Starting samples import.")
@@ -480,7 +480,7 @@ def _build_pipeline_app():
     offline_app.add_url_rule(
         OFFLINE_PREFIX + "BiobankSamplesPipeline",
         endpoint="biobankSamplesPipeline",
-        view_func=biobank_samples_pipeline,
+        view_func=run_biobank_samples_pipeline,
         methods=["GET"],
     )
 


### PR DESCRIPTION
If the biobank samples import run fails on an old file, the daily reconciliation report will run anyway and generate duplicate files. To fix that, this PR brings the two jobs back together so reconciliation reports don't go out if the import didn't work.