### PR TITLE
[PDR-236] (Workaround) Temporary solution to support CORE_MINUS_PM in PDR

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -294,6 +294,10 @@ class BQParticipantSummarySchema(BQSchema):
 
     # PDR-178:  Add cabor_authored to align with RDR consent_for_cabor / consent_for_cabor_authored
     cabor_authored = BQField('cabor_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    biobank_id = BQField('biobank_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+
+    # PDR-236:  Support for new RDR participant_summary.enrollment_core_minus_pm_time field in PDR data
+    enrollment_core_minus_pm = BQField('enrollment_core_minus_pm', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
 
 class BQParticipantSummary(BQTable):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -165,6 +165,9 @@ class BQPDRParticipantSummarySchema(BQSchema):
     cabor_authored = BQField('cabor_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     biobank_id = BQField('biobank_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
+    # PDR-236:  Support for new RDR participant_summary.enrollment_core_minus_pm_time field in PDR data
+    enrollment_core_minus_pm = BQField('enrollment_core_minus_pm', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
 
 class BQPDRParticipantSummary(BQTable):
     """ PDR Participant Summary BigQuery Table """

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -44,7 +44,7 @@ from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireH
 from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
     SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus, DeceasedStatus, \
-    DeceasedReportStatus, QuestionnaireResponseStatus
+    DeceasedReportStatus, QuestionnaireResponseStatus, EnrollmentStatus
 from rdr_service.resource import generators, schemas
 from rdr_service.resource.constants import SchemaID
 
@@ -151,7 +151,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             # prep patient status history
             summary = self._merge_schema_dicts(summary, self._prep_patient_status_info(p_id, ro_session))
             # calculate enrollment status for participant
-            summary = self._merge_schema_dicts(summary, self._calculate_enrollment_status(summary))
+            summary = self._merge_schema_dicts(summary, self._calculate_enrollment_status(summary, p_id, ro_session))
             # # Depreciated for now: calculate enrollment status times
             # summary = self._merge_schema_dicts(summary, self._calculate_enrollment_timestamps(summary))
             # calculate distinct visits
@@ -944,10 +944,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         return data
 
-    def _calculate_enrollment_status(self, summary):
+    def _calculate_enrollment_status(self, summary, p_id, ro_session):
         """
         Calculate the participant's enrollment status
         :param summary: summary data
+        :param p_id:  (int) participant ID
+        :param ro_session: Readonly DAO session object
         :return: dict
         """
         status = EnrollmentStatusV2.REGISTERED
@@ -1128,6 +1130,28 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         if status > EnrollmentStatusV2.REGISTERED:
             data['enrollment_member'] = \
                 enrollment_member_time if enrollment_member_time != datetime.datetime.max else None
+
+        # PDR-236 WORKAROUND.  The logic for determining CORE_MINUS_PM enrollment status and calculating the new
+        # enrollment_core_minus_pm timestamp will need to be incorporated above.  For now, check the
+        # RDR participant_summary data directly and use its values.  This is done after the existing calculation
+        # because RDR and PDR use different enrollment status buckets (EnrollmentStatus vs. EnrollmentStatusV2)
+        # PDR calculations should take precedence except when RDR has CORE_MINUS_PM as the status
+        ps = ro_session.query(ParticipantSummary.enrollmentStatus,
+                              ParticipantSummary.enrollmentStatusCoreMinusPMTime,
+                              ParticipantSummary.enrollmentStatusMemberTime) \
+            .filter(ParticipantSummary.participantId == p_id).first()
+
+        if ps:
+            # Always use RDR's enrollmentCoreMinusPMTime timestamp, regardless of current
+            # enrollment status (status could have since been upgraded if PM was later completed)
+            data['enrollment_core_minus_pm'] = ps.enrollmentStatusCoreMinusPMTime
+            if ps.enrollmentStatus == EnrollmentStatus.CORE_MINUS_PM:
+                data['enrollment_status'] = str(EnrollmentStatusV2.CORE_MINUS_PM)
+                data['enrollment_status_id'] = int(EnrollmentStatusV2.CORE_MINUS_PM)
+
+            # Temporary/extra QC check of pre-existing calculation logic, since we have RDR timestamp to compare to
+            if data['enrollment_member'] != ps.enrollmentStatusMemberTime:
+                logging.debug(f'enrollment_member PDR/RDR mismatch for participant {p_id}')
 
         return data
 

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -219,6 +219,7 @@ class ParticipantSummarySchema(Schema):
     enrollment_member = fields.DateTime()
     enrollment_core_ordered = fields.DateTime()
     enrollment_core_stored = fields.DateTime()
+    enrollment_core_minus_pm = fields.DateTime()
 
     # These EHR fields are populated from Curation data.
     ehr_status = fields.EnumString(enum=EhrStatus)

--- a/rdr_service/resource/schemas/pdr_participant.py
+++ b/rdr_service/resource/schemas/pdr_participant.py
@@ -62,6 +62,7 @@ class PDRParticipantSummarySchema(Schema):
     enrollment_member = fields.DateTime()
     enrollment_core_ordered = fields.DateTime()
     enrollment_core_stored = fields.DateTime()
+    enrollment_core_minus_pm = fields.DateTime()
 
     consent_cohort = fields.EnumString(enum=ParticipantCohort)
     consent_cohort_id = fields.EnumInteger(enum=ParticipantCohort)


### PR DESCRIPTION
This is an interim solution for picking up the new CORE_MINUS_PM enrollment status for PDR.  It uses the values from RDR `participant_summary.`  Eventually, the `_calculate_enrollment_status() `method needs to be updated to incorporate business logic for the CORE_MINUS_PM and related cases (e.g., if PM later received or not losing CORE status, etc.)

The `bigquery_sync` and `resource_data` generated JSON is available on stable for PIDS:  
101024510, 101968876, 186693040