### PR TITLE
[DA-1905] Control sample fix during AW1 ingestion

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -636,9 +636,10 @@ class GenomicSetMemberDao(UpdatableDao):
             ).all()
         return members
 
-    def get_control_sample(self, sample_id):
+    def get_control_sample_parent(self, genome_type, sample_id):
         """
-        Returns the GenomicSetMember record for a control sample
+        Returns the GenomicSetMember parent record for a control sample
+        :param genome_type:
         :param sample_id:
         :return: GenomicSetMember
         """
@@ -647,8 +648,33 @@ class GenomicSetMemberDao(UpdatableDao):
                 GenomicSetMember
             ).filter(
                 GenomicSetMember.genomicWorkflowState == GenomicWorkflowState.CONTROL_SAMPLE,
-                GenomicSetMember.sampleId == sample_id
-            ).first()
+                GenomicSetMember.sampleId == sample_id,
+                GenomicSetMember.genomeType == genome_type
+            ).one_or_none()
+
+    def get_control_sample_for_gc_and_genome_type(self, _site, genome_type, biobank_id,
+                                                  collection_tube_id, sample_id):
+        """
+        Returns the GenomicSetMember record for a control sample based on
+        GC site, genome type, biobank ID, and collection tube ID.
+
+        :param collection_tube_id:
+        :param biobank_id:
+        :param genome_type:
+        :param sample_id:
+        :return: GenomicSetMember
+        """
+        with self.session() as session:
+            return session.query(
+                GenomicSetMember
+            ).filter(
+                GenomicSetMember.sampleId == sample_id,
+                GenomicSetMember.genomeType == genome_type,
+                GenomicSetMember.gcSiteId == _site,
+                GenomicSetMember.biobankId == biobank_id,
+                GenomicSetMember.collectionTubeId == collection_tube_id,
+                GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE
+            ).one_or_none()
 
 
 class GenomicJobRunDao(UpdatableDao):

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -372,7 +372,6 @@ class GenomicFileIngester:
 
             if control_sample_parent:
                 logging.warning(f"Control sample found: {row_copy['parentsampleid']}")
-                # print(f"Control sample found: {row_copy['parentsampleid']}")
 
                 # Check if the control sample member exists for this GC, BID, collection tube, and sample ID
                 # Since the Biobank is reusing the sample and collection tube IDs (which are supposed to be unique)
@@ -402,7 +401,8 @@ class GenomicFileIngester:
             member = self.member_dao.get_member_from_collection_tube(row_copy['collectiontubeid'],
                                                                      row_copy['testname'])
 
-            # Since not a control sample, check if collection tube id was swapped by Biobank
+            # Since member not found, and not a control sample,
+            # check if collection tube id was swapped by Biobank
             if member is None:
                 bid = row_copy['biobankid']
 
@@ -427,6 +427,8 @@ class GenomicFileIngester:
                     raise ValueError(f"Invalid collection tube ID: {row_copy['collectiontubeid']}, "
                                      f"biobank id: {row_copy['biobankid']}, "
                                      f"genome type: {row_copy['testname']}")
+
+                    # TODO: write to logging table
 
             # Process the attribute data
             member_changed, member = self._process_aw1_attribute_data(row_copy, member)
@@ -917,9 +919,13 @@ class GenomicFileIngester:
 
                 # check whether metrics object exists for that member
                 existing_metrics_obj = self.metrics_dao.get_metrics_by_member_id(member.id)
+
                 if existing_metrics_obj is not None:
+
                     if self.controller.skip_updates:
+                        # when running tool, updates can be skipped
                         continue
+
                     else:
                         metric_id = existing_metrics_obj.id
                 else:
@@ -944,10 +950,10 @@ class GenomicFileIngester:
             else:
                 logging.error(f"No genomic set member for bid,sample_id: "
                               f"{row_copy['biobankid']}, {row_copy['sampleid']}")
-                print(f"No genomic set member for bid,sample_id: "
-                              f"{row_copy['biobankid']}, {row_copy['sampleid']}")
 
-                #return GenomicSubProcessResult.ERROR
+                # TODO: insert into logging table
+
+                return GenomicSubProcessResult.ERROR
 
         return GenomicSubProcessResult.SUCCESS
 

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -364,54 +364,69 @@ class GenomicFileIngester:
             if row_copy['biobankid'] == "":
                 continue
 
-            # Find the existing GenomicSetMember
-            # Set the member based on collection tube ID
-            # row_copy['testname'] is the genome type (i.e. aou_array, aou_wgs)
-            member = self.member_dao.get_member_from_collection_tube(row_copy['collectiontubeid'],
-                                                                     row_copy['testname'])
+            # Check if this sample has a control sample parent tube
+            control_sample_parent = self.member_dao.get_control_sample_parent(
+                row_copy['testname'],
+                int(row_copy['parentsampleid'])
+            )
 
