### PR TITLE
Fixes for BQ schema issues

### DIFF
--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -284,7 +284,7 @@ class BQPDRModuleView(BQView):
     SELECT ps.id, ps.created, ps.modified, ps.participant_id,
            nt.mod_module, nt.mod_baseline_module,
            CAST(nt.mod_authored AS DATETIME) as mod_authored, CAST(nt.mod_created AS DATETIME) as mod_created,
-           nt.mod_language, nt.mod_status, nt.mod_status_id
+           nt.mod_language, nt.mod_status, nt.mod_status_id, nt.mod_external_id
       FROM (
         SELECT *,
             ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY modified desc, test_participant desc) AS rn

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -107,10 +107,11 @@ class _BQModuleSchema(BQSchema):
                 from questionnaire_question qq where qq.questionnaire_id in (
                     select qc.questionnaire_id from questionnaire_concept qc
                             where qc.code_id = (
-                                select code_id from code c2 where c2.value = :module_id and system = :system
+                                select code_id from code c2 where c2.value = :module_id and c2.system = :system
                             )
                 )
             ) qq2 on qq2.code_id = c.code_id
+            where c.system = :system
             order by c.code_id
         """
         with dao.session() as session:
@@ -181,7 +182,7 @@ class _BQModuleSchema(BQSchema):
                 # flag duplicate fields.
                 found = False
                 for fld in fields:
-                    if fld['name'] == name:
+                    if fld['name'].lower() == name.lower():
                         found = True
                         break
 

--- a/rdr_service/resource/schemas/questionnaires.py
+++ b/rdr_service/resource/schemas/questionnaires.py
@@ -99,6 +99,7 @@ class _QuestionnaireSchema:
                              )
                  )
              ) qq2 on qq2.code_id = c.code_id
+             where c.system = :system
              order by c.code_id;
          """
         with dao.session() as session:

--- a/rdr_service/resource/schemas/questionnaires.py
+++ b/rdr_service/resource/schemas/questionnaires.py
@@ -158,7 +158,7 @@ class _QuestionnaireSchema:
                 # flag duplicate fields.
                 found = False
                 for fld in _schema:
-                    if fld['name'] == name:
+                    if fld['name'].lower() == name.lower():
                         found = True
                         break
 

--- a/rdr_service/tools/tool_libs/bq_migrate.py
+++ b/rdr_service/tools/tool_libs/bq_migrate.py
@@ -270,7 +270,7 @@ class BQMigration(object):
 
                 if not rs_json:
                     if self.args.check_schemas:
-                        _logger.info('{0}: {1}.{2} does not exist'.format(project_id, dataset_id,table_id))
+                        _logger.info('{0}: {1}.{2} does not exist'.format(project_id, dataset_id, table_id))
                         continue
                     else:
                         self.create_table(bq_table, project_id, dataset_id, table_id)


### PR DESCRIPTION
Fixes for BQ schema generation issues found during PDR rebuild:
* Update the SQL for the BQ `v_pdr_participant_module` view to include the new `mod_external_id` field
* Restrict the queries to find questionnaire question codes based on the system value (to resolve issues with noncomformant data that exists in stable environment)
* Make the checks for duplicate field names when generating a module schema case-insentive

The stable and production BQ schemas have already been migrated with these changes incorporated