### PR TITLE
Update call to create_task() 

### DIFF
--- a/rdr_service/cloud_utils/gcp_cloud_tasks.py
+++ b/rdr_service/cloud_utils/gcp_cloud_tasks.py
@@ -81,7 +81,7 @@ class GCPCloudTask(object):
         while retry:
             retry -= 1
             try:
-                response = self._client.create_task(parent, task)
+                response = self._client.create_task(parent=parent, task=task)
                 if not quiet:
                     logging.info('Created task {0}'.format(response.name))
                 return


### PR DESCRIPTION
This small PR updates the call to `create_task()`. The resource rebuild tool fails when positional arguments are given for `parent` and `task` due to other expected parameters. This was updated to call `create_task()` with keyword arguments to fix the error.