### PR TITLE
Fix AW4 ingestion

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -789,7 +789,8 @@ class GenomicFileIngester:
                 row_copy = dict(zip([key.lower().replace(' ', '').replace('_', '')
                                      for key in row], row.values()))
                 sample_id = row_copy['sampleid']
-                genome_type = GENOME_TYPE_ARRAY if self.job_id == GenomicJob.AW4_ARRAY_WORKFLOW else GENOME_TYPE_WGS
+                genome_type = GENOME_TYPE_ARRAY \
+                    if self.job_id == GenomicJob.AW4_ARRAY_WORKFLOW else GENOME_TYPE_WGS
 
                 member = self.member_dao.get_member_from_aw3_sample(sample_id,
                                                                     genome_type)
@@ -798,12 +799,7 @@ class GenomicFileIngester:
                     continue
 
                 member.aw4ManifestJobRunID = self.job_run_id
-
-                # Set the QC status and fingerprint path
                 member.qcStatus = self._get_qc_status_from_value(row_copy['qcstatus'])
-
-                if self.job_id == GenomicJob.AW4_ARRAY_WORKFLOW:
-                    member.fingerprintPath = row_copy['fppath']
 
                 self.member_dao.update(member)
 
@@ -1396,7 +1392,6 @@ class GenomicFileValidator:
             "vcfindexpath",
             "researchid",
             "qcstatus",
-            "fppath",
         )
 
         self.AW4_WGS_SCHEMA = (

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -3061,10 +3061,13 @@ class GenomicPipelineTest(BaseTestCase):
         # Set up test Aw4 manifest
         bucket_name = config.getSetting(config.DRC_BROAD_BUCKET_NAME)
         sub_folder = config.getSetting(config.DRC_BROAD_AW4_SUBFOLDERS[0])
+        file_name = 'AoU_DRCB_GEN_2020-07-11-00-00-00.csv'
 
-        self._create_ingestion_test_file('AoU_DRCB_GEN_2020-07-11-00-00-00.csv',
-                                         bucket_name, folder=sub_folder,
-                                         include_timestamp=False)
+        self._create_ingestion_test_file(file_name,
+                                         bucket_name,
+                                         folder=sub_folder,
+                                         include_timestamp=False
+                                        )
         # Run Workflow
         genomic_pipeline.aw4_array_manifest_workflow()  # run_id 2
 
@@ -3075,17 +3078,15 @@ class GenomicPipelineTest(BaseTestCase):
                 self.assertEqual(2, member.aw4ManifestJobRunID)
             if member.id == 1:
                 self.assertEqual(GenomicQcStatus.PASS, member.qcStatus)
-                self.assertEqual("gs://drc-broad-test/fp_path_1.vcf.gz", member.fingerprintPath)
             if member.id == 2:
                 self.assertEqual(GenomicQcStatus.FAIL, member.qcStatus)
-                self.assertEqual("gs://drc-broad-test/fp_path_2.vcf.gz", member.fingerprintPath)
 
         # Test Files Processed
         file_record = self.file_processed_dao.get(1)
         self.assertEqual(2, file_record.runId)
-        self.assertEqual(f'/{bucket_name}/{sub_folder}/AoU_DRCB_GEN_2020-07-11-00-00-00.csv',
+        self.assertEqual(f'/{bucket_name}/{sub_folder}/{file_name}',
                          file_record.filePath)
-        self.assertEqual('AoU_DRCB_GEN_2020-07-11-00-00-00.csv', file_record.fileName)
+        self.assertEqual(file_name, file_record.fileName)
 
         # Test the job result
         run_obj = self.job_run_dao.get(2)

--- a/tests/test-data/AoU_DRCB_GEN_2020-07-11-00-00-00.csv
+++ b/tests/test-data/AoU_DRCB_GEN_2020-07-11-00-00-00.csv
@@ -1,3 +1,3 @@
-biobank_id,sample_id,sex_at_birth,site_id,red_idat_path,red_idat_md5_path,green_idat_path,green_idat_md5_path,vcf_path,vcf_index_path,research_id,QC_status,fp_path
-1,1001,f,BI,1234_1_Red.idat,1234_1_Red.idat.md5sum,1234_1_Grn.idat,1234_1_Grn.idat.md5sum,1234_1_vcf.gz,1234_1_vcf.gz.tbi,109001,PASS,gs://drc-broad-test/fp_path_1.vcf.gz
-2,1002,f,BI,1234_2_Red.idat,1234_2_Red.idat.md5sum,1234_2_Grn.idat,1234_2_Grn.idat.md5sum,1234_2_vcf.gz,1234_2_vcf.gz.tbi,109002,FAIL,gs://drc-broad-test/fp_path_2.vcf.gz
+biobank_id,sample_id,sex_at_birth,site_id,red_idat_path,red_idat_md5_path,green_idat_path,green_idat_md5_path,vcf_path,vcf_index_path,research_id,QC_status
+1,1001,f,BI,1234_1_Red.idat,1234_1_Red.idat.md5sum,1234_1_Grn.idat,1234_1_Grn.idat.md5sum,1234_1_vcf.gz,1234_1_vcf.gz.tbi,109001,PASS
+2,1002,f,BI,1234_2_Red.idat,1234_2_Red.idat.md5sum,1234_2_Grn.idat,1234_2_Grn.idat.md5sum,1234_2_vcf.gz,1234_2_vcf.gz.tbi,109002,FAIL


### PR DESCRIPTION
Broad requested for a column to be added to the AW4 ingestion, and the file validators on our side was failing the file becuase it was never added to the manifests, so in turn there have been a few files that have not been ingested. This fixes that be removing the logic for that column. The failed ingestions will also be rectified. 
