### PR TITLE
[DA-257] Questionnaire response validation logs

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -168,13 +168,10 @@ class ResponseValidator:
         elif question.questionType in (SurveyQuestionType.TEXT, SurveyQuestionType.NOTES):
             if answer.valueString is None:
                 logging.warning(f'No valueString answer given for text-based question {answer.question.code.value}')
-        elif question.questionType in (SurveyQuestionType.CALC,
-                                       SurveyQuestionType.YESNO,
-                                       SurveyQuestionType.TRUEFALSE,
-                                       SurveyQuestionType.FILE,
-                                       SurveyQuestionType.SLIDER):
+        else:
             # There aren't alot of surveys in redcap right now, so it's unclear how these would be answered
-            logging.warning(f'No validation implemented for answer to {answer.question.code.value}')
+            logging.warning(f'No validation check implemented for answer to {answer.question.code.value} '
+                            f'with question type {question.questionType}')
 
     def check_response(self, response: QuestionnaireResponse):
         if self.survey is None:

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -165,6 +165,9 @@ class ResponseValidator:
                     f'Answer for {answer.question.code.value} gives no value code id '
                     f'when the question has options defined'
                 )
+        elif question.questionType in (SurveyQuestionType.TEXT, SurveyQuestionType.NOTES):
+            if answer.valueString is None:
+                logging.warning(f'No valueString answer given for text-based question {answer.question.code.value}')
         elif question.questionType in (SurveyQuestionType.CALC,
                                        SurveyQuestionType.YESNO,
                                        SurveyQuestionType.TRUEFALSE,

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -153,9 +153,7 @@ class ResponseValidator:
         if question.questionType in (SurveyQuestionType.UNKNOWN,
                                      SurveyQuestionType.DROPDOWN,
                                      SurveyQuestionType.RADIO,
-                                     SurveyQuestionType.CHECKBOX,
-                                     SurveyQuestionType.YESNO,
-                                     SurveyQuestionType.TRUEFALSE):
+                                     SurveyQuestionType.CHECKBOX):
             number_of_selectable_options = len(question.options)
             if number_of_selectable_options == 0 and answer.valueCodeId is not None:
                 # TODO: int test that the questionId is set for the answer
@@ -167,6 +165,13 @@ class ResponseValidator:
                     f'Answer for {answer.question.code.value} gives no value code id '
                     f'when the question has options defined'
                 )
+        elif question.questionType in (SurveyQuestionType.CALC,
+                                       SurveyQuestionType.YESNO,
+                                       SurveyQuestionType.TRUEFALSE,
+                                       SurveyQuestionType.FILE,
+                                       SurveyQuestionType.SLIDER):
+            # There aren't alot of surveys in redcap right now, so it's unclear how these would be answered
+            logging.warning(f'No validation implemented for answer to {answer.question.code.value}')
 
     def check_response(self, response: QuestionnaireResponse):
         if self.survey is None:
@@ -184,7 +189,10 @@ class ResponseValidator:
         # TODO: check that
         #   answers of the expected type (date, code for multi-select, integer, free-text)
         #   multi-select answers give an option that is valid for the question
+        #    e
         #   that there aren't more answers than expected (there could be fewer answers than what's in the survey)
+        #   (checkbox questions get multiple answers)
+        #    e
         #   a question isn't answered multiple times
         #   if there isn't branching logic on a question, then we should reasonably be able to assume that it
         #                   was answered

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -150,9 +150,12 @@ class ResponseValidator:
 
     @classmethod
     def _check_answer_has_expected_data_type(cls, answer: QuestionnaireResponseAnswer, question: SurveyQuestion):
-        if question.questionType == SurveyQuestionType.UNKNOWN:
-            # The only data type validation check that can be made is to see if the
-            # question definition specifies that there are options
+        if question.questionType in (SurveyQuestionType.UNKNOWN,
+                                     SurveyQuestionType.DROPDOWN,
+                                     SurveyQuestionType.RADIO,
+                                     SurveyQuestionType.CHECKBOX,
+                                     SurveyQuestionType.YESNO,
+                                     SurveyQuestionType.TRUEFALSE):
             number_of_selectable_options = len(question.options)
             if number_of_selectable_options == 0 and answer.valueCodeId is not None:
                 # TODO: int test that the questionId is set for the answer

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -155,20 +155,21 @@ class ResponseValidator:
             # question definition specifies that there are options
             number_of_selectable_options = len(question.options)
             if number_of_selectable_options == 0 and answer.valueCodeId is not None:
