### PR TITLE
[ROC-828] Update Curation ETL process to ignore duplicate questionnaire responses

### DIFF
--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Column, DateTime, Index, String, SmallInteger, ForeignKey, Integer
+from sqlalchemy import BigInteger, Column, DateTime, Index, String, SmallInteger, Integer
 from sqlalchemy.dialects.mysql import DECIMAL, TINYINT
 
 from rdr_service.model.base import Base

--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -1,7 +1,8 @@
-from sqlalchemy import BigInteger, Column, DateTime, Index, String, SmallInteger
+from sqlalchemy import BigInteger, Column, DateTime, Index, String, SmallInteger, ForeignKey, Integer
 from sqlalchemy.dialects.mysql import DECIMAL, TINYINT
 
 from rdr_service.model.base import Base
+from rdr_service.model.utils import UTCDateTime
 
 
 class QuestionnaireAnswersByModule(Base):
@@ -43,5 +44,20 @@ class SrcClean(Base):
     __table_args__ = (Index('idx_src_clean_participant_id', participant_id), )
 
 
+class TemporaryQuestionnaireResponse(Base):
+    """"A temporary table to store duplicated QuestionnaireResponses."""
+
+    __tablename__ = "tmp_questionnaire_response"
+    questionnaireResponseId = Column("questionnaire_response_id", Integer, primary_key=True, autoincrement=False)
+    participantId = Column("participant_id", Integer, nullable=True)
+    questionnaireId = Column("questionnaire_id", Integer, nullable=True)
+    created = Column("created", UTCDateTime, nullable=True)
+    authored = Column("authored", UTCDateTime, nullable=True)
+    identifier = Column("identifier", String(50), nullable=True)
+    duplicate = Column("duplicate", Integer, nullable=True)
+    removed = Column("removed", Integer, nullable=True)
+
+
+TemporaryQuestionnaireResponse.__table__.schema = 'cdm'
 QuestionnaireAnswersByModule.__table__.schema = 'cdm'
 SrcClean.__table__.schema = 'cdm'

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -251,7 +251,7 @@ class CurationExportClass(ToolBase):
             QuestionnaireQuestion
         ).filter(
             QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
-            or_(TemporaryQuestionnaireResponse.duplicate == None,
+            or_(TemporaryQuestionnaireResponse.duplicate.is_(None),
                 TemporaryQuestionnaireResponse.duplicate == 0)
         )
 
@@ -358,7 +358,7 @@ class CurationExportClass(ToolBase):
                 QuestionnaireResponseAnswer.valueString.isnot(None)
             ),
             QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
-            or_(TemporaryQuestionnaireResponse.duplicate == None,
+            or_(TemporaryQuestionnaireResponse.duplicate.is_(None),
                 TemporaryQuestionnaireResponse.duplicate == 0)
         )
 

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -14,7 +14,7 @@ from typing import Type
 from rdr_service import config
 from rdr_service.code_constants import PPI_SYSTEM, CONSENT_FOR_STUDY_ENROLLMENT_MODULE, STREET_ADDRESS_QUESTION_CODE,\
     STREET_ADDRESS2_QUESTION_CODE
-from rdr_service.etl.model.src_clean import QuestionnaireAnswersByModule, SrcClean
+from rdr_service.etl.model.src_clean import QuestionnaireAnswersByModule, SrcClean, TemporaryQuestionnaireResponse
 from rdr_service.model.code import Code
 from rdr_service.model.hpo import HPO
 from rdr_service.model.participant import Participant
@@ -232,6 +232,9 @@ class CurationExportClass(ToolBase):
                 QuestionnaireConcept.questionnaireId == QuestionnaireResponse.questionnaireId,
                 QuestionnaireConcept.questionnaireVersion == QuestionnaireResponse.questionnaireVersion
             )
+        ).outerjoin(
+            TemporaryQuestionnaireResponse,
+            TemporaryQuestionnaireResponse.questionnaireResponseId == QuestionnaireResponse.questionnaireResponseId
         ).join(
             Code,
             Code.codeId == QuestionnaireConcept.codeId
@@ -247,7 +250,9 @@ class CurationExportClass(ToolBase):
         ).join(
             QuestionnaireQuestion
         ).filter(
-            QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS
+            QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
+            or_(TemporaryQuestionnaireResponse.duplicate == None,
+                TemporaryQuestionnaireResponse.duplicate == 0)
         )
 
         insert_query = insert(QuestionnaireAnswersByModule).from_select(column_map.keys(), answers_by_module_select)
@@ -308,6 +313,9 @@ class CurationExportClass(ToolBase):
             HPO
         ).join(
             QuestionnaireResponse
+        ).outerjoin(
+            TemporaryQuestionnaireResponse,
+            TemporaryQuestionnaireResponse.questionnaireResponseId == QuestionnaireResponse.questionnaireResponseId
         ).join(
             QuestionnaireConcept,
             and_(
@@ -349,7 +357,9 @@ class CurationExportClass(ToolBase):
                 QuestionnaireResponseAnswer.valueDateTime.isnot(None),
                 QuestionnaireResponseAnswer.valueString.isnot(None)
             ),
-            QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS
+            QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
+            or_(TemporaryQuestionnaireResponse.duplicate == None,
+                TemporaryQuestionnaireResponse.duplicate == 0)
         )
 
         return column_map, questionnaire_answers_select, module_code, question_code

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from rdr_service.code_constants import PPI_SYSTEM
+from rdr_service.etl.model.src_clean import TemporaryQuestionnaireResponse
 from rdr_service.model.api_user import ApiUser
 from rdr_service.model.biobank_order import BiobankMailKitOrder, BiobankOrder, BiobankOrderHistory,\
     BiobankOrderedSample, BiobankOrderedSampleHistory, BiobankOrderIdentifier, BiobankSpecimen, BiobankSpecimenAttribute
@@ -100,6 +101,11 @@ class DataGenerator:
         self._commit_to_database(questionnaire_response)
         return questionnaire_response
 
+    def create_database_duplicate_temp_questionnaire_response(self, questionnaire_response, **kwargs):
+        tmp_questionnaire_response = self._tmp_questionnaire_response(questionnaire_response, **kwargs)
+        self._commit_to_database(tmp_questionnaire_response)
+        return tmp_questionnaire_response
+
     def _questionnaire_response(self, **kwargs):
         for field, default in [('created', datetime.now()),
                                ('resource', 'test'),
@@ -112,6 +118,19 @@ class DataGenerator:
             kwargs['questionnaireResponseId'] = self.unique_questionnaire_response_id()
 
         return QuestionnaireResponse(**kwargs)
+
+    def _tmp_questionnaire_response(self, questionnaire_response, **kwargs):
+        for field, default in [('created', datetime.now()),
+                               ('duplicate', 1),
+                               ('removed', None),
+                               ('identifier', 'test-id')]:
+            if field not in kwargs:
+                kwargs[field] = default
+
+        if 'questionnaireResponseId' not in kwargs:
+            kwargs['questionnaireResponseId'] = questionnaire_response.questionnaireResponseId
+
+        return TemporaryQuestionnaireResponse(**kwargs)
 
     def create_database_questionnaire_question(self, **kwargs):
         questionnaire_question = self._questionnaire_question(**kwargs)


### PR DESCRIPTION
This PR updates the curation ETL tool to exclude duplicate questionnaire responses from the `cdm.tmp_questionnaire_response` table.
A new model was added to the etl model definitions in `src_clean.py`: `TemporaryQuestionnaireResponse`. This is ignored by the alembic versioning system for RDR. The table already exists in the `cdm` schema, adding the model allows ORM support which was required by the curation tool.
