### PR TITLE
[DA-1911] Data-dictionary updater

### DIFF
--- a/rdr_service/model/bigquery_sync.py
+++ b/rdr_service/model/bigquery_sync.py
@@ -9,6 +9,7 @@ class BigQuerySync(Base):
     BigQuery synchronization table
     """
     __tablename__ = 'bigquery_sync'
+    __rdr_internal_table__ = True
 
     # Primary Key
     id = Column('id', Integer, primary_key=True, autoincrement=True, nullable=False)

--- a/rdr_service/model/biobank_mail_kit_order.py
+++ b/rdr_service/model/biobank_mail_kit_order.py
@@ -67,7 +67,10 @@ class BiobankMailKitOrder(Base):
     """PTSC payload; device name"""
     # itemReference/Device/Identifier[0] (system=SKU)
     itemSKUCode = Column("item_sku_code", String(80), nullable=True)
-    """Sku of the order"""
+    """
+    Sku of the order
+    @rdr_dictionary_show_unique_values
+    """
     # itemReference/Device/Identifier[1] (system=SNOMED)
     itemSNOMEDCode = Column("item_snomed_code", String(80), nullable=True)
     """snomed code"""
@@ -114,13 +117,17 @@ class BiobankMailKitOrder(Base):
     """
     Whether it was part of a salivary order or the salivary pilot; easy way to filter DVs out of biobank_orders
     (if it contains value here, it should be a DV order)
+    @rdr_dictionary_show_unique_values
     """
 
     orderStatus = Column("order_status", Enum(OrderShipmentStatus), default=OrderShipmentStatus.UNSET)
     """The fulfillment status of the order"""
 
     shipmentCarrier = Column("shipment_carrier", String(80), nullable=True)
-    """The carrier for the biobank order shipment; which carrier to query for order_status"""
+    """
+    The carrier for the biobank order shipment; which carrier to query for order_status
+    @rdr_dictionary_show_unique_values
+    """
 
     shipmentEstArrival = Column("shipment_est_arrival", DateTime, nullable=True)
     """The estimated arrival datetime for the shipment"""
@@ -146,7 +153,10 @@ class BiobankMailKitOrder(Base):
     """
 
     biobankStatus = Column("biobank_status", String(30), nullable=True)
-    """Response from the Mayo Clinic API about the RDR creating the biobank order"""
+    """
+    Response from the Mayo Clinic API about the RDR creating the biobank order
+    @rdr_dictionary_show_unique_values
+    """
 
     biobankReceived = Column("biobank_received", UTCDateTime6, nullable=True)
     """The datetime when the biobank order was received"""

--- a/rdr_service/model/biobank_order.py
+++ b/rdr_service/model/biobank_order.py
@@ -95,7 +95,10 @@ class BiobankOrderBase(object):
     """
 
     orderOrigin = Column("order_origin", String(80))
-    """Where it came from - HealthPro, etc."""
+    """
+    Where it came from - HealthPro, etc.
+    @rdr_dictionary_show_unique_values
+    """
 
     @declared_attr
     def participantId(cls):
@@ -113,6 +116,7 @@ class BiobankOrderBase(object):
     # For syncing new orders.
     @declared_attr
     def logPositionId(cls):
+        """@rdr_dictionary_internal_column"""
         return Column("log_position_id", Integer, ForeignKey("log_position.log_position_id"), nullable=False)
 
     # The site that created the order -- createdInfo['site'] in the resulting JSON
@@ -186,7 +190,10 @@ class BiobankQuestOrderSiteAddress(Base):
 
 class BiobankOrderIdentifierBase(object):
     system = Column("system", String(80), primary_key=True)
-    """Whether the order originated from Mayo Clinic or HealthPro"""
+    """
+    Whether the order originated from Mayo Clinic or HealthPro
+    @rdr_dictionary_show_unique_values
+    """
     value = Column("value", String(80), primary_key=True, index=True)
     """The internal ID of the system"""
 
@@ -218,6 +225,7 @@ class BiobankOrderedSampleBase(object):
     """
     What the test ordered is.
     Unique within an order, though the same test may be redone in another order for the participant.
+    @rdr_dictionary_show_unique_values
     """
 
     description = Column("description", UnicodeText, nullable=False)

--- a/rdr_service/model/biobank_stored_sample.py
+++ b/rdr_service/model/biobank_stored_sample.py
@@ -57,7 +57,10 @@ class BiobankStoredSample(Base):
     As requested/suggested by Mayo, it should be 12 alphanumeric characters long
     """
     test = Column("test", String(80), nullable=False, index=True)
-    """The name of the test run to produce this sample"""
+    """
+    The name of the test run to produce this sample
+    @rdr_dictionary_show_unique_values
+    """
 
     # Timestamp when Biobank finished receiving/preparing the sample (status changed from "In Prep"
     # to "In Circulation" in Mayo). This is the end time used for order-to-sample latency measurement.
@@ -107,6 +110,7 @@ class BiobankStoredSampleStatusImportTmp(Base):
     This table will store the data from these old inventory files in the RDR.
     """
     __tablename__ = "biobank_stored_sample_status_import_tmp"
+    __rdr_internal_table__ = True
 
     id = Column('id', Integer, primary_key=True, autoincrement=True, nullable=False)
 

--- a/rdr_service/model/code.py
+++ b/rdr_service/model/code.py
@@ -45,6 +45,9 @@ class _CodeBase(object):
 
     codeId = Column("code_id", Integer, primary_key=True)
     system = Column("system", String(255), nullable=False)
+    """
+    @rdr_dictionary_show_unique_values
+    """
     value = Column("value", String(80), nullable=False)
     # OMOP codes are supposed to be at most 50 characters long; for legacy codes that exceeded this
     # limit, we populate a shortened version for use in OMOP here. Otherwise, shortValue is identical

--- a/rdr_service/model/hpo.py
+++ b/rdr_service/model/hpo.py
@@ -15,9 +15,13 @@ class HPO(Base):
     name = Column("name", String(20))
     """
     An identifier for the HPO (just the resource id, like PITT — not a reference like Organization/PITT)
