### PR TITLE
Removing unnecessary validation check

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -345,16 +345,6 @@ class QuestionnaireResponseDao(BaseDao):
         answer_validator = ResponseValidator(questionnaire_history, session)
         answer_validator.check_response(questionnaire_response)
 
-        # Get the questions from the questionnaire history record.
-        q_question_ids = set([question.questionnaireQuestionId for question in questionnaire_history.questions])
-        for answer in questionnaire_response.answers:
-            if answer.questionId not in q_question_ids:
-                raise BadRequest(
-                    f"Questionnaire response contains question ID {answer.questionId} not in questionnaire."
-                )
-        # TODO: this check can integrate with the validator
-        #  when we start rejecting responses based on the validators results
-
         questionnaire_response.created = clock.CLOCK.now()
         if not questionnaire_response.authored:
             questionnaire_response.authored = questionnaire_response.created

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -612,12 +612,12 @@ class QuestionnaireResponseApiTest(BaseTestCase):
         participant_id = self.create_participant()
         questionnaire_id = self.create_questionnaire("questionnaire1.json")
         q = QuestionnaireDao()
-        quesstionnaire = q.get(questionnaire_id)
-        make_transient(quesstionnaire)
-        quesstionnaire.status = QuestionnaireDefinitionStatus.INVALID
+        questionnaire = q.get(questionnaire_id)
+        make_transient(questionnaire)
+        questionnaire.status = QuestionnaireDefinitionStatus.INVALID
         with q.session() as session:
-            existing_obj = q.get_for_update(session, q.get_id(quesstionnaire))
-            q._do_update(session, quesstionnaire, existing_obj)
+            existing_obj = q.get_for_update(session, q.get_id(questionnaire))
+            q._do_update(session, questionnaire, existing_obj)
         q.get(questionnaire_id)
 
         with open(data_path("questionnaire_response3.json")) as fd:
@@ -1099,7 +1099,7 @@ class QuestionnaireResponseApiTest(BaseTestCase):
         self.assertEqual(bqrs[0].status_id, 0)
 
     @mock.patch('rdr_service.dao.questionnaire_response_dao.logging')
-    def test_link_id_validation(self, mock_logging):
+    def test_link_id_does_not_exist(self, mock_logging):
         # Get a participant set up for the test
         participant_id = self.create_participant()
         self.send_consent(participant_id)


### PR DESCRIPTION
TL;DR: The error will only raise if something went wrong when finding the questionnaire again. If the answer has a questionId then it was already found on the questionnaire. I also fixed up some naming issues I noticed when looking through the tests.


This removes the code that raises a BadRequest when an answer was found with a questionId from a different QuestionnaireHistory than expected. In reality this would only raise an error if there was something wrong with how the questionnaire was found. Here's my reasoning:
- An error is raised if the `answer.questionId` for any of the answers doesn't exist in `q_question_ids`
- `q_question_ids` is a list of question ids retrieved from the `questionnaire_history` object that we load on line 335
- `questionnaire_history` on line 335 is loaded from the db using the questionnaire id and semantic version that we have stored on the `questionnaire_response` object being inserted
- The `questionnaire_response` object is created way down in the `from_client_json` method on line 808 (818 before the deletion).
- `questionnaire_response` gets the semantic version and id of the `questionnaire` that is loaded on line 790 (800 before the deletion).
- That `questionnaire` is also used when creating the QuestionnaireResponseAnswer objects. The `_extract_codes_and_answers` method gets all the questions from the questionnaire and stores them in a dictionary keyed by their link id
- The `_populate_codes_and_answers` method then goes through all the answers in the response, creating QuestionnaireResponseAnswer objects and setting their `questionId` by looking up the question from questionnaire by using the link-id. If the answer uses a link-id that doesn't match up with a question on the survey, then no QuestionnaireResponseAnswer is created.

So, because the questionIds for the response answers are derived from the questionnaire that the response is for. The only way this check could find any answers that have question ids that aren't in the questionnaire history is if a different questionnaire was loaded on line 335 than the questionnaire used when parsing the response.