### PR TITLE
[DA-1953] Refactor AW1 raw tool; implement AW2 raw tool

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -35,7 +35,7 @@ from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.query import FieldFilter, Operator, OrderBy, Query
 from rdr_service.resource.generators.genomics import genomic_set_member_update, genomic_manifest_feedback_update, \
     genomic_manifest_file_update
-from rdr_service.genomic.genomic_mappings import genome_type_to_aw1_file_prefix as genome_type_map
+from rdr_service.genomic.genomic_mappings import genome_type_to_aw1_aw2_file_prefix as genome_type_map
 
 class GenomicSetDao(UpdatableDao):
     """ Stub for GenomicSet model """
@@ -1521,7 +1521,8 @@ class GenomicAW1RawDao(BaseDao):
         with self.session() as session:
             return session.query(GenomicAW1Raw).filter(
                 GenomicAW1Raw.biobank_id == biobank_id,
-                GenomicAW1Raw.file_path.like(f"%{genome_type_map[genome_type]}%")
+                GenomicAW1Raw.file_path.like(f"%{genome_type_map[genome_type]}%"),
+                GenomicAW1Raw.ignore_flag == 0
             ).one()
 
 
@@ -1552,6 +1553,14 @@ class GenomicAW2RawDao(BaseDao):
                 GenomicAW2Raw.file_path == filepath
             ).one_or_none()
 
+    def get_raw_record_from_bid_genome_type(self, biobank_id, genome_type):
+
+        with self.session() as session:
+            return session.query(GenomicAW2Raw).filter(
+                GenomicAW2Raw.biobank_id == biobank_id,
+                GenomicAW2Raw.file_path.like(f"%{genome_type_map[genome_type]}%"),
+                GenomicAW2Raw.ignore_flag == 0
+            ).one()
 
 class GenomicIncidentDao(UpdatableDao):
     def __init__(self):

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -398,7 +398,7 @@ class GenomicJobController:
             raise ValueError(f'contamination must be a number for member_id: {member.id}')
 
         # Calculate contamination_category using an ingester
-        ingester = GenomicFileIngester(_controller=self)
+        ingester = GenomicFileIngester(_controller=self, job_id=self.job_id)
         category = ingester.calculate_contamination_category(member.collectionTubeId,
                                                              raw.contamination, member)
         raw.contamination_category = category

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -330,7 +330,7 @@ class GenomicJobController:
                 genomic_gc_validation_metrics_batch_update(metrics)
 
             # Members
-            bq_genomic_set_member_batch_update(metrics,project_id=self.bq_project_id)
+            bq_genomic_set_member_batch_update(metrics, project_id=self.bq_project_id)
             genomic_set_member_batch_update(completed_members)
 
         return self.compile_raw_ingestion_results(completed_members, missing, multiples, metrics)

