### PR TITLE
Adding ability to manually sync consents for specific participant ids

### DIFF
--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -225,7 +225,7 @@ def manually_trigger_consent_sync():
     # do_sync_consent_files will filter by any kwargs passed to it, even if they're None.
     # So if something like start_date is passed in as None, it will try to filter by comparing to a start_date of none.
     parameters = {}
-    for field_name in ['all_va', 'start_date', 'end_date']:
+    for field_name in ['all_va', 'start_date', 'end_date', 'ids']:
         if field_name in request_json:
             parameters[field_name] = request_json.get(field_name)
 

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -152,7 +152,7 @@ def get_org_data_map():
     return config.getSettingJson(config.CONSENT_SYNC_BUCKETS)
 
 
-def build_participant_query(session, org_ids, start_date=None, end_date=None, all_va=False):
+def build_participant_query(session, org_ids, start_date=None, end_date=None, all_va=False, ids: list=None):
     participant_query = session.query(
         Participant.participantId,
         Participant.participantOrigin,
@@ -200,6 +200,9 @@ def build_participant_query(session, org_ids, start_date=None, end_date=None, al
         participant_query = participant_query.filter(Organization.externalId.like('VA_%'))
     else:
         participant_query = participant_query.filter(Organization.externalId.in_(org_ids))
+
+    if ids:
+        participant_query = participant_query.filter(Participant.participantId.in_(ids))
 
     return participant_query
 

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -152,7 +152,7 @@ def get_org_data_map():
     return config.getSettingJson(config.CONSENT_SYNC_BUCKETS)
 
 
-def build_participant_query(session, org_ids, start_date=None, end_date=None, all_va=False, ids: list=None):
+def build_participant_query(session, org_ids, start_date=None, end_date=None, all_va=False, ids: list = None):
     participant_query = session.query(
         Participant.participantId,
         Participant.participantOrigin,


### PR DESCRIPTION
Some more tweaking for consent sync to get the server to allow for specifying which participants to sync the consents for.