### PR TITLE
[DA-1895] CE exclusion in AWO && Gem_A1 manifest | restart cron jobs

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -62,7 +62,7 @@ cron:
 - description: Genomic Pipeline AW0 (Cohort 3) Workflow
   url: /offline/GenomicC3AW0Workflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every wednesday 06:30
   target: offline
 - description: Genomic AW1 Failures Workflow
   url: /offline/GenomicFailuresWorkflow
@@ -87,7 +87,7 @@ cron:
 - description: Genomic GEM A1 Workflow
   url: /offline/GenomicGemA1Workflow
   timezone: America/New_York
-  schedule: 1 of jan 12:00
+  schedule: every tuesday 00:00
   target: offline
 - description: Genomic GEM A2 Workflow
   url: /offline/GenomicGemA2Workflow

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2145,6 +2145,7 @@ class GenomicBiobankSamplesCoupler:
             AND ss.test in ('1ED04', '1ED10', '1SAL2')
             AND ss.rdr_created > :from_date_param
             AND ps.consent_cohort = :cohort_3_param
+            AND ps.participant_origin != 'careevolution'
             AND m.id IS NULL
         """
         params = {
@@ -2158,6 +2159,7 @@ class GenomicBiobankSamplesCoupler:
             "cohort_3_param": ParticipantCohort.COHORT_3.__int__(),
             "ignore_param": GenomicWorkflowState.IGNORE.__int__(),
         }
+
         with self.samples_dao.session() as session:
             result = session.execute(_new_samples_sql, params).fetchall()
 
@@ -2747,7 +2749,8 @@ class ManifestDefinitionProvider:
                     (GenomicSetMember.genomeType == "aou_array") &
                     (ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN) &
                     (ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED) &
-                    (ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED)
+                    (ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED) &
+                    (ParticipantSummary.participantOrigin != 'careevolution')
                 ).group_by(
                         GenomicSetMember.biobankId,
                         GenomicSetMember.sampleId,

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2860,7 +2860,6 @@ class ManifestDefinitionProvider:
                     (GenomicFileProcessed.genomicManifestFileId == self.kwargs['kwargs']['input_manifest'].id)
                 )
             )
-
         return query_sql
 
     def _get_manifest_columns(self, manifest_type):

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -975,7 +975,7 @@ class GenomicPipelineTest(BaseTestCase):
     def test_new_participant_workflow(self):
         # Test for Cohort 3 workflow
         # create test samples
-        test_biobank_ids = (100001, 100002, 100003, 100004, 100005, 100006, 100007, 100008)
+        test_biobank_ids = (100001, 100002, 100003, 100004, 100005, 100006, 100007, 100008, 100009)
         fake_datetime_old = datetime.datetime(2019, 12, 31, tzinfo=pytz.utc)
         fake_datetime_new = datetime.datetime(2020, 1, 5, tzinfo=pytz.utc)
         # update the sites' States for the state test (NY or AZ)
@@ -999,7 +999,8 @@ class GenomicPipelineTest(BaseTestCase):
                                sampleStatus1SAL2=0 if bid == 100005 else 1,
                                samplesToIsolateDNA=0,
                                race=Race.HISPANIC_LATINO_OR_SPANISH,
-                               consentCohort=3)
+                               consentCohort=3,
+                               participantOrigin='example' if bid != 100009 else 'careevolution')
             # Insert participant races
             race_answer = ParticipantRaceAnswers(
                 participantId=p.participantId,

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1995,8 +1995,8 @@ class GenomicPipelineTest(BaseTestCase):
                                               runStatus=GenomicSubProcessStatus.COMPLETED,
                                               runResult=GenomicSubProcessResult.SUCCESS))
 
-        self._create_fake_datasets_for_gc_tests(3, arr_override=True,
-                                                array_participants=range(1, 4),
+        self._create_fake_datasets_for_gc_tests(4, arr_override=True,
+                                                array_participants=range(1, 5),
                                                 recon_gc_man_id=1,
                                                 genome_center='jh',
                                                 genomic_workflow_state=GenomicWorkflowState.AW1)
@@ -2006,6 +2006,8 @@ class GenomicPipelineTest(BaseTestCase):
         ror_start = datetime.datetime(2020, 7, 11, 0, 0, 0, 0)
         for p in ps_list:
             p.consentForGenomicsRORAuthored = ror_start
+            if p.biobankId == 3:
+                p.participantOrigin = 'careevolution'
             self.summary_dao.update(p)
 
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_BAYLOR
@@ -2018,7 +2020,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         self._create_stored_samples([
             (1, 1001),
-            (2, 1002)
+            (2, 1002),
+            (3, 1003)
         ])
 
         genomic_pipeline.ingest_genomic_centers_metrics_files()  # run_id = 2
@@ -2039,6 +2042,13 @@ class GenomicPipelineTest(BaseTestCase):
             f'test_data_folder/10002_R01C02_grn.idat',
             f'test_data_folder/10002_R01C02_red.idat.md5sum',
             f'test_data_folder/10002_R01C02_grn.idat.md5sum',
+            f'test_data_folder/10003_R01C03.vcf.gz',
+            f'test_data_folder/10003_R01C03.vcf.gz.tbi',
+            f'test_data_folder/10003_R01C03.vcf.gz.md5sum',
+            f'test_data_folder/10003_R01C03_red.idat',
+            f'test_data_folder/10003_R01C03_grn.idat',
+            f'test_data_folder/10003_R01C03_red.idat.md5sum',
+            f'test_data_folder/10003_R01C03_grn.idat.md5sum',
         )
         for f in sequencing_test_files:
             self._write_cloud_csv(f, 'attagc', bucket=bucket_name)

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1000,7 +1000,7 @@ class GenomicPipelineTest(BaseTestCase):
                                samplesToIsolateDNA=0,
                                race=Race.HISPANIC_LATINO_OR_SPANISH,
                                consentCohort=3,
-                               participantOrigin='example' if bid != 100009 else 'careevolution')
+                               participantOrigin='careevolution' if bid == 100009 else 'example')
             # Insert participant races
             race_answer = ParticipantRaceAnswers(
                 participantId=p.participantId,

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -2012,7 +2012,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_BAYLOR
 
-        self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest.csv',
+        self._create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest_2.csv',
                                          bucket_name,
                                          folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1]))
 

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,3 +1,4 @@
 Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Notes
 T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Pass,This sample passed
 T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Pass,This sample passed
+T3,1003,T1_1993,10003,10003_R01C03,0.3456789012,True,0.01,Pass,This sample passed

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest_2.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest_2.csv
@@ -1,3 +1,4 @@
 Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Notes
 T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Pass,This sample passed
 T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Pass,This sample passed
+T3,1003,T1_1993,10003,10003_R01C03,0.3456789012,True,0.01,Pass,This sample passed


### PR DESCRIPTION
- update cron jobs back to correct schedule
- adding careevolution exclusion in manifests
- test for care evolution in new p's exclusion
- better
- adding test in gem A1 for exclusion
- fixing unit test

We need to exclude the Care evolution records from the AW0 and GEM_A1 manifests in the genomic pipeline. This filters them out based on their `participant_origin`.
This also need to restart the cron jobs that have the dates changed so they are inactive back to correct execution date/times.
