### PR TITLE
Activating cloud debugger

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,13 +8,6 @@ import subprocess
 import os
 
 
-if os.getenv('GAE_ENV', '').startswith('standard'):
-    try:
-        import googleclouddebugger
-        googleclouddebugger.enable()
-    except ImportError:
-        pass
-
 def print_service_list():
     print("Possible services are --flask, --gunicorn and --service.")
 

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -2,6 +2,14 @@
 
 This defines the APIs and the handlers for the APIs. All responses are JSON.
 """
+import os
+if os.getenv('GAE_ENV', '').startswith('standard'):
+    try:
+        import googleclouddebugger
+        googleclouddebugger.enable()
+    except ImportError:
+        pass
+
 import logging
 
 # pylint: disable=unused-import

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -1,4 +1,12 @@
 """The main API definition file for endpoints that trigger MapReduces and batch tasks."""
+import os
+if os.getenv('GAE_ENV', '').startswith('standard'):
+    try:
+        import googleclouddebugger
+        googleclouddebugger.enable()
+    except ImportError:
+        pass
+
 import json
 import logging
 import traceback

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,6 @@ google-cloud-storage
 google-cloud-bigquery
 google-cloud-datastore
 google-cloud-firestore
-google-python-cloud-debugger
 google-cloud-logging
 google-cloud-tasks
 googlemaps   # Used in tools/import_organizations.py

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -41,7 +41,6 @@ google-cloud-firestore==1.7.0  # via -r requirements.in
 google-cloud-logging==1.15.0  # via -r requirements.in
 google-cloud-storage==1.28.1  # via -r requirements.in
 google-cloud-tasks==1.5.0  # via -r requirements.in
-google-python-cloud-debugger==2.14  # via -r requirements.in
 google-resumable-media==0.5.0  # via google-cloud-bigquery, google-cloud-storage
 googleapis-common-protos[grpc]==1.51.0  # via google-api-core, grpc-google-iam-v1
 googlemaps==4.4.1         # via -r requirements.in


### PR DESCRIPTION
It looks like the cloud debugger is a little picky about how it gets enabled. This moves the activation code into the `main` for the default and offline services and gets snapshots and logpoints working in the cloud debugger.

The instructions for installing the debugger don't mention needing to install the package: it looks like it's just a part of the environment already. Removing it from our requirements files to resolve issues we've seen with it.