+                # TODO: int test that the questionId is set for the answer
                 logging.warning(
-                    f'Answer for question {answer.questionId} gives a value code id when no options are defined'
+                    f'Answer for {answer.question.code.value} gives a value code id when no options are defined'
                 )
             elif number_of_selectable_options > 0 and answer.valueCodeId is None:
                 logging.warning(
-                    f'Answer for question {answer.questionId} gives no value code id '
-                    'when the question has options defined'
+                    f'Answer for {answer.question.code.value} gives no value code id '
+                    f'when the question has options defined'
                 )
 
     def check_response(self, response: QuestionnaireResponse):
         if self.survey is None:
             return None
 
-        for answer in response.answers:
+        for answer in response.answers:  # todo: int test that the answers relationship is set
             survey_question = self._code_to_question_map.get(answer.question.codeId)
             if not survey_question:
                 # TODO: write test for this

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -340,10 +340,12 @@ class QuestionnaireResponseDao(BaseDao):
             session, [questionnaire_response.questionnaireId, questionnaire_response.questionnaireSemanticVersion]
         )
 
-        answer_validator = ResponseValidator(questionnaire_history, session)
-        answer_validator.check_response(questionnaire_response)
-        # todo: check that this integration works as expected
-        #  and see if the validation following this call is still needed (or if it can be fixed up a bit)
+        if questionnaire_history:
+            answer_validator = ResponseValidator(questionnaire_history, session)
+            answer_validator.check_response(questionnaire_response)
+        else:
+            logging.error('No questionnaire_history available for validation')
+        # todo: see if the validation following this call is still needed (or if it can be fixed up a bit)
 
         if not questionnaire_history:
             raise BadRequest(

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -153,7 +153,7 @@ class ResponseValidator:
 
     @classmethod
     def _build_question_id_map(cls, questionnaire_history: QuestionnaireHistory) -> Dict[int, QuestionnaireQuestion]:
-        return {question.questionnaireId: question for question in questionnaire_history.questions}
+        return {question.questionnaireQuestionId: question for question in questionnaire_history.questions}
 
     @classmethod
     def _validate_min_max(cls, answer, min_str, max_str, parser_function, question_code):
@@ -254,7 +254,7 @@ class ResponseValidator:
                     logging.error(f'Question code used by the answer to question {answer.questionId} does not match a '
                                   f'code found on the survey definition')
                 else:
-                    self._check_answer_has_expected_data_type(answer, survey_question)
+                    self._check_answer_has_expected_data_type(answer, survey_question, questionnaire_question)
 
                 if survey_question.codeId in question_codes_answered:
                     logging.error(f'Too many answers given for {survey_question.code.value}')

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -181,11 +181,16 @@ class ResponseValidator:
                 logging.warning(
                     f'Answer for {question_code} gives a value code id when no options are defined'
                 )
-            elif number_of_selectable_options > 0 and answer.valueCodeId is None:
-                logging.warning(
-                    f'Answer for {question_code} gives no value code id '
-                    f'when the question has options defined'
-                )
+            elif number_of_selectable_options > 0:
+                if answer.valueCodeId is None:
+                    logging.warning(
+                        f'Answer for {question_code} gives no value code id '
+                        f'when the question has options defined'
+                    )
+                elif answer.valueCodeId not in [option.codeId for option in question.options]:
+                    # todo: int test, would this code be filled in?
+                    logging.warning(f'{answer.code.value} is an invalid answer to {question_code}')
+
         elif question.questionType in (SurveyQuestionType.TEXT, SurveyQuestionType.NOTES):
             if answer.valueString is None and question.validation is None:
                 logging.warning(f'No valueString answer given for text-based question {question_code}')
@@ -237,9 +242,6 @@ class ResponseValidator:
                 self._check_answer_has_expected_data_type(answer, survey_question)
 
         # TODO: check that
-        #   answers of the expected type (date, code for multi-select, integer, free-text)
-        #   multi-select answers give an option that is valid for the question
-        #    e
         #   that there aren't more answers than expected (there could be fewer answers than what's in the survey)
         #   (checkbox questions get multiple answers)
         #    e

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -6,8 +6,8 @@ from datetime import datetime
 from dateutil import parser
 import pytz
 from sqlalchemy import or_
-from typing import Dict
 from sqlalchemy.orm import joinedload, subqueryload
+from typing import Dict
 from werkzeug.exceptions import BadRequest
 
 from rdr_service.lib_fhir.fhirclient_1_0_6.models import questionnaireresponse as fhir_questionnaireresponse
@@ -132,9 +132,6 @@ class ResponseValidator:
                 Survey.replacedTime > questionnaire_history.created
             )
         ).options(
-            joinedload(Survey.questions),
-            joinedload(Survey.questions).joinedload(SurveyQuestion.code),
-            joinedload(Survey.questions).joinedload(SurveyQuestion.options),
             joinedload(Survey.questions).joinedload(SurveyQuestion.options).joinedload(SurveyQuestionOption.code)
         )
         num_surveys_found = survey_query.count()

