### PR TITLE
[DA-1885] Fix AW2F query to remove ignored records

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2632,6 +2632,7 @@ class ManifestDefinitionProvider:
                     )
                 ).where(
                     (GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE) &
+                    (GenomicGCValidationMetrics.ignoreFlag == 0) &
                     (GenomicFileProcessed.genomicManifestFileId == self.kwargs['kwargs']['input_manifest'].id)
                 )
             )


### PR DESCRIPTION
This PR adds a filter clause to the AW2F query to only return `GenomicGCValidationMetrics` objects that have `ignoreFlag == 0`. Unit tests were updated to test that the AW2F manifest did not include the ignored record.