### PR TITLE
[DA-1883] Targeted ingestion tool for AW1 and AW2 data

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -722,6 +722,17 @@ class GenomicFileProcessedDao(UpdatableDao):
     def get_id(self, obj):
         return obj.id
 
+    def get_max_file_processed_for_filepath(self, filepath):
+        """
+        Looks up the latest GenomicFileProcessed object associated to the filepath
+        :param filepath:
+        :return: GenomicFileProcessed object
+        """
+        with self.session() as session:
+            return session.query(GenomicFileProcessed).filter(
+                GenomicFileProcessed.filePath == filepath
+            ).order_by(GenomicFileProcessed.id.desc()).first()
+
     def get_files_for_run(self, run_id):
         """
         Returns the list of GenomicFileProcessed objects for a run ID.

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -185,14 +185,14 @@ class GenomicJobController:
                                                 target_file=file_path[1:])  # strip leading "/"
 
             self.ingester.file_obj = file_processed
+            self.job_result = GenomicSubProcessResult.SUCCESS
 
             if self.job_id == GenomicJob.AW1_MANIFEST:
-                self.ingester.ingest_single_aw1_row_for_member(member)
+                self.job_result = self.ingester.ingest_single_aw1_row_for_member(member)
 
             if self.job_id == GenomicJob.METRICS_INGESTION:
-                self.ingester.ingest_single_aw2_row_for_member(member)
+                self.job_result = self.ingester.ingest_single_aw2_row_for_member(member)
 
-            self.job_result = GenomicSubProcessResult.SUCCESS
         else:
             print(f'No file processed IDs for {file_path}')
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -164,9 +164,10 @@ class GenomicJobController:
         """
         return self.manifest_feedback_dao.get_feedback_equals_record_count()
 
-    def ingest_aw1_data_for_member(self, file_path, member):
+    def ingest_awn_data_for_member(self, file_path, member):
         """
         Executed from genomic tools. Ingests data for a single GenomicSetMember
+        Currently supports AW1 and AW2
         :param file_path:
         :param member:
         :return:
@@ -185,7 +186,11 @@ class GenomicJobController:
 
             self.ingester.file_obj = file_processed
 
-            self.ingester.ingest_single_aw1_row_for_member(member)
+            if self.job_id == GenomicJob.AW1_MANIFEST:
+                self.ingester.ingest_single_aw1_row_for_member(member)
+
+            if self.job_id == GenomicJob.METRICS_INGESTION:
+                self.ingester.ingest_single_aw2_row_for_member(member)
 
             self.job_result = GenomicSubProcessResult.SUCCESS
         else:

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1475,11 +1475,11 @@ class IngestionClass(GenomicManifestBase):
 
         # Validate arguments
         if not self.args.csv and not self.args.member_ids:
-            _logger.error('Either --csv or --samples must be provided.')
+            _logger.error('Either --csv or --member_ids must be provided.')
             return 1
 
         if self.args.csv and self.args.member_ids:
-            _logger.error('Arguments --csv and --samples may not be used together.')
+            _logger.error('Arguments --csv and --member_ids may not be used together.')
             return 1
 
         if self.args.csv:

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1509,7 +1509,6 @@ class IngestionClass(GenomicManifestBase):
             manifest_data_types = ('AW1', 'AW2')
 
             bucket_name = None
-            file_name = None
 
             if self.args.manifest_file:
                 _logger.info(f'Manifest file supplied: {self.args.manifest_file}')
@@ -1521,7 +1520,8 @@ class IngestionClass(GenomicManifestBase):
                 # Run AW1 ingestion on sample list
                 _logger.info("Ingesting AW1 data for ids.")
 
-                # TODO: look up AW1 file for sample if none supplied
+                # TODO: Future enhancements:
+                #  look up AW1 file for sample if none supplied
 
                 if bucket_name:
                     # ingest AW1 data using controller
@@ -1534,12 +1534,20 @@ class IngestionClass(GenomicManifestBase):
                         for member_id in member_ids:
                             self.run_ingestion_for_member_id(controller, member_id, bucket_name)
 
-
-
             elif self.args.data_type.lower() == "aw2":
                 # Run AW2 ingestion on sample list
                 _logger.info("Ingesting AW2 data for ids.")
-                pass
+
+                if bucket_name:
+                    # ingest AW1 data using controller
+                    with GenomicJobController(GenomicJob.METRICS_INGESTION,
+                                              storage_provider=self.gscp,
+                                              bq_project_id=self.gcp_env.project) as controller:
+
+                        controller.bypass_record_count = self.args.bypass_record_count
+
+                        for member_id in member_ids:
+                            self.run_ingestion_for_member_id(controller, member_id, bucket_name)
 
             else:
                 _logger.error(
@@ -1556,11 +1564,7 @@ class IngestionClass(GenomicManifestBase):
 
             member = self.dao.get(member_id)
 
-            if controller.job_id == GenomicJob.AW1_MANIFEST:
-                controller.ingest_aw1_data_for_member(f"/{self.args.manifest_file}", member)
-
-            if controller.job_id == GenomicJob.METRICS_INGESTION:
-                pass
+            controller.ingest_awn_data_for_member(f"/{self.args.manifest_file}", member)
 
             return 0
 


### PR DESCRIPTION
This tool allows for the ingestion of a single row from an AW1 or AW2 manifest. Using a provided `genomic_set_member.id`, the manifest file path, and the manifest data type (AW1 or AW2), the tool will ingest only the row associated with the `genomic_set_member` record.