### PR TITLE
[DA-1938] Modify Ingestion Cloud Functions

### DIFF
--- a/rdr_service/gcloud_functions/genomic_aw1_baylor_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw1_baylor_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw1_broad_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw1_broad_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw1_northwest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw1_northwest_function/main.py
@@ -37,6 +37,11 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
             _logger.info(f'Skipping file {self.event.name}, name does not match AW1 file.')
             return
 
+        # Northwest moves their files to a `downloaded` subfolder. Ignore these.
+        if 'downloaded' in self.event.name.lower():
+            _logger.info(f'Skipping file {self.event.name}, in downloaded folder.')
+            return
+
         _logger.info(f"file found: {self.event.name}")
 
         cloud_file_path = f'{self.event.bucket}/{self.event.name}'

--- a/rdr_service/gcloud_functions/genomic_aw1_northwest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw1_northwest_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw2_baylor_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw2_baylor_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw2_broad_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw2_broad_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw2_northwest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw2_northwest_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw5_baylor_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw5_baylor_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw5_broad_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw5_broad_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_aw5_northwest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw5_northwest_function/main.py
@@ -24,7 +24,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/gcloud_functions/genomic_manifest_generic_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_manifest_generic_function/main.py
@@ -27,7 +27,7 @@ deploy_args = [
     '--memory=512'
 ]
 
-task_queue = 'resource-tasks'
+task_queue = 'genomics'
 _logger = logging.getLogger('function')
 
 

--- a/rdr_service/queue.yaml
+++ b/rdr_service/queue.yaml
@@ -35,3 +35,10 @@ queue:
   max_concurrent_requests: 25
   retry_parameters:
     task_retry_limit: 5
+
+- name: genomics
+  target: resource
+  rate: 50/s
+  max_concurrent_requests: 25
+  retry_parameters:
+    task_retry_limit: 0


### PR DESCRIPTION
This PR adds a new task queue for genomics with 0 retries. All genomics cloud functions were updated to use this task queue. The Northwest AW1 cloud function was updated to ignore files in the `downloaded` sub-folder.