### PR TITLE
Minor fixes for consent sync

### DIFF
--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -183,22 +183,22 @@ def build_participant_query(session, org_ids, start_date=None, end_date=None, al
     if start_date and end_date:
         participant_query = participant_query.filter(
             or_(
-                ParticipantSummary.consentForStudyEnrollmentAuthored.between(start_date, end_date),
-                ParticipantSummary.consentForElectronicHealthRecordsAuthored.between(start_date, end_date)
+                ParticipantSummary.consentForStudyEnrollmentTime.between(start_date, end_date),
+                ParticipantSummary.consentForElectronicHealthRecordsTime.between(start_date, end_date)
             )
         )
     elif start_date:
         participant_query = participant_query.filter(
             or_(
-                ParticipantSummary.consentForStudyEnrollmentAuthored > start_date,
-                ParticipantSummary.consentForElectronicHealthRecordsAuthored > start_date
+                ParticipantSummary.consentForStudyEnrollmentTime > start_date,
+                ParticipantSummary.consentForElectronicHealthRecordsTime > start_date
             )
         )
     elif end_date:
         participant_query = participant_query.filter(
             or_(
-                ParticipantSummary.consentForStudyEnrollmentAuthored < end_date,
-                ParticipantSummary.consentForElectronicHealthRecordsAuthored < end_date
+                ParticipantSummary.consentForStudyEnrollmentTime < end_date,
+                ParticipantSummary.consentForElectronicHealthRecordsTime < end_date
             )
         )
 

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -159,21 +159,15 @@ def build_participant_query(session, org_ids, start_date=None, end_date=None, al
         Site.googleGroup,
         Organization.externalId
     ).join(
-        Organization,
-        Organization.organizationId == Participant.organizationId,
-        isouter=True
+        Organization, Organization.organizationId == Participant.organizationId, isouter=True
     ).join(
-        Site,
-        Site.siteId == Participant.siteId,
-        isouter=True
+        Site, Site.siteId == Participant.siteId, isouter=True
     ).join(
-        ParticipantSummary,
-        Participant.participantSummary,
-        isouter=True
+        ParticipantSummary, Participant.participantSummary, isouter=True
     ).filter(
         Participant.isGhostId.isnot(True),
         Participant.isTestParticipant.isnot(True),
-        ParticipantSummary.consentForStudyEnrollment == QuestionnaireStatus.SUBMITTED,
+        ParticipantSummary.consentForStudyEnrollment == int(QuestionnaireStatus.SUBMITTED),
         or_(
             ParticipantSummary.email.is_(None),
             ParticipantSummary.email.notlike('%@example.com')
@@ -203,13 +197,9 @@ def build_participant_query(session, org_ids, start_date=None, end_date=None, al
         )
 
     if all_va:
-        participant_query = participant_query.filter(
-            Organization.externalId.like('VA_%')
-        )
+        participant_query = participant_query.filter(Organization.externalId.like('VA_%'))
     else:
-        participant_query = participant_query.filter(
-            Organization.externalId.in_(org_ids)
-        )
+        participant_query = participant_query.filter(Organization.externalId.in_(org_ids))
 
     return participant_query
 

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -158,12 +158,12 @@ def build_participant_query(session, org_ids, start_date=None, end_date=None, al
         Participant.participantOrigin,
         Site.googleGroup,
         Organization.externalId
-    ).join(
-        Organization, Organization.organizationId == Participant.organizationId, isouter=True
-    ).join(
-        Site, Site.siteId == Participant.siteId, isouter=True
-    ).join(
-        ParticipantSummary, Participant.participantSummary, isouter=True
+    ).outerjoin(
+        Organization, Organization.organizationId == Participant.organizationId
+    ).outerjoin(
+        Site, Site.siteId == Participant.siteId
+    ).outerjoin(
+        ParticipantSummary, Participant.participantSummary
     ).filter(
         Participant.isGhostId.isnot(True),
         Participant.isTestParticipant.isnot(True),

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -180,14 +180,21 @@ def build_participant_query(session, org_ids, start_date=None, end_date=None, al
         )
     )
 
-    if start_date:
+    if start_date and end_date:
+        participant_query = participant_query.filter(
+            or_(
+                ParticipantSummary.consentForStudyEnrollmentAuthored.between(start_date, end_date),
+                ParticipantSummary.consentForElectronicHealthRecordsAuthored.between(start_date, end_date)
+            )
+        )
+    elif start_date:
         participant_query = participant_query.filter(
             or_(
                 ParticipantSummary.consentForStudyEnrollmentAuthored > start_date,
                 ParticipantSummary.consentForElectronicHealthRecordsAuthored > start_date
             )
         )
-    if end_date:
+    elif end_date:
         participant_query = participant_query.filter(
             or_(
                 ParticipantSummary.consentForStudyEnrollmentAuthored < end_date,

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -3,18 +3,23 @@ Sync Consent Files
 
 Organize all consent files from PTSC source bucket into proper awardee buckets.
 """
-import collections
 from datetime import datetime, timedelta
 import logging
 import pytz
 import os
 import shutil
+from sqlalchemy import or_
 import tempfile
 from zipfile import ZipFile
 
 from rdr_service import config
 from rdr_service.api_util import copy_cloud_file, download_cloud_file, get_blob, list_blobs, parse_date
 from rdr_service.dao import database_factory
+from rdr_service.model.organization import Organization
+from rdr_service.model.participant import Participant
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.site import Site
+from rdr_service.participant_enums import QuestionnaireStatus
 from rdr_service.services.gcp_utils import gcp_cp
 from rdr_service.storage import GoogleCloudStorageProvider
 
@@ -24,8 +29,6 @@ SOURCE_BUCKET = {
 }
 DEFAULT_GOOGLE_GROUP = "no-site-assigned"
 TEMP_CONSENTS_PATH = os.path.join(tempfile.gettempdir(), "temp_consents")
-
-ParticipantData = collections.namedtuple("ParticipantData", ("participant_id", "origin_id", "google_group", "org_id"))
 
 
 def get_consent_destination(zipping=False, add_protocol=False, **kwargs):
@@ -122,21 +125,21 @@ def do_sync_consent_files(zip_files=False, **kwargs):
     if all_va:
         logging.info('only interacting with VA files')
     file_filter = kwargs.get('file_filter', 'pdf')
-    for participant_data in _iter_participants_data(org_ids, **kwargs):
-        logging.info(f'Syncing files for {participant_data.participant_id}')
-        source_bucket = SOURCE_BUCKET.get(participant_data.origin_id, SOURCE_BUCKET[next(iter(SOURCE_BUCKET))])
+    for participant_id, origin, site_google_group, org_external_id in _iter_participants_data(org_ids, **kwargs):
+        logging.info(f'Syncing files for {participant_id}')
+        source_bucket = SOURCE_BUCKET.get(origin, SOURCE_BUCKET[next(iter(SOURCE_BUCKET))])
         source = "/{source_bucket}/Participant/P{participant_id}/"\
             .format(source_bucket=source_bucket,
-                    participant_id=participant_data.participant_id)
+                    participant_id=participant_id)
         if all_va:
             destination_bucket = 'aou179'
         else:
-            destination_bucket = org_buckets[participant_data.org_id]
+            destination_bucket = org_buckets[org_external_id]
         destination = get_consent_destination(zip_files,
                                               bucket_name=destination_bucket,
-                                              org_external_id=participant_data.org_id,
-                                              site_name=participant_data.google_group or DEFAULT_GOOGLE_GROUP,
-                                              p_id=participant_data.participant_id)
+                                              org_external_id=org_external_id,
+                                              site_name=site_google_group or DEFAULT_GOOGLE_GROUP,
+                                              p_id=participant_id)
 
         cloudstorage_copy_objects_task(source, destination, start_date=start_date,
                                        file_filter=file_filter, zip_files=zip_files)
@@ -149,76 +152,66 @@ def get_org_data_map():
     return config.getSettingJson(config.CONSENT_SYNC_BUCKETS)
 
 
-PARTICIPANT_DATA_SQL = """
-select
-  participant.participant_id,
-  participant.participant_origin,
-  site.google_group,
-  organization.external_id
-from participant
-left join organization
-  on participant.organization_id = organization.organization_id
-left join site
-  on participant.site_id = site.site_id
-left join participant_summary summary
-  on participant.participant_id = summary.participant_id
-where participant.is_ghost_id is not true
-  and participant.is_test_participant is not true
-  and summary.consent_for_study_enrollment = 1
-  and (
-    summary.email is null
-    or summary.email not like '%@example.com'
-  )
-"""
+def build_participant_query(session, org_ids, start_date=None, end_date=None, all_va=False):
+    participant_query = session.query(
+        Participant.participantId,
+        Participant.participantOrigin,
+        Site.googleGroup,
+        Organization.externalId
+    ).join(
+        Organization,
+        Organization.organizationId == Participant.organizationId,
+        isouter=True
+    ).join(
+        Site,
+        Site.siteId == Participant.siteId,
+        isouter=True
+    ).join(
+        ParticipantSummary,
+        Participant.participantSummary,
+        isouter=True
+    ).filter(
+        Participant.isGhostId.isnot(True),
+        Participant.isTestParticipant.isnot(True),
+        ParticipantSummary.consentForStudyEnrollment == QuestionnaireStatus.SUBMITTED,
+        or_(
+            ParticipantSummary.email.is_(None),
+            ParticipantSummary.email.notlike('%@example.com')
+        )
+    )
 
-participant_filters_sql = {
-    'start_date': """
-        and (
-            summary.consent_for_study_enrollment_time > :start_date
-            or
-            summary.consent_for_electronic_health_records_time > :start_date
+    if start_date:
+        participant_query = participant_query.filter(
+            or_(
+                ParticipantSummary.consentForStudyEnrollmentAuthored > start_date,
+                ParticipantSummary.consentForElectronicHealthRecordsAuthored > start_date
             )
-        """,
-    'end_date': """
-        and (
-            summary.consent_for_study_enrollment_time < :end_date
-            or
-            summary.consent_for_electronic_health_records_time < :end_date
+        )
+    if end_date:
+        participant_query = participant_query.filter(
+            or_(
+                ParticipantSummary.consentForStudyEnrollmentAuthored < end_date,
+                ParticipantSummary.consentForElectronicHealthRecordsAuthored < end_date
             )
-        """,
-    'org_ids': """
-        and organization.external_id in :org_ids
-    """,
-    'all_va': """
-        and organization.external_id like 'VA_%'
-    """
-}
+        )
 
-
-def build_participant_query(org_ids, **kwargs):
-    participant_sql = PARTICIPANT_DATA_SQL
-    parameters = {}
-
-    for filter_field in ['start_date', 'end_date']:
-        if filter_field in kwargs:
-            participant_sql += participant_filters_sql[filter_field]
-            parameters[filter_field] = kwargs[filter_field]
-
-    if kwargs.get('all_va'):
-        participant_sql += participant_filters_sql['all_va']
+    if all_va:
+        participant_query = participant_query.filter(
+            Organization.externalId.like('VA_%')
+        )
     else:
-        participant_sql += participant_filters_sql['org_ids']
-        parameters['org_ids'] = org_ids
+        participant_query = participant_query.filter(
+            Organization.externalId.in_(org_ids)
+        )
 
-    return participant_sql, parameters
+    return participant_query
 
 
 def _iter_participants_data(org_ids, **kwargs):
-    participant_sql, parameters = build_participant_query(org_ids, **kwargs)
-
     with database_factory.make_server_cursor_database().session() as session:
-        for row in session.execute(participant_sql, parameters):
-            yield ParticipantData(*row)
+        participant_query = build_participant_query(session, org_ids, **kwargs)
+        for participant_data in participant_query:
+            yield participant_data
 
 
 def _download_file(source, destination):

--- a/rdr_service/tools/tool_libs/sync_consent.py
+++ b/rdr_service/tools/tool_libs/sync_consent.py
@@ -3,8 +3,9 @@ import MySQLdb
 import logging
 import pytz
 
+from rdr_service.config import CONSENT_SYNC_BUCKETS
 from rdr_service.dao import database_factory
-from rdr_service.offline.sync_consent_files import get_org_data_map, build_participant_query, \
+from rdr_service.offline.sync_consent_files import build_participant_query, \
     DEFAULT_GOOGLE_GROUP, get_consent_destination, archive_and_upload_consents, copy_file
 from rdr_service.services.system_utils import print_progress_bar
 from rdr_service.storage import GoogleCloudStorageProvider
@@ -64,7 +65,8 @@ class SyncConsentClass(ToolBase):
             filter_pids = open(self.args.pid_file).read().strip().split('\n')
             filter_pids = [int(x) for x in filter_pids]
 
-        org_buckets = get_org_data_map()
+        server_config = self.get_server_config()
+        org_buckets = server_config[CONSENT_SYNC_BUCKETS]
 
         try:
             logger.info("retrieving participant information...")

--- a/tests/cron_job_tests/test_sync_consent_files.py
+++ b/tests/cron_job_tests/test_sync_consent_files.py
@@ -61,7 +61,7 @@ class SyncConsentFilesTest(BaseTestCase):
         if consents:
             summary_data.update(consentForElectronicHealthRecords=1,
                                 consentForStudyEnrollment=1,
-                                consentForStudyEnrollmentTime=consent_time)
+                                consentForStudyEnrollmentAuthored=consent_time)
         if email:
             summary.email = email
             summary_data['email'] = email
@@ -339,11 +339,11 @@ class SyncConsentFilesTest(BaseTestCase):
         self._create_participant(5, self.org1.organizationId, None, consents=True, email="foo@example.com")
         self._create_participant(6, org2.organizationId, site2.siteId, consents=True)
         participant_data_list = list(sync_consent_files._iter_participants_data(['test_one', 'test_two']))
-        participant_ids = [d.participant_id for d in participant_data_list]
+        participant_ids = [d.participantId for d in participant_data_list]
         self.assertEqual(len(participant_ids), 3, "finds correct number of results")
         self.assertEqual(participant_ids, [1, 3, 6], "finds valid participants")
-        self.assertEqual(participant_data_list[0].google_group, "group1", "Includes google group")
-        self.assertEqual(participant_data_list[1].google_group, None, "allows None for google group")
+        self.assertEqual(participant_data_list[0].googleGroup, "group1", "Includes google group")
+        self.assertEqual(participant_data_list[1].googleGroup, None, "allows None for google group")
 
     @mock.patch("rdr_service.offline.sync_consent_files.list_blobs")
     @mock.patch("rdr_service.offline.sync_consent_files.copy_cloud_file")

--- a/tests/cron_job_tests/test_sync_consent_files.py
+++ b/tests/cron_job_tests/test_sync_consent_files.py
@@ -61,8 +61,8 @@ class SyncConsentFilesTest(BaseTestCase):
         if consents:
             summary_data.update(consentForElectronicHealthRecords=1,
                                 consentForStudyEnrollment=1,
-                                consentForStudyEnrollmentAuthored=consent_time,
-                                consentForElectronicHealthRecordsAuthored=ehr_consent_time)
+                                consentForStudyEnrollmentTime=consent_time,
+                                consentForElectronicHealthRecordsTime=ehr_consent_time)
         if email:
             summary.email = email
             summary_data['email'] = email

--- a/tests/tool_tests/test_sync_consent.py
+++ b/tests/tool_tests/test_sync_consent.py
@@ -1,10 +1,7 @@
 from collections import namedtuple
 from datetime import datetime
 import mock
-import os
-from pathlib import Path
 import pytz
-import tempfile
 
 from rdr_service import config
 from rdr_service.participant_enums import QuestionnaireStatus
@@ -28,14 +25,6 @@ class SyncConsentTest(ToolTestMixin, BaseTestCase):
             participant=self.participant,
             consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED
         )
-
-    @staticmethod
-    def setup_local_file_creation(mock_gcp_cp):
-        # Actually create the files locally so the zipping code will have something to work with
-        def create_local_file(source, destination, **_):
-            if destination.startswith(tempfile.gettempdir()):
-                Path(os.path.join(destination, Path(source).name)).touch()
-        mock_gcp_cp.side_effect = create_local_file
 
     @classmethod
     def run_sync(cls, date_limit='2020-05-01', end_date=None, org_id='test_org', destination_bucket=None,
@@ -66,52 +55,6 @@ class SyncConsentTest(ToolTestMixin, BaseTestCase):
         return FakeFile(name=f'Participant/P{participant.participantId}/{file_name}',
                         updated=datetime.now(pytz.timezone('Etc/Greenwich')))
 
-    @staticmethod
-    def assertZipFilesCreated(mock_zip_file, directory, relative_path):
-        zip_instance = mock_zip_file.return_value
-        zip_instance_context = zip_instance.__enter__.return_value
-        mock_zip_write = zip_instance_context.write
-        mock_zip_write.assert_any_call(os.path.join(directory, relative_path), arcname=f'/{relative_path}')
-
-    def test_zip_file_download(self, mock_gcp_cp, _):
-        self.run_sync(zip_files=True, consent_files=[self._fake_file(self.participant, 'one.pdf')])
-
-        # Assert that the files were copied locally for zipping
-        zip_path = '{temp_dir}/temp_consents/{bucket}/{org_id}/{site}/P{participant_id}/'.format(
-            temp_dir=tempfile.gettempdir(),
-            bucket='test_dest_bucket',
-            org_id='test_org',
-            site='test_site_google_group',
-            participant_id=self.participant.participantId
-        )
-        mock_gcp_cp.assert_any_call(
-            f'gs://uploads_bucket/Participant/P{self.participant.participantId}/one.pdf',
-            zip_path,
-            flags='-m')
-
-    @mock.patch('rdr_service.offline.sync_consent_files.ZipFile')
-    def test_zip_file_write(self, mock_zip_file, mock_gcp_cp, _):
-        self.setup_local_file_creation(mock_gcp_cp)
-
-        self.run_sync(zip_files=True, consent_files=[self._fake_file(self.participant, 'one.pdf')])
-
-        # Assert that the correct files were written into the zip
-        zip_path = f'{tempfile.gettempdir()}/temp_consents/test_dest_bucket/test_org/test_site_google_group/'
-        self.assertZipFilesCreated(mock_zip_file,
-                                   zip_path,
-                                   f'P{self.participant.participantId}/one.pdf')
-
-    def test_zip_file_upload(self, mock_gcp_cp, mock_upload_file):
-        self.setup_local_file_creation(mock_gcp_cp)
-
-        self.run_sync(zip_files=True, consent_files=[self._fake_file(self.participant, 'one.pdf')])
-
-        # Assert that the zip was uploaded to the correct location
-        mock_upload_file.assert_any_call(
-            f'{tempfile.gettempdir()}/temp_consents/test_dest_bucket/test_org/test_site_google_group.zip',
-            'test_dest_bucket/Participant/test_org/test_site_google_group.zip'
-        )
-
     def test_moving_cloud_file(self, mock_gcp_cp, _):
         self.run_sync(consent_files=[self._fake_file(self.participant, 'one.pdf')])
 
@@ -120,29 +63,3 @@ class SyncConsentTest(ToolTestMixin, BaseTestCase):
             f'gs://uploads_bucket/Participant/P{self.participant.participantId}/one.pdf',
             f'gs://test_dest_bucket/Participant/test_org/test_site_google_group/P{self.participant.participantId}/',
             flags='-m', args='-r')
-
-    # There's a switch that targets the VA upload bucket for all organizations that belong under the VA hpo
-    def test_va_zip_upload(self, mock_gcp_cp, mock_upload_file):
-        self.setup_local_file_creation(mock_gcp_cp)
-        site = self.data_generator.create_database_site(googleGroup='boston_site')
-        org = self.data_generator.create_database_organization(externalId='VA_BOSTON')
-        va_participant = self.data_generator.create_database_participant(organizationId=org.organizationId, siteId=site.siteId)
-        self.data_generator.create_database_participant_summary(
-            participant=va_participant,
-            consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED
-        )
-
-        self.run_sync(zip_files=True, all_va=True, consent_files=[self._fake_file(va_participant, 'consent.pdf')])
-
-        # Assert that the zip was uploaded to the VA bucket
-        mock_upload_file.assert_any_call(
-            f'{tempfile.gettempdir()}/temp_consents/aou179/VA_BOSTON/boston_site.zip',
-            'aou179/Participant/VA_BOSTON/boston_site.zip'
-        )
-
-    def test_loading_only_va_participants(self, mock_gcp_cp, _):
-        # The test setup creates a participant that should have a file downloaded if they were loaded from the database.
-        # But they're not in a VA organization, so we shouldn't see a call for them.
-
-        self.run_sync(zip_files=True, all_va=True, consent_files=[self._fake_file(self.participant, 'consent.pdf')])
-        mock_gcp_cp.assert_not_called()


### PR DESCRIPTION
This PR does some more refactoring to the consent sync code, as well as updating some behavior:
- Uses sqlalchemy for finding participants to sync (rather than raw sql)
- If both `start_date` and `end_date` were provided it was possible for the sql to include participants that had a consentForEnrollment date before the `start_date` and an ehrConsent date after the `end_date`, this adds extra logic to limit the range for each field
- Fixes the tool code so that it can get the org-to-bucket map (from the server config)
- Removes functionality for tool to download consent files for zipping. For security reasons consent files should remain in the cloud, a later PR will add the option back in and set the tool up to use the cloud endpoint for zipping