--- a/rdr_service/model/questionnaire.py
+++ b/rdr_service/model/questionnaire.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
 )
 from sqlalchemy import BLOB  # pylint: disable=unused-import
 from sqlalchemy.orm import relationship
+from typing import List
 
 from rdr_service.model.base import Base
 from rdr_service.model.utils import Enum, UTCDateTime
@@ -65,7 +66,7 @@ class Questionnaire(QuestionnaireBase, Base):
 class QuestionnaireHistory(QuestionnaireBase, Base):
     __tablename__ = "questionnaire_history"
     version = Column("version", Integer, primary_key=True)
-    concepts = relationship("QuestionnaireConcept", cascade="all, delete-orphan")
+    concepts: List['QuestionnaireConcept'] = relationship("QuestionnaireConcept", cascade="all, delete-orphan")
     questions = relationship("QuestionnaireQuestion", cascade="all, delete-orphan")
 
 

--- a/rdr_service/model/questionnaire.py
+++ b/rdr_service/model/questionnaire.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import relationship
 from typing import List
 
 from rdr_service.model.base import Base
+from rdr_service.model.code import Code
 from rdr_service.model.utils import Enum, UTCDateTime
 from rdr_service.participant_enums import QuestionnaireDefinitionStatus
 from rdr_service.model.field_types import BlobUTF8
@@ -67,7 +68,7 @@ class QuestionnaireHistory(QuestionnaireBase, Base):
     __tablename__ = "questionnaire_history"
     version = Column("version", Integer, primary_key=True)
     concepts: List['QuestionnaireConcept'] = relationship("QuestionnaireConcept", cascade="all, delete-orphan")
-    questions = relationship("QuestionnaireQuestion", cascade="all, delete-orphan")
+    questions: List['QuestionnaireQuestion'] = relationship("QuestionnaireQuestion", cascade="all, delete-orphan")
 
 
 class QuestionnaireConcept(Base):
@@ -128,3 +129,5 @@ class QuestionnaireQuestion(Base):
         ),
         UniqueConstraint("questionnaire_id", "questionnaire_version", "link_id"),
     )
+
+    code = relationship(Code)

--- a/rdr_service/model/questionnaire_response.py
+++ b/rdr_service/model/questionnaire_response.py
@@ -15,10 +15,8 @@ from sqlalchemy.sql import text
 from typing import List
 
 from rdr_service.model.base import Base
-from rdr_service.model.code import Code
 from rdr_service.model.utils import EnumZeroBased, UTCDateTime
 from rdr_service.model.field_types import BlobUTF8
-from rdr_service.model.questionnaire import QuestionnaireQuestion
 from rdr_service.participant_enums import QuestionnaireResponseStatus
 
 
@@ -125,9 +123,6 @@ class QuestionnaireResponseAnswer(Base):
     When the response is a Uniform Resource Identifier Reference (RFC 3986 ).
     Note: URIs are case sensitive. For UUID (urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7) use all lowercase
     """
-
-    question = relationship(QuestionnaireQuestion)
-    code = relationship(Code)
 
 
 class QuestionnaireResponseExtension(Base):

--- a/rdr_service/model/questionnaire_response.py
+++ b/rdr_service/model/questionnaire_response.py
@@ -15,6 +15,7 @@ from sqlalchemy.sql import text
 from typing import List
 
 from rdr_service.model.base import Base
+from rdr_service.model.code import Code
 from rdr_service.model.utils import EnumZeroBased, UTCDateTime
 from rdr_service.model.field_types import BlobUTF8
 from rdr_service.model.questionnaire import QuestionnaireQuestion
@@ -126,6 +127,7 @@ class QuestionnaireResponseAnswer(Base):
     """
 
     question = relationship(QuestionnaireQuestion)
