### PR TITLE
Trim list of versions at the end of deploy

### DIFF
--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -760,7 +760,7 @@ def gcp_delete_versions(service_name: str, version_names: List[str]):
     """
 
     version_list_str = ' '.join(version_names)
-    args = f'versions delete --service={service_name} {version_list_str}'
+    args = f'versions delete --service={service_name} {version_list_str} --quiet'
 
     exit_code, _, error = gcp_gcloud_command('app', args)
     if exit_code != 0:

--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -14,6 +14,7 @@ import shlex
 import subprocess
 from collections import OrderedDict
 from random import choice
+from typing import List
 
 from .gcp_config import GCP_INSTANCES, GCP_PROJECTS, GCP_REPLICA_INSTANCES, GCP_SERVICE_KEY_STORE
 from .system_utils import run_external_program, which
@@ -702,14 +703,17 @@ def gcp_mv(src, dest, args=None, flags=None):
     return True
 
 
-def gcp_get_app_versions(running_only: bool = False):
+def gcp_get_app_versions(running_only: bool = False, sort_by: List[str] = None):
     """
     Get the list of current App Engine services and versions.
     :param running_only: Only showing running versions if True.
+    :param sort_by: List of strings specifying what the list of versions should be sorted by
     :return: dict(service_name: dict(version, split, deployed, status))
     """
 
     args = "versions list"
+    if sort_by:
+        args += f" --sort-by={','.join(sort_by)}"
     pcode, so, se = gcp_gcloud_command("app", args)
 
     if pcode != 0 or not so:
@@ -745,6 +749,23 @@ def gcp_get_app_versions(running_only: bool = False):
             })
 
     return services
+
+
+def gcp_delete_versions(service_name: str, version_names: List[str]):
+    """
+    Delete the versions from the specified service
+
+    :param service_name: Specifies the service to delete the versions from
+    :param version_names: Names of the versions to delete
+    """
+
+    version_list_str = ' '.join(version_names)
+    args = f'versions delete --service={service_name} {version_list_str}'
+
+    exit_code, _, error = gcp_gcloud_command('app', args)
+    if exit_code != 0:
+        _logger.error(error)
+        _logger.error('Failed to delete the versions.')
 
 
 def gcp_app_services_split_traffic(service: str, versions: list, split_by: str = 'random'):

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -355,10 +355,11 @@ class DeployAppClass(object):
 
         return 0 if result else 1
 
-    def manage_cloud_version_numbers(self):
+    @staticmethod
+    def manage_cloud_version_numbers():
         _logger.info('Getting version list for services...')
-        max_versions = 60  # 110
-        num_to_trim = 1
+        max_versions = 200  # GAE allows a max of 210 versions
+        num_to_trim = 10  # Number of versions to delete each time we hit our max_versions count
 
         # Order lists with oldest versions first
         version_lists_by_service = gcp_get_app_versions(sort_by=['LAST_DEPLOYED'])
@@ -366,8 +367,10 @@ class DeployAppClass(object):
             version_count = len(version_list)
             if version_count > max_versions:
                 _logger.warning(f'{version_count} versions found on {service_name.upper()}, deleting the following:')
+
                 versions_to_delete = [version_data['version'] for version_data in version_list[:num_to_trim]]
                 _logger.warning(versions_to_delete)
+
                 gcp_delete_versions(service_name, versions_to_delete)
 
     def tag_people(self):
@@ -464,6 +467,7 @@ class DeployAppClass(object):
                 return 1
 
         result = self.deploy_app()
+        self.manage_cloud_version_numbers()
 
         git_checkout_branch(self._current_git_branch)
         _logger.info('Returned to git branch/tag: %s ...', self._current_git_branch)


### PR DESCRIPTION
GAE only allows 210 versions of a service before it won't let us make any more. Occasionally we've run into the error when deploying and needed to go through the services and delete some of them before trying to deploy again. This adds some code to the end of the deploy script to make sure we don't hit the maximum number of versions.

It gets the list of versions for each service (in order of oldest to newest by service) and checks the number of versions for each service. If it's more than a threshold (set lower than the max) it will delete a batch of the versions from the service. Normally this won't add much to the deploy process (half a second to check the number and not need to take action passed that). If it needs to delete versions it seems to do them individually and take about a second on each one. But the trade-off could be worth it.