+    @rdr_dictionary_show_unique_values
     """
     displayName = Column("display_name", String(255))
-    """The hpo display name"""
+    """
+    The hpo display name
+    @rdr_dictionary_show_unique_values
+    """
     organizationType = Column("organization_type", Enum(OrganizationType), default=OrganizationType.UNSET)
     """The type of organization responsible for signing up participants"""
     organizations = relationship("Organization", cascade="all, delete-orphan", order_by="Organization.externalId")

--- a/rdr_service/model/metrics.py
+++ b/rdr_service/model/metrics.py
@@ -37,6 +37,7 @@ class MetricsBucket(Base):
   """
 
     __tablename__ = "metrics_bucket"
+    __rdr_internal_table__ = True
     metricsVersionId = Column(
         "metrics_version_id",
         Integer,

--- a/rdr_service/model/metrics_cache.py
+++ b/rdr_service/model/metrics_cache.py
@@ -10,6 +10,7 @@ class MetricsEnrollmentStatusCache(Base):
   """
 
     __tablename__ = "metrics_enrollment_status_cache"
+    __rdr_internal_table__ = True
     dateInserted = Column("date_inserted", UTCDateTime, default=clock.CLOCK.now, nullable=False, primary_key=True)
     hpoId = Column("hpo_id", String(20), primary_key=True)
     hpoName = Column("hpo_name", String(255), primary_key=True)
@@ -26,6 +27,7 @@ class MetricsRaceCache(Base):
   """
 
     __tablename__ = "metrics_race_cache"
+    __rdr_internal_table__ = True
     dateInserted = Column("date_inserted", UTCDateTime, default=clock.CLOCK.now, nullable=False, primary_key=True)
     type = Column("type", String(50), primary_key=True)
     registeredFlag = Column("registered_flag", Boolean, nullable=False, primary_key=True)
@@ -56,6 +58,7 @@ class MetricsGenderCache(Base):
   """
 
     __tablename__ = "metrics_gender_cache"
+    __rdr_internal_table__ = True
     dateInserted = Column("date_inserted", UTCDateTime, default=clock.CLOCK.now, nullable=False, primary_key=True)
     type = Column("type", String(50), primary_key=True)
     enrollment_status = Column("enrollment_status", String(50), primary_key=True, default="")
@@ -72,6 +75,7 @@ class MetricsAgeCache(Base):
   """
 
     __tablename__ = "metrics_age_cache"
+    __rdr_internal_table__ = True
     dateInserted = Column("date_inserted", UTCDateTime, default=clock.CLOCK.now, nullable=False, primary_key=True)
     enrollment_status = Column("enrollment_status", String(50), primary_key=True, default="")
     type = Column("type", String(50), primary_key=True)
@@ -88,6 +92,7 @@ class MetricsRegionCache(Base):
   """
 
     __tablename__ = "metrics_region_cache"
+    __rdr_internal_table__ = True
     dateInserted = Column("date_inserted", UTCDateTime, default=clock.CLOCK.now, nullable=False, primary_key=True)
     enrollmentStatus = Column("enrollment_status", String(50), primary_key=True, default="")
     hpoId = Column("hpo_id", String(20), primary_key=True)
@@ -103,6 +108,7 @@ class MetricsLanguageCache(Base):
   """
 
     __tablename__ = "metrics_language_cache"
+    __rdr_internal_table__ = True
     dateInserted = Column("date_inserted", UTCDateTime, default=clock.CLOCK.now, nullable=False, primary_key=True)
     enrollmentStatus = Column("enrollment_status", String(50), primary_key=True, default="")
     hpoId = Column("hpo_id", String(20), primary_key=True)
@@ -117,6 +123,7 @@ class MetricsLifecycleCache(Base):
     """
 
     __tablename__ = "metrics_lifecycle_cache"
+    __rdr_internal_table__ = True
     dateInserted = Column("date_inserted", UTCDateTime, default=clock.CLOCK.now, nullable=False, primary_key=True)
     enrollmentStatus = Column('enrollment_status', String(50), primary_key=True, default='')
     type = Column("type", String(50), primary_key=True)
@@ -144,6 +151,7 @@ class MetricsLifecycleCache(Base):
 
 class MetricsCacheJobStatus(Base):
     __tablename__ = "metrics_cache_job_status"
+    __rdr_internal_table__ = True
     id = Column("id", Integer, primary_key=True, autoincrement=True, nullable=False)
     cacheTableName = Column("cache_table_name", String(100), nullable=False)
     type = Column("type", String(50))

--- a/rdr_service/model/organization.py
+++ b/rdr_service/model/organization.py
@@ -14,7 +14,10 @@ class Organization(Base):
     organizationId = Column("organization_id", Integer, primary_key=True)
     # External ID for the organization, e.g. WISC_MADISON
     externalId = Column("external_id", String(80), nullable=False)
-    """Vibrent's internal ID for organizations"""
+    """
+    Vibrent's internal ID for organizations
+    @rdr_dictionary_show_unique_values
+    """
     displayName = Column("display_name", String(255), nullable=False)
     """Human readable display name for the organization, e.g. University of Wisconsin, Madison"""
     hpoId = Column("hpo_id", Integer, ForeignKey("hpo.hpo_id"), nullable=False)

--- a/rdr_service/model/participant.py
+++ b/rdr_service/model/participant.py
@@ -67,6 +67,7 @@ class ParticipantBase(object):
     participantOrigin = Column("participant_origin", String(80), nullable=False)
     """
     The originating resource for participant, this (unlike clientId) will not change.
+    @rdr_dictionary_show_unique_values
     """
 
     # Default values for withdrawal and suspension are managed through the DAO (instead of column

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -177,7 +177,10 @@ class ParticipantSummary(Base):
     """The email address participant provided to register; they must provide an email or a login_phone_number"""
 
     primaryLanguage = Column("primary_language", String(80))
-    """Indicates the language of the consent that the participant signed. We only have "en" or "es" for now."""
+    """
+    Indicates the language of the consent that the participant signed. We only have "en" or "es" for now.
+    @rdr_dictionary_show_unique_values
+    """
 
     recontactMethodId = Column("recontact_method_id", Integer, ForeignKey("code.code_id"))
     """Which method the participant would like used for contact, i.e., phone or email"""
@@ -292,7 +295,7 @@ class ParticipantSummary(Base):
     """
     Depends on a number of factors including questionnaires and biobank samples completed
 
-    :ref:`Enumerated values <enrollment_status>`
+    :ref:`Enumerated values <enrollment_status>
     """
 
     enrollmentStatusMemberTime = Column("enrollment_status_member_time", UTCDateTime)
@@ -490,7 +493,10 @@ class ParticipantSummary(Base):
 
     # The originating resource for participant, this (unlike clientId) will not change.
     participantOrigin = Column("participant_origin", String(80), nullable=False)
-    """The sign up portal the participant used to enroll (Vibrent, Care Evolution)."""
+    """
+    The sign up portal the participant used to enroll (Vibrent, Care Evolution).
+    @rdr_dictionary_show_unique_values
+    """
 
     # Note: leaving for future use if we go back to using a relationship to PatientStatus table.
     # # patientStatuses = relationship("PatientStatus", back_populates="participantSummary")

--- a/rdr_service/model/patient_status.py
+++ b/rdr_service/model/patient_status.py
@@ -32,6 +32,9 @@ class PatientStatus(Base, ModelMixin):
     """Reference to a physical location pairing level below organization"""
     comment = Column("comment", Text, nullable=True)
     authored = Column("authored", UTCDateTime)
+    """
+    The exact time a patient status was entered for HealthPro, to support enrollment information sharing across sites
+    """
     user = Column("user", String(80), nullable=False)
     """PMI Ops email that sent the data from the site"""
 

--- a/rdr_service/model/requests_log.py
+++ b/rdr_service/model/requests_log.py
@@ -10,6 +10,7 @@ class RequestsLog(Base):
   """
 
     __tablename__ = "requests_log"
+    __rdr_internal_table__ = True
 
     # Primary Key
     id = Column("id", Integer, primary_key=True, autoincrement=True, nullable=False)

--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -283,4 +283,5 @@ class DataDictionaryUpdater:
         ) as sheet:
             self._populate_schema_tabs(sheet)
             self._populate_hpo_key_tab(sheet)
+            self._populate_site_key_tab(sheet)
             self._populate_questionnaire_key_tab(sheet)

--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import joinedload
 from rdr_service.model.base import Base
 from rdr_service.model.code import Code
 from rdr_service.model.hpo import HPO
-from rdr_service.model.questionnaire import Questionnaire
+from rdr_service.model.questionnaire import QuestionnaireHistory
 from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.model.site import Site
 from rdr_service.services.google_sheets_client import GoogleSheetsClient
@@ -151,7 +151,7 @@ class DataDictionaryUpdater:
         ]))
         # Display the target column names of foreign keys
         sheet.update_cell(current_row, 12, ', '.join([
-            foreign_key.column.name.ljust(20) for foreign_key in reflected_column.foreign_keys
+            foreign_key.column.name for foreign_key in reflected_column.foreign_keys
         ]))
 
         is_deprecated, deprecation_note = self._get_deprecation_status_and_note(reflected_table_name)
@@ -178,7 +178,7 @@ class DataDictionaryUpdater:
         return False
 
     def _populate_questionnaire_key_tab(self, sheet: GoogleSheetsClient):
-        query = self.session.query(Questionnaire).options(joinedload(Questionnaire.concepts))
+        query = self.session.query(QuestionnaireHistory).options(joinedload(QuestionnaireHistory.concepts))
         questionnaire_data_list = query.all()
         sheet.set_current_tab(questionnaire_key_tab_id)
         for row_number, questionnaire_data in enumerate(questionnaire_data_list):

--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -33,6 +33,7 @@ class DataDictionaryUpdater:
             'metrics_lifecycle_cache_bak',
             'metrics_race_cache_bak',
             'metrics_region_cache_bak',
+            'ptsc_cohort',
             'temp_debug_bigquery_sync',
             'tmp_participants'
         ]

--- a/rdr_service/services/google_sheets_client.py
+++ b/rdr_service/services/google_sheets_client.py
@@ -15,10 +15,15 @@ class GoogleSheetsClient:
     currently work (such as formula manipulation and making new tabs).
     """
 
-    def __init__(self, spreadsheet_id, service_key_id):
+    def __init__(self, spreadsheet_id, service_key_id, tab_offsets=None):
         """
         :param spreadsheet_id: Google Drive id of the spreadsheet.
         :param service_key_id: Key id for the service account used.
+        :type tab_offsets: Dictionary specifying tab names and offsets for them (defined in Google Sheet cell
+                notation such as B4). Giving a cell value will specify that any changes for that tab use that cell
+                as the origin. So with an origin of B4 an update to C5 would be given as row 1 and column 1.
+                Used to prevent updating headers in the target spreadsheet.
+                WARNING: Does not support columns past Z
         """
 
         # Load credentials from service key file
@@ -33,6 +38,11 @@ class GoogleSheetsClient:
         self._default_tab_id = None
         self._tabs = None
         self._empty_cell_value = ''
+        self._tab_offsets = {tab_name: {
+            'row': int(offset[1:]) - 1,  # convert row number specified in a system of counting from 1
+            'col': ord(offset[:1].upper()) - ord('A'),  # Get column number (A = 0, B = 1, ...)
+            'offset_str': offset
+        } for tab_name, offset in tab_offsets.items()} if tab_offsets else {}
 
     def __enter__(self):
         self.download_values()
@@ -40,6 +50,23 @@ class GoogleSheetsClient:
 
     def __exit__(self, *_):
         self.upload_values()
+
+    @classmethod
+    def _initialize_empty_tab(cls):
+        return []
+
+    def _get_offset_row_col(self, tab_id):
+        tab_offset_data = self._tab_offsets.get(tab_id, {
+            'row': 0,
+            'col': 0
+        })
+        return tab_offset_data['row'], tab_offset_data['col']
+
+    def _get_offset_string(self, tab_id):
+        tab_offset_data = self._tab_offsets.get(tab_id, {
+            'offset_str': 'A1'
+        })
+        return tab_offset_data['offset_str']
 
     def download_values(self):
         """
@@ -70,12 +97,11 @@ class GoogleSheetsClient:
                 row_values = row_data.get('values')
                 if row_values:
                     for col_number, cell_data in enumerate(row_values):
-                        cell_value = cell_data.get('formattedValue', self._empty_cell_value)
-                        self.update_cell(row_number, col_number, cell_value, tab_id)
+                        row_offset, col_offset = self._get_offset_row_col(tab_id)
 
-    @classmethod
-    def _initialize_empty_tab(cls):
-        return []
+                        if row_number >= row_offset and col_number >= col_offset:
+                            cell_value = cell_data.get('formattedValue', self._empty_cell_value)
+                            self.update_cell(row_number - row_offset, col_number - col_offset, cell_value, tab_id)
 
     def set_current_tab(self, tab_id):
         """
@@ -130,9 +156,9 @@ class GoogleSheetsClient:
             body={
                 'valueInputOption': 'RAW',
                 'data': [{
-                    'range': f"'{tab_title}'!A1",
+                    'range': f"'{tab_id}'!{self._get_offset_string(tab_id)}",
                     'values': tab_data
-                } for tab_title, tab_data in self._tabs.items()]
+                } for tab_id, tab_data in self._tabs.items()]
             }
         )
         request.execute()

