### PR TITLE
[DA-1888] Filtering in-progress responses from curation ETL

### DIFF
--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -20,7 +20,7 @@ from rdr_service.model.hpo import HPO
 from rdr_service.model.participant import Participant
 from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory, QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
-from rdr_service.participant_enums import WithdrawalStatus
+from rdr_service.participant_enums import QuestionnaireResponseStatus, WithdrawalStatus
 from rdr_service.services.gcp_utils import gcp_sql_export_csv
 from rdr_service.tools.tool_libs._tool_base import cli_run, ToolBase
 
@@ -246,6 +246,8 @@ class CurationExportClass(ToolBase):
             QuestionnaireResponseAnswer.questionnaireResponseId == QuestionnaireResponse.questionnaireResponseId
         ).join(
             QuestionnaireQuestion
+        ).filter(
+            QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS
         )
 
         insert_query = insert(QuestionnaireAnswersByModule).from_select(column_map.keys(), answers_by_module_select)
@@ -346,7 +348,8 @@ class CurationExportClass(ToolBase):
                 QuestionnaireResponseAnswer.valueDate.isnot(None),
                 QuestionnaireResponseAnswer.valueDateTime.isnot(None),
                 QuestionnaireResponseAnswer.valueString.isnot(None)
-            )
+            ),
+            QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS
         )
 
         return column_map, questionnaire_answers_select, module_code, question_code

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -668,13 +668,13 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         for i in range(0, len(list_a)):
             self.assertEqual(list_a[i].asdict(), list_b[i].asdict())
 
-    def assertEmpty(self, obj):
+    def assertEmpty(self, obj: list):
         """Assert that a list is empty"""
-        self.assertFalse(obj, "List is not empty (it is truthy)")
+        self.assertFalse(obj, "List is not empty")
 
-    def assertNotEmpty(self, obj):
+    def assertNotEmpty(self, obj: list):
         """Assert than a list is not empty"""
-        self.assertTrue(obj, "List is empty (it is falsy)")
+        self.assertTrue(obj, "List is empty")
 
     @staticmethod
     def get_restore_or_cancel_info(reason=None, author=None, site=None, status=None):

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -668,6 +668,14 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         for i in range(0, len(list_a)):
             self.assertEqual(list_a[i].asdict(), list_b[i].asdict())
 
+    def assertEmpty(self, obj):
+        """Assert that a list is empty"""
+        self.assertFalse(obj, "List is not empty (it is truthy)")
+
+    def assertNotEmpty(self, obj):
+        """Assert than a list is not empty"""
+        self.assertTrue(obj, "List is empty (it is falsy)")
+
     @staticmethod
     def get_restore_or_cancel_info(reason=None, author=None, site=None, status=None):
         """get a patch request to cancel or restore a PM order,

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -262,7 +262,7 @@ class CurationEtlTest(BaseTestCase):
 
     def test_later_in_progress_response_not_used(self):
         """
-        Make sure later, in-progress responses don't make us filter out full and volid responses that should be used
+        Make sure later, in-progress responses don't make us filter out full and valid responses that should be used
         """
 
         # Create a questionnaire response that might be used instead of the default for the test suite
@@ -273,7 +273,6 @@ class CurationEtlTest(BaseTestCase):
             created=datetime(2020, 5, 10),
             status=QuestionnaireResponseStatus.IN_PROGRESS
         )
-
         self.run_tool()
 
         # Make sure src_clean only has data from the full response


### PR DESCRIPTION
The curation team requested that we don't send in-progress responses for now. These changes filter the responses out of src_clean and make sure in-progress responses don't affect the logic for finding a participant's latest response to a survey.