### PR TITLE
Removing codeowners file to disable automatically tagging reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# each of the owners will be requested for
-# review when someone opens a pull request.
-*       @j-kanuch @robabram @pegbertsch @wangy70 @kenny-skaggs @dtharpeuno


### PR DESCRIPTION
This will let us specify individuals as reviewers and keep github from automatically adding everyone else.