### PR TITLE
Quick tool for backfilling survey objects from existing module codes

### DIFF
--- a/rdr_service/model/survey.py
+++ b/rdr_service/model/survey.py
@@ -37,6 +37,7 @@ class SurveyQuestionType(messages.Enum):
     TRUEFALSE = 7
     FILE = 8
     SLIDER = 9
+    UNKNOWN = 10
 
 
 class SurveyQuestion(Base):

--- a/rdr_service/tools/tool_libs/survey_backfill.py
+++ b/rdr_service/tools/tool_libs/survey_backfill.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+import logging
+from typing import List
+
+from rdr_service.model.code import Code, CodeType
+from rdr_service.model.survey import Survey, SurveyQuestion, SurveyQuestionOption, SurveyQuestionType
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
+
+tool_cmd = 'survey-back-fill'
+tool_desc = 'Create survey structure objects for codes'
+
+
+class SurveyBackFill(ToolBase):
+    @classmethod
+    def get_direct_children_codes(cls, parent_code, session) -> List[Code]:
+        return session.query(Code).filter(Code.parentId == parent_code.codeId)
+
+    def get_descendant_codes(self, parent_code: Code, child_type: CodeType, session):
+        children_matching_type = []
+        children: List[Code] = self.get_direct_children_codes(parent_code, session)
+
+        if children:
+            direct_children_of_given_type = [child for child in children if child.codeType == child_type]
+            children_matching_type.extend(direct_children_of_given_type)
+
+            for child in children:
+                children_matching_type.extend(self.get_descendant_codes(child, child_type, session))
+
+        return children_matching_type
+
+    def build_options(self, question_code, session):
+        return [SurveyQuestionOption(
+            code=code,
+            display=code.display
+        ) for code in self.get_descendant_codes(question_code, CodeType.ANSWER, session)]
+
+    def build_questions(self, module_code, session):
+        questions = []
+        question_codes = self.get_descendant_codes(module_code, CodeType.QUESTION, session)
+        for code in question_codes:
+            survey_question_obj = SurveyQuestion(
+                code=code,
+                questionType=SurveyQuestionType.UNKNOWN,
+                display=code.display
+            )
+            survey_question_obj.options = self.build_options(code, session)
+            questions.append(survey_question_obj)
+
+        return questions
+
+    def run(self):
+        with self.get_session() as session:
+            module_code = session.query(Code).filter(Code.value == self.args.module_code).one()
+
+            existing_survey = session.query(Survey).filter(Survey.code == module_code).one_or_none()
+            if existing_survey:
+                logging.info(f'Skipping {module_code.value} (survey already exists)')
+            else:
+                survey_obj = Survey(
+                    code=module_code,
+                    importTime=datetime.utcnow(),
+                    redcapProjectTitle=module_code.display
+                )
+                survey_obj.questions = self.build_questions(module_code, session)
+                session.add(survey_obj)
+
+
+def add_additional_arguments(parser):
+    parser.add_argument('--module-code', required=True, help='Module code value to back fill')
+
+
+def run():
+    return cli_run(tool_cmd, tool_desc, SurveyBackFill, add_additional_arguments)

--- a/tests/helpers/tool_test_mixin.py
+++ b/tests/helpers/tool_test_mixin.py
@@ -35,8 +35,8 @@ class ToolTestMixin:
 
         return args_obj
 
-    @staticmethod
-    def run_tool(tool_class: Type[ToolBase], tool_args: dict = None, server_config: dict = None):
+    @classmethod
+    def run_tool(cls, tool_class: Type[ToolBase], tool_args: dict = None, server_config: dict = None):
         gcp_env = ToolTestMixin._build_env(server_config)
         tool_args = ToolTestMixin._build_args(tool_args)
 

