### PR TITLE
[PDR-261] Fix logic for PDR generator ubr_age_at_consent flag setting

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -1459,7 +1459,6 @@ def rebuild_bq_participant(p_id, ps_bqgen=None, pdr_bqgen=None, project_id=None,
 
     w_dao = BigQuerySyncDao()
 
-
     with w_dao.session() as w_session:
         # save the participant summary record if this is a full rebuild.
         if not patch_data and isinstance(patch_data, dict):

--- a/rdr_service/dao/bq_pdr_participant_summary_dao.py
+++ b/rdr_service/dao/bq_pdr_participant_summary_dao.py
@@ -213,8 +213,10 @@ class BQPDRParticipantSummaryGenerator(BigQueryGenerator):
                         break
 
             if consent_date:
-                age = int((consent_date - ps_bqr.date_of_birth).days / 365)
-                if not 18 <= age <= 65:
+                # PDR-261:  Should not use years (integer) alone;  anyone older than 65 by even a day should be
+                # flagged as UBR, so use float
+                age = (consent_date - ps_bqr.date_of_birth).days / 365
+                if not 18.0 <= age <= 65.0:
                     data['ubr_age_at_consent'] = 1
 
         # pylint: disable=unused-variable

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -70,41 +70,43 @@ class ParticipantResourceClass(object):
         :return: 0 if successful otherwise 1
         """
         try:
-            rebuild_bq_participant(pid, project_id=self.gcp_env.project)
-            rebuild_participant_summary_resource(pid)
+            if not self.args.modules_only:
+                rebuild_bq_participant(pid, project_id=self.gcp_env.project)
+                rebuild_participant_summary_resource(pid)
 
-            mod_bqgen = BQPDRQuestionnaireResponseGenerator()
+            if not self.args.no_modules:
+                mod_bqgen = BQPDRQuestionnaireResponseGenerator()
 
-            # Generate participant questionnaire module response data
+                # Generate participant questionnaire module response data
 
-            modules = (
-                BQPDRConsentPII,
-                BQPDRTheBasics,
-                BQPDRLifestyle,
-                BQPDROverallHealth,
-                BQPDREHRConsentPII,
-                BQPDRDVEHRSharing,
-                BQPDRCOPEMay,
-                BQPDRCOPENov,
-                BQPDRCOPEDec,
-                BQPDRCOPEFeb,
-                BQPDRFamilyHistory,
-                BQPDRPersonalMedicalHistory,
-                BQPDRHealthcareAccess
-            )
+                modules = (
+                    BQPDRConsentPII,
+                    BQPDRTheBasics,
+                    BQPDRLifestyle,
+                    BQPDROverallHealth,
+                    BQPDREHRConsentPII,
+                    BQPDRDVEHRSharing,
+                    BQPDRCOPEMay,
+                    BQPDRCOPENov,
+                    BQPDRCOPEDec,
+                    BQPDRCOPEFeb,
+                    BQPDRFamilyHistory,
+                    BQPDRPersonalMedicalHistory,
+                    BQPDRHealthcareAccess
+                )
 
-            for module in modules:
-                mod = module()
+                for module in modules:
+                    mod = module()
 
-                table, mod_bqrs = mod_bqgen.make_bqrecord(pid, mod.get_schema().get_module_name())
-                if not table:
-                    continue
+                    table, mod_bqrs = mod_bqgen.make_bqrecord(pid, mod.get_schema().get_module_name())
+                    if not table:
+                        continue
 
-                w_dao = BigQuerySyncDao()
-                with w_dao.session() as w_session:
-                    for mod_bqr in mod_bqrs:
-                        mod_bqgen.save_bqrecord(mod_bqr.questionnaire_response_id, mod_bqr, bqtable=table,
-                                                w_dao=w_dao, w_session=w_session, project_id=self.gcp_env.project)
+                    w_dao = BigQuerySyncDao()
+                    with w_dao.session() as w_session:
+                        for mod_bqr in mod_bqrs:
+                            mod_bqgen.save_bqrecord(mod_bqr.questionnaire_response_id, mod_bqr, bqtable=table,
+                                                    w_dao=w_dao, w_session=w_session, project_id=self.gcp_env.project)
         except NotFound:
             return 1
         return 0
@@ -832,6 +834,10 @@ def run():
     rebuild_parser.add_argument("--pid", help="rebuild single participant id", type=int, default=None)  # noqa
     rebuild_parser.add_argument("--all-pids", help="rebuild all participants", default=False,
                                 action="store_true")  # noqa
+    rebuild_parser.add_argument("--no-modules", default=False, action="store_true",
+                                help="do not rebuild participant questionnaire response data for pdr_mod_* tables")
+    rebuild_parser.add_argument("--modules-only", default=False, action="store_true",
+                                help="only rebuild participant questionnaire response data for pdr_mod_* tables")
     update_argument(rebuild_parser, dest='from_file',
                     help="rebuild participant ids from a file with a list of pids")
 


### PR DESCRIPTION
Adjust `ubr_age_at_consent` calculation so people over 65 (but not yet 66) are counted in UBR group

Also:  add options to `resource participant` tool restrict rebuilding of participant data to just the `pdr_participant`  data record (`--no-modules` option), or just the questionnaires (`pdr_mod_*` records ) for a participant but not their `pdr_participant` data (`--modules-only `option)