### PR TITLE
Raising operational error for client request

### DIFF
--- a/tests/dao_tests/test_participant_dao.py
+++ b/tests/dao_tests/test_participant_dao.py
@@ -599,7 +599,7 @@ class ParticipantDaoTest(BaseTestCase):
 
         # Use the error logging to know when the lock timout was triggered,
         # unlock the participant table after the first failure
-        mock_logging.error.side_effect = lambda *_, **__: self.session.commit()
+        mock_logging.warning.side_effect = lambda *_, **__: self.session.commit()
 
         test_client_id = 'lock_wait_test'  # Something unique to use to pull this specific participant from the db
         participant = self.data_generator._participant_with_defaults(


### PR DESCRIPTION
In a recent PR I had operational errors (lock wait timeouts) use the retry loop if something happened. But if the loop hit the same operational error each time it would no longer send back the details, it would instead send the message that it retried multiple times and failed.

This updates the code to check if it's on the last try. If it is then it raises the error (as if it hadn't been in the retry loop).