### PR TITLE
Fixing column offset for data-dictionary update

### DIFF
--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -464,6 +464,7 @@ class DataDictionaryUpdater:
             self.gcp_service_key_id,
             tab_offsets={
                 changelog_tab_id: 'A2',
+                dictionary_tab_id: 'B1',
                 internal_tables_tab_id: 'B1',
                 hpo_key_tab_id: 'A2',
                 questionnaire_key_tab_id: 'A2',

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -233,7 +233,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             [self._empty_cell],
             [self._empty_cell],
             [self._empty_cell],
-            *rows
+            *[[self._empty_cell, *row] for row in rows]
         )
 
     def test_version_added_display(self):


### PR DESCRIPTION
I missed that the main schema tab on the data-dictionary has column A hidden. So this shifts everything to start the rows at B instead.