--- a/rdr_service/genomic/genomic_mappings.py
+++ b/rdr_service/genomic/genomic_mappings.py
@@ -2,7 +2,7 @@
 This module provides central location for all genomics_mappings
 """
 
-genome_type_to_aw1_file_prefix = {
+genome_type_to_aw1_aw2_file_prefix = {
             "aou_array": "_GEN_",
             "aou_wgs": "_SEQ_",
         }
@@ -31,4 +31,20 @@ raw_aw1_to_genomic_set_member_fields = {
     "test_name": "gcManifestTestName",
     "failure_mode": "gcManifestFailureMode",
     "failure_mode_desc": "gcManifestFailureDescription"
+}
+
+raw_aw2_to_genomic_set_member_fields = {
+    "lims_id": "limsId",
+    "chipwellbarcode": "chipwellbarcode",
+    "call_rate": "callRate",
+    "mean_coverage": "meanCoverage",
+    "genome_coverage": "genomeCoverage",
+    "aouhdr_coverage": "aouHdrCoverage",
+    "contamination": "contamination",
+    "sex_concordance": "sexConcordance",
+    "sex_ploidy": "sexPloidy",
+    "aligned_q30_bases": "alignedQ30Bases",
+    "array_concordance": "arrayConcordance",
+    "processing_status": "processingStatus",
+    "notes": "notes",
 }

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -988,8 +988,8 @@ class GenomicProcessRunner(GenomicManifestBase):
 
         if gen_job_name in ('METRICS_INGESTION', 'AW4_ARRAY_WORKFLOW', 'AW4_WGS_WORKFLOW'):
             try:
-                if self.args.manifest_file or self.args.csv:
-                    _logger.info(f'File(s) Specified: {self.args.file or self.args.csv}')
+                if self.args.manifest_file:
+                    _logger.info(f'File(s) Specified: {self.args.manifest_file}')
                     return self.run_manifest_ingestion()
 
                 elif self.args.csv:

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1550,7 +1550,7 @@ class IngestionClass(GenomicManifestBase):
 
                         controller.bypass_record_count = self.args.bypass_record_count
 
-                        results = controller.ingest_member_ids_from_aw1_raw_table(member_ids)
+                        results = controller.ingest_member_ids_from_awn_raw_table(1, member_ids)
 
                         logging.info(results)
 
@@ -1571,7 +1571,15 @@ class IngestionClass(GenomicManifestBase):
                 _logger.info("Ingesting AW2 data for ids.")
 
                 if self.args.use_raw:
-                    pass
+
+                    with GenomicJobController(GenomicJob.METRICS_INGESTION,
+                                              bq_project_id=self.gcp_env.project,
+                                              server_config=self.get_server_config()) as controller:
+                        controller.bypass_record_count = self.args.bypass_record_count
+
+                        results = controller.ingest_member_ids_from_awn_raw_table(2, member_ids)
+
+                        logging.info(results)
 
                 if bucket_name:
                     # ingest AW1 data using controller

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -14,7 +14,7 @@ from rdr_service.model.genomics import (
     GenomicSet,
     GenomicSetMember,
     GenomicAW1Raw,
-    GenomicFileProcessed)
+    GenomicFileProcessed, GenomicAW2Raw)
 from rdr_service.model.log_position import LogPosition
 from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
@@ -548,6 +548,14 @@ class DataGenerator:
 
     def _genomic_aw1_raw(self, **kwargs):
         return GenomicAW1Raw(**kwargs)
+
+    def create_database_genomic_aw2_raw(self, **kwargs):
+        raw = self._genomic_aw2_raw(**kwargs)
+        self._commit_to_database(raw)
+        return raw
+
+    def _genomic_aw2_raw(self, **kwargs):
+        return GenomicAW2Raw(**kwargs)
 
     def create_database_genomic_file_processed(self, **kwargs):
         file = self._genomic_file_processed(**kwargs)

--- a/tests/tool_tests/test_genomic_utils.py
+++ b/tests/tool_tests/test_genomic_utils.py
@@ -1,8 +1,8 @@
 from unittest import mock
 
 from rdr_service import clock
-from rdr_service.dao.genomics_dao import GenomicSetMemberDao
-from rdr_service.participant_enums import GenomicJob
+from rdr_service.dao.genomics_dao import GenomicSetMemberDao, GenomicGCValidationMetricsDao
+from rdr_service.participant_enums import GenomicJob, GenomicContaminationCategory, GenomicWorkflowState
 from rdr_service.tools.tool_libs.genomic_utils import GenomicProcessRunner, LoadRawManifest, IngestionClass
 from tests.helpers.tool_test_mixin import ToolTestMixin
 from tests.helpers.unittest_base import BaseTestCase
@@ -50,6 +50,48 @@ class GenomicUtilsGeneralTest(GenomicUtilsTestBase):
     def setUp(self):
         super(GenomicUtilsGeneralTest, self).setUp()
 
+    def setup_raw_test_data(self, test_aw1, test_aw2):
+        gen_set = self.data_generator.create_database_genomic_set(
+            genomicSetName=".",
+            genomicSetCriteria=".",
+            genomicSetVersion=1
+        )
+
+        self.data_generator.create_database_genomic_set_member(
+            genomicSetId=gen_set.id,
+            biobankId="1",
+            genomeType="aou_array",
+            genomicWorkflowState=GenomicWorkflowState.AW0
+        )
+
+        self.data_generator.create_database_genomic_job_run(
+            jobId=GenomicJob.AW1_MANIFEST,
+            startTime=clock.CLOCK.now(),
+        )
+
+        self.data_generator.create_database_genomic_job_run(
+            jobId=GenomicJob.METRICS_INGESTION,
+            startTime=clock.CLOCK.now(),
+        )
+
+        # AW1 file_processed
+        self.data_generator.create_database_genomic_file_processed(
+            runId=1,
+            startTime=clock.CLOCK.now(),
+            filePath=f'/{test_aw1}',
+            bucketName="test-bucket",
+            fileName="test_GEN_sample_manifest.csv"
+        )
+
+        # AW2 file_processed
+        self.data_generator.create_database_genomic_file_processed(
+            runId=2,
+            startTime=clock.CLOCK.now(),
+            filePath=f'/{test_aw2}',
+            bucketName="test-bucket",
+            fileName="test_GEN_data_manifest.csv"
+        )
+
     @mock.patch('rdr_service.offline.genomic_pipeline.load_awn_manifest_into_raw_table')
     def test_load_manifest_into_raw_table(self, load_job_mock):
 
@@ -67,23 +109,15 @@ class GenomicUtilsGeneralTest(GenomicUtilsTestBase):
             self.assertEqual(test_file, kwargs['file_path'])
             self.assertEqual("aw1", kwargs['manifest_type'])
 
-    def test_ingest_aw1_from_raw_table(self):
-        gen_set = self.data_generator.create_database_genomic_set(
-            genomicSetName=".",
-            genomicSetCriteria=".",
-            genomicSetVersion=1
-        )
+    def test_ingest_awn_from_raw_table(self):
 
-        self.data_generator.create_database_genomic_set_member(
-            genomicSetId=gen_set.id,
-            biobankId="1",
-            genomeType="aou_array"
-        )
+        test_aw1 = "test-bucket/test_folder/test_GEN_sample_manifest.csv"
+        test_aw2 = "test-bucket/test_folder/test_GEN_data_manifest.csv"
 
-        test_file = "test-bucket/test_folder/test_GEN_manifest_file.csv"
+        self.setup_raw_test_data(test_aw1=test_aw1, test_aw2=test_aw2)
 
         self.data_generator.create_database_genomic_aw1_raw(
-            file_path=test_file,
+            file_path=test_aw1,
             package_id="pkg-1",
             well_position="A01",
             sample_id="1001",
@@ -92,33 +126,56 @@ class GenomicUtilsGeneralTest(GenomicUtilsTestBase):
             test_name="aou_array",
         )
 
-        self.data_generator.create_database_genomic_job_run(
-            jobId=GenomicJob.AW1_MANIFEST,
-            startTime=clock.CLOCK.now(),
+        self.data_generator.create_database_genomic_aw2_raw(
+            file_path=test_aw2,
+            biobank_id="A1",
+            sample_id="1001",
+            contamination="0.005",
+            call_rate="",
+            processing_status="Pass",
+            chipwellbarcode="10001_R01C01",
         )
 
-        self.data_generator.create_database_genomic_file_processed(
-            runId=1,
-            startTime=clock.CLOCK.now(),
-            filePath=f'/{test_file}',
-            bucketName="test-bucket",
-            fileName="test_GEN_manifest_file.csv"
-        )
-
+        # Test AW1
         GenomicUtilsGeneralTest.run_tool(IngestionClass, tool_args={
             'command': 'sample-ingestion',
-            'manifest_file': test_file,
+            'manifest_file': test_aw1,
             'data_type': 'aw1',
             'use_raw': True,
             'member_ids': "1",
             'csv': False,
         })
 
-        dao = GenomicSetMemberDao()
-        m = dao.get(1)
+        mdao = GenomicSetMemberDao()
+        m = mdao.get(1)
 
         self.assertEqual(m.gcManifestWellPosition, "A01")
         self.assertEqual(m.collectionTubeId, "111000")
         self.assertEqual(m.packageId, "pkg-1")
         self.assertEqual(m.gcManifestWellPosition, "A01")
         self.assertEqual(m.sampleId, "1001")
+        self.assertEqual(GenomicWorkflowState.AW1, m.genomicWorkflowState)
+        self.assertEqual(1, m.aw1FileProcessedId)
+
+        # Test AW2
+        GenomicUtilsGeneralTest.run_tool(IngestionClass, tool_args={
+            'command': 'sample-ingestion',
+            'manifest_file': test_aw2,
+            'data_type': 'aw2',
+            'use_raw': True,
+            'member_ids': "1",
+            'csv': False,
+        })
+
+        vdao = GenomicGCValidationMetricsDao()
+        v = vdao.get(1)
+
+        self.assertEqual(GenomicContaminationCategory.NO_EXTRACT, v.contaminationCategory)
+        self.assertEqual('0.005', v.contamination)
+        self.assertEqual("Pass", v.processingStatus)
+        self.assertEqual("10001_R01C01", v.chipwellbarcode)
+        self.assertEqual(1, v.genomicSetMemberId)
+
+        m = mdao.get(1)
+        self.assertEqual(GenomicWorkflowState.AW2, m.genomicWorkflowState)
+        self.assertEqual(2, m.aw2FileProcessedId)


### PR DESCRIPTION
This PR refactors the AW1 raw ingestion tool and implements the AW2 branch. Methods were renamed where applicable to share between AW1 and AW2 ingestions.  PDR support was added after loading the `GenomicSetMember` and `GenomicGCValidationMetrics` objects.