### PR TITLE
Remove log message when skipping file

### DIFF
--- a/rdr_service/gcloud_functions/genomic_aw1_baylor_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw1_baylor_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if '_sample_manifests' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match AW1 file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_aw1_broad_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw1_broad_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if '_sample_manifests' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match AW1 file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_aw1_northwest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw1_northwest_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if '_sample_manifests' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match AW1 file.')
             return
 
         # Northwest moves their files to a `downloaded` subfolder. Ignore these.

--- a/rdr_service/gcloud_functions/genomic_aw2_baylor_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw2_baylor_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if '_data_manifests' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match Data Manifest file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_aw2_broad_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw2_broad_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if '_data_manifests' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match Data Manifest file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_aw2_northwest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw2_northwest_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if '_data_manifests' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match Data Manifest file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_aw5_baylor_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw5_baylor_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if 'aw5' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match Data Manifest file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_aw5_broad_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw5_broad_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if 'aw5' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match Data Manifest file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_aw5_northwest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_aw5_northwest_function/main.py
@@ -34,7 +34,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if 'aw5' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match Data Manifest file.')
             return
 
         _logger.info(f"file found: {self.event.name}")

--- a/rdr_service/gcloud_functions/genomic_manifest_generic_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_manifest_generic_function/main.py
@@ -37,7 +37,6 @@ class GenomicManifestGenericFunction(FunctionStoragePubSubHandler):
         """ Handle storage object created event. """
         # Verify this is a file that we want to process.
         if 'aw1_genotyping_sample_manifests' not in self.event.name.lower():
-            _logger.info(f'Skipping file {self.event.name}, name does not match AW1 file.')
             return
 
         _logger.info(f"file found: {self.event.name}")


### PR DESCRIPTION
@pegbertsch @dtharpeuno 
This PR removes the log message when a non-target file is uploaded to a GCS bucket tracked by a genomic cloud function. 