### PR TITLE
[DA-1932] Adding needs_disposal_ceremony column to withdrawal report

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -70,6 +70,9 @@ RACE_HISPANIC_CODE = "WhatRaceEthnicity_Hispanic"
 RACE_FREETEXT_CODE = "WhatRaceEthnicity_FreeText"
 RACE_NONE_OF_THESE_CODE = "WhatRaceEthnicity_RaceEthnicityNoneOfThese"
 
+WITHDRAWAL_CEREMONY_QUESTION_CODE = "withdrawalaianceremony"
+WITHDRAWAL_CEREMONY_YES = "withdrawalaianceremony_yes"
+
 # Consent answer codes
 CONSENT_PERMISSION_YES_CODE = "ConsentPermission_Yes"
 CONSENT_PERMISSION_NO_CODE = "ConsentPermission_No"

--- a/rdr_service/dao/database_utils.py
+++ b/rdr_service/dao/database_utils.py
@@ -8,7 +8,7 @@ from rdr_service.dao.database_factory import get_database
 
 _DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 # MySQL uses %i for minutes
-_MYSQL_DATE_FORMAT = "%Y-%m-%dT%H:%i:%SZ"
+MYSQL_ISO_DATE_FORMAT = "%Y-%m-%dT%H:%i:%SZ"
 _ISODATE_PATTERN = "ISODATE\[([^\]]+)\]"
 _YEARS_OLD_PATTERN = "YEARS_OLD\[([^\],]+), +([^\],]+)\]"
 _NULL_SAFE_PATTERN = "<=>"
@@ -50,7 +50,7 @@ def replace_years_old(sql):
 def replace_isodate(sql):
     if _is_sqlite():
         return re.sub(_ISODATE_PATTERN, r"strftime('{}', \1)".format(_DATE_FORMAT), sql)
-    return re.sub(_ISODATE_PATTERN, r"DATE_FORMAT(\1, '{}')".format(_MYSQL_DATE_FORMAT), sql)
+    return re.sub(_ISODATE_PATTERN, r"DATE_FORMAT(\1, '{}')".format(MYSQL_ISO_DATE_FORMAT), sql)
 
 
 def replace_null_safe_equals(sql):

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -16,7 +16,8 @@ from sqlalchemy.sql.functions import concat
 
 from rdr_service import clock, config
 from rdr_service.api_util import list_blobs, open_cloud_file
-from rdr_service.code_constants import PPI_SYSTEM, RACE_AIAN_CODE, RACE_QUESTION_CODE
+from rdr_service.code_constants import PPI_SYSTEM, RACE_AIAN_CODE, RACE_QUESTION_CODE, WITHDRAWAL_CEREMONY_YES,\
+    WITHDRAWAL_CEREMONY_QUESTION_CODE
 from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN,\
     BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
