### PR TITLE
[DA-1921] workspace_backfill

### DIFF
--- a/rdr_service/api/workbench_api.py
+++ b/rdr_service/api/workbench_api.py
@@ -1,5 +1,6 @@
 from rdr_service import app_util
 from rdr_service import clock
+from flask import request
 from rdr_service.api.base_api import BaseApi
 from rdr_service.api_util import WORKBENCH_AND_REDCAP
 from rdr_service.dao.bq_workbench_dao import rebuild_bq_workpaces, rebuild_bq_wb_researchers
@@ -16,6 +17,9 @@ class WorkbenchWorkspaceApi(BaseApi):
         now = clock.CLOCK.now()
         metadata_dao = MetadataDao()
         metadata_dao.upsert(WORKBENCH_LAST_SYNC_KEY, date_value=now)
+        backfill_arg = request.args.get('backfill')
+        is_backfill = True if backfill_arg and backfill_arg.lower() == 'true' else False
+        self.dao.is_backfill = is_backfill
         return super().post()
 
     def _do_insert(self, m):

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -35,6 +35,8 @@ from rdr_service.participant_enums import WorkbenchWorkspaceStatus, WorkbenchWor
 class WorkbenchWorkspaceDao(UpdatableDao):
     def __init__(self):
         super().__init__(WorkbenchWorkspaceApproved, order_by_ending=["id"])
+        self.is_backfill = False
+        self.workspace_snapshot_dao = WorkbenchWorkspaceHistoryDao()
 
     def get_id(self, obj):
         return obj.id
@@ -258,16 +260,21 @@ class WorkbenchWorkspaceDao(UpdatableDao):
 
     def insert_with_session(self, session, workspaces):
         new_workspaces = []
-        workspace_snapshot_dao = WorkbenchWorkspaceHistoryDao()
         for workspace in workspaces:
-            is_exist = workspace_snapshot_dao.is_snapshot_exist_with_session(session, workspace.workspaceSourceId,
-                                                                             workspace.modifiedTime)
-            if is_exist:
-                continue
-            session.add(workspace)
-            new_workspaces.append(workspace)
-            if workspace.excludeFromPublicDirectory is not True:
-                self.add_approved_workspace_with_session(session, workspace)
+            if self.is_backfill:
+                backfilled_snapshot = self.backfill_workspace_with_session(session, workspace)
+                if backfilled_snapshot:
+                    new_workspaces.append(backfilled_snapshot)
+            else:
+                is_exist = self.workspace_snapshot_dao.get_exist_snapshot_with_session(session,
+                                                                                       workspace.workspaceSourceId,
+                                                                                       workspace.modifiedTime)
+                if is_exist:
+                    continue
+                session.add(workspace)
+                new_workspaces.append(workspace)
+                if workspace.excludeFromPublicDirectory is not True:
+                    self.add_approved_workspace_with_session(session, workspace)
 
         return new_workspaces
 
@@ -639,6 +646,23 @@ class WorkbenchWorkspaceDao(UpdatableDao):
             "data": expected_result
         }
 
+    def backfill_workspace_with_session(self, session, backfilled_workspace):
+        exist_approved = self.get_workspace_by_workspace_id_with_session(session,
+                                                                         backfilled_workspace.workspaceSourceId)
+        if exist_approved:
+            for k, v in backfilled_workspace:
+                if k not in ('id', 'workbenchWorkspaceUser', 'excludeFromPublicDirectory', 'isReviewed'):
+                    setattr(exist_approved, k, v)
+
+        exist_snapshot = self.workspace_snapshot_dao.get_exist_snapshot_with_session(
+            session, backfilled_workspace.workspaceSourceId, backfilled_workspace.modifiedTime)
+        if exist_snapshot:
+            for k, v in backfilled_workspace:
+                if k not in ('id', 'workbenchWorkspaceUser', 'excludeFromPublicDirectory', 'isReviewed'):
+                    setattr(exist_snapshot, k, v)
+
+        return exist_snapshot
+
     def add_approved_workspace_with_session(self, session, workspace_snapshot, is_reviewed=False):
         exist = self.get_workspace_by_workspace_id_with_session(session, workspace_snapshot.workspaceSourceId)
 
