### PR TITLE
[PDR-235] PDR MIGRATION Support for partial/IN_PROGRESS COPE Survey responses

### DIFF
--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -122,7 +122,7 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
                 data = self.ro_dao.to_dict(qr, result_proxy=responses)
                 # PDR-235:  Adding response status enum values (IN_PROGRESS, COMPLETED, ...)  to the response metadata
                 # dict.  Providing both string and integer key/value pairs, per the PDR BigQuery schema conventions
-                if data['status']:
+                if isinstance(data['status'], int):
                     data['status_id'] = int(QuestionnaireResponseStatus(data['status']))
                     data['status'] = str(QuestionnaireResponseStatus(data['status']))
 
@@ -172,7 +172,9 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
                         'participant_id',
                         'questionnaire_response_id',
                         'questionnaire_id',
-                        'external_id'
+                        'external_id',
+                        'status',
+                        'status_id'
                     ):
                         continue
 

--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -191,12 +191,6 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
                     if fld_name in ('StreetAddress_PIIZIP', 'EmploymentWorkAddress_ZipCode') and len(fld_value) > 2:
                         setattr(bqr, fld_name, fld_value[:3])
 
-                    # PDR-235: Adding status enum values (IN_PROGRESS, COMPLETED, ...)
-                    # Provide both string and integer enum fields, per the PDR BigQuery schema conventions
-                    if fld_name == 'status':
-                        setattr(bqr, fld_name, str(QuestionnaireResponseStatus(fld_value)))
-                        setattr(bqr, 'status_id', int(QuestionnaireResponseStatus(fld_value)))
-
                 bqrs.append(bqr)
                 if latest:
                     break

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -68,6 +68,8 @@ class BQModuleStatusSchema(BQSchema):
     mod_status_id = BQField('mod_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
                             fld_enum=BQModuleStatusEnum)
     mod_external_id = BQField('mod_external_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    mod_response_status = BQField('mod_response_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    mod_response_status_id = BQField('mod_response_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQConsentSchema(BQSchema):
@@ -84,7 +86,8 @@ class BQConsentSchema(BQSchema):
     consent_module_created = BQField('consent_module_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     consent_expired = BQField('consent_expired', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     consent_module_external_id = BQField('consent_module_external_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-
+    consent_response_status = BQField('consent_response_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    consent_response_status_id = BQField('consent_response_status_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
 
 class BQRaceSchema(BQSchema):
     """

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -74,10 +74,14 @@ class _BQModuleSchema(BQSchema):
         fields.append({'name': 'participant_id', 'type': BQFieldTypeEnum.INTEGER.name,
                        'mode': BQFieldModeEnum.REQUIRED.name})
         fields.append({'name': 'questionnaire_response_id', 'type': BQFieldTypeEnum.INTEGER.name,
-                       'mode': BQFieldModeEnum.REQUIRED.name}),
+                       'mode': BQFieldModeEnum.REQUIRED.name})
         fields.append({'name': 'questionnaire_id', 'type': BQFieldTypeEnum.INTEGER.name,
-                       'mode': BQFieldModeEnum.NULLABLE.name}),
+                       'mode': BQFieldModeEnum.NULLABLE.name})
         fields.append({'name': 'external_id', 'type': BQFieldTypeEnum.STRING.name,
+                       'mode': BQFieldModeEnum.NULLABLE.name})
+        fields.append({'name': 'status', 'type': BQFieldTypeEnum.STRING.name,
+                       'mode': BQFieldModeEnum.NULLABLE.name})
+        fields.append({'name': 'status_id', 'type': BQFieldTypeEnum.INTEGER.name,
                        'mode': BQFieldModeEnum.NULLABLE.name})
 
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1220,7 +1220,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                    q.version,
                    qr.authored,
                    qr.language,
-                   qr.participant_id
+                   qr.participant_id,
+                   qr.status
             FROM questionnaire_response qr
                     INNER JOIN questionnaire_concept qc on qr.questionnaire_id = qc.questionnaire_id
                     INNER JOIN questionnaire q on q.questionnaire_id = qc.questionnaire_id

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -42,7 +42,7 @@ from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireH
 from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
     SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus, DeceasedStatus, \
-    DeceasedReportStatus
+    DeceasedReportStatus, QuestionnaireResponseStatus
 from rdr_service.resource import generators, schemas
 from rdr_service.resource.constants import SchemaID
 
@@ -426,9 +426,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # Responses are sorted by authored date ascending and then created date descending
         # This should result in a list where any replays of a response are adjacent (most recently created first)
         query = ro_session.query(
-            QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
-            QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
-                code_id_query). \
+                QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
+                QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
+                QuestionnaireResponse.status, code_id_query). \
             join(QuestionnaireHistory). \
             filter(QuestionnaireResponse.participantId == p_id). \
             order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
@@ -461,7 +461,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     'language': row.language,
                     'status': module_status.name,
                     'status_id': module_status.value,
-                    'external_id': row.externalId
+                    'external_id': row.externalId,
+                    'response_status': str(QuestionnaireResponseStatus(row.status)),
+                    'response_status_id': int(QuestionnaireResponseStatus(row.status))
                 }
 
                 # check if this is a module with consents.
@@ -488,7 +490,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                             'consent_module': module_name,
                             'consent_module_authored': row.authored,
                             'consent_module_created': row.created,
-                            'consent_module_external_id': row.externalId
+                            'consent_module_external_id': row.externalId,
+                            'consent_response_status': str(QuestionnaireResponseStatus(row.status)),
+                            'consent_response_status_id': int(QuestionnaireResponseStatus(row.status))
                         }
                         # Note:  Based on currently available modules when a module has no
                         # associated answer options (like ConsentPII or ProgramUpdate), any submitted response is given

--- a/rdr_service/resource/schemas/questionnaires.py
+++ b/rdr_service/resource/schemas/questionnaires.py
@@ -66,7 +66,10 @@ class _QuestionnaireSchema:
             'authored': fields.DateTime(),
             'language': fields.String(validate=validate.Length(max=2)),
             'participant_id': fields.String(validate=validate.Length(max=10), required=True),
-            'questionnaire_response_id': fields.Int32(required=True)
+            'questionnaire_response_id': fields.Int32(required=True),
+            'questionnaire_id': fields.Int32(required=True),
+            'external_id': fields.String(validate=validate.Length(max=100)),
+            'status': fields.String(validate=validate.Length(max=50))
         }
 
         dao = ResourceDataDao(backup=True)


### PR DESCRIPTION
This updates the PDR data schemas to include QuestionnaireResponseStatus details in the participant module/consent nested records and the BQPDRQuestionnaireResponse data.

This will require a BQ schema migration for the participant and survey module data tables in BigQuery, as well as a full PDR participant data rebuild to populate the new fields.