--- a/rdr_service/services/google_sheets_client.py
+++ b/rdr_service/services/google_sheets_client.py
@@ -92,7 +92,7 @@ class GoogleSheetsClient:
 
             # Initialize the internal tab structure and parse the values from the response
             self._tabs[tab_id] = self._initialize_empty_tab()
-            tab_grid_data = tab['data'][0]['rowData']
+            tab_grid_data = tab['data'][0].get('rowData', [])
             for row_number, row_data in enumerate(tab_grid_data):
                 row_values = row_data.get('values')
                 if row_values:

--- a/rdr_service/tools/tool_libs/update_data_dictionary.py
+++ b/rdr_service/tools/tool_libs/update_data_dictionary.py
@@ -1,0 +1,246 @@
+from sqlalchemy import MetaData
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sphinx.pycode import ModuleAnalyzer
+
+from rdr_service.model.base import Base
+from rdr_service.services.google_sheets_client import GoogleSheetsClient
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
+
+tool_cmd = 'update-data-dictionary'
+tool_desc = 'Update the RDR data-dictionary'
+
+
+class UpdateDataDictionary(ToolBase):
+    def __init__(self, *args, **kwargs):
+        super(UpdateDataDictionary, self).__init__(*args, **kwargs)
+        self.internal_table_list = [
+            'alembic_version',
+            'metrics_age_cache_bak',
+            'metrics_enrollment_status_cache_bak',
+            'metrics_gender_cache_bak',
+            'metrics_lifecycle_cache_bak',
+            'metrics_race_cache_bak',
+            'metrics_region_cache_bak',
+            'temp_debug_bigquery_sync',
+            'tmp_participants'
+        ]
+        # List out deprecated tables that aren't mapped in the ORM,
+        # giving notes about why it's deprecated and its replacement if there is one
+        self._deprecated_table_map = {
+            'biobank_dv_order': 'use biobank_mail_kit_order table instead',
+            'biobank_dv_order_history': 'use biobank_mail_kit_order_history table instead'
+        }
+        # List of history tables that have been created using rdr_service.model.base.add_table_history_table.
+        # Used to switch to non-history table for ORM descriptions since these tables aren't represented in ORM
+        self._alembic_history_table_list = [
+            'biobank_mail_kit_order_history',
+            'genomic_set_member_history',
+            'participant_gender_answers_history',
+            'participant_race_answers_history',
+            'patient_status_history'
+        ]
+
+    # TODO:
+    #  Create ability to clear cells in content and further rows (if the update is shorter than what was there)
+
+    def _is_alembic_generated_history_table(self, table_name):
+        return table_name in self._alembic_history_table_list
+
+    def _get_class_for_table(self, table_name):
+        if self._is_alembic_generated_history_table(table_name):
+            table_name = table_name[:-8]  # Trim "_history" from the table name for finding the corresponding ORM model
+
+        for model in Base._decl_class_registry.values():
+            if getattr(model, '__tablename__', '') == table_name:
+                return model
+
+    @classmethod
+    def _get_column_definition_from_model(cls, model, column_name):
+        for attribute in model.__dict__.values():
+            if isinstance(attribute, InstrumentedAttribute) and attribute.expression.key == column_name:
+                return attribute
+
+    @classmethod
+    def _trim_whitespace_lines_from_ends_of_list(cls, strings_list):
+        content_lines = []
+        empty_lines_in_content = []
+        for line in strings_list:
+            line = line.strip()
+
+            if line:
+                # Found a line with content, append it to the result
+                # (preceded by any empty lines between this and previous content)
+                content_lines.extend(empty_lines_in_content)
+                empty_lines_in_content.clear()
+
+                content_lines.append(line)
+            else:
+                # Empty line, ignore if before any content
+                if content_lines:
+                    empty_lines_in_content.append(line)
+
+        return content_lines
+
+    def _get_column_docstring_list(self, column_definition, analyzer: ModuleAnalyzer):
+        if column_definition.__doc__:
+            return column_definition.__doc__.split('\n')
+        else:
+            # Search for field definitions, starting with the class name and working up through the inheritance path
+            class_names = [column_definition.class_.__name__]
+            class_names.extend([base.__name__ for base in column_definition.class_.__bases__])
+            for class_name in class_names:
+                for (attr_doc_class_name, field_name), doc_str_list in analyzer.find_attr_docs().items():
+                    if class_name == attr_doc_class_name and column_definition.key == field_name:
+                        return doc_str_list
+
+        return []
+
+    def _get_column_description(self, column_definition, analyzer: ModuleAnalyzer):
+        return '\n'.join([line for line in self._trim_whitespace_lines_from_ends_of_list(
+            self._get_column_docstring_list(column_definition, analyzer)
+        ) if not line.startswith('@rdr_dictionary')])
+
+    def _get_deprecation_status_and_note(self, table_name):
+        if table_name in self._deprecated_table_map:
+            return True, self._deprecated_table_map[table_name]
+
+        return False, None
+
+    def _write_to_sheet(self, sheet: GoogleSheetsClient, tab_id, current_row, reflected_table_name, reflected_column,
+                        column_description, display_unique_data, value_meaning_map, session):
+        sheet.set_current_tab(tab_id)
+        sheet.update_cell(current_row, 0, reflected_table_name)
+        sheet.update_cell(current_row, 1, reflected_column.name)
+        sheet.update_cell(current_row, 2, f'{reflected_table_name}.{reflected_column.name}')
+        sheet.update_cell(current_row, 3, str(reflected_column.type))
+        sheet.update_cell(current_row, 4, column_description)
+
+        if display_unique_data:
+            distinct_values = session.execute(f'select distinct {reflected_column.name} from {reflected_table_name}')
+            unique_values_display_list = [str(value) if value is not None else 'NULL' for (value,) in distinct_values]
+
+            sheet.update_cell(current_row, 5, str(len(unique_values_display_list)))
+            sheet.update_cell(current_row, 6, ', '.join(
+                sorted(unique_values_display_list, key=lambda val_str: val_str.lower())
+            ))
+
+        if value_meaning_map:
+            sheet.update_cell(current_row, 7, value_meaning_map)
+
+        sheet.update_cell(current_row, 8, ' ')
+        sheet.update_cell(current_row, 9, 'Yes' if reflected_column.primary_key else 'No')
+        sheet.update_cell(current_row, 10, 'Yes' if len(reflected_column.foreign_keys) > 0 else 'No')
+        # Display the targets of foreign keys as target_table_name.target_column_name
+        sheet.update_cell(current_row, 11, ', '.join([
+            f'{foreign_key.column.table}.{foreign_key.column.name}' for foreign_key in reflected_column.foreign_keys
+        ]))
+        # Display the target column names of foreign keys
+        sheet.update_cell(current_row, 12, ', '.join([
+            foreign_key.column.name.ljust(20) for foreign_key in reflected_column.foreign_keys
+        ]))
+
+        is_deprecated, deprecation_note = self._get_deprecation_status_and_note(reflected_table_name)
+        if is_deprecated:
+            sheet.update_cell(current_row, 13, f'Deprecated: {deprecation_note}')
+
+    def _get_is_internal_column(self, model, table_name, column_definition, analyzer: ModuleAnalyzer):
+        if model and getattr(model, '__rdr_internal_table__', False):
+            return True
+        elif column_definition and analyzer and any([
+            docstring_line == '@rdr_dictionary_internal_column'
+            for docstring_line in self._get_column_docstring_list(column_definition, analyzer)
+        ]):
+            return True
+        else:
+            return table_name in self.internal_table_list or table_name.startswith('metrics_tmp_participant')
+
+    def _get_column_should_show_unique_values(self, column_definition, analyzer: ModuleAnalyzer):
+        if column_definition and analyzer:
+            for docstring_line in self._get_column_docstring_list(column_definition, analyzer):
+                if docstring_line == '@rdr_dictionary_show_unique_values':
+                    return True
+
+        return False
+
+    def run(self):
+        super(UpdateDataDictionary, self).run()
+
+        dictionary_tab_id = 'RDR Data Dictionary'
+        internal_tables_tab_id = 'RDR Internal Only'
+        current_row_tracker = {
+            dictionary_tab_id: 4,
+            internal_tables_tab_id: 4
+        }
+        with GoogleSheetsClient(
+            '1cmFnjyIqBHNbRmJ677WJjkAcGc0y2I7yfcUfpoOm1X4',
+            self.gcp_env.service_key_id,
+            tab_offsets={
+                internal_tables_tab_id: 'B1'
+            }
+        ) as sheet:
+            with self.get_session(alembic=True) as session:
+                metadata = MetaData()
+                metadata.reflect(bind=session.bind)  # , views=True)
+
+                for table_name in sorted(metadata.tables.keys()):
+                    table_data = metadata.tables[table_name]
+
+                    print('==========================')
+                    print('--------', table_name, '------------')
+
+
+
+                    model = self._get_class_for_table(table_name)
+                    analyzer = ModuleAnalyzer.for_module(model.__module__) if model else None
+
+                    for column in sorted(table_data.columns, key=lambda col: col.name):
+
+                        column_description = ''
+                        show_unique_values = False
+                        value_meaning_map = None
+                        column_definition = None
+                        if model:
+                            column_definition = self._get_column_definition_from_model(model, column.name)
+                            if column_definition:
+                                enum_definition = getattr(column_definition.expression.type, 'enum_type', None)
+                                if enum_definition:
+                                    value_meaning_map = ', '.join([
+                                        f'{str(option)} = {int(option)}' for option in enum_definition
+                                    ])
+
+                                if enum_definition or \
+                                        self._get_column_should_show_unique_values(column_definition, analyzer):
+                                    show_unique_values = True
+
+                            if self._is_alembic_generated_history_table(table_name) and column.name in [
+                                'revision_action', 'revision_id', 'revision_dt'
+                            ]:
+                                if column.name == 'revision_action':
+                                    column_description = 'What operation was done for that record - INSERT or UPDATE'
+                                elif column.name == 'revision_id':
+                                    column_description = 'Auto-incremented value used with the id column as the ' \
+                                                         'primary key for the history table'
+                                elif column.name == 'revision_dt':
+                                    column_description =\
+                                        'When that record was created in the history table specifically (if main ' \
+                                        'table is updated; previous version if/when a record is updated; if never ' \
+                                        'changed, it appears as it was originally created)'
+                            else:
+                                column_description = self._get_column_description(column_definition, analyzer)
+
+                        if self._get_is_internal_column(model, table_name, column_definition, analyzer):
+                            sheet_tab_id = internal_tables_tab_id
+                        else:
+                            sheet_tab_id = dictionary_tab_id
+
+                        self._write_to_sheet(sheet, sheet_tab_id, current_row_tracker[sheet_tab_id], table_name, column,
+                                             column_description, show_unique_values, value_meaning_map, session)
+                        current_row_tracker[sheet_tab_id] += 1
+
+
+def add_additional_arguments(_):
+    pass
+
+
+def run():
+    return cli_run(tool_cmd, tool_desc, UpdateDataDictionary, add_additional_arguments)

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -1,0 +1,46 @@
+import mock
+
+from rdr_service.services.data_dictionary_updater import DataDictionaryUpdater, dictionary_tab_id,\
+    internal_tables_tab_id, hpo_key_tab_id, questionnaire_key_tab_id, site_key_tab_id
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class DataDictionaryUpdaterTest(BaseTestCase):
+    def setUp(self, **kwargs) -> None:
+        super(DataDictionaryUpdaterTest, self).setUp(**kwargs)
+        self.updater = DataDictionaryUpdater('', '', self.session)
+
+        # Patch system calls that the sheets client uses
+        self.patchers = []  # We'll need to stop the patchers when the tests are done
+        for module_to_patch in [
+            'rdr_service.services.google_sheets_client.gcp_get_iam_service_key_info',
+            'rdr_service.services.google_sheets_client.ServiceAccountCredentials'
+        ]:
+            patcher = mock.patch(module_to_patch)
+            patcher.start()
+            self.patchers.append(patcher)
+
+        # Get sheets api service mock so that the tests can check calls to the google api
+        service_patcher = mock.patch('rdr_service.services.google_sheets_client.discovery')
+        self.patchers.append(service_patcher)
+        mock_discovery = service_patcher.start()
+        self.mock_spreadsheets_return = mock_discovery.build.return_value.spreadsheets.return_value
+
+        # We can't create tabs through code, so we need to initialize the tabs through the download
+        self.tab_names = [
+            dictionary_tab_id, internal_tables_tab_id, hpo_key_tab_id, questionnaire_key_tab_id, site_key_tab_id
+        ]
+        self.mock_spreadsheets_return.get.return_value.execute.return_value = {
+            'sheets': [{
+                'properties': {'title': tab_name},
+                'data': [{}]
+            } for tab_name in self.tab_names]
+        }
+
+    def tearDown(self):
+        for patcher in self.patchers:
+            patcher.stop()
+
+    def test_spreadsheet_downloads_values_from_drive(self):
+        self.updater.run_update()
+        print('bob')

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -1,8 +1,5 @@
-import mock
-
 from rdr_service.services.data_dictionary_updater import DataDictionaryUpdater, dictionary_tab_id,\
     internal_tables_tab_id, hpo_key_tab_id, questionnaire_key_tab_id, site_key_tab_id