@@ -688,12 +712,13 @@ class WorkbenchWorkspaceHistoryDao(UpdatableDao):
             .options(subqueryload(WorkbenchWorkspaceSnapshot.workbenchWorkspaceUser)) \
             .filter(WorkbenchWorkspaceSnapshot.id == snapshot_id).first()
 
-    def is_snapshot_exist_with_session(self, session, workspace_id, modified_time):
+    def get_exist_snapshot_with_session(self, session, workspace_id, modified_time):
         record = session.query(WorkbenchWorkspaceSnapshot) \
+            .options(subqueryload(WorkbenchWorkspaceSnapshot.workbenchWorkspaceUser))\
             .filter(WorkbenchWorkspaceSnapshot.workspaceSourceId == workspace_id,
                     WorkbenchWorkspaceSnapshot.modifiedTime == modified_time) \
             .first()
-        return True if record else False
+        return record
 
     def get_all_with_children(self):
         with self.session() as session:

--- a/tests/api_tests/test_workbench_api.py
+++ b/tests/api_tests/test_workbench_api.py
@@ -516,6 +516,182 @@ class WorkbenchApiTest(BaseTestCase):
             self.assertEqual(results[2].workbenchWorkspaceUser[0].role, WorkbenchWorkspaceUserRole.WRITER)
             self.assertEqual(results[2].workbenchWorkspaceUser[1].role, WorkbenchWorkspaceUserRole.READER)
 
