### PR TITLE
Fixes for building local database

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -209,6 +209,8 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             return True
         except exc.ProgrammingError:
             pass
+        except exc.OperationalError:
+            logging.warning('Unexpected error found when checking for tmp_questionnaire_response table', exc_info=True)
         return False
 
     def _prep_participant(self, p_id, ro_session):

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -817,7 +817,11 @@ def _validate_consent_pdfs(resource):
         _raise_if_gcloud_file_missing("/{}{}".format(consent_bucket, local_pdf_path))
         found_pdf = True
 
-    return found_pdf
+    if config.GAE_PROJECT == 'localhost':
+        # Pretend we found a valid consent if we're running on a development machine
+        return True
+    else:
+        return found_pdf
 
 
 def _raise_if_gcloud_file_missing(path):

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -72,6 +72,10 @@ class QuestionnaireResponseApiTest(BaseTestCase):
 
     def test_consent_submission_requires_signature(self):
         """Consent questionnaire responses should only mark a participant as consented if they have consented"""
+        # Set the config up to imitate a server environment enough for the dao to check for consent files
+        previous_config_project_setting = config.GAE_PROJECT
+        config.GAE_PROJECT = 'test-environment'
+
         participant_id = self.create_participant()
         self.send_consent(participant_id, authored=datetime.datetime.now(), string_answers=[
             ('firstName', 'Bob'),
@@ -83,6 +87,9 @@ class QuestionnaireResponseApiTest(BaseTestCase):
             ParticipantSummary.participantId == from_client_participant_id(participant_id)
         ).one_or_none()
         self.assertIsNone(summary)
+
+        # Set the config back so that the rest of the tests are ok
+        config.GAE_PROJECT = previous_config_project_setting
 
     def test_update_baseline_questionnaires_first_complete_authored(self):
         participant_id = self.create_participant()


### PR DESCRIPTION
The `setup_local_database.sh` script was seeing some issues from recent changes. There's a possible OperationalError that can come up when checking for the `tmp_questionnaire_response` table. And the consent responses get rejected when trying to create local participants.