### PR TITLE
Catching mysterious operational error

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import MySQLdb
 import re
 
 from collections import OrderedDict
@@ -212,7 +213,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             return True
         except exc.ProgrammingError:
             pass
-        except exc.OperationalError:
+        except (exc.OperationalError, MySQLdb._exceptions.OperationalError):
             logging.warning('Unexpected error found when checking for tmp_questionnaire_response table',
                             exc_info=True)
         return False

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import MySQLdb
 import re
 
 from collections import OrderedDict
@@ -214,7 +215,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             return True
         except exc.ProgrammingError:
             pass
-        except exc.OperationalError:
+        except (exc.OperationalError, MySQLdb._exceptions.OperationalError):
             msg = 'Unexpected error found when checking for tmp_questionnaire_response table'
             logging.warning(msg, exc_info=False)
         return False


### PR DESCRIPTION
Peggy was seeing an instance of `MySQLdb._exceptions.OperationalError` come up when her unit tests were trying to check for the `cdm.tmp_questionnaire_response` table.