+    code = relationship(Code)
 
 
 class QuestionnaireResponseExtension(Base):

--- a/rdr_service/model/questionnaire_response.py
+++ b/rdr_service/model/questionnaire_response.py
@@ -12,10 +12,12 @@ from sqlalchemy import (
 from sqlalchemy import BLOB  # pylint: disable=unused-import
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import text
+from typing import List
 
 from rdr_service.model.base import Base
 from rdr_service.model.utils import EnumZeroBased, UTCDateTime
 from rdr_service.model.field_types import BlobUTF8
+from rdr_service.model.questionnaire import QuestionnaireQuestion
 from rdr_service.participant_enums import QuestionnaireResponseStatus
 
 
@@ -48,7 +50,9 @@ class QuestionnaireResponse(Base):
         default=QuestionnaireResponseStatus.COMPLETED,
         server_default=text(str(int(QuestionnaireResponseStatus.COMPLETED)))
     )
-    answers = relationship("QuestionnaireResponseAnswer", cascade="all, delete-orphan")
+    answers: List['QuestionnaireResponseAnswer'] = relationship(
+        "QuestionnaireResponseAnswer", cascade="all, delete-orphan"
+    )
     extensions = relationship('QuestionnaireResponseExtension')
 
     __table_args__ = (
@@ -120,6 +124,8 @@ class QuestionnaireResponseAnswer(Base):
     When the response is a Uniform Resource Identifier Reference (RFC 3986 ).
     Note: URIs are case sensitive. For UUID (urn:uuid:53fefa32-fcbb-4ff8-8a92-55ee120877b7) use all lowercase
     """
+
+    question = relationship(QuestionnaireQuestion)
 
 
 class QuestionnaireResponseExtension(Base):

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -177,13 +177,13 @@ class ResponseValidatorTest(BaseTestCase):
         validator = ResponseValidator(questionnaire_history, self.session)
         validator.check_response(response)
 
-        no_validation_check_message = 'No validation implemented for answer to {}'
+        no_validation_check_message = 'No validation check implemented for answer to {} with question type {}'
         mock_logging.warning.assert_has_calls([
-            mock.call(no_validation_check_message.format(calc_question_code.value)),
-            mock.call(no_validation_check_message.format(yesno_question_code.value)),
-            mock.call(no_validation_check_message.format(truefalse_question_code.value)),
-            mock.call(no_validation_check_message.format(file_question_code.value)),
-            mock.call(no_validation_check_message.format(slider_question_code.value)),
+            mock.call(no_validation_check_message.format(calc_question_code.value, SurveyQuestionType.CALC)),
+            mock.call(no_validation_check_message.format(yesno_question_code.value, SurveyQuestionType.YESNO)),
+            mock.call(no_validation_check_message.format(truefalse_question_code.value, SurveyQuestionType.TRUEFALSE)),
+            mock.call(no_validation_check_message.format(file_question_code.value, SurveyQuestionType.FILE)),
+            mock.call(no_validation_check_message.format(slider_question_code.value, SurveyQuestionType.SLIDER))
         ])
 
     @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -196,3 +196,27 @@ class ResponseValidatorTest(BaseTestCase):
             mock.call(no_validation_check_message.format(slider_question_code.value)),
         ])
 
+    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
+    def test_log_for_text_questions_not_answered_with_text(self, mock_logging):
+        text_question_code = self.data_generator.create_database_code(value='text_question')
+        note_question_code = self.data_generator.create_database_code(value='note_question')
+
+        questionnaire_history, response = self._build_questionnaire_and_response(
+            questions={
+                text_question_code: QuestionDefinition(question_type=SurveyQuestionType.TEXT),
+                note_question_code: QuestionDefinition(question_type=SurveyQuestionType.NOTES)
+            },
+            answers={
+                text_question_code: QuestionnaireResponseAnswer(valueInteger=1),
+                note_question_code: QuestionnaireResponseAnswer(valueInteger=1)
+            }
+        )
+
+        validator = ResponseValidator(questionnaire_history, self.session)
+        validator.check_response(response)
+
+        mock_logging.warning.assert_has_calls([
+            mock.call(f'No valueString answer given for text-based question {text_question_code.value}'),
+            mock.call(f'No valueString answer given for text-based question {note_question_code.value}')
+        ])
+

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -1,58 +1,109 @@
+from dataclasses import dataclass, field
 from datetime import datetime
 import mock
+from typing import Dict, List
 
 from rdr_service.dao.questionnaire_response_dao import ResponseValidator
+from rdr_service.model.code import Code
 from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory
-from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
+from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireQuestion,\
+    QuestionnaireResponseAnswer
 from rdr_service.model.survey import SurveyQuestionType
 from tests.helpers.unittest_base import BaseTestCase
 
 
+@dataclass
+class QuestionDefinition:
+    question_type: SurveyQuestionType = None
+    options: List[Code] = field(default_factory=list)
+
+
 class ResponseValidatorTest(BaseTestCase):
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
-    def test_simple_survey_response_validation(self, mock_logging):
-        """
-        This test uses a Survey structure that looks like what we have from the legacy code system.
-        """
+    def _build_questionnaire_and_response(self, questions: Dict[Code, QuestionDefinition],
+                                          answers: Dict[Code, QuestionnaireResponseAnswer],
+                                          survey_import_time=datetime(2020, 12, 4),
+                                          questionnaire_created_time=datetime(2021, 4, 1)):
         module_code = self.data_generator.create_database_code(value='test_survey')
-        multi_select_question_code = self.data_generator.create_database_code(value='multi_select')
 
-        survey_import_time = datetime(2020, 12, 4)
-        questionnaire_created_time = datetime(2021, 4, 1)
-
-        survey_question_options = [
-            self.data_generator.create_database_survey_question_option(codeId=option_code.codeId)
-            for option_code in [
-                self.data_generator.create_database_code(value='option_a'),
-                self.data_generator.create_database_code(value='option_b')
+        # Build survey structure for defined questions
+        survey_questions = []
+        for question_code, definition in questions.items():
+            survey_question_options = [
+                self.data_generator.create_database_survey_question_option(codeId=option_code.codeId)
+                for option_code in definition.options
             ]
-        ]
-        survey_question = self.data_generator.create_database_survey_question(
-            code=multi_select_question_code,
-            options=survey_question_options,
-            questionType=SurveyQuestionType.UNKNOWN
-        )
+            survey_questions.append(self.data_generator.create_database_survey_question(
+                code=question_code,
+                options=survey_question_options,
+                questionType=definition.question_type
+            ))
         self.data_generator.create_database_survey(
             importTime=survey_import_time,
             code=module_code,
-            questions=[survey_question]
+            questions=survey_questions
         )
 
-        questionnaire_concept = QuestionnaireConcept(codeId=module_code.codeId)
+        # Build related QuestionnaireHistory for the response
+        questionnaire_questions = [
+            QuestionnaireQuestion(
+                codeId=question_code.codeId,
+                code=question_code
+            )
+            for question_code in questions.keys()
+        ]
         questionnaire_history = QuestionnaireHistory(
-            created=questionnaire_created_time,
-            concepts=[questionnaire_concept]
+            questions=questionnaire_questions,
+            concepts=[QuestionnaireConcept(codeId=module_code.codeId)],
+            created=questionnaire_created_time
         )
 
-        multi_select_answer = QuestionnaireResponseAnswer(
-            valueString='answering with string rather than something selected from a list of options'
-        )
+        # Build the response to the questionnaire
+        question_code_map: Dict[int, QuestionnaireQuestion] = {
+            question.codeId: question for question in questionnaire_questions
+        }
+        for code, answer in answers.items():
+            question = question_code_map[code.codeId]
+            answer.questionId = question.questionnaireQuestionId
+            answer.question = question
         questionnaire_response = QuestionnaireResponse(
-            answers=[multi_select_answer]
+            answers=list(answers.values())
+        )
+
+        return questionnaire_history, questionnaire_response
+
+    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
+    def test_simple_survey_response_validation(self, mock_logging):
+        """
+        For surveys derived from the legacy code system, we can only verify that questions that
+        have options are responded to with valueCodeId
+        """
+        multi_select_question_code = self.data_generator.create_database_code(value='multi_select')
+        free_text_question_code = self.data_generator.create_database_code(value='free_text')
+
+        questionnaire_history, response = self._build_questionnaire_and_response(
+            questions={
+                multi_select_question_code: QuestionDefinition(question_type=SurveyQuestionType.UNKNOWN, options=[
+                    self.data_generator.create_database_code(value='option_a'),
+                    self.data_generator.create_database_code(value='option_b')
+                ]),
+                free_text_question_code: QuestionDefinition(question_type=SurveyQuestionType.UNKNOWN)
+            },
+            answers={
+                multi_select_question_code: QuestionnaireResponseAnswer(
+                    valueString='answering with string rather than something selected from a list of options'
+                ),
+                free_text_question_code: QuestionnaireResponseAnswer(
+                    valueCodeId=self.data_generator.create_database_code(value='unknown_option')
+                )
+            }
         )
 
         validator = ResponseValidator(questionnaire_history, self.session)
-        validator.check_response(questionnaire_response)
+        validator.check_response(response)
 
-        mock_logging.assert_called_with()
+        mock_logging.warning.assert_has_calls([
+            mock.call(f'Answer for {multi_select_question_code.value} gives no value code id when the question '
+                      f'has options defined'),
+            mock.call(f'Answer for {free_text_question_code.value} gives a value code id when no options are defined')
+        ])
 

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+import mock
+
+from rdr_service.dao.questionnaire_response_dao import ResponseValidator
+from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory
+from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
+from rdr_service.model.survey import SurveyQuestionType
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ResponseValidatorTest(BaseTestCase):
+    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
+    def test_simple_survey_response_validation(self, mock_logging):
+        """
+        This test uses a Survey structure that looks like what we have from the legacy code system.
+        """
+        module_code = self.data_generator.create_database_code(value='test_survey')
+        multi_select_question_code = self.data_generator.create_database_code(value='multi_select')
+
+        survey_import_time = datetime(2020, 12, 4)
+        questionnaire_created_time = datetime(2021, 4, 1)
+
+        survey_question_options = [
+            self.data_generator.create_database_survey_question_option(codeId=option_code.codeId)
+            for option_code in [
+                self.data_generator.create_database_code(value='option_a'),
+                self.data_generator.create_database_code(value='option_b')
+            ]
+        ]
+        survey_question = self.data_generator.create_database_survey_question(
+            code=multi_select_question_code,
+            options=survey_question_options,
+            questionType=SurveyQuestionType.UNKNOWN
+        )
+        self.data_generator.create_database_survey(
+            importTime=survey_import_time,
+            code=module_code,
+            questions=[survey_question]
+        )
+
+        questionnaire_concept = QuestionnaireConcept(codeId=module_code.codeId)
+        questionnaire_history = QuestionnaireHistory(
+            created=questionnaire_created_time,
+            concepts=[questionnaire_concept]
+        )
+
+        multi_select_answer = QuestionnaireResponseAnswer(
+            valueString='answering with string rather than something selected from a list of options'
+        )
+        questionnaire_response = QuestionnaireResponse(
+            answers=[multi_select_answer]
+        )
+
+        validator = ResponseValidator(questionnaire_history, self.session)
+        validator.check_response(questionnaire_response)
+
+        mock_logging.assert_called_with()
+

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -20,6 +20,7 @@ class QuestionDefinition:
     validation_max: str = None
 
 
+@mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
 class ResponseValidatorTest(BaseTestCase):
     def _build_questionnaire_and_response(self, questions: Dict[Code, QuestionDefinition],
                                           answers: Dict[Code, QuestionnaireResponseAnswer],
@@ -76,7 +77,6 @@ class ResponseValidatorTest(BaseTestCase):
 
         return questionnaire_history, questionnaire_response
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_simple_survey_response_validation(self, mock_logging):
         """
         For surveys derived from the legacy code system, we can only verify that questions that
@@ -112,7 +112,6 @@ class ResponseValidatorTest(BaseTestCase):
             mock.call(f'Answer for {free_text_question_code.value} gives a value code id when no options are defined')
         ])
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_option_select_data_type_validation(self, mock_logging):
         """
         Survey questions that are defined with options should be answered with valueCodeId
@@ -151,7 +150,6 @@ class ResponseValidatorTest(BaseTestCase):
             mock.call(no_value_code_id_used_message.format(checkbox_question_code.value))
         ])
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_log_for_unimplemented_validation(self, mock_logging):
         calc_question_code = self.data_generator.create_database_code(value='calc_question')
         yesno_question_code = self.data_generator.create_database_code(value='yesno_question')
@@ -191,7 +189,6 @@ class ResponseValidatorTest(BaseTestCase):
             mock.call(no_validation_check_message.format(slider_question_code.value, SurveyQuestionType.SLIDER))
         ])
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_log_for_text_questions_not_answered_with_text(self, mock_logging):
         text_question_code = self.data_generator.create_database_code(value='text_question')
         note_question_code = self.data_generator.create_database_code(value='note_question')
@@ -215,7 +212,6 @@ class ResponseValidatorTest(BaseTestCase):
             mock.call(f'No valueString answer given for text-based question {note_question_code.value}')
         ])
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_question_validation_data_type(self, mock_logging):
         """Validation strings give that a TEXT question should be another datatype"""
         date_question_code = self.data_generator.create_database_code(value='date_question')
@@ -250,7 +246,6 @@ class ResponseValidatorTest(BaseTestCase):
             mock.call(f'Unrecognized validation string "abc" for question {unknown_question_code.value}')
         ])
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_question_validation_min_max(self, mock_logging):
         date_question_code = self.data_generator.create_database_code(value='date_question')
         integer_question_code = self.data_generator.create_database_code(value='integer_question')
@@ -301,7 +296,6 @@ class ResponseValidatorTest(BaseTestCase):
             )
         ])
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_option_select_option_validation(self, mock_logging):
         """
         Survey questions that are defined with options should be answered with one of those options