--- a/tests/tool_tests/test_survey_back_fill.py
+++ b/tests/tool_tests/test_survey_back_fill.py
@@ -1,0 +1,116 @@
+
+from rdr_service.model.code import CodeType
+from rdr_service.model.survey import Survey, SurveyQuestionType
+from rdr_service.tools.tool_libs.survey_backfill import SurveyBackFill
+from tests.helpers.unittest_base import BaseTestCase
+from tests.helpers.tool_test_mixin import ToolTestMixin
+
+
+class CopeAnswerTest(ToolTestMixin, BaseTestCase):
+
+    def test_creating_basic_survey_structure(self):
+        module_code = self.data_generator.create_database_code(
+            display='Test module',
+            value='test_module',
+            codeType=CodeType.MODULE
+        )
+
+        # Make a simple question in the module
+        self.data_generator.create_database_code(
+            display='free text question',
+            value='text_question',
+            codeType=CodeType.QUESTION,
+            parentId=module_code.codeId
+        )
+
+        # Make a question with options in the module
+        multiple_choice_code = self.data_generator.create_database_code(
+            display='multiple choice question',
+            value='choice_question',
+            codeType=CodeType.QUESTION,
+            parentId=module_code.codeId
+        )
+        self.data_generator.create_database_code(
+            display='Option A',
+            value='option_a',
+            codeType=CodeType.ANSWER,
+            parentId=multiple_choice_code.codeId
+        )
+        self.data_generator.create_database_code(
+            display='Option B',
+            value='option_b',
+            codeType=CodeType.ANSWER,
+            parentId=multiple_choice_code.codeId
+        )
+
+        # Run the back fill to create the survey objects for the codes
+        self.run_tool(SurveyBackFill, tool_args={
+            'module_code': 'test_module'
+        })
+
+        # Check that everything transferred as expected to the Survey structure
+        survey: Survey = self.session.query(Survey).one()
+
+        self.assertEqual('Test module', survey.redcapProjectTitle)
+
+        first_question = survey.questions[0]
+        self.assertEqual('free text question', first_question.display)
+        self.assertEqual(SurveyQuestionType.UNKNOWN, first_question.questionType)
+
+        second_question = survey.questions[1]
+        self.assertEqual('multiple choice question', second_question.display)
+        self.assertEqual(SurveyQuestionType.UNKNOWN, second_question.questionType)
+
+        # Check that the options got set up
+        self.assertEqual('Option A', second_question.options[0].display)
+        self.assertEqual('Option B', second_question.options[1].display)
+
+    def test_topic_codes_are_transparent(self):
+        """To make sure we can get SurveyQuestions set up for questions that are nested in topics"""
+        module_code = self.data_generator.create_database_code(
+            display='Test module',
+            value='test_module',
+            codeType=CodeType.MODULE
+        )
+
+        # Make a simple question in the module
+        self.data_generator.create_database_code(
+            display='free text question',
+            value='text_question',
+            codeType=CodeType.QUESTION,
+            parentId=module_code.codeId
+        )
+
+        # Make a topic
+        topic_code = self.data_generator.create_database_code(
+            display='Topic',
+            value='topic_code',
+            codeType=CodeType.TOPIC,
+            parentId=module_code.codeId
+        )
+
+        # Add some questions to the topic
+        self.data_generator.create_database_code(
+            display='topic question one',
+            value='topic_one',
+            codeType=CodeType.QUESTION,
+            parentId=topic_code.codeId
+        )
+        self.data_generator.create_database_code(
+            display='topic question two',
+            value='topic_two',
+            codeType=CodeType.QUESTION,
+            parentId=topic_code.codeId
+        )
+
+        # Run the back fill to create the survey objects for the codes
+        self.run_tool(SurveyBackFill, tool_args={
+            'module_code': 'test_module'
+        })
+
+        # Check that all the expected questions were created for the survey
+        survey: Survey = self.session.query(Survey).one()
+        self.assertEqual('free text question', survey.questions[0].display)
+        self.assertEqual('topic question one', survey.questions[1].display)
+        self.assertEqual('topic question two', survey.questions[2].display)
+


### PR DESCRIPTION
The new Survey objects are designed to capture more information from Redcap, but they're also meant to be a new way of representing the parenting between codes. This adds a tool for creating Survey objects for codes we have in the database so we have one place to look for code hierarchy (whether the codes came from redcap or not).

We won't need the tool after the backfill is complete, so I plan on deleting the tool after it's been used. I wrote the unit tests with that in mind, so they're mostly to let me step through the code while it's running (rather than built for making sure the functionality persists over time).