### PR TITLE
Remove BQ generators for manifest file and feedback

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -11,8 +11,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from rdr_service import clock, config
 from rdr_service.dao.base_dao import UpdatableDao, BaseDao, UpsertableDao
-from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, \
-    bq_genomic_manifest_feedback_update
+from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.genomics import (
     GenomicSet,
@@ -33,8 +32,7 @@ from rdr_service.participant_enums import (
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.query import FieldFilter, Operator, OrderBy, Query
-from rdr_service.resource.generators.genomics import genomic_set_member_update, \
-    genomic_manifest_feedback_update
+from rdr_service.resource.generators.genomics import genomic_set_member_update
 
 
 class GenomicSetDao(UpdatableDao):
@@ -1236,8 +1234,9 @@ class GenomicManifestFeedbackDao(BaseDao):
             with self.session() as session:
                 session.merge(fb)
 
-            bq_genomic_manifest_feedback_update(fb.id, project_id=_project_id)
-            genomic_manifest_feedback_update(fb.id)
+            # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+            # bq_genomic_manifest_feedback_update(fb.id, project_id=_project_id)
+            # genomic_manifest_feedback_update(fb.id)
         else:
             raise ValueError(f'No feedback record for manifest id {manifest_id}')
 

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse
 import sqlalchemy
 
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_gc_validation_metrics_update, \
-    bq_genomic_set_update, bq_genomic_file_processed_update, bq_genomic_manifest_file_update
+    bq_genomic_set_update, bq_genomic_file_processed_update
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 
@@ -23,7 +23,7 @@ from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.participant import Participant
 from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_gc_validation_metrics_update, \
-    genomic_set_update, genomic_file_processed_update, genomic_manifest_file_update
+    genomic_set_update, genomic_file_processed_update
 from rdr_service.services.jira_utils import JiraTicketHandler
 from rdr_service.api_util import (
     open_cloud_file,
@@ -417,8 +417,9 @@ class GenomicFileIngester:
                 with self.manifest_dao.session() as s:
                     s.merge(manifest_file)
 
-                    bq_genomic_manifest_file_update(manifest_file.id, project_id=self.controller.bq_project_id)
-                    genomic_manifest_file_update(manifest_file.id)
+                    # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+                    # bq_genomic_manifest_file_update(manifest_file.id, project_id=self.controller.bq_project_id)
+                    # genomic_manifest_file_update(manifest_file.id)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -16,8 +16,7 @@ from rdr_service.config import (
     getSettingList,
     GENOME_TYPE_ARRAY,
     MissingConfigException)
-from rdr_service.dao.bq_genomics_dao import bq_genomic_job_run_update, bq_genomic_file_processed_update, \
-    bq_genomic_manifest_file_update, bq_genomic_manifest_feedback_update
+from rdr_service.dao.bq_genomics_dao import bq_genomic_job_run_update, bq_genomic_file_processed_update
 from rdr_service.model.genomics import GenomicManifestFile, GenomicManifestFeedback
 from rdr_service.participant_enums import (
     GenomicSubProcessResult,
@@ -33,8 +32,7 @@ from rdr_service.dao.genomics_dao import (
     GenomicFileProcessedDao,
     GenomicJobRunDao,
     GenomicManifestFileDao, GenomicManifestFeedbackDao)
-from rdr_service.resource.generators.genomics import genomic_job_run_update, genomic_file_processed_update, \
-    genomic_manifest_file_update, genomic_manifest_feedback_update
+from rdr_service.resource.generators.genomics import genomic_job_run_update, genomic_file_processed_update
 
 
 class GenomicJobController:
@@ -116,8 +114,10 @@ class GenomicJobController:
         )
 
         file = self.manifest_file_dao.insert(file_to_insert)
-        bq_genomic_manifest_file_update(file.id, self.bq_project_id)
-        genomic_manifest_file_update(file.id)
+
+        # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+        # bq_genomic_manifest_file_update(file.id, self.bq_project_id)
+        # genomic_manifest_file_update(file.id)
 
         return file
 
@@ -141,8 +141,10 @@ class GenomicJobController:
         )
 
         feedback = self.manifest_feedback_dao.insert(feedback_to_insert)
-        bq_genomic_manifest_feedback_update(feedback.id, self.bq_project_id)
-        genomic_manifest_feedback_update(feedback.id)
+
+        # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+        # bq_genomic_manifest_feedback_update(feedback.id, self.bq_project_id)
+        # genomic_manifest_feedback_update(feedback.id)
 
         return feedback
 
@@ -440,8 +442,9 @@ class GenomicJobController:
                 )
                 new_manifest_record = self.manifest_file_dao.insert(new_manifest_obj)
 
-                bq_genomic_manifest_file_update(new_manifest_obj.id, self.bq_project_id)
-                genomic_manifest_file_update(new_manifest_obj.id)
+                # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+                # bq_genomic_manifest_file_update(new_manifest_obj.id, self.bq_project_id)
+                # genomic_manifest_file_update(new_manifest_obj.id)
 
                 # update feedback records if manifest is a feedback manifest
                 if "feedback_record" in kwargs.keys():


### PR DESCRIPTION
This PR temporarily disables the BQ generators for the `genomic_manifest_file` and `genomic_manifest_feedback` tables. This will allow for local runs of the AW2 ingestion process without disrupting the Big Query sync job due to a mismatch between the production and local schemas.