-from tests.helpers.unittest_base import BaseTestCase
 from tests.service_tests.test_google_sheets_client import GoogleSheetsTestBase
 
 
@@ -17,7 +14,172 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             dictionary_tab_id, internal_tables_tab_id, hpo_key_tab_id, questionnaire_key_tab_id, site_key_tab_id
         ]
 
+    def _get_tab_rows(self, tab_id):
+        for tab_data in self._get_uploaded_sheet_data():
+            if tab_data['range'][1:].startswith(tab_id):  # slicing to get rid of the quot used in the reference
+                return tab_data['values']
+
+        return None
+
+    def assert_has_row(self, table_name, column_name, tab_values, expected_data_type=None, expected_description=None,
+                       expected_unique_value_count=None, expected_unique_values_list=None,
+                       expected_value_meaning_map=None, expected_is_primary_key=None,
+                       expected_is_foreign_key=None, expected_foreign_key_target_table_fields=None,
+                       expected_foreign_key_target_columns=None, expected_deprecated_note=None):
+
+        # Find a row with the given table and column names
+        row_found = False
+        for row_values in tab_values:
+            row_values_dict = {
+                'row_table_name': None, 'row_column_name': None, 'table_column_concat': None, 'data_type': None,
+                'description': None, 'unique_value_count': None, 'unique_value_list': None, 'value_meaning_map': None,
+                'values_key': None, 'is_primary_key': None, 'is_foreign_key': None,
+                'foreign_key_target_table_fields': None, 'foreign_key_target_columns': None, 'deprecated_note': None
+            }
+            row_values_dict.update(zip(row_values_dict, row_values))
+
+            if row_values_dict['row_table_name'] == table_name and row_values_dict['row_column_name'] == column_name:
+                row_found = True
+                self.assertEqual(f'{table_name}.{column_name}', row_values_dict['table_column_concat'])
+
+                # Compare the values displayed for the column in the data-dictionary values with the expected values
+                if expected_data_type:
+                    self.assertEqual(expected_data_type, row_values_dict['data_type'])
+                if expected_description:
+                    self.assertEqual(expected_description, row_values_dict['description'])
+                if expected_unique_value_count:
+                    self.assertEqual(expected_unique_value_count, row_values_dict['unique_value_count'])
+                if expected_unique_values_list:
+                    self.assertEqual(expected_unique_values_list, row_values_dict['unique_value_list'])
+                if expected_value_meaning_map:
+                    self.assertEqual(expected_value_meaning_map, row_values_dict['value_meaning_map'])
+                if expected_is_primary_key is not None:
+                    self.assertEqual('Yes' if expected_is_primary_key else 'No', row_values_dict['is_primary_key'])
+                if expected_is_foreign_key is not None:
+                    self.assertEqual('Yes' if expected_is_foreign_key else 'No', row_values_dict['is_foreign_key'])
+                if expected_foreign_key_target_table_fields:
+                    self.assertEqual(
+                        expected_foreign_key_target_table_fields,
+                        row_values_dict['foreign_key_target_table_fields']
+                    )
+                if expected_foreign_key_target_columns:
+                    self.assertEqual(expected_foreign_key_target_columns, row_values_dict['foreign_key_target_columns'])
+                if expected_deprecated_note:
+                    self.assertEqual(expected_deprecated_note, row_values_dict['deprecated_note'])
+
+        if not row_found:
+            self.fail(f'{table_name}.{column_name} not found in results')
+
     def test_updating_data_dictionary_tab(self):
         self.updater.run_update()
