### PR TITLE
Aborting workers rather than quitting them

### DIFF
--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -50,4 +50,4 @@ def post_request(worker, request, environment, response):  # pylint: disable=unu
         # WARNING: As of now the parameters sig and frame aren't used by the thread worker (our current default). If
         # we change to another worker type, or if Gunicorn updates the handle_quit code to do something with them,
         # then we may need to pass something in.
-        worker.handle_quit(None, None)
+        worker.handle_abort(None, None)


### PR DESCRIPTION
Part of the `handle_quit` method for Gunicorn's thread workers is to shutdown the thread pool. It seems like if a request can come in at just the right time, a Gunicorn worker that is shutting down can still accept the request but then crash when trying to interact with the thread pool.

The `handle_abort` method does everything that `handle_quit` does, except shutting down the thread pool. This may mean that if a worker is still able to accept a request, then it will process it as it's shutting down. But that should be ok.

I've tested this locally and was able to reproduce the 502 error received when the thread pool error happens. Switching to the abort method resolves the problem.