@@ -329,7 +323,6 @@ class ResponseValidatorTest(BaseTestCase):
             f'Code ID {unrecognized_answer_code.codeId} is an invalid answer to {dropdown_question_code.value}'
         )
 
-    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
     def test_questions_answered_multiple_times(self, mock_logging):
         """We should only get one answer for a question (except Checkbox questions)"""
         dropdown_question_code = self.data_generator.create_database_code(value='dropdown_select')

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -108,17 +108,13 @@ class ResponseValidatorTest(BaseTestCase):
         ])
 
     @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
-    def test_simple_survey_response_validation(self, mock_logging):
+    def test_option_select_validation(self, mock_logging):
         """
         Survey questions that are defined with options should be answered with valueCodeId
         """
         dropdown_question_code = self.data_generator.create_database_code(value='multi_select')
         radio_question_code = self.data_generator.create_database_code(value='radio_select')
         checkbox_question_code = self.data_generator.create_database_code(value='checkbox_select')
-
-        yesno_question_code = self.data_generator.create_database_code(value='yesno_select')
-        truefalse_question_code = self.data_generator.create_database_code(value='truefalse_select')
-        # todo: check how these are answered in the cope surveys (if they're there)
 
         # The validator only checks to see if there are options and doesn't really mind what they are,
         # using the same options for all the questions for simplicity
