### PR TITLE
[ROC-884] Flagging when participants that haven't yet consented are withdrawn with a status other than EARLY_OUT

### DIFF
--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -196,6 +196,12 @@ class ParticipantDao(UpdatableDao):
 
             need_new_summary = True
 
+            # Participants that haven't yet consented should be withdrawn with EARLY_OUT
+            if existing_obj.participantSummary is None and obj.withdrawalStatus != WithdrawalStatus.EARLY_OUT:
+                logging.error(
+                    f'Un-consented participant {existing_obj.participantId} was withdrawn with {obj.withdrawalStatus}'
+                )
+
         if obj.suspensionStatus != existing_obj.suspensionStatus:
             obj.suspensionTime = obj.lastModified if obj.suspensionStatus == SuspensionStatus.NO_CONTACT else None
             need_new_summary = True

--- a/tests/dao_tests/test_participant_dao.py
+++ b/tests/dao_tests/test_participant_dao.py
@@ -489,6 +489,16 @@ class ParticipantDaoTest(BaseTestCase):
         with self.assertRaises(Forbidden):
             self.dao.update(p)
 
+    @mock.patch('rdr_service.dao.participant_dao.logging')
+    def test_error_log_for_incorrect_status_on_participant(self, mock_logging):
+        """Participants that have not yet consented should only be withdrawn with the status of EARLY_OUT"""
+        participant = self.data_generator.create_database_participant()
+        participant.withdrawalStatus = WithdrawalStatus.NO_USE
+        self.dao.update(participant)
+        mock_logging.error.assert_called_with(
+            f'Un-consented participant {participant.participantId} was withdrawn with NO_USE'
+        )
+
     def test_update_not_exists(self):
         p = self.data_generator._participant_with_defaults(participantId=1, biobankId=2)
         with self.assertRaises(NotFound):


### PR DESCRIPTION
It seems that if a participant hasn't consented yet, they should only have the EARLY_OUT status. This sets up the code to let us know if any requests deviate from that. In the future (after tracking down and investigating/correcting any incorrect data that comes through) we can potentially make changes to return 400/BadRequest whenever that happens.