-            # If member not found, check if:
-            #  this is a control sample
-            #  or if collection tube was changed by Biobank
-            if member is None:
-                # Check if this is a new control sample and make new member from it
-                if self._check_if_control_sample(int(row_copy['parentsampleid'])) is not None:
-                    logging.warning(f"Control sample found: {row_copy['parentsampleid']}")
+            if control_sample_parent:
+                logging.warning(f"Control sample found: {row_copy['parentsampleid']}")
+                # print(f"Control sample found: {row_copy['parentsampleid']}")
 
+                # Check if the control sample member exists for this GC, BID, collection tube, and sample ID
+                # Since the Biobank is reusing the sample and collection tube IDs (which are supposed to be unique)
+                cntrl_sample_member = self.member_dao.get_control_sample_for_gc_and_genome_type(
+                    _site,
+                    row_copy['testname'],
+                    row_copy['biobankid'],
+                    row_copy['collectiontubeid'],
+                    row_copy['sampleid']
+                )
+
+                if not cntrl_sample_member:
+                    # Insert new GenomicSetMember record if none exists
+                    # for this control sample, genome type, and gc site
                     member = self.create_new_member_from_aw1_control_sample(row_copy)
 
                     # Update member for PDR
                     bq_genomic_set_member_update(member.id, project_id=self.controller.bq_project_id)
                     genomic_set_member_update(member.id)
 
-                    continue
+                # Skip rest of iteration and go to next row
+                continue
+
+            # Find the existing GenomicSetMember
+            # Set the member based on collection tube ID
+            # row_copy['testname'] is the genome type (i.e. aou_array, aou_wgs)
+            member = self.member_dao.get_member_from_collection_tube(row_copy['collectiontubeid'],
+                                                                     row_copy['testname'])
+
+            # Since not a control sample, check if collection tube id was swapped by Biobank
+            if member is None:
+                bid = row_copy['biobankid']
+
+                # Strip biobank prefix if it's there
+                if bid[0].isalpha():
+                    bid = bid[1:]
+
+                member = self.member_dao.get_member_from_biobank_id_in_state(bid,
+                                                                             row_copy['testname'],
+                                                                             _state)
+
+                # If member found, validate new collection tube ID, set collection tube ID
+                if member:
+                    if self._validate_collection_tube_id(row_copy['collectiontubeid'], bid):
+                        with self.member_dao.session() as session:
+                            self._record_sample_as_contaminated(session, member.collectionTubeId)
+
+                        member.collectionTubeId = row_copy['collectiontubeid']
 
                 else:
-                    # Not a control sample, continue with next check
-                    # Since not a control sample, check if collection tube id was swapped by Biobank
-                    if member is None:
-                        bid = row_copy['biobankid']
-
-                        # Strip biobank prefix if it's there
-                        if bid[0].isalpha():
-                            bid = bid[1:]
-
-                        member = self.member_dao.get_member_from_biobank_id_in_state(bid,
-                                                                                     row_copy['testname'], _state)
-
-                        # If member found, validate new collection tube ID, set collection tube ID
-                        if member:
-                            if self._validate_collection_tube_id(row_copy['collectiontubeid'], bid):
-                                with self.member_dao.session() as session:
-                                    self._record_sample_as_contaminated(session, member.collectionTubeId)
-
-                                member.collectionTubeId = row_copy['collectiontubeid']
-
-                        else:
-                            # Couldn't find genomic set member based on either biobank ID or collection tube
-                            raise ValueError(f"Invalid collection tube ID: {row_copy['collectiontubeid']}, "
-                                             f"biobank id: {row_copy['biobankid']}, "
-                                             f"genome type: {row_copy['testname']}")
+                    # Couldn't find genomic set member based on either biobank ID or collection tube
+                    raise ValueError(f"Invalid collection tube ID: {row_copy['collectiontubeid']}, "
+                                     f"biobank id: {row_copy['biobankid']}, "
+                                     f"genome type: {row_copy['testname']}")
 
             # Process the attribute data
             member_changed, member = self._process_aw1_attribute_data(row_copy, member)
@@ -480,7 +495,7 @@ class GenomicFileIngester:
         # Open file and pull row based on member.biobankId
         with self.controller.storage_provider.open(self.target_file, 'r') as aw1_file:
             reader = csv.DictReader(aw1_file, delimiter=',')
