### PR TITLE
Fixing how workers exit when memory limit is reached

### DIFF
--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -40,8 +40,13 @@ def post_request(worker, request, environment, response):  # pylint: disable=unu
     # they're using more than 250 megabytes
     memory_threshold_kilobytes = 256000  # 250 megabytes (250 x 1024)
     if memory_used_kilobytes > memory_threshold_kilobytes:
-        # This is copied from Gunicorn's code for closing out a sync worker after reaching the max_requests limit
-        worker.alive = False
+        # This will safely start shutting down a worker: letting it continue with the request it is
+        # currently processing, but closing it off from further requests (as was seen with thread workers when we
+        # set alive to False).
+        # WARNING: As of now the parameters sig and frame aren't used by the thread worker (our current default). If
+        # we change to another worker type, or if Gunicorn updates the handle_quit code to do something with them,
+        # then we may need to pass something in.
+        worker.handle_quit(None, None)
 
         memory_used_megabytes = round(memory_used_kilobytes / 1024, 2)
         # Logs from the worker appear beside the normal app logs, but without log levels attached to them.


### PR DESCRIPTION
We've occasionally been seeing the BigQuerySync job hanging, only starting again when a long-running job completes (often times one of the Genomics jobs, but in at least one instance it was ParticipantCountsOverTime). When looking through the logs, it looks as if a call to BigQuerySync is made and will not start processing until after the long-running job completes. This situation only occurs if the long-running job is running in a worker-process that is nearing the memory limit and has had `alive` set to False.

A worker that has started shutting down is left running to complete the task that it has already started, but it shouldn't be able to take new requests. In these cases, the worker shutting down won't process the request (or even accept the socket connection) but somehow seems to reserving the incoming request somehow and preventing other workers from processing and completing it.

Calling the handle_quit method on the worker shuts down its thread pool and exits its process. Doing this has reliably shown (in local tests) that the worker won't be able to affect future requests (other workers are able to handle them) while still working on requests that it already has threads working on.