### PR TITLE
Fix for setup_local_db script errors

### DIFF
--- a/rdr_service/tools/setup_local_database.sh
+++ b/rdr_service/tools/setup_local_database.sh
@@ -51,7 +51,7 @@ trap finish EXIT
 echo "Setting database configuration..."
 echo '{"db_connection_string": "'$DB_CONNECTION_STRING'", ' \
      ' "backup_db_connection_string": "'$DB_CONNECTION_STRING'", ' \
-     ' "unittest_db_connection_string": "'<overridden in tests>'",' \
+     ' "unittest_db_connection_string": "<overridden in tests>",' \
      ' "db_password": "'$RDR_PASSWORD'", ' \
      ' "db_connection_name": "", '\
      ' "db_user": "'$RDR_DB_USER'", '\


### PR DESCRIPTION
I misunderstood the syntax of the bash script in a previous PR. This sets it up so that the text is written to the config file rather than trying to parse it.