### PR TITLE
Making ppi-validator case insensitive for answer codes

### DIFF
--- a/rdr_service/api/check_ppi_data_api.py
+++ b/rdr_service/api/check_ppi_data_api.py
@@ -8,48 +8,49 @@ from rdr_service.code_constants import EMAIL_QUESTION_CODE, PPI_SYSTEM
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseAnswerDao
-from rdr_service.model.code import CodeType
+from rdr_service.model.code import Code, CodeType
 from rdr_service.model.participant_summary import ParticipantSummary
 
 
 @auth_required(PTC_AND_HEALTHPRO)
 def check_ppi_data():
-    """Validates the questions/responses for test participants.
+    """
+    Validates the questions/responses for test participants.
 
-  Typically called from rdr_client/check_ppi_data.py.
+    Typically called from rdr_client/check_ppi_data.py.
 
-  The request contains a ppi_data dict which maps test participant e-mail addresses/phone number
-  to their responses. All code and answer values are unparsed strings. Values may be empty,
-  and multiple values for one answer may be separated by | characters.
-  {
-    'ppi_data': {
-      'email@address.com|5555555555': {
-        'PIIName_First': 'Alex',
-        'Insurance_HealthInsurance': 'HealthInsurance_Yes',
-        'EmplymentWorkAddress_AddressLineOne': '',
-        'Race_WhatRaceEthnicity': 'WhatRaceEthnicity_Hispanic|WhatRaceEthnicity_Black',
-        ...
-      },
-      'email2@address.com': { ... }
+    The request contains a ppi_data dict which maps test participant e-mail addresses/phone number
+    to their responses. All code and answer values are unparsed strings. Values may be empty,
+    and multiple values for one answer may be separated by | characters.
+    {
+        'ppi_data': {
+          'email@address.com|5555555555': {
+            'PIIName_First': 'Alex',
+            'Insurance_HealthInsurance': 'HealthInsurance_Yes',
+            'EmplymentWorkAddress_AddressLineOne': '',
+            'Race_WhatRaceEthnicity': 'WhatRaceEthnicity_Hispanic|WhatRaceEthnicity_Black',
+            ...
+          },
+          'email2@address.com': { ... }
+        }
     }
-  }
 
-  The response contains a ppi_results dict which maps test participant e-mail addresses to their
-  individual results. Each participant's results has test/error counts and a list of human-readable
-  error messages.
-  {
-    'ppi_results': {
-      'email@address.com|5555555555': {
-        'tests_count': number,
-        'errors_count': number,
-        'error_messages' : [
-          'formatted error message detailing an error',
-        ]
-      },
-      'email@b.com': { ... }
+    The response contains a ppi_results dict which maps test participant e-mail addresses to their
+    individual results. Each participant's results has test/error counts and a list of human-readable
+    error messages.
+    {
+        'ppi_results': {
+          'email@address.com|5555555555': {
+            'tests_count': number,
+            'errors_count': number,
+            'error_messages' : [
+              'formatted error message detailing an error',
+            ]
+          },
+          'email@b.com': { ... }
+        }
     }
-  }
-  """
+    """
     _sanity_check_codebook()
     ppi_results = {}
     ppi_data = request.get_json(force=True)["ppi_data"]
@@ -77,6 +78,37 @@ class _ValidationResult(object):
 
     def to_json(self):
         return {"tests_count": self.tests_count, "errors_count": self.errors_count, "error_messages": self.messages}
+
+def _answers_match(expected_answer: str, actual_answer):
+    """
+    Compare the expected answer (represented by a string) to the
+    actual answer we have (a string or possibly something else)
+    """
+    if isinstance(actual_answer, Code):
+        return expected_answer.lower() == actual_answer.value.lower()
+    elif isinstance(actual_answer, bool):
+        return expected_answer.lower() == str(actual_answer).lower()
+    else:
+        return expected_answer == actual_answer
+
+
+def _list_of_expected_answers_match_actual(expected_answers: set, actual_answers: set):
+    """
+    Compare a list of expected answers for a question to the list we actually have,
+    making sure they match and neither list has extras.
+    """
+    if len(expected_answers) != len(actual_answers):
+        # The number of expected answers doesn't match what we have
+        return False
+
+    for expected_answer in expected_answers:
+        # All expected answers should have a match in the list of actual answers
+        if not any([_answers_match(expected_answer, actual) for actual in actual_answers]):
+            return False
+
+    # Each list has the same number of elements, and every expected answer was found in the actual answers.
+    # So the lists match.
+    return True
 
 
 def _get_validation_result(key, codes_to_answers):
@@ -120,21 +152,31 @@ def _get_validation_result(key, codes_to_answers):
                     continue
 
             if answer_string:
-                expected_values = set(_boolean_to_lower(v.strip()) for v in answer_string.split("|"))
+                expected_values = set(v.strip() for v in answer_string.split("|"))
             else:
                 expected_values = set()
-            if expected_values != qra_values:
+
+            if not _list_of_expected_answers_match_actual(expected_values, qra_values):
                 result.add_error(
                     f"{question_code.value}: Expected {_format_values(expected_values)}, \
                     found {_format_values(qra_values)}."
                 )
+
     return result
 
 
 def _format_values(values):
     if not values:
         return "no answer"
-    return repr(sorted(list(values)))
+
+    value_string_list = []
+    for value in values:
+        if isinstance(value, Code):
+            value_str = value.value
+        else:
+            value_str = value
+        value_string_list.append(value_str)
+    return repr(sorted(value_string_list))
 
 
 def _get_value_for_qra(qra, question_code, code_dao, session):
@@ -145,7 +187,7 @@ def _get_value_for_qra(qra, question_code, code_dao, session):
     if qra.valueDecimal is not None:
         return str(qra.valueDecimal)
     if qra.valueBoolean is not None:
-        return str(qra.valueBoolean).lower()
+        return qra.valueBoolean
     if qra.valueDate is not None:
         return qra.valueDate.isoformat()
     if qra.valueDateTime is not None:
@@ -156,11 +198,5 @@ def _get_value_for_qra(qra, question_code, code_dao, session):
             raise ValueError(
                 f"Unexpected value {code.value} with non-PPI system {code.system} for question {question_code}."
             )
-        return code.value
+        return code
     raise ValueError(f"Answer for question {question_code} has no value set.")
-
-
-def _boolean_to_lower(value):
-    if value.lower() == "true" or value.lower() == "false":
-        return value.lower()
-    return value

--- a/tests/api_tests/test_ppi_data_check_api.py
+++ b/tests/api_tests/test_ppi_data_check_api.py
@@ -1,0 +1,60 @@
+from rdr_service.model.code import CodeType
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class CheckPpiDataApiTest(BaseTestCase):
+    def setUp(self):
+        super(CheckPpiDataApiTest, self).setUp(with_consent_codes=True)
+
+        self.participant_summary = self.data_generator.create_database_participant_summary(email='test@example.com')
+
+        questions_and_answers = [
+            ('first_question_code', 'first_answer_code'),
+            ('Second_CODE', 'ANOTHER_ANSWER'),
+            ('LAST_CODE', 'Final_Answer|with_additional_option')
+        ]
+
+        questionnaire = self.data_generator.create_database_questionnaire_history()
+        for question_code_value, _ in questions_and_answers:
+            question_code = self.data_generator.create_database_code(
+                value=question_code_value,
+                codeType=CodeType.QUESTION
+            )
+            self.data_generator.create_database_questionnaire_question(
+                questionnaireId=questionnaire.questionnaireId,
+                questionnaireVersion=questionnaire.version,
+                codeId=question_code.codeId
+            )
+
+        questionnaire_response = self.data_generator.create_database_questionnaire_response(
+            participantId=self.participant_summary.participantId,
+            questionnaireId=questionnaire.questionnaireId,
+            questionnaireVersion=questionnaire.version
+        )
+        for question_index, (_, answer_code_values) in enumerate(questions_and_answers):
+            question = questionnaire.questions[question_index]
+
+            for answer_value in answer_code_values.split('|'):
+                answer_code = self.data_generator.create_database_code(value=answer_value)
+                self.data_generator.create_database_questionnaire_response_answer(
+                    questionnaireResponseId=questionnaire_response.questionnaireResponseId,
+                    questionId=question.questionnaireQuestionId,
+                    valueCodeId=answer_code.codeId
+                )
+
+    def test_case_insensitive_answer_code_matching(self):
+        """Make sure case doesn't matter when matching answer codes against what the server has"""
+
+        ppi_check_payload = {
+            'ppi_data': {
+                self.participant_summary.email: {
+                    'fIrSt_QuEsTiOn_CoDe': 'First_Answer_Code',
+                    'SECOND_CODE': 'another_answer',
+                    'last_code': 'Final_ANSWER|WITH_ADDITIONAL_OPTION'
+                }
+            }
+        }
+        response = self.send_post('CheckPpiData', ppi_check_payload)
+
+        response_error_count = response['ppi_results']['test@example.com']['errors_count']
+        self.assertEqual(0, response_error_count, 'Differences in case should not cause errors')


### PR DESCRIPTION
This PR updates the ppi-validator tool used by QA to allow for differences in case between the code used as part of an answer in a questionnaire response, and the value entered by QA when specifying the answer RDR should have for a participant.

Previously any questionnaire response answers were converted to string values when compared against what QA provided as expectations. Case sensitivity for string answers should still apply, but not for code values. So I modified the code a bit to return the actual object for the code answer given rather than a string representation of it. Then I replaced the comparison code so that it would continue to compare string values in a case sensitive way, but convert code values to lower case when comparing the expected to the actual.

Boolean answer comparison was doing something similar, so I refactored that functionality to how it works with codes so that they were consistent with each other.