-        vals = self._get_uploaded_sheet_data()
-        print('bob')
+        dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
+
+        # Check for some generic columns and definitions
+        self.assert_has_row(
+            'participant_summary', 'deceased_status', dictionary_tab_rows,
+            expected_data_type='SMALLINT(6)',
+            expected_description="Indicates whether the participant has a PENDING or APPROVED deceased reports.\n\n"
+                                 "Will be UNSET for participants that have no deceased reports or only DENIED reports."
+        )
+        self.assert_has_row(
+            'biobank_stored_sample', 'disposed', dictionary_tab_rows,
+            expected_data_type='DATETIME',
+            expected_description="The datetime at which the sample was disposed of"
+        )
+
+    def test_show_unique_values(self):
+        # Create some data for checking the dictionary values list
+        self.data_generator.create_database_participant(participantOrigin='test')
+
+        self.updater.run_update()
+        dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
+
+        # Check that enumerations show the value meanings and unique value count
+        # This check assumes that Organization's isObsolete property is based on an Enum,
+        # and that the test data only has Organizations that don't have isObsolete set
+        self.assert_has_row(
+            'organization', 'is_obsolete', dictionary_tab_rows,
+            expected_unique_values_list='NULL',
+            expected_unique_value_count='1',
+            expected_value_meaning_map="ACTIVE = 0, OBSOLETE = 1"
+        )
+
+        # Check that a column will show unique values when it is explicitly set to
+        # This check assumes that Participant's participantOrigin is set to show unique values
+        self.assert_has_row(
+            'participant', 'participant_origin', dictionary_tab_rows,
+            expected_unique_values_list='test',
+            expected_unique_value_count='1',
+            expected_value_meaning_map=''
+        )
+
+    def test_primary_and_foreign_key_columns(self):
+        self.updater.run_update()
+        dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
+
+        # Check the primary key column indicator
+        self.assert_has_row('participant', 'participant_id', dictionary_tab_rows, expected_is_primary_key=True)
+
+        # Check the foreign key column indicator
+        self.assert_has_row('participant', 'site_id', dictionary_tab_rows, expected_is_foreign_key=True)
+
+        # Check the foreign key column target fields
+        self.assert_has_row(
+            'participant', 'site_id', dictionary_tab_rows,
+            expected_foreign_key_target_table_fields='site.site_id',
+            expected_foreign_key_target_columns='site_id'
+        )
+
+    def test_internal_tab_values(self):
+        self.updater.run_update()
+        internal_tab_rows = self._get_tab_rows(internal_tables_tab_id)
+
+        # Check that ORM mapped tables can appear in the internal tab when marked as internal
+        self.assert_has_row('bigquery_sync', 'id', internal_tab_rows)
+
+    def test_hpo_and_site_key_tabs(self):
+        # Create hpo and site for test
+        self.data_generator.create_database_hpo(hpoId=1000, name='DictionaryTest', displayName='Dictionary Test')
+        self.data_generator.create_database_site(siteId=4000, siteName='Test', googleGroup='test_site_group')
+
+        self.updater.run_update()
+
+        # Check that the expected hpo row gets into the spreadsheet
+        hpo_rows = self._get_tab_rows(hpo_key_tab_id)
+        self.assertTrue([1000, 'DictionaryTest', 'Dictionary Test'] in hpo_rows)
+
+        # Check that the expected site row gets into the spreadsheet
+        site_rows = self._get_tab_rows(site_key_tab_id)
+        self.assertIn([4000, 'Test', 'test_site_group'], site_rows)
+
+    def test_questionnaire_key_tab(self):
+        # Create two questionnaires for the test, one without any responses and another that has one
+        code = self.data_generator.create_database_code(display='Test Questionnaire', shortValue='test_questionnaire')
+
+        no_response_questionnaire = self.data_generator.create_database_questionnaire_history()
+        response_questionnaire = self.data_generator.create_database_questionnaire_history()
+        for questionnaire in [no_response_questionnaire, response_questionnaire]:
+            self.data_generator.create_database_questionnaire_concept(
+                questionnaireId=questionnaire.questionnaireId,
+                questionnaireVersion=questionnaire.version,
+                codeId=code.codeId
+            )
+
+        participant = self.data_generator.create_database_participant()
+        self.data_generator.create_database_questionnaire_response(
+            questionnaireId=response_questionnaire.questionnaireId,
+            questionnaireVersion=response_questionnaire.version,
+            participantId=participant.participantId
+        )
+
+        # Check that the questionnaire values output as expected
+        self.updater.run_update()
+        questionnaire_values = self._get_tab_rows(questionnaire_key_tab_id)
+        self.assertIn(
+            [no_response_questionnaire.questionnaireId, code.display, code.shortValue, 'N'],
+            questionnaire_values
+        )
+        self.assertIn(
+            [response_questionnaire.questionnaireId, code.display, code.shortValue, 'Y'],
+            questionnaire_values
+        )

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -3,44 +3,21 @@ import mock
 from rdr_service.services.data_dictionary_updater import DataDictionaryUpdater, dictionary_tab_id,\
     internal_tables_tab_id, hpo_key_tab_id, questionnaire_key_tab_id, site_key_tab_id
 from tests.helpers.unittest_base import BaseTestCase
