### PR TITLE
[PDR-178] PDR MIGRATION Add cabor_authored to PDR participant data

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -21,7 +21,9 @@ from rdr_service.code_constants import (
     EHR_CONSENT_EXPIRED_YES,
     CONSENT_COPE_YES_CODE,
     CONSENT_COPE_NO_CODE,
-    CONSENT_COPE_DEFERRED_CODE
+    CONSENT_COPE_DEFERRED_CODE,
+    CABOR_SIGNATURE_QUESTION_CODE,
+    PMI_SKIP_CODE
 )
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
@@ -440,12 +442,12 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         # "signature" in a ConsentPII, it sets the participant_summary.consent_for_cabor / consent_for_cabor_authored
         # fields and will never update them based on subsequent ConsentPII payloads.  To match RDR in determining
         # the CABoR consent authored date, we can't rely on "layered" answers returned by get_module_answers().
-        # Instead we'll go back through the raw response dict of dicts; top level key is a questionnaire_response_id,
-        # its value is a dict of key/value pairs (metadata fields and answers) associated with that response
+        # Instead we'll go back through the raw responses dict of dicts; top level key is a questionnaire_response_id,
+        # its value is a dict of key/value pairs (metadata and question codes/answers) associated with the response
         # Search for the first response with a signed CABoR (if one exists) and use that response's authored date
         for response_id_key in responses:
             fields = responses.get(response_id_key)
-            if fields.get('ExtraConsent_CABoRSignature', None):
+            if fields.get(CABOR_SIGNATURE_QUESTION_CODE, PMI_SKIP_CODE) != PMI_SKIP_CODE:
                 data['cabor_authored'] = fields.get('authored')
                 break
 

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -395,10 +395,15 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         :param p_id: participant id
         :return: dict
         """
-        qnans = self.get_module_answers(self.ro_dao, 'ConsentPII', p_id, cdm_db_exists=self.cdm_db_exists)
+
+        # PDR-178:  Retrieve both the processed (layered) answers result, and the raw responses. This allows us to
+        # do some extra processing of the ConsentPII data without having to query all over again.
+        qnans, responses = self.get_module_answers(self.ro_dao, 'ConsentPII', p_id, return_responses=True,
+                                        cdm_db_exists=self.cdm_db_exists)
         if not qnans:
             # return the minimum data required when we don't have the questionnaire data.
             return {'email': None, 'is_ghost_id': 0}
+
         qnan = BQRecord(schema=None, data=qnans)  # use only most recent response.
 
         try:
@@ -427,8 +432,22 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                     'addr_zip': qnan.get('StreetAddress_PIIZIP'),
                     'addr_country': 'US'
                 }
-            ]
+            ],
+            'cabor_authored': None
         }
+
+        # PDR-178:  RDR handles CABoR consents a little differently in that once it receives an initial CABoR
+        # "signature" in a ConsentPII, it sets the participant_summary.consent_for_cabor / consent_for_cabor_authored
+        # fields and will never update them based on subsequent ConsentPII payloads.  To match RDR in determining
+        # the CABoR consent authored date, we can't rely on "layered" answers returned by get_module_answers().
+        # Instead we'll go back through the raw response dict of dicts; top level key is a questionnaire_response_id,
+        # its value is a dict of key/value pairs (metadata fields and answers) associated with that response
+        # Search for the first response with a signed CABoR (if one exists) and use that response's authored date
+        for response_id_key in responses:
+            fields = responses.get(response_id_key)
+            if fields.get('ExtraConsent_CABoRSignature', None):
+                data['cabor_authored'] = fields.get('authored')
+                break
 
         return data
 
@@ -440,21 +459,51 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         :return: dict
         """
 
-        code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
-            filter(QuestionnaireResponse.questionnaireId ==
-                   QuestionnaireConcept.questionnaireId).label('codeId')
+        if not self.cdm_db_exists:
+            code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
+                filter(QuestionnaireResponse.questionnaireId ==
+                       QuestionnaireConcept.questionnaireId).label('codeId')
 
