### PR TITLE
[PDR-255] PDR COPE Survey data using different status than RDR for deferrals

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -94,7 +94,7 @@ _consent_answer_status_map = {
     # COPE_A_13
     CONSENT_COPE_NO_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     # COPE_A_231
-    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'ConsentAncestryTraits_Yes': BQModuleStatusEnum.SUBMITTED,
     'ConsentAncestryTraits_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE,

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -93,7 +93,7 @@ _consent_answer_status_map = {
     # COPE_A_13
     CONSENT_COPE_NO_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     # COPE_A_231
-    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NOT_SURE,
+    CONSENT_COPE_DEFERRED_CODE: BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'ConsentAncestryTraits_Yes': BQModuleStatusEnum.SUBMITTED,
     'ConsentAncestryTraits_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE


### PR DESCRIPTION
When a participant defers taking a COPE survey ("Yes, I would like to take the survey later" COPE_A_231 answer) PDR generators were using SUBMITTED_NOT_SURE as the status instead of SUBMITTED_NO_CONSENT as the RDR logic does