### PR TITLE
[PDR Fix] Correct issue with participant data test_participant field

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -151,8 +151,11 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             # summary = self._merge_schema_dicts(summary, self._calculate_enrollment_timestamps(summary))
             # calculate distinct visits
             summary = self._merge_schema_dicts(summary, self._calculate_distinct_visits(summary))
-            # calculate test participant status
-            summary = self._merge_schema_dicts(summary, self._calculate_test_participant(summary))
+            # calculate test participant status (if it was not already set by _prep_participant() )
+            # TODO:  If a backfill for the DA-1800 Participant.isTestParticipant field is done, we may be able to
+            # remove this call/method entirely and rely solely on the value assigned by _prep_participant()
+            if summary['test_participant'] == 0:
+                summary = self._merge_schema_dicts(summary, self._calculate_test_participant(summary))
 
             return BQRecord(schema=BQParticipantSummarySchema, data=summary, convert_to_enum=convert_to_enum)
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -148,8 +148,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             # summary = self._merge_schema_dicts(summary, self._calculate_enrollment_timestamps(summary))
             # calculate distinct visits
             summary = self._merge_schema_dicts(summary, self._calculate_distinct_visits(summary))
-            # calculate test participant status
-            summary = self._merge_schema_dicts(summary, self._calculate_test_participant(summary))
+            # calculate test participant status (if it was not already set by _prep_participant() )
+            # TODO:  If a backfill for the DA-1800 Participant.isTestParticipant field is done, we may be able to
+            # remove this call/method entirely and rely solely on value assigned by _prep_participant()
+            if summary['test_participant'] == 0:
+                summary = self._merge_schema_dicts(summary, self._calculate_test_participant(summary))
 
             # data = self.ro_dao.to_resource_dict(summary, schema=schemas.ParticipantSchema)
 


### PR DESCRIPTION
The participant data generators use `_merge_schema_dicts()` at each step to add more fields from data dicts returned by various sub-methods to a summary data dict.  

With DA-1800 implementation of a new `is_test_participant` flag in the `participant` table, the `_prep_participant()` method could return a `test_participant` key with a value of 1 in the data dict it returned.  Later when `_calculate_test_participant()` was called, it would also return a `test_participant` key/value pair in its data dict.

The merge method adds the values for like keys in the dicts being merged, so we could end up with `test_participant` key set to a value of 2.  This was inconsistent with the PDR BQ views that filter test participants based on the expected values of 0 or 1 only.

Tweaked the logic to only call `_calculate_test_participant()`  if we didn't already know this was a test pid.  We may be able to eventually eliminate that method entirely, but it's still needed for now since we haven't fully populated the new flag in the `participant` table yet for all test participants,  and still need to look for the old criteria instead.

