### PR TITLE
[DA-1950] Create AW2F cronjob

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -39,3 +39,8 @@ cron:
   timezone: America/New_York
   schedule: every day 03:15
   target: offline
+- description: Genomic AW2F Manifest Workflow
+  url: /offline/GenomicAW2ManifestWorkflow
+  timezone: America/New_York
+  schedule: every monday 00:00
+  target: offline

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1447,6 +1447,26 @@ class GenomicManifestFeedbackDao(BaseDao):
 
         return list(results)
 
+    def get_feedback_count_within_threshold(self, theta):
+        """
+        Retrieves feedback records where feedback count is >= a threshold of record_count
+        :param theta: threshold
+        :return: list of feedback records
+        """
+        with self.session() as session:
+            results = session.query(GenomicManifestFeedback).join(
+                GenomicManifestFile,
+                GenomicManifestFile.id == GenomicManifestFeedback.inputManifestFileId
+            ).filter(
+                GenomicManifestFeedback.ignoreFlag == 0,
+                GenomicManifestFeedback.feedbackComplete == 0,
+                GenomicManifestFeedback.feedbackRecordCount != 0,
+                GenomicManifestFeedback.feedbackRecordCount >= GenomicManifestFile.recordCount * theta,
+                GenomicManifestFeedback.feedbackManifestFileId.is_(None),
+            ).all()
+
+        return list(results)
+
     def get_feedback_record_counts_from_filepath(self, filepath):
         with self.session() as session:
             return session.query(GenomicManifestFeedback.feedbackRecordCount).join(

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1445,7 +1445,7 @@ class GenomicManifestFeedbackDao(BaseDao):
                 GenomicManifestFeedback.feedbackManifestFileId.is_(None),
             ).all()
 
-        return list(results)
+        return results
 
     def get_feedback_count_within_threshold(self, theta):
         """
@@ -1465,7 +1465,7 @@ class GenomicManifestFeedbackDao(BaseDao):
                 GenomicManifestFeedback.feedbackManifestFileId.is_(None),
             ).all()
 
-        return list(results)
+        return results
 
     def get_feedback_record_counts_from_filepath(self, filepath):
         with self.session() as session:

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -63,7 +63,7 @@ class GenomicJobController:
         self.task_data = task_data
         self.bypass_record_count = False
         self.skip_updates = False
-        self.feedback_threshold = float(2/3)
+        self.feedback_threshold = 2/3
 
         self.subprocess_results = set()
         self.job_result = GenomicSubProcessResult.UNSET

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -63,6 +63,7 @@ class GenomicJobController:
         self.task_data = task_data
         self.bypass_record_count = False
         self.skip_updates = False
+        self.feedback_threshold = float(2/3)
 
         self.subprocess_results = set()
         self.job_result = GenomicSubProcessResult.UNSET
@@ -160,13 +161,13 @@ class GenomicJobController:
 
         return feedback_file
 
-    def get_feedback_complete_records(self):
+    def get_feedback_records_to_send(self):
         """
         Retrieves genomic_manifest_feedback records that are complete
         and have not had a feedback_manifest_ID
         :return: list of GenomicManifestFeedback
         """
-        return self.manifest_feedback_dao.get_feedback_equals_record_count()
+        return self.manifest_feedback_dao.get_feedback_count_within_threshold(self.feedback_threshold)
 
     def ingest_awn_data_for_member(self, file_path, member):
         """

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -306,7 +306,7 @@ def scan_and_complete_feedback_records():
     """
     with GenomicJobController(GenomicJob.FEEDBACK_SCAN) as controller:
         # Get feedback records that are complete
-        fb_recs = controller.get_feedback_complete_records()
+        fb_recs = controller.get_feedback_records_to_send()
 
         for f in fb_recs:
             create_aw2f_manifest(f)

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -653,7 +653,7 @@ def _build_pipeline_app():
         view_func=genomic_wgs_data_reconciliation_workflow, methods=["GET"]
     )
     offline_app.add_url_rule(
-        OFFLINE_PREFIX + "GenomicFeedbackManifestWorkflow",
+        OFFLINE_PREFIX + "GenomicAW2ManifestWorkflow",
         endpoint="genomic_scan_feedback_records",
         view_func=genomic_scan_feedback_records, methods=["GET"]
     )


### PR DESCRIPTION
This PR creates the cron job for the AW2F manifest generation. The query to select feedback records was updated to use a threshold of 2/3 of the `genomic_manifest_file.record_count` of the `input_manifest_id`.