@@ -131,16 +127,12 @@ class ResponseValidatorTest(BaseTestCase):
             questions={
                 dropdown_question_code: QuestionDefinition(question_type=SurveyQuestionType.DROPDOWN, options=options),
                 radio_question_code: QuestionDefinition(question_type=SurveyQuestionType.RADIO, options=options),
-                checkbox_question_code: QuestionDefinition(question_type=SurveyQuestionType.CHECKBOX, options=options),
-                yesno_question_code: QuestionDefinition(question_type=SurveyQuestionType.YESNO, options=options),
-                truefalse_question_code: QuestionDefinition(question_type=SurveyQuestionType.TRUEFALSE, options=options)
+                checkbox_question_code: QuestionDefinition(question_type=SurveyQuestionType.CHECKBOX, options=options)
             },
             answers={
                 dropdown_question_code: QuestionnaireResponseAnswer(valueString='text answer'),
                 radio_question_code: QuestionnaireResponseAnswer(valueString='text answer'),
-                checkbox_question_code: QuestionnaireResponseAnswer(valueString='text answer'),
-                yesno_question_code: QuestionnaireResponseAnswer(valueString='text answer'),
-                truefalse_question_code: QuestionnaireResponseAnswer(valueString='text answer')
+                checkbox_question_code: QuestionnaireResponseAnswer(valueString='text answer')
             }
         )
 
