### PR TITLE
[DA-1938] Add 1 retry to genomics queue after 3 minutes

### DIFF
--- a/rdr_service/queue.yaml
+++ b/rdr_service/queue.yaml
@@ -41,5 +41,6 @@ queue:
   rate: 50/s
   max_concurrent_requests: 25
   retry_parameters:
-    task_retry_limit: 0
+    task_retry_limit: 1
+    min_backoff_seconds: 180
 


### PR DESCRIPTION
This increases retries to 1 for the genomics task queue. A previous PR had set this to 0, however there was a recent incident where having at least 1 retry was shown to be beneficial. The retry time was increased to 180s.