### PR TITLE
[PDR-243] Correct PDR participant biospec data to reflect FINALIZED

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -878,8 +878,8 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 'bbo_finalized_site': row.finalized_site,
                 'bbo_finalized_site_id': row.finalized_site_id,
                 'bbo_finalized_time': row.finalized_time,
-                'bbo_finalized_status': str(OrderStatus(finalized_status)),
-                'bbo_finalized_status_id': int(OrderStatus(finalized_status)),
+                'bbo_finalized_status': str(finalized_status),
+                'bbo_finalized_status_id': int(finalized_status),
                 'bbo_tests_ordered': len(bos_results),
                 'bbo_tests_stored': stored_count,
                 'bbo_samples': bbo_samples

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -44,7 +44,7 @@ from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireH
 from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
     SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus, DeceasedStatus, \
-    DeceasedReportStatus, QuestionnaireResponseStatus, EnrollmentStatus
+    DeceasedReportStatus, QuestionnaireResponseStatus, EnrollmentStatus, OrderStatus
 from rdr_service.resource.helpers import DateCollection
 
 
@@ -790,6 +790,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                    bo.collected_site_id, (select google_group from site where site.site_id = bo.collected_site_id) as collected_site,
                    bo.processed_site_id, (select google_group from site where site.site_id = bo.processed_site_id) as processed_site,
                    bo.finalized_site_id, (select google_group from site where site.site_id = bo.finalized_site_id) as finalized_site,
+                   bo.finalized_time,
                    case when exists (
                      select bmko.participant_id
                      from biobank_mail_kit_order bmko
@@ -854,13 +855,21 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 if stored_sample:
                     stored_count += 1
 
+            # PDR-243:  calculate an UNSET or FINALIZED OrderStatus to include with the biobank order data.  Aligns
+            # with how RDR summarizes biospecimen details in participant_summary.biospecimen_* fields.  Intended to
+            # replace the need for a separate BQPDRBiospecimenSchema nested field in the participant data once PDR
+            # users update their queries to use the biobank order data instead of the biospec data.
+            bb_order_status = BiobankOrderStatus(row.order_status) if row.order_status else BiobankOrderStatus.UNSET
+            if row.finalized_time and bb_order_status != BiobankOrderStatus.CANCELLED:
+                finalized_status = OrderStatus.FINALIZED
+            else:
+                finalized_status = OrderStatus.UNSET
+
             order = {
                 'bbo_biobank_order_id': row.biobank_order_id,
                 'bbo_created': row.created,
-                'bbo_status': str(
-                    BiobankOrderStatus(row.order_status) if row.order_status else BiobankOrderStatus.UNSET),
-                'bbo_status_id': int(
-                    BiobankOrderStatus(row.order_status) if row.order_status else BiobankOrderStatus.UNSET),
+                'bbo_status': str(bb_order_status),
+                'bbo_status_id': int(bb_order_status),
                 'bbo_dv_order': row.dv_order,
                 'bbo_collected_site': row.collected_site,
                 'bbo_collected_site_id': row.collected_site_id,
@@ -868,6 +877,9 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 'bbo_processed_site_id': row.processed_site_id,
                 'bbo_finalized_site': row.finalized_site,
                 'bbo_finalized_site_id': row.finalized_site_id,
+                'bbo_finalized_time': row.finalized_time,
+                'bbo_finalized_status': str(OrderStatus(finalized_status)),
+                'bbo_finalized_status_id': int(OrderStatus(finalized_status)),
                 'bbo_tests_ordered': len(bos_results),
                 'bbo_tests_stored': stored_count,
                 'bbo_samples': bbo_samples
@@ -876,7 +888,8 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             orders.append(order)
 
         # Add any "orderless" stored samples for this participant.  They will all be associated with a
-        # "pseudo" order with an order id of 'UNSET'
+        # "pseudo" order with an order id of 'UNSET'.  The remaining BQBiobankOrderSchema fields will remain
+        # null
         if len(bss_missing_orders):
             orderless_stored_samples = list()
             for bss_row in bss_missing_orders:

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -156,6 +156,12 @@ class BQBiobankOrderSchema(BQSchema):
     bbo_samples = BQRecordField('bbo_samples', schema=BQBiobankSampleSchema)
     bbo_tests_ordered = BQField('bbo_tests_ordered', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     bbo_tests_stored = BQField('bbo_tests_stored', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    # PDR-243:  Including calculated OrderStatus (UNSET/FINALIZED) and finalized time analogous to the RDR
+    # participant_summary.biospecimen_* fields that are based on non-cancelled orders.
+    bbo_finalized_time = BQField('bbo_finalized_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    bbo_finalized_status = BQField('bbo_finalized_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    bbo_finalized_status_id = BQField('bbo_finalized_status_id',
+                                      BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQPatientStatusSchema(BQSchema):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -22,7 +22,7 @@ class BQPDRPhysicalMeasurements(BQSchema):
     pm_status_id = BQField('pm_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     pm_finalized = BQField('pm_finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
-
+# TODO:  Deprecate use of this class and add these fields to the BQBiobankOrderSchema
 class BQPDRBiospecimenSchema(BQSchema):
     """
     PDR Summary of Biobank Orders and Tests
@@ -36,7 +36,6 @@ class BQPDRBiospecimenSchema(BQSchema):
     biosp_baseline_tests = BQField('biosp_baseline_tests', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     biosp_baseline_tests_confirmed = BQField('biosp_baseline_tests_confirmed',
                                              BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-
 
 class BQPDREhrReceiptSchema(BQSchema):
     """

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -875,8 +875,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'finalized_site': row.finalized_site,
                 'finalized_site_id': row.finalized_site_id,
                 'finalized_time': row.finalized_time,
-                'finalized_status': str(OrderStatus(finalized_status)),
-                'finalized_status_id': int(OrderStatus(finalized_status)),
+                'finalized_status': str(finalized_status),
+                'finalized_status_id': int(finalized_status),
                 'tests_ordered': len(bos_results),
                 'tests_stored': stored_count,
                 'samples': bbo_samples

--- a/rdr_service/resource/schemas/pdr_participant.py
+++ b/rdr_service/resource/schemas/pdr_participant.py
@@ -33,6 +33,9 @@ class PDRBiobankOrderSchema(BiobankOrderSchema):
     isolate_dna_confirmed = fields.Boolean()
     baseline_tests = fields.Int32()
     baseline_tests_confirmed = fields.Int32()
+    finalized_time = fields.DateTime()
+    finalized_status = fields.String()
+    finalized_status_id = fields.Int32()
 
 
 class PDRParticipantSchema(Schema):
@@ -146,6 +149,7 @@ class PDRParticipantSchema(Schema):
     deceased_status = fields.EnumString(enum=DeceasedStatus)
     deceased_status_id = fields.EnumInteger(enum=DeceasedStatus)
     deceased_authored = fields.DateTime()
+
     # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR
     # date_of_death = fields.Date()
 


### PR DESCRIPTION
RDR participant summary uses a combination of finalized details and BiobankOrderStatus details (UNSET/AMENDED/CANCELLED) to translate a participant's biobank history into the `participant_summary.biospecimen_status` value (looks for orders that are not CANCELLED and also finalized and maps that to OrderStatus value FINALIZED, or UNSET otherwise).

PDR had been pulling the BiobankOrderStatus enum class values directly from the biobank order details and so wasn't reflecting the OrderStatus mapping.   This updates the logic to provide an analogous OrderStatus value in the data.