### PR TITLE
Logging memory usage when rebooting worker due to memory limits

### DIFF
--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -40,6 +40,10 @@ def post_request(worker, request, environment, response):  # pylint: disable=unu
     # they're using more than 250 megabytes
     memory_threshold_kilobytes = 256000  # 250 megabytes (250 x 1024)
     if memory_used_kilobytes > memory_threshold_kilobytes:
+        memory_used_megabytes = round(memory_used_kilobytes / 1024, 2)
+        # Logs from the worker appear beside the normal app logs, but without log levels attached to them.
+        worker.log.info(f"Restarting worker found to be using {memory_used_megabytes} megabytes (pid: {os.getpid()})")
+
         # This will safely start shutting down a worker: letting it continue with the request it is
         # currently processing, but closing it off from further requests (as was seen with thread workers when we
         # set alive to False).
@@ -47,7 +51,3 @@ def post_request(worker, request, environment, response):  # pylint: disable=unu
         # we change to another worker type, or if Gunicorn updates the handle_quit code to do something with them,
         # then we may need to pass something in.
         worker.handle_quit(None, None)
-
-        memory_used_megabytes = round(memory_used_kilobytes / 1024, 2)
-        # Logs from the worker appear beside the normal app logs, but without log levels attached to them.
-        worker.log.info(f"Restarting worker found to be using {memory_used_megabytes} megabytes (pid: {os.getpid()})")

--- a/rdr_service/tools/tool_libs/bq_migrate.py
+++ b/rdr_service/tools/tool_libs/bq_migrate.py
@@ -270,7 +270,7 @@ class BQMigration(object):
 
                 if not rs_json:
                     if self.args.check_schemas:
-                        _logger.info('{0}: {1}.{2} does not exist'.format(project_id, dataset_id,table_id))
+                        _logger.info('{0}: {1}.{2} does not exist'.format(project_id, dataset_id, table_id))
                         continue
                     else:
                         self.create_table(bq_table, project_id, dataset_id, table_id)


### PR DESCRIPTION
`handle_quit` on the worker calls `sys.exit`, so logging doesn't happen afterwards (since the process is already exited. Moving the log statement up so we can see them again. Until this is released we can still detect when the memory limit is reached by using the logs of an individual worker exiting (gunicorn prints it out in the arbiter), and when a single worker boots up.