### PR TITLE
disable wgs reconciliation and aw3 cron job

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -132,7 +132,7 @@ cron:
 - description: Genomic AW3 WGS Workflow
   url: /offline/GenomicAW3WGSWorkflow
   timezone: America/New_York
-  schedule: every monday 07:00
+  schedule: 1 of jan 12:00
   target: offline
 - description: Genomic AW4 Workflow
   url: /offline/GenomicAW4Workflow

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -94,11 +94,6 @@ cron:
   timezone: America/New_York
   schedule: every day 05:30
   target: offline
-- description: Genomic Reconciliation WGS Data Workflow
-  url: /offline/GenomicWGSReconciliationWorkflow
-  timezone: America/New_York
-  schedule: every day 20:30
-  target: offline
 - description: Genomic GEM A1 Workflow
   url: /offline/GenomicGemA1Workflow
   timezone: America/New_York

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -132,7 +132,7 @@ cron:
 - description: Genomic AW3 WGS Workflow
   url: /offline/GenomicAW3WGSWorkflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: 1 of jan 00:00
   target: offline
 - description: Genomic AW4 Workflow
   url: /offline/GenomicAW4Workflow

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -402,6 +402,11 @@ def genomic_aw3_array_workflow():
 @app_util.auth_required_cron
 @_alert_on_exceptions
 def genomic_aw3_wgs_workflow():
+    """Temporarily running this manually for E2E Testing"""
+    now = datetime.utcnow()
+    if now.day == 0o1 and now.month == 0o1:
+        logging.info("skipping the scheduled run.")
+        return '{"success": "true"}'
     genomic_pipeline.aw3_wgs_manifest_workflow()
     return '{"success": "true"}'
 


### PR DESCRIPTION
This PR disables the WGS reconciliation cron job and temporarily turns off the automated runs for the WGS AW3. 