### PR TITLE
[DA-1866]  Genomic AW1 Tool and Process Updates

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse
 import sqlalchemy
 
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_gc_validation_metrics_update, \
-    bq_genomic_set_update, bq_genomic_file_processed_update
+    bq_genomic_set_update, bq_genomic_file_processed_update, bq_genomic_manifest_file_update
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 
@@ -23,7 +23,7 @@ from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.participant import Participant
 from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_gc_validation_metrics_update, \
-    genomic_set_update, genomic_file_processed_update
+    genomic_set_update, genomic_file_processed_update, genomic_manifest_file_update
 from rdr_service.services.jira_utils import JiraTicketHandler
 from rdr_service.api_util import (
     open_cloud_file,
@@ -416,6 +416,9 @@ class GenomicFileIngester:
 
                 with self.manifest_dao.session() as s:
                     s.merge(manifest_file)
+
+                    bq_genomic_manifest_file_update(manifest_file.id, project_id=self.controller.bq_project_id)
+                    genomic_manifest_file_update(manifest_file.id)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -58,7 +58,7 @@ from rdr_service.dao.genomics_dao import (
     GenomicFileProcessedDao,
     GenomicSetDao,
     GenomicJobRunDao,
-    GenomicManifestFeedbackDao)
+    GenomicManifestFeedbackDao, GenomicManifestFileDao)
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.site_dao import SiteDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
@@ -120,6 +120,7 @@ class GenomicFileIngester:
         self.job_run_dao = GenomicJobRunDao()
         self.sample_dao = BiobankStoredSampleDao()
         self.feedback_dao = GenomicManifestFeedbackDao()
+        self.manifest_dao = GenomicManifestFileDao()
 
     def generate_file_processing_queue(self):
         """
@@ -306,6 +307,8 @@ class GenomicFileIngester:
             'gcManifestFailureDescription': 'failuremodedesc',
         }
         try:
+            count = 0
+
             for row in data['rows']:
                 row_copy = dict(zip([key.lower().replace(' ', '').replace('_', '')
                                      for key in row], row.values()))
@@ -394,10 +397,25 @@ class GenomicFileIngester:
                     member.genomicWorkflowStateModifiedTime = clock.CLOCK.now()
 
                 self.member_dao.update(member)
+                count += 1
 
                 # Update member for PDR
                 bq_genomic_set_member_update(member.id, project_id=self.controller.bq_project_id)
                 genomic_set_member_update(member.id)
+
+            # Update the record count with the number of ingested records.
+            manifest_file = self.manifest_dao.get(self.file_obj.genomicManifestFileId)
+
+            # TODO: AW1F files won't have a manifest record,
+            #  this will be added in a follow-up PR
+            if manifest_file is not None:
+                # We want to add the record count to the existing record count for that manifest record
+                manifest_file.recordCount += count
+                manifest_file.processingComplete = 1
+                manifest_file.processingCompleteDate = clock.CLOCK.now()
+
+                with self.manifest_dao.session() as s:
+                    s.merge(manifest_file)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1,7 +1,6 @@
 """
 This module tracks and validates the status of Genomics Pipeline Subprocesses.
 """
-import csv
 import logging
 from datetime import datetime
 
@@ -9,7 +8,7 @@ import pytz
 from sendgrid import sendgrid
 
 from rdr_service import clock, config
-from rdr_service.api_util import list_blobs, open_cloud_file
+from rdr_service.api_util import list_blobs
 
 from rdr_service.config import (
     GENOMIC_GC_METRICS_BUCKET_NAME,
@@ -105,13 +104,6 @@ class GenomicJobController:
         except AttributeError:
             raise AttributeError("upload_date, manifest_type, and file_path required")
 
-        try:
-            with open_cloud_file(_file_path) as csv_file:
-                csv_reader = csv.DictReader(csv_file, delimiter=",")
-                count = len(list(csv_reader))
-        except FileNotFoundError:
-            raise
-
         file_to_insert = GenomicManifestFile(
             created=now,
             modified=now,
@@ -119,7 +111,7 @@ class GenomicJobController:
             manifestTypeId=_manifest_type,
             filePath=_file_path,
             bucketName=_file_path.split('/')[0],
-            recordCount=count,
+            recordCount=0,  # Initializing with 0, counting records when processing file
             rdrProcessingComplete=0,
         )
 

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -315,10 +315,11 @@ def create_aw2f_manifest(feedback_record):
                                      feedback_record=feedback_record)
 
 
-def execute_genomic_manifest_file_pipeline(_task_data: dict):
+def execute_genomic_manifest_file_pipeline(_task_data: dict, project_id=None):
     """
     Entrypoint for new genomic manifest file pipelines
     Sets up the genomic manifest file record and begin pipeline
+    :param project_id:
     :param _task_data: dictionary of metadata needed by the controller
     """
     task_data = JSONObject(_task_data)
@@ -333,7 +334,7 @@ def execute_genomic_manifest_file_pipeline(_task_data: dict):
         raise AttributeError("file_data is required to execute manifest file pipeline")
 
     with GenomicJobController(GenomicJob.GENOMIC_MANIFEST_FILE_TRIGGER,
-                              task_data=task_data) as controller:
+                              task_data=task_data, bq_project_id=project_id) as controller:
         manifest_file = controller.insert_genomic_manifest_file_record()
 
         if task_data.file_data.create_feedback_record:
@@ -344,6 +345,9 @@ def execute_genomic_manifest_file_pipeline(_task_data: dict):
     if task_data.job:
         task_data.manifest_file = manifest_file
         dispatch_genomic_job_from_task(task_data)
+
+    else:
+        return manifest_file
 
 
 def dispatch_genomic_job_from_task(_task_data: JSONObject):


### PR DESCRIPTION
This PR adds the creation of `genomic_manifest_file` and `genomic_manifest_feedback` records to the AW1 process-runner tool. This PR also updates the AW1 ingestion to calculate the `genomic_manifest_file.record_count` for ingested files. Unit tests were updated to accommodate these changes.