-            row = [r for r in reader if r['Biobank Id'] == str(member.biobankId)][0]
+            row = [r for r in reader if r['BIOBANK_ID'][1:] == str(member.biobankId)][0]
 
             # Alter field names to remove spaces and change to lower case
             row = dict(zip([key.lower().replace(' ', '').replace('_', '')
@@ -903,7 +918,10 @@ class GenomicFileIngester:
                 # check whether metrics object exists for that member
                 existing_metrics_obj = self.metrics_dao.get_metrics_by_member_id(member.id)
                 if existing_metrics_obj is not None:
-                    metric_id = existing_metrics_obj.id
+                    if self.controller.skip_updates:
+                        continue
+                    else:
+                        metric_id = existing_metrics_obj.id
                 else:
                     metric_id = None
 
@@ -926,8 +944,10 @@ class GenomicFileIngester:
             else:
                 logging.error(f"No genomic set member for bid,sample_id: "
                               f"{row_copy['biobankid']}, {row_copy['sampleid']}")
+                print(f"No genomic set member for bid,sample_id: "
+                              f"{row_copy['biobankid']}, {row_copy['sampleid']}")
 
-                return GenomicSubProcessResult.ERROR
+                #return GenomicSubProcessResult.ERROR
 
         return GenomicSubProcessResult.SUCCESS
 
@@ -1030,15 +1050,6 @@ class GenomicFileIngester:
         """
         return self.file_obj.fileName.split('/')[-1].split("_")[0].lower()
 
-    def _check_if_control_sample(self, sample_id):
-        """
-        Checks a sample against the list of control samples
-        In genomic_set_member
-        :param sample_id:
-        :return: True if sample exists, else false.
-        """
-
-        return self.member_dao.get_control_sample(sample_id)
 
     def _validate_collection_tube_id(self, collection_tube_id, bid):
         """

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -61,6 +61,7 @@ class GenomicJobController:
         self.bq_project_id = bq_project_id
         self.task_data = task_data
         self.bypass_record_count = False
+        self.skip_updates = False
 
         self.subprocess_results = set()
         self.job_result = GenomicSubProcessResult.UNSET

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1578,6 +1578,7 @@ class IngestionClass(GenomicManifestBase):
                                               bq_project_id=self.gcp_env.project) as controller:
 
                         controller.bypass_record_count = self.args.bypass_record_count
+                        controller.skip_updates = True
 
                         for member_id in member_ids:
                             self.run_ingestion_for_member_id(controller, member_id, bucket_name)

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1845,18 +1845,19 @@ class GenomicPipelineTest(BaseTestCase):
         # Setup Test file
         gc_manifest_file = test_data.open_genomic_set_file("AW1-Control-Sample-Test.csv")
 
-        gc_manifest_filename = "RDR_AoU_GEN_PKG-1908-218051.csv"
+        fake_filenames = ("RDR_AoU_GEN_PKG-1908-218051.csv", "JH_AoU_GEN_PKG-1908-218051.csv")
 
-        self._write_cloud_csv(
-            gc_manifest_filename,
-            gc_manifest_file,
-            bucket=_FAKE_GENOMIC_CENTER_BUCKET_A,
-            folder=_FAKE_GENOTYPING_FOLDER,
-        )
+        for gc_manifest_filename in fake_filenames:
+            self._write_cloud_csv(
+                gc_manifest_filename,
+                gc_manifest_file,
+                bucket=_FAKE_GENOMIC_CENTER_BUCKET_A,
+                folder=_FAKE_GENOTYPING_FOLDER,
+            )
 
         # Get bucket, subfolder, and filename from argument
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
-        file_name = _FAKE_GENOTYPING_FOLDER + '/' + gc_manifest_filename
+        file_name = _FAKE_GENOTYPING_FOLDER + '/' + fake_filenames[0]
 
         # Set up file/JSON
         task_data = {
@@ -1877,6 +1878,23 @@ class GenomicPipelineTest(BaseTestCase):
         new_member = self.member_dao.get_member_from_collection_tube(1, 'aou_wgs')
 
         self.assertEqual('HG-002', new_member.biobankId)
+
+        # Test new control sample inserted again for different GC
+        file_name = _FAKE_GENOTYPING_FOLDER + '/' + fake_filenames[1]
+        task_data['file_data']['file_path'] = f"{bucket_name}/{file_name}"
+
+        # Call pipeline function twice
+        genomic_pipeline.execute_genomic_manifest_file_pipeline(task_data)  # job_id 3 & 4
+
+        # No new GenomicSetMembers should be inserted in this run
+        genomic_pipeline.execute_genomic_manifest_file_pipeline(task_data)  # job_id 5 & 6
+
+        members = self.member_dao.get_all()
+        members.sort(key=lambda x: x.id)
+
+        self.assertEqual(3, len(members))
+        self.assertEqual('rdr', members[1].gcSiteId)
+        self.assertEqual('jh', members[2].gcSiteId)
 
     def test_aw1f_ingestion_workflow(self):
         # Setup test data: 1 aou_array, 1 aou_wgs


### PR DESCRIPTION
This PR fixes an issue during the AW1 ingestion when a control sample with the same Biobank ID, sample ID, and collection tube ID is provided multiple times for different genome centers.
The AW1 ingestion workflow was updated as follows:
- The logic to determine if the current row's parent sample was a control sample happens first, determining if the row is a control sample.
- If the row is a control sample, there is a check to see if a `genomic_set_member` record has already been created matching the `sample_id`, `biobank_id`, `genome_type`, and `gc_site_id` (genome center, and `collection_tube_id`.
- If a row already exists, the record is skipped, if not, a new `genomic_set_member` record is inserted.