### PR TITLE
[ROC-801] Create endpoint for manually initiating a sync of the consent files on the server

### DIFF
--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -215,6 +215,7 @@ def manually_trigger_consent_sync():
     request_json = request.json
 
     all_va = request.json.get('all_va')
+    zip_files = request.json.get('zip_files')
 
     start_date_str = request_json.get('start_date')
     start_date = parse_date(start_date_str) if start_date_str else None
@@ -222,7 +223,12 @@ def manually_trigger_consent_sync():
     end_date_str = request_json.get('end_date')
     end_date = parse_date(end_date_str) if end_date_str else None
 
-    sync_consent_files.do_sync_consent_files(all_va=all_va, start_date=start_date, end_date=end_date)
+    sync_consent_files.do_sync_consent_files(
+        zip_files=zip_files,
+        all_va=all_va,
+        start_date=start_date,
+        end_date=end_date
+    )
     return '{"success": "true"}'
 
 


### PR DESCRIPTION
This creates an endpoint on the offline server that allows us to start the consent sync process with some parameters. Currently the cron job for syncing consents will only work with the most recent month of data. This lets us specify a start date, end date, whether to sync VA file, and whether they should be zipped.

This is in response to a need to sync consent files for the VA. For them to be able to access the files, we need to upload them as zip archives in the VA bucket. That all needs to be processed in the cloud, so this will act as our way of initiating and giving it the correct time frame.

I plan on refactoring the sync-consents tool and essentially replacing its functionality with a call to this, but for now this is all I need to get into the hotfix.