-        # Responses are sorted by authored date ascending and then created date descending
-        # This should result in a list where any replays of a response are adjacent (most recently created first)
-        query = ro_session.query(
-                QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
-                QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
-                QuestionnaireResponse.status, code_id_query). \
-            join(QuestionnaireHistory). \
-            filter(QuestionnaireResponse.participantId == p_id). \
-            order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
-        # sql = self.ro_dao.query_to_text(query)
-        results = query.all()
+            # Responses are sorted by authored date ascending and then created date descending
+            # This should result in a list where any replays of a response are adjacent (most recently created first)
+            query = ro_session.query(
+                    QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
+                    QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
+                    QuestionnaireResponse.status, code_id_query). \
+                join(QuestionnaireHistory). \
+                filter(QuestionnaireResponse.participantId == p_id). \
+                order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
+            #sql = self.ro_dao.query_to_text(query)
+            results = query.all()
+
+        # Temporary: Use raw sql instead to facilitate joining across databases to the cdm.tmp_questionnaire_response
+        # table where we have flagged duplicate response payloads sent by PTSC for filtering out during PDR data
+        # rebuilds.  See:  ROC-825
+        else:
+            # This SQL statement is based off of the query_to_text() output for the SQLAlchemy query above, and then
+            # modified to add the additional filtering when joined with cdm.temp_questionnaire_response (and match
+            # expected column names to what the SQLAlchemy query also returns)
+            _raw_sql = """
+                SELECT qr.questionnaire_response_id questionnaireResponseId,
+                       qr.authored,
+                       qr.created,
+                       qr.language,
+                       qh.external_id externalId,
+                       qr.status,
+                  (SELECT max(questionnaire_concept.code_id) AS max_1
+                   FROM questionnaire_concept
+                   WHERE qr.questionnaire_id = questionnaire_concept.questionnaire_id) AS `codeId`
+                FROM questionnaire_response qr
+                INNER JOIN questionnaire_history qh
+                      ON qh.questionnaire_id = qr.questionnaire_id
+                      AND qh.version = qr.questionnaire_version
+                LEFT OUTER JOIN cdm.tmp_questionnaire_response tqr
+                      ON qr.questionnaire_response_id = tqr.questionnaire_response_id
+                WHERE qr.participant_id = :pid
+                      AND (tqr.duplicate is NULL or tqr.duplicate = 0)
+                ORDER BY qr.authored, qr.created DESC;
+            """
+            results = ro_session.execute(_raw_sql, {'pid': p_id})
 
         data = {
             'consent_cohort': BQConsentCohort.UNSET.name,
@@ -1223,7 +1272,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         return data
 
     @staticmethod
-    def get_module_answers(ro_dao, module, p_id, qr_id=None, cdm_db_exists=False):
+    def get_module_answers(ro_dao, module, p_id, qr_id=None, return_responses=False, cdm_db_exists=False):
         """
         Retrieve the questionnaire module answers for the given participant id.  This retrieves all responses to
         the module and applies/layers the answers from each response to the final data dict returned.
@@ -1231,8 +1280,9 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         :param module: Module name
         :param p_id: participant id.
         :param qr_id: questionnaire response id
+        :param return_responses:  Return the responses (unlayered) in addition to the processed answer data
         :param cdm_db_exists: Temporary arg.
-        :return: dict
+        :return: dicts
         """
         _module_info_sql = """
             SELECT DISTINCT qr.questionnaire_id,
@@ -1333,7 +1383,15 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             if qr_id and qr_id == questionnaire_response_id:
                 break
 
-        return data if data else None
+        # Map empty data dict to a None return and return the unlayered raw responses if requested
+        # Returning the raw responses enables some additional special case logic in _prep_consentpii()
+        rtn_data = None
+        if bool(data):
+            rtn_data = data
+        if return_responses:
+            return rtn_data, answers
+        else:
+            return rtn_data
 
     @staticmethod
     def is_replay(prev_data_dict, data_dict, created_key=None):
@@ -1398,6 +1456,7 @@ def rebuild_bq_participant(p_id, ps_bqgen=None, pdr_bqgen=None, project_id=None,
     pdr_bqr = pdr_bqgen.make_bqrecord(p_id, ps_bqr=ps_bqr)
 
     w_dao = BigQuerySyncDao()
+
 
     with w_dao.session() as w_session:
         # save the participant summary record if this is a full rebuild.

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -292,6 +292,9 @@ class BQParticipantSummarySchema(BQSchema):
     # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR
     # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
 
+    # PDR-178:  Add cabor_authored to align with RDR consent_for_cabor / consent_for_cabor_authored
+    cabor_authored = BQField('cabor_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
 
 class BQParticipantSummary(BQTable):
     """ Participant Summary BigQuery Table """

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -159,6 +159,11 @@ class BQPDRParticipantSummarySchema(BQSchema):
     # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR
     # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
 
+    # PDR-178:  CABoR details.  This is part of ConsentPII, but for various reasons the easiest way to align with
+    # RDR CABoR tracking is to surface the appropriate authored date here.  Presence of a date (vs. null/None also
+    # acts as the true/false flag equivalent to RDR participant_summary.consent_for_cabor field
+    cabor_authored = BQField('cabor_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
 
 class BQPDRParticipantSummary(BQTable):
     """ PDR Participant Summary BigQuery Table """

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -22,7 +22,9 @@ from rdr_service.code_constants import (
     EHR_CONSENT_EXPIRED_YES,
     CONSENT_COPE_YES_CODE,
     CONSENT_COPE_NO_CODE,
-    CONSENT_COPE_DEFERRED_CODE
+    CONSENT_COPE_DEFERRED_CODE,
+    CABOR_SIGNATURE_QUESTION_CODE,
+    PMI_SKIP_CODE
 )
 from rdr_service.dao.resource_dao import ResourceDataDao
 # TODO: Replace BQRecord here with a Resource alternative.
@@ -441,11 +443,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # fields and will never update them based on subsequent ConsentPII payloads.  To match RDR in determining
         # the CABoR consent authored date, we can't rely on "layered" answers returned by get_module_answers().
         # Instead we'll go back through the raw response dict of dicts; top level key is a questionnaire_response_id,
-        # its value is a dict of key/value pairs (metadata fields and answers) associated with that response
+        # its value is a dict of key/value pairs (metadata and question codes/answers) associated with the response
         # Search for the first response with a signed CABoR (if one exists) and use that response's authored date
         for response_id_key in responses:
             fields = responses.get(response_id_key)
-            if fields.get('ExtraConsent_CABoRSignature', None):
+            if fields.get(CABOR_SIGNATURE_QUESTION_CODE, PMI_SKIP_CODE) != PMI_SKIP_CODE:
                 data['cabor_authored'] = fields.get('authored')
                 break
 

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -270,6 +270,9 @@ class ParticipantSchema(Schema):
 
     patient_statuses = fields.Nested(PatientStatusSchema)
 
+    # PDR-178:  Add CABoR authored to participant top-level schema
+    cabor_authored = fields.DateTime()
+
     class Meta:
         schema_id = SchemaID.participant
         resource_uri = 'Participant'


### PR DESCRIPTION
This adds support for including an indicator if a participant completed/signed the CA Bill of Rights (CABoR) consent when they submitted their primary consent.

To simplify how this is handled in the PDR participant data and match the RDR logic for determining the `consent_for_cabor_authored` date, the PDR generators will search for the first / earliest ConsentPII response that contained a valid `ExtraConsent_CABorSignature` answer value and include that authored date in the `pdr_participant` data.  

Also: updates PR [#2213](https://github.com/all-of-us/raw-data-repository/pull/2213) for using the `cdm.tmp_questionnaire_response` table to identify duplicate responses that should be omitted when rebuilding PDR participant data. The original PR did not cover all cases where the workaround would improve rebuild performance.

A subset of sandbox participants have been rebuilt using these PDR generator changes