@@ -151,9 +143,7 @@ class ResponseValidatorTest(BaseTestCase):
         mock_logging.warning.assert_has_calls([
             mock.call(no_value_code_id_used_message.format(dropdown_question_code.value)),
             mock.call(no_value_code_id_used_message.format(radio_question_code.value)),
-            mock.call(no_value_code_id_used_message.format(checkbox_question_code.value)),
-            mock.call(no_value_code_id_used_message.format(yesno_question_code.value)),
-            mock.call(no_value_code_id_used_message.format(truefalse_question_code.value)),
+            mock.call(no_value_code_id_used_message.format(checkbox_question_code.value))
         ])
 
     @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -156,3 +156,43 @@ class ResponseValidatorTest(BaseTestCase):
             mock.call(no_value_code_id_used_message.format(truefalse_question_code.value)),
         ])
 
+    @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
+    def test_log_for_unimplemented_validation(self, mock_logging):
+        calc_question_code = self.data_generator.create_database_code(value='calc_question')
+        yesno_question_code = self.data_generator.create_database_code(value='yesno_question')
+        truefalse_question_code = self.data_generator.create_database_code(value='truefalse_question')
+        file_question_code = self.data_generator.create_database_code(value='file_question')
+        slider_question_code = self.data_generator.create_database_code(value='slider_question')
+
+        questionnaire_history, response = self._build_questionnaire_and_response(
+            questions={
+                calc_question_code: QuestionDefinition(question_type=SurveyQuestionType.CALC),
+                yesno_question_code: QuestionDefinition(question_type=SurveyQuestionType.YESNO),
+                truefalse_question_code: QuestionDefinition(question_type=SurveyQuestionType.TRUEFALSE),
+                file_question_code: QuestionDefinition(question_type=SurveyQuestionType.FILE),
+                slider_question_code: QuestionDefinition(question_type=SurveyQuestionType.SLIDER)
+            },
+            answers={
+                question_code: QuestionnaireResponseAnswer()
+                for question_code in [
+                    calc_question_code,
+                    yesno_question_code,
+                    truefalse_question_code,
+                    file_question_code,
+                    slider_question_code
+                ]
+            }
+        )
+
+        validator = ResponseValidator(questionnaire_history, self.session)
+        validator.check_response(response)
+
+        no_validation_check_message = 'No validation implemented for answer to {}'
+        mock_logging.warning.assert_has_calls([
+            mock.call(no_validation_check_message.format(calc_question_code.value)),
+            mock.call(no_validation_check_message.format(yesno_question_code.value)),
+            mock.call(no_validation_check_message.format(truefalse_question_code.value)),
+            mock.call(no_validation_check_message.format(file_question_code.value)),
+            mock.call(no_validation_check_message.format(slider_question_code.value)),
+        ])
+

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -18,7 +18,7 @@ from rdr_service.model.questionnaire import Questionnaire, QuestionnaireConcept,
     QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.model.site import Site