+from tests.service_tests.test_google_sheets_client import GoogleSheetsTestBase
 
 
-class DataDictionaryUpdaterTest(BaseTestCase):
+class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
     def setUp(self, **kwargs) -> None:
         super(DataDictionaryUpdaterTest, self).setUp(**kwargs)
         self.updater = DataDictionaryUpdater('', '', self.session)
 
-        # Patch system calls that the sheets client uses
-        self.patchers = []  # We'll need to stop the patchers when the tests are done
-        for module_to_patch in [
-            'rdr_service.services.google_sheets_client.gcp_get_iam_service_key_info',
-            'rdr_service.services.google_sheets_client.ServiceAccountCredentials'
-        ]:
-            patcher = mock.patch(module_to_patch)
-            patcher.start()
-            self.patchers.append(patcher)
-
-        # Get sheets api service mock so that the tests can check calls to the google api
-        service_patcher = mock.patch('rdr_service.services.google_sheets_client.discovery')
-        self.patchers.append(service_patcher)
-        mock_discovery = service_patcher.start()
-        self.mock_spreadsheets_return = mock_discovery.build.return_value.spreadsheets.return_value
-
-        # We can't create tabs through code, so we need to initialize the tabs through the download
-        self.tab_names = [
+    @classmethod
+    def _default_tab_names(cls):
+        return [
             dictionary_tab_id, internal_tables_tab_id, hpo_key_tab_id, questionnaire_key_tab_id, site_key_tab_id
         ]
-        self.mock_spreadsheets_return.get.return_value.execute.return_value = {
-            'sheets': [{
-                'properties': {'title': tab_name},
-                'data': [{}]
-            } for tab_name in self.tab_names]
-        }
 
-    def tearDown(self):
-        for patcher in self.patchers:
-            patcher.stop()
-
-    def test_spreadsheet_downloads_values_from_drive(self):
+    def test_updating_data_dictionary_tab(self):
         self.updater.run_update()
+        vals = self._get_uploaded_sheet_data()
         print('bob')

--- a/tests/service_tests/test_google_sheets_client.py
+++ b/tests/service_tests/test_google_sheets_client.py
@@ -61,7 +61,6 @@ class GoogleSheetsApiTest(BaseTestCase):
         # _ _ 'another tab for testing'
         # Tab title: 'Final tab'
         # 'test'
-
         empty_cell = self._mock_cell(None)
         first_tab_title = 'first_tab'
         first_tab_data = {
@@ -208,3 +207,72 @@ class GoogleSheetsApiTest(BaseTestCase):
                 [''],
                 ['', '', '', '8']
             ], sheet.get_tab_values())
