### PR TITLE
Remove C1, C2 AW0 job, change C3 schedule

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -59,20 +59,10 @@ cron:
   schedule: every day 02:45
   timezone: America/New_York
   target: offline
-- description: Genomic Pipeline AW0 (Cohort 1) Workflow
-  url: /offline/GenomicC1AW0Workflow
-  timezone: America/New_York
-  schedule: every monday 07:15
-  target: offline
-- description: Genomic Pipeline AW0 (Cohort 2) Workflow
-  url: /offline/GenomicC2AW0Workflow
-  schedule: every monday 07:00
-  timezone: America/New_York
-  target: offline
 - description: Genomic Pipeline AW0 (Cohort 3) Workflow
   url: /offline/GenomicC3AW0Workflow
   timezone: America/New_York
-  schedule: every wednesday 06:30
+  schedule: 1 of jan 12:00
   target: offline
 - description: Genomic AW1 Failures Workflow
   url: /offline/GenomicFailuresWorkflow


### PR DESCRIPTION
This PR removes the Cohort 1 and Cohort 2 AW0 cron jobs and temporarily suspends the Cohort 3 AW0 cron job. The GEM A1 cron job is currently temporarily suspended on the devel branch. Both of these cron jobs will be enabled again when the CE participants are removed from the genomics system.