### PR TITLE
[ROC-512] Looking up site by google group in case insensitive way

### DIFF
--- a/rdr_service/dao/site_dao.py
+++ b/rdr_service/dao/site_dao.py
@@ -57,8 +57,8 @@ class SiteDao(CacheAllDao):
     def get_id(self, obj):
         return obj.siteId
 
-    def get_by_google_group(self, google_group):
-        return self._get_cache().index_maps["googleGroup"].get(google_group)
+    def get_by_google_group(self, google_group: str):
+        return self._get_cache().index_maps["googleGroup"].get(google_group.lower())
 
     @staticmethod
     def _to_json(model):

--- a/rdr_service/dao/site_dao.py
+++ b/rdr_service/dao/site_dao.py
@@ -57,8 +57,10 @@ class SiteDao(CacheAllDao):
     def get_id(self, obj):
         return obj.siteId
 
-    def get_by_google_group(self, google_group: str):
-        return self._get_cache().index_maps["googleGroup"].get(google_group.lower())
+    def get_by_google_group(self, google_group):
+        if isinstance(google_group, str):
+            google_group = google_group.lower()
+        return self._get_cache().index_maps["googleGroup"].get(google_group)
 
     @staticmethod
     def _to_json(model):

--- a/rdr_service/tools/tool_libs/bq_migrate.py
+++ b/rdr_service/tools/tool_libs/bq_migrate.py
@@ -270,7 +270,7 @@ class BQMigration(object):
 
                 if not rs_json:
                     if self.args.check_schemas:
-                        _logger.info('{0}: {1}.{2} does not exist'.format(project_id, dataset_id,table_id))
+                        _logger.info('{0}: {1}.{2} does not exist'.format(project_id, dataset_id, table_id))
                         continue
                     else:
                         self.create_table(bq_table, project_id, dataset_id, table_id)


### PR DESCRIPTION
PTSC has some site google groups in their HOS system in camel-case (while most are lower case). When they send us updates through the Organization endpoint, we convert the google group to lower-case and save it that way (since HPRO uses them in lower case). But when PTSC tries to pair a participant using the google group name the way they have it in HOS (camel-case) the RDR doesn't find the site and unpairs the participant.

This updates the code used when finding the site so that it is case-insensitive. That way PTSC can continue to use the google group name as camel-case, even when the RDR code saves it as lower-case.