+
+    def test_functionality_for_shifting_sheet_range(self):
+        """
+        To work with pre-existing sheets (that have pre-existing headers and special formatting) we should be
+        able to offset the values that are uploaded as an update.
+        """
+
+
+        # Mock a spreadsheet with three tabs on google drive
+        # The test spreadsheet looks like this (underscores represent a cell that will be blank):
+        # Tab title: 'first_tab'
+        # _ _ '7' _ '9'
+        # _ '2' '3'
+        # Tab title: 'another tab'
+        # 'another tab for testing'
+        # _
+        # _
+        # _ _ '7' _ '9'
+        empty_cell = self._mock_cell(None)
+        first_tab_title = 'first_tab'
+        first_tab_data = {
+            'properties': {'title': first_tab_title},
+            'data': [{
+                'rowData': [
+                    {'values': [empty_cell, empty_cell, self._mock_cell('7'), empty_cell, self._mock_cell('9')]},
+                    {'values': [empty_cell, self._mock_cell('2'), self._mock_cell('3')]}
+                ]
+            }]
+        }
+        second_tab_title = 'another tab'
+        second_tab_data = {
+            'properties': {'title': second_tab_title},
+            'data': [{
+                'rowData': [
+                    {'values': [self._mock_cell('another tab for testing')]},
+                    {'values': [empty_cell]},
+                    {'values': [empty_cell]},
+                    {'values': [empty_cell, empty_cell, self._mock_cell('7'), empty_cell, self._mock_cell('9')]}
+                ]
+            }]
+        }
+        self.mock_spreadsheets_return.get.return_value.execute.return_value = {
+            'sheets': [first_tab_data, second_tab_data]
+        }
+
+        # Set offsets for the tabs and then update some values
+        with GoogleSheetsClient('', '', tab_offsets={
+            first_tab_title: 'B2',
+            second_tab_title: 'D3'
+        }) as sheet:
+            sheet.update_cell(0, 0, 'two', tab_id=first_tab_title)
+            sheet.update_cell(0, 1, '8', tab_id=second_tab_title)
+
+        # Make sure that the offsets were used when uploading values
+        tabs_uploaded = self.mock_spreadsheets_return.values.return_value.batchUpdate\
+            .call_args.kwargs.get('body').get('data')
+
+        first_uploaded_tab_data = tabs_uploaded[0]
+        self.assertEqual(f"'{first_tab_title}'!B2", first_uploaded_tab_data['range'])
+        self.assertEqual([
+            ['two', '3']
+        ], first_uploaded_tab_data['values'])
+
+        second_uploaded_tab_data = tabs_uploaded[1]
+        self.assertEqual(f"'{second_tab_title}'!D3", second_uploaded_tab_data['range'])
+        self.assertEqual([
+            ['', '8'],
+            ['', '9']
+        ], second_uploaded_tab_data['values'])

--- a/tests/service_tests/test_google_sheets_client.py
+++ b/tests/service_tests/test_google_sheets_client.py
@@ -34,6 +34,7 @@ class GoogleSheetsTestBase(BaseTestCase):
         }
 
     def tearDown(self):
+        super(GoogleSheetsTestBase, self).tearDown()
         for patcher in self.patchers:
             patcher.stop()
 


### PR DESCRIPTION
This is work in progress for automatically updating the data-dictionary with the database schema. It uses the schema gathered from the database, and pairs that with information from tables that are mapped to ORM models and others that are hardcoded. The Sphinx code parser is used to get to the docstrings on class-level attributes for the ORM models. There it looks for special strings (such as `@rdr_dictionary_show_unique_values`) to know how and where to display data for the column in the data-dictionary.

This is most of the work for updating the data-dictionary. But it still needs to be set up as part of the deploy process and it needs to be able to write the change-log. Further PRs will wrap up the rest of the work for it.