### PR TITLE
temporarily suspend GEM A1 manifest cron job

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -97,7 +97,7 @@ cron:
 - description: Genomic GEM A1 Workflow
   url: /offline/GenomicGemA1Workflow
   timezone: America/New_York
-  schedule: every tuesday 00:00
+  schedule: 1 of jan 12:00
   target: offline
 - description: Genomic GEM A2 Workflow
   url: /offline/GenomicGemA2Workflow


### PR DESCRIPTION
This PR temporarily suspends the GEM A1 cron job until CE participants are filtered out.