-from rdr_service.model.survey import Survey
+from rdr_service.model.survey import Survey, SurveyQuestion, SurveyQuestionOption
 from rdr_service.offline.biobank_samples_pipeline import _PMI_OPS_SYSTEM
 from rdr_service.participant_enums import (
     DeceasedNotification,
@@ -502,6 +502,22 @@ class DataGenerator:
             module_code = self.create_database_code()
             kwargs['codeId'] = module_code.codeId
         return Survey(**kwargs)
+
+    def create_database_survey_question(self, **kwargs):
+        survey_question = self._survey_question(**kwargs)
+        self._commit_to_database(survey_question)
+        return survey_question
+
+    def _survey_question(self, **kwargs):
+        return SurveyQuestion(**kwargs)
+
+    def create_database_survey_question_option(self, **kwargs):
+        survey_question_option = self._survey_question_option(**kwargs)
+        self._commit_to_database(survey_question_option)
+        return survey_question_option
+
+    def _survey_question_option(self, **kwargs):
+        return SurveyQuestionOption(**kwargs)
 
     def create_database_genomic_manifest_file(self, **kwargs):
         manifest = self._genomic_manifest_file(**kwargs)


### PR DESCRIPTION
This uses information we're able to get from the codes we previously had and the data we're able to pull about surveys from Redcap to check the questionnaire response. It compares the answers to what we we expect (based on the definition of the question). For now, it will only record log messages. No responses should be rejected because of the current changes. But, as this is tweaked and updated, we can start upgrading certain checks and allow them to reject the response.

We'd expect:
- any questions that have options defined (and/or are of the type CHECKBOX, DROPDOWN, or RADIO) should be answered with a `valueCodeId` value
- any questions defined as TEXT or NOTES type questions should be answered with a `valueString` answer (unless they have validations defined)
- for any questions of the TEXT or NOTES type that have validation strings defined:
  - a question with a validation string of `date...` should be answered with `valueDate`
  - questions with a validation string of `integer` should be answered with `valueInteger`
  - if a question has a validation_min or validation_max, any answer should fall within the defined range
- Questions should only be answered once in a response (except the CHECKBOX answer type, we get a distinct answer for each option selected on those)