### PR TITLE
Order csv result in genomic new participant workflow unit test

### DIFF
--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -3,6 +3,7 @@ import datetime
 import time
 import os
 import mock
+import operator
 
 import pytz
 from dateutil.parser import parse
@@ -1127,6 +1128,8 @@ class GenomicPipelineTest(BaseTestCase):
             missing_cols = set(ExpectedCsvColumns.ALL) - set(csv_reader.fieldnames)
             self.assertEqual(0, len(missing_cols))
             rows = list(csv_reader)
+
+            rows.sort(key=operator.itemgetter(ExpectedCsvColumns.BIOBANK_ID, ExpectedCsvColumns.GENOME_TYPE ))
 
             self.assertEqual("T100002", rows[0][ExpectedCsvColumns.BIOBANK_ID])
             self.assertEqual(100002, int(rows[0][ExpectedCsvColumns.SAMPLE_ID]))


### PR DESCRIPTION
This PR fixes an issue with the ordering of the CSV result in the new participant workflow unit test. The CSV result is now being sorted before the test assertions.