### PR TITLE
[DA-1914] Add optional character to regex pattern to support UW naming convention.

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1854,7 +1854,7 @@ class GenomicReconciler:
 
                     # Naming rule for WGS files:
                     filename_exp = rf"{gc_prefix}_([A-Z]?){metric.biobankId}_{metric.sampleId}" \
-                                   rf"_{metric.GenomicGCValidationMetrics.limsId}_(\d+){file_type_expression}$"
+                                   rf"_{metric.GenomicGCValidationMetrics.limsId}_(\w*)(\d+){file_type_expression}$"
 
                     file_exists = self._get_full_filename_with_expression(filename_exp)
 
@@ -2003,10 +2003,17 @@ class GenomicReconciler:
         """
         filenames = [name for name in self.file_list if re.search(expression, name)]
 
+        def sort_filenames(name):
+            version = name.split('.')[0].split('_')[-1]
+
+            if version[0].isalpha():
+                version = version[1:]
+
+            return int(version)
+
         # Naturally sort the list in descending order of revisions
         # ex: [name_11.ext, name_10.ext, name_9.ext, name_8.ext, etc.]
-        filenames.sort(reverse=True,
-                       key=lambda name: int(name.split('.')[0].split('_')[-1]))
+        filenames.sort(reverse=True, key=sort_filenames)
 
         return filenames[0] if len(filenames) > 0 else 0
 

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1054,11 +1054,11 @@ class GenomicPipelineTest(BaseTestCase):
             f'test_data_folder/RDR_2_1002_10002_1.hard-filtered.vcf.gz',
             f'test_data_folder/RDR_2_1002_10002_1.hard-filtered.vcf.gz.tbi',
             f'test_data_folder/RDR_2_1002_10002_1.hard-filtered.vcf.gz.md5sum',
-            f'test_data_folder/RDR_2_1002_10002_1.vcf.gz',
-            f'test_data_folder/RDR_2_1002_10002_1.vcf.gz.tbi',
-            f'test_data_folder/RDR_2_1002_10002_2.vcf.gz.md5sum',
-            f'test_data_folder/RDR_2_1002_10002_2.cram',
-            f'test_data_folder/RDR_2_1002_10002_2.cram.md5sum',
+            f'test_data_folder/RDR_2_1002_10002_v1.vcf.gz',
+            f'test_data_folder/RDR_2_1002_10002_v1.vcf.gz.tbi',
+            f'test_data_folder/RDR_2_1002_10002_v2.vcf.gz.md5sum',
+            f'test_data_folder/RDR_2_1002_10002_v2.cram',
+            f'test_data_folder/RDR_2_1002_10002_v2.cram.md5sum',
         )
         for f in sequencing_test_files:
             self._write_cloud_csv(f, 'attagc', bucket=bucket_name)


### PR DESCRIPTION
This PR updates the WGS data reconciliation workflow file naming pattern. UW has a different naming convention than the other 2 GCs: they include a "v" before the version, i.e. "..._v1.cram".  Because "v" is not an integer, the sorting function needed to be updated. Because of the inconsistencies between the GCs, the workflow was modified to recognize both file naming conventions.