@@ -321,6 +322,7 @@ def _query_and_write_withdrawal_report(exporter, file_path, report_cover_range, 
         concat(literal_column(f'"{get_biobank_id_prefix()}"'), Participant.biobankId).label('biobank_id'),
         func.date_format(Participant.withdrawalTime, MYSQL_ISO_DATE_FORMAT).label('withdrawal_time'),
         _NATIVE_AMERICAN_YN,
+        _CEREMONY_REQUESTED_YN,
         Participant.participantOrigin.label('participant_origin')
     ]).filter(
         Participant.withdrawalTime >= now - datetime.timedelta(days=report_cover_range),
@@ -549,22 +551,35 @@ _NATIVE_AMERICAN_SQL = """
         AND qra.value_code_id = :native_american_race_code_id
         AND qra.end_time IS NULL) is_native_american"""
 
-race_question_code_alias = aliased(Code)
-race_answer_code_alias = aliased(Code)
-_NATIVE_AMERICAN_YN = case([(
-    Query([QuestionnaireResponse])
-    .join(QuestionnaireResponseAnswer)
-    .join(QuestionnaireQuestion)
-    .join(race_question_code_alias, race_question_code_alias.codeId == QuestionnaireQuestion.codeId)
-    .join(race_answer_code_alias, race_answer_code_alias.codeId == QuestionnaireResponseAnswer.valueCodeId)
-    .filter(
-        QuestionnaireResponse.participantId == Participant.participantId,  # Expected from outer query
-        race_question_code_alias.value == literal_column(f'"{RACE_QUESTION_CODE}"'),
-        race_answer_code_alias.value == literal_column(f'"{RACE_AIAN_CODE}"'),
-        QuestionnaireResponseAnswer.endTime.is_(None)
-    ).exists(),
-    literal_column('"Y"')
-)], else_=literal_column('"N"')).label('is_native_american')
+
+def _participant_has_answer(question_code_value, answer_value):
+    question_code = aliased(Code)
+    answer_code = aliased(Code)
+    return (
+        Query([QuestionnaireResponse])
+        .join(QuestionnaireResponseAnswer)
+        .join(QuestionnaireQuestion)
+        .join(question_code, question_code.codeId == QuestionnaireQuestion.codeId)
+        .join(answer_code, answer_code.codeId == QuestionnaireResponseAnswer.valueCodeId)
+        .filter(
+            QuestionnaireResponse.participantId == Participant.participantId,  # Expected from outer query
+            question_code.value == literal_column(f'"{question_code_value}"'),
+            answer_code.value == literal_column(f'"{answer_value}"'),
+            QuestionnaireResponseAnswer.endTime.is_(None)
+        ).exists()
+    )
+
+
+_NATIVE_AMERICAN_YN = case(
+    [(_participant_has_answer(RACE_QUESTION_CODE, RACE_AIAN_CODE), literal_column('"Y"'))],
+    else_=literal_column('"N"')
+).label('is_native_american')
+
+
+_CEREMONY_REQUESTED_YN = case(
+    [(_participant_has_answer(WITHDRAWAL_CEREMONY_QUESTION_CODE, WITHDRAWAL_CEREMONY_YES), literal_column('"Y"'))],
+    else_=literal_column('"N"')
+).label('needs_disposal_ceremony')
 
 # Joins orders and samples, and computes some derived values (elapsed_hours, counts).
 # MySQL does not support FULL OUTER JOIN, so instead we UNION ALL a LEFT OUTER JOIN

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -534,12 +534,10 @@ class BiobankSamplesPipelineTest(BaseTestCase):
         # mocking the upload method to keep it from trying to upload something
         with mock.patch('rdr_service.offline.sql_exporter.csv.writer') as mock_writer_class,\
                 mock.patch('rdr_service.offline.sql_exporter.SqlExporter.upload_export_file'):
-            exporter = SqlExporter('test_bucket_name')
             day_range_of_report = 10
-            biobank_samples_pipeline._query_and_write_withdrawal_report(exporter, 'test_file_path', {
-                'race_question': self.race_question_code,
-                'native_american_race': self.native_answer_code
-            }, day_range_of_report, datetime.now())
+            biobank_samples_pipeline._query_and_write_withdrawal_report(
+                SqlExporter(''), '', day_range_of_report, datetime.now()
+            )
 
             # Check that the participants are written to the export with the expected values
             withdrawal_iso_str = two_days_ago.strftime('%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
This adds the `neads_disposal_ceremony` column to the withdrawal report for the biobank reconciliation pipeline and does some refactoring to the surrounding code.

- I renamed `_MYSQL_DATE_FORMAT` to make it publicly available from the module and make it clearer that it's the ISO date format
- Added the WITHDRAWAL_CEREMONY_QUESTION_CODE AND WITHDRAWAL_CEREMONY_YES value constants
- Moved the withdrawal ceremony generation into it's own function named `_query_and_write_withdrawal_report` (so that it was easier to test in isolation)
- Replaced the withdrawal report raw SQL with a SqlAlchemy representation (also replaced some `COUNT` checks with exist queries)