### PR TITLE
[DA-1867] Update manifest and feedback record insertion

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -89,11 +89,6 @@ cron:
   timezone: America/New_York
   schedule: 1 of jan 12:00
   target: offline
-- description: Genomic Reconciliation Array Data Workflow
-  url: /offline/GenomicArrayReconciliationWorkflow
-  timezone: America/New_York
-  schedule: every day 05:30
-  target: offline
 - description: Genomic GEM A1 Workflow
   url: /offline/GenomicGemA1Workflow
   timezone: America/New_York

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1194,6 +1194,13 @@ class GenomicManifestFileDao(BaseDao):
     def from_client_json(self):
         pass
 
+    def get_manifest_file_from_filepath(self, filepath):
+        with self.session() as session:
+            return session.query(GenomicManifestFile).filter(
+                GenomicManifestFile.filePath == filepath,
+                GenomicManifestFile.ignore_flag == 0
+            ).one_or_none()
+
 
 class GenomicManifestFeedbackDao(BaseDao):
     def __init__(self):

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -11,8 +11,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from rdr_service import clock, config
 from rdr_service.dao.base_dao import UpdatableDao, BaseDao, UpsertableDao
-from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, \
-    bq_genomic_manifest_feedback_update
+from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.genomics import (
     GenomicSet,
@@ -33,8 +32,7 @@ from rdr_service.participant_enums import (
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.query import FieldFilter, Operator, OrderBy, Query
-from rdr_service.resource.generators.genomics import genomic_set_member_update, \
-    genomic_manifest_feedback_update
+from rdr_service.resource.generators.genomics import genomic_set_member_update
 
 
 class GenomicSetDao(UpdatableDao):
@@ -1236,8 +1234,9 @@ class GenomicManifestFeedbackDao(BaseDao):
             with self.session() as session:
                 session.merge(fb)
 
-            bq_genomic_manifest_feedback_update(fb.id, project_id=_project_id)
-            genomic_manifest_feedback_update(fb.id)
+            # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+            # bq_genomic_manifest_feedback_update(fb.id, project_id=_project_id)
+            # genomic_manifest_feedback_update(fb.id)
         else:
             raise ValueError(f'No feedback record for manifest id {manifest_id}')
 

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -11,7 +11,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from rdr_service import clock, config
 from rdr_service.dao.base_dao import UpdatableDao, BaseDao, UpsertableDao
-from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update
+from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_manifest_feedback_update
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.genomics import (
     GenomicSet,
@@ -32,7 +32,7 @@ from rdr_service.participant_enums import (
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.query import FieldFilter, Operator, OrderBy, Query
-from rdr_service.resource.generators.genomics import genomic_set_member_update
+from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_manifest_feedback_update
 
 
 class GenomicSetDao(UpdatableDao):
@@ -1241,9 +1241,8 @@ class GenomicManifestFeedbackDao(BaseDao):
             with self.session() as session:
                 session.merge(fb)
 
-            # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
-            # bq_genomic_manifest_feedback_update(fb.id, project_id=_project_id)
-            # genomic_manifest_feedback_update(fb.id)
+            bq_genomic_manifest_feedback_update(fb.id, project_id=_project_id)
+            genomic_manifest_feedback_update(fb.id)
         else:
             raise ValueError(f'No feedback record for manifest id {manifest_id}')
 

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse
 import sqlalchemy
 
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_gc_validation_metrics_update, \
-    bq_genomic_set_update, bq_genomic_file_processed_update, bq_genomic_manifest_file_update
+    bq_genomic_set_update, bq_genomic_file_processed_update
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 
@@ -23,7 +23,7 @@ from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.participant import Participant
 from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_gc_validation_metrics_update, \
-    genomic_set_update, genomic_file_processed_update, genomic_manifest_file_update
+    genomic_set_update, genomic_file_processed_update
 from rdr_service.services.jira_utils import JiraTicketHandler
 from rdr_service.api_util import (
     open_cloud_file,
@@ -417,8 +417,9 @@ class GenomicFileIngester:
                 with self.manifest_dao.session() as s:
                     s.merge(manifest_file)
 
-                    bq_genomic_manifest_file_update(manifest_file.id, project_id=self.controller.bq_project_id)
-                    genomic_manifest_file_update(manifest_file.id)
+                    # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+                    # bq_genomic_manifest_file_update(manifest_file.id, project_id=self.controller.bq_project_id)
+                    # genomic_manifest_file_update(manifest_file.id)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -13,7 +13,7 @@ from dateutil.parser import parse
 import sqlalchemy
 
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_gc_validation_metrics_update, \
-    bq_genomic_set_update, bq_genomic_file_processed_update
+    bq_genomic_set_update, bq_genomic_file_processed_update, bq_genomic_manifest_file_update
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.genomic.genomic_state_handler import GenomicStateHandler
 
@@ -23,7 +23,7 @@ from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.participant import Participant
 from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_gc_validation_metrics_update, \
-    genomic_set_update, genomic_file_processed_update
+    genomic_set_update, genomic_file_processed_update, genomic_manifest_file_update
 from rdr_service.services.jira_utils import JiraTicketHandler
 from rdr_service.api_util import (
     open_cloud_file,
@@ -417,9 +417,8 @@ class GenomicFileIngester:
                 with self.manifest_dao.session() as s:
                     s.merge(manifest_file)
 
-                    # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
-                    # bq_genomic_manifest_file_update(manifest_file.id, project_id=self.controller.bq_project_id)
-                    # genomic_manifest_file_update(manifest_file.id)
+                    bq_genomic_manifest_file_update(manifest_file.id, project_id=self.controller.bq_project_id)
+                    genomic_manifest_file_update(manifest_file.id)
 
             return GenomicSubProcessResult.SUCCESS
         except RuntimeError:

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -16,8 +16,7 @@ from rdr_service.config import (
     getSettingList,
     GENOME_TYPE_ARRAY,
     MissingConfigException)
-from rdr_service.dao.bq_genomics_dao import bq_genomic_job_run_update, bq_genomic_file_processed_update, \
-    bq_genomic_manifest_file_update, bq_genomic_manifest_feedback_update
+from rdr_service.dao.bq_genomics_dao import bq_genomic_job_run_update, bq_genomic_file_processed_update
 from rdr_service.model.genomics import GenomicManifestFile, GenomicManifestFeedback
 from rdr_service.participant_enums import (
     GenomicSubProcessResult,
@@ -33,8 +32,7 @@ from rdr_service.dao.genomics_dao import (
     GenomicFileProcessedDao,
     GenomicJobRunDao,
     GenomicManifestFileDao, GenomicManifestFeedbackDao)
-from rdr_service.resource.generators.genomics import genomic_job_run_update, genomic_file_processed_update, \
-    genomic_manifest_file_update, genomic_manifest_feedback_update
+from rdr_service.resource.generators.genomics import genomic_job_run_update, genomic_file_processed_update
 
 
 class GenomicJobController:
@@ -116,8 +114,10 @@ class GenomicJobController:
         )
 
         file = self.manifest_file_dao.insert(file_to_insert)
-        bq_genomic_manifest_file_update(file.id, self.bq_project_id)
-        genomic_manifest_file_update(file.id)
+
+        # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+        # bq_genomic_manifest_file_update(file.id, self.bq_project_id)
+        # genomic_manifest_file_update(file.id)
 
         return file
 
@@ -141,8 +141,10 @@ class GenomicJobController:
         )
 
         feedback = self.manifest_feedback_dao.insert(feedback_to_insert)
-        bq_genomic_manifest_feedback_update(feedback.id, self.bq_project_id)
-        genomic_manifest_feedback_update(feedback.id)
+
+        # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+        # bq_genomic_manifest_feedback_update(feedback.id, self.bq_project_id)
+        # genomic_manifest_feedback_update(feedback.id)
 
         return feedback
 
@@ -440,8 +442,9 @@ class GenomicJobController:
                 )
                 new_manifest_record = self.manifest_file_dao.insert(new_manifest_obj)
 
-                bq_genomic_manifest_file_update(new_manifest_obj.id, self.bq_project_id)
-                genomic_manifest_file_update(new_manifest_obj.id)
+                # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
+                # bq_genomic_manifest_file_update(new_manifest_obj.id, self.bq_project_id)
+                # genomic_manifest_file_update(new_manifest_obj.id)
 
                 # update feedback records if manifest is a feedback manifest
                 if "feedback_record" in kwargs.keys():

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -449,9 +449,8 @@ class GenomicJobController:
                 )
                 new_manifest_record = self.manifest_file_dao.insert(new_manifest_obj)
 
-                # TODO: Deactivating until 1.87.1 (ignore_flag) is on Prod
-                # bq_genomic_manifest_file_update(new_manifest_obj.id, self.bq_project_id)
-                # genomic_manifest_file_update(new_manifest_obj.id)
+                bq_genomic_manifest_file_update(new_manifest_obj.id, self.bq_project_id)
+                genomic_manifest_file_update(new_manifest_obj.id)
 
                 # update feedback records if manifest is a feedback manifest
                 if "feedback_record" in kwargs.keys():


### PR DESCRIPTION
This PR updates the genomic controller to only insert `genomic_manifest_file` and `genomic_manifest_feedback` records if they do not currently exist. The BQ generators for these two tables were re-enabled. The array data reconciliation cron job was disabled and will be re-enabled in a follow-up PR once the process is refactored.