### PR TITLE
More error logging around calls to the mayolink api

### DIFF
--- a/rdr_service/api/mayolink_api.py
+++ b/rdr_service/api/mayolink_api.py
@@ -1,6 +1,7 @@
 import json
-import xml.etree.ElementTree as ET
 import httplib2
+import logging
+import xml.etree.ElementTree as ET
 import xmltodict
 from werkzeug.exceptions import ServiceUnavailable
 
@@ -41,11 +42,12 @@ class MayoLinkApi:
                 result = self._xml_to_dict(content)
                 return result
             else:
+                logging.error(content)
                 raise ServiceUnavailable("Mayolink service return {} rather than 201".format(response['status']))
         except httplib2.HttpLib2Error:
-            pass
+            logging.error('HttpLib2Error exception encountered', exc_info=True)
         except OSError:
-            pass
+            logging.error('OSError exception encountered', exc_info=True)
 
         raise ServiceUnavailable("Mayolink service unavailable, please re-try later")
 


### PR DESCRIPTION
We're seeing some 400's being returned from the Mayolink API. I'm continuing to investigate what happened with the requests, but it might be helpful in the future to see any messages from Mayolink about what was wrong with the request.

This also adds logs to track some other exceptions that could occur when making the API call. If we see any of these occur there might be a chance we can mitigate them and improve the workflow.