### PR TITLE
[DA-1867] Fix AW2 sample contamination error

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1220,9 +1220,10 @@ class GenomicManifestFeedbackDao(BaseDao):
                 GenomicManifestFeedback.ignoreFlag == 0
             ).one_or_none()
 
-    def increment_feedback_count(self, manifest_id):
+    def increment_feedback_count(self, manifest_id, _project_id):
         """
         Update the manifest feedback record's count
+        :param _project_id:
         :param manifest_id:
         :return:
         """
@@ -1235,7 +1236,7 @@ class GenomicManifestFeedbackDao(BaseDao):
             with self.session() as session:
                 session.merge(fb)
 
-            bq_genomic_manifest_feedback_update(fb.id)
+            bq_genomic_manifest_feedback_update(fb.id, project_id=_project_id)
             genomic_manifest_feedback_update(fb.id)
         else:
             raise ValueError(f'No feedback record for manifest id {manifest_id}')

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -619,7 +619,7 @@ class GenomicFileIngester:
                 # Calculate contamination_category if contamination supplied
                 try:
                     contamination_value = float(row_copy['contamination'])
-                    category = self.calculate_contamination_category(sample_id, contamination_value, member)
+                    category = self.calculate_contamination_category(member.collectionTubeId, contamination_value, member)
                     row_copy['contamination_category'] = category
 
                 except (KeyError, ValueError):
@@ -649,7 +649,7 @@ class GenomicFileIngester:
 
             else:
                 logging.error(f"No genomic set member for bid,sample_id: {row_copy['biobankid']}, {sample_id}")
-                continue
+                return GenomicSubProcessResult.ERROR
 
         return GenomicSubProcessResult.SUCCESS
 

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -619,7 +619,8 @@ class GenomicFileIngester:
                 # Calculate contamination_category if contamination supplied
                 try:
                     contamination_value = float(row_copy['contamination'])
-                    category = self.calculate_contamination_category(member.collectionTubeId, contamination_value, member)
+                    category = self.calculate_contamination_category(member.collectionTubeId,
+                                                                     contamination_value, member)
                     row_copy['contamination_category'] = category
 
                 except (KeyError, ValueError):
@@ -644,8 +645,9 @@ class GenomicFileIngester:
                 # For feedback manifest loop
                 # Get the genomic_manifest_file
                 manifest_file = self.file_processed_dao.get(member.aw1FileProcessedId)
-                if manifest_file is not None:
-                    self.feedback_dao.increment_feedback_count(manifest_file.genomicManifestFileId)
+                if manifest_file is not None and existing_metrics_obj is None:
+                    self.feedback_dao.increment_feedback_count(manifest_file.genomicManifestFileId,
+                                                               _project_id=self.controller.bq_project_id)
 
             else:
                 logging.error(f"No genomic set member for bid,sample_id: {row_copy['biobankid']}, {sample_id}")

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -343,6 +343,8 @@ class GenomicPipelineTest(BaseTestCase):
                                                 array_participants=(1, 2),
                                                 genomic_workflow_state=GenomicWorkflowState.AW1)
 
+        self._update_test_sample_ids()
+
         # Setup Test file
         aw2_manifest_file = test_data.open_genomic_set_file("RDR_AoU_GEN_TestDataManifest.csv")
 


### PR DESCRIPTION
This PR fixes a bug in the new samples contamination pipeline. I missed this in a previous code review when this was originally implemented. When calculating the contamination category, we want to write the genomic set member's `collection_tube_id` to the `genomic_sample_contamination` table, not the `sample_id`. The `collection_tube_id` corresponds to the `biobank_stored_sample_id` in the `biobank_stored_sample` table.
Additionally, the project ID was added to the call to `bq_genomic_manifest_feedback_update()` to write the correct ID when running the workflow by a local tool. The condition to increment the feedback count was also modified to only increment the count if the metrics object did not exist previously.
Finally, the ingestion process was modified so that if a member object cannot be found, the process will return an ERROR result status.