### PR TITLE
Moving unit test sql server port

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,8 +25,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.unittests:
-        # pylint: disable=unused-import
-        import tests.helpers.mysql_helper  # need to execute file to set unittest db connection string
+        from tests.helpers.mysql_helper import configure_unittest_connection_string
+        configure_unittest_connection_string()
         os.environ["UNITTEST_FLAG"] = "1"
     env = dict(os.environ)
 

--- a/main.py
+++ b/main.py
@@ -25,6 +25,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.unittests:
+        # pylint: disable=unused-import
+        import tests.helpers.mysql_helper  # need to execute file to set unittest db connection string
         os.environ["UNITTEST_FLAG"] = "1"
     env = dict(os.environ)
 

--- a/rdr_service/.configs/db_config.json
+++ b/rdr_service/.configs/db_config.json
@@ -1,7 +1,7 @@
 {
     "db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
     "backup_db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
-    "unittest_db_connection_string": "mysql+mysqldb://root@127.0.0.1:9306",
+    "unittest_db_connection_string": "<overridden in tests>",
     "db_password": "rdr!pwd",
     "db_connection_name": "",
     "db_user": "rdr",

--- a/rdr_service/tools/setup_local_database.sh
+++ b/rdr_service/tools/setup_local_database.sh
@@ -51,7 +51,7 @@ trap finish EXIT
 echo "Setting database configuration..."
 echo '{"db_connection_string": "'$DB_CONNECTION_STRING'", ' \
      ' "backup_db_connection_string": "'$DB_CONNECTION_STRING'", ' \
-     ' "unittest_db_connection_string": "'mysql+mysqldb://root@127.0.0.1:9306'",' \
+     ' "unittest_db_connection_string": "'<overridden in tests>'",' \
      ' "db_password": "'$RDR_PASSWORD'", ' \
      ' "db_connection_name": "", '\
      ' "db_user": "'$RDR_DB_USER'", '\

--- a/rdr_service/tools/tool_libs/setup_local_db.py
+++ b/rdr_service/tools/tool_libs/setup_local_db.py
@@ -102,7 +102,7 @@ class SetupLocalDB:  # pylint: disable=too-many-instance-attributes
         return {
             "db_connection_string": self.db_connection_string,
             "backup_db_connection_string": self.db_connection_string,
-            "unittest_db_connection_string": "mysql+mysqldb://root@127.0.0.1:9306",
+            "unittest_db_connection_string": "<overridden in tests>",
             "db_password": self.rdr_password,
             "db_connection_name": "",
             "db_user": self.rdr_db_user,

--- a/tests/.test_configs/db_config.json
+++ b/tests/.test_configs/db_config.json
@@ -1,7 +1,7 @@
 {
     "db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
     "backup_db_connection_string": "mysql+mysqldb://rdr:rdr!pwd@127.0.0.1/?charset=utf8",
-    "unittest_db_connection_string": "mysql+mysqldb://root@127.0.0.1:9306/?charset=utf8",
+    "unittest_db_connection_string": "<overridden in tests>",
     "db_password": "rdr!pwd",
     "db_connection_name": "",
     "db_user": "rdr",

--- a/tests/helpers/mysql_helper.py
+++ b/tests/helpers/mysql_helper.py
@@ -175,6 +175,7 @@ def _initialize_database(with_data=True, with_consent_codes=False):
             initialize = False
         else:
             session = database.make_session()
+            session.execute('USE rdr')
             _clear_data(session)
             session.commit()
             session.close()

--- a/tests/helpers/mysql_helper.py
+++ b/tests/helpers/mysql_helper.py
@@ -48,8 +48,10 @@ BASE_PATH = '{0}/rdr-mysqld'.format(tempfile.gettempdir())
 MYSQL_HOST = "127.0.0.1"  # Do not use 'localhost', we want to force using an IP socket.
 MYSQL_PORT = os.getenv('RDR_UNITTEST_SQL_SERVER_PORT', 10010)
 
-db_conn_str = f'mysql+mysqldb://root@{MYSQL_HOST}:{MYSQL_PORT}/?charset=utf8'
-config.override_setting('unittest_db_connection_string', db_conn_str)
+
+def configure_unittest_connection_string():
+    db_conn_str = f'mysql+mysqldb://root@{MYSQL_HOST}:{MYSQL_PORT}/?charset=utf8'
+    config.override_setting('unittest_db_connection_string', db_conn_str)
 
 
 def start_mysql_instance():
@@ -147,8 +149,10 @@ def _initialize_database(with_data=True, with_consent_codes=False):
     :param with_data: Populate with basic data
     :param with_consent_codes: Populate with consent codes.
     """
-    # Set this so the database factory knows to use the unittest connection string from the config.
+
+    # Set these so the database factory knows to connect to the unittest mysql server instance.
     os.environ["UNITTEST_FLAG"] = "1"
+    configure_unittest_connection_string()
 
     database = database_factory.get_database(db_name=None)
     engine = database.get_engine()


### PR DESCRIPTION
9306 seems to be a default port for Mysql and we can occasionally see another server running there. This updates the unit test code to use another port (10010 by default, but can also be overridden with a environment variable).

The code uses the db_config file when looking for how to connect to the database. That can be overridden, but only if the file originally had something for the key anyway. So these changes needed to leave something in the db_config setup so that it could later be found and overridden.