+    def test_backfill_workspace(self):
+        # create researchers first
+        researchers_json = [
+            {
+                "userId": 1,
+                "creationTime": "2019-11-26T21:21:13.056Z",
+                "modifiedTime": "2019-11-26T21:21:13.056Z",
+                "givenName": "string_modify",
+                "familyName": "string_modify",
+                "streetAddress1": "string",
+                "streetAddress2": "string",
+                "city": "string",
+                "state": "string",
+                "zipCode": "string",
+                "country": "string",
+                "ethnicity": "HISPANIC",
+                "gender": ["MAN"],
+                "race": ["ASIAN"],
+                "affiliations": [
+                    {
+                        "institution": "string_modify",
+                        "role": "string",
+                        "nonAcademicAffiliation": True
+                    }
+                ]
+            }
+        ]
+        self.send_post('workbench/directory/researchers', request_data=researchers_json)
+
+        # test create workspace
+        request_json = [
+            {
+                "workspaceId": 1,
+                "name": "string",
+                "creationTime": "2019-11-25T17:43:41.085Z",
+                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "status": "ACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 1,
+                        "role": "READER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "creator": {
+                    "userId": 1,
+                    "givenName": "aaa",
+                    "familyName": "bbb"
+                },
+                "excludeFromPublicDirectory": False,
+                "ethicalLegalSocialImplications": True,
+                "reviewRequested": True,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "string",
+                "otherPurposeDetails": "string",
+                "methodsDevelopment": True,
+                "controlSet": True,
+                "ancestry": True,
+                "socialBehavioral": True,
+                "populationHealth": True,
+                "drugDevelopment": True,
+                "commercialPurpose": True,
+                "educational": True,
+                "otherPurpose": True,
+                "scientificApproaches": 'string',
+                "intendToStudy": 'string',
+                "findingsFromStudy": 'string',
+                "focusOnUnderrepresentedPopulations": True,
+                "workspaceDemographic": {
+                    "raceEthnicity": ['AIAN', 'MENA'],
+                    "age": ['AGE_0_11', 'AGE_65_74'],
+                    "sexAtBirth": "INTERSEX",
+                    "genderIdentity": "OTHER_THAN_MAN_WOMAN",
+                    "sexualOrientation": "OTHER_THAN_STRAIGHT",
+                    "geography": "RURAL",
+                    "disabilityStatus": "DISABILITY",
+                    "accessToCare": "NOT_EASILY_ACCESS_CARE",
+                    "educationLevel": "LESS_THAN_HIGH_SCHOOL",
+                    "incomeLevel": "BELOW_FEDERAL_POVERTY_LEVEL_200_PERCENT",
+                    "others": "string"
+                },
+                "cdrVersionName": "irving"
+            }
+        ]
+
+        self.send_post('workbench/directory/workspaces', request_data=request_json)
+
+        workspace_dao = WorkbenchWorkspaceDao()
+        results = workspace_dao.get_all_with_children()
+        self.assertEqual(workspace_dao.count(), 1)
+        self.assertEqual(results[0].workspaceSourceId, 1)
+        self.assertEqual(results[0].name, 'string')
+        self.assertEqual(results[0].ethicalLegalSocialImplications, True)
+        self.assertEqual(results[0].scientificApproaches, 'string')
+        self.assertEqual(results[0].intendToStudy, 'string')
+        self.assertEqual(results[0].cdrVersion, 'irving')
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].userId, 1)
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].isCreator, True)
+
+        workspace_history_dao = WorkbenchWorkspaceHistoryDao()
+        results = workspace_history_dao.get_all_with_children()
+        self.assertEqual(workspace_history_dao.count(), 1)
+        self.assertEqual(results[0].workspaceSourceId, 1)
+        self.assertEqual(results[0].name, 'string')
+        self.assertEqual(results[0].scientificApproaches, 'string')
+        self.assertEqual(results[0].intendToStudy, 'string')
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].userId, 1)
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].isCreator, True)
+        self.assertEqual('irving', results[0].cdrVersion)
+
+        # test backfill workspace
+        update_json = [
+            {
+                "workspaceId": 1,
+                "name": "string_modify",
+                "creationTime": "2019-11-25T17:43:41.085Z",
+                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "status": "ACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 1,
+                        "role": "READER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "creator": {
+                    "userId": 1,
+                    "givenName": "aaa",
+                    "familyName": "bbb"
+                },
+                "excludeFromPublicDirectory": False,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "string",
+                "otherPurposeDetails": "string",
+                "methodsDevelopment": True,
+                "controlSet": True,
+                "ancestry": True,
+                "socialBehavioral": True,
+                "populationHealth": True,
+                "drugDevelopment": True,
+                "commercialPurpose": True,
+                "educational": True,
+                "otherPurpose": True,
+                "scientificApproaches": 'string2',
+                "intendToStudy": 'string2',
+                "findingsFromStudy": 'string2',
+                "focusOnUnderrepresentedPopulations": True,
+                "workspaceDemographic": {
+
+                },
+                "cdrVersionName": "irving2"
+            }
+        ]
+
+        self.send_post('workbench/directory/workspaces?backfill=true', request_data=update_json)
+        workspace_dao = WorkbenchWorkspaceDao()
+        self.assertEqual(workspace_dao.count(), 1)
+        results = workspace_dao.get_all_with_children()
+        self.assertEqual(results[0].workspaceSourceId, 1)
+        self.assertEqual(results[0].name, 'string_modify')
+        self.assertEqual(results[0].scientificApproaches, 'string2')
+        self.assertEqual(len(results[0].workbenchWorkspaceUser), 1)
+        self.assertEqual(results[0].cdrVersion, 'irving2')
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].userId, 1)
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].isCreator, True)
+
+        workspace_history_dao = WorkbenchWorkspaceHistoryDao()
+        results = workspace_history_dao.get_all_with_children()
+        self.assertEqual(workspace_history_dao.count(), 1)
+        self.assertEqual(results[0].workspaceSourceId, 1)
+        self.assertEqual(results[0].name, 'string_modify')
+        self.assertEqual(results[0].scientificApproaches, 'string2')
+        self.assertEqual(results[0].cdrVersion, 'irving2')
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].userId, 1)
+        self.assertEqual(results[0].workbenchWorkspaceUser[0].isCreator, True)
+
     def test_invalid_input_for_workspace(self):
         request_json = [
             {


### PR DESCRIPTION
workbench workspace silent backfill without sending the record to REDCap for review.
Add a query parameter to the workbench workspace sync API, like `url?backfill=true` for silent backfill.