### PR TITLE
Fix log message in DeleteOldKeys cron job

### DIFF
--- a/rdr_service/offline/sa_key_remove.py
+++ b/rdr_service/offline/sa_key_remove.py
@@ -27,7 +27,7 @@ def delete_service_account_keys():
 
         for account in accounts:
             if account["email"] in service_accounts_with_long_lived_keys:
-                logging.info("Skip key expiration check for Service Account {}".format(account))
+                logging.info("Skip key expiration check for Service Account {}".format(account["email"]))
                 continue
 
             serviceaccount = project_name + "/serviceAccounts/" + account["email"]


### PR DESCRIPTION
Based on testing new logic to enable exclusion of specific SA from the key deletion, the log message that is now getting generated was printing out more detail about the service account than is needed/prudent.  Limit to just displaying the SA email in the log message