### PR TITLE
Printing times for when migrations start and end

### DIFF
--- a/rdr_service/alembic.ini
+++ b/rdr_service/alembic.ini
@@ -64,5 +64,5 @@ level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
 datefmt = %H:%M:%S

--- a/rdr_service/tools/tool_libs/alembic.py
+++ b/rdr_service/tools/tool_libs/alembic.py
@@ -4,6 +4,7 @@
 #
 
 import argparse
+from datetime import datetime
 
 # pylint: disable=superfluous-parens
 # pylint: disable=broad-except
@@ -73,6 +74,7 @@ class AlembicManagerClass(object):
         if se:
             _logger.error(se)
 
+        _logger.info(f'Alembic command finished at {datetime.now()}')
         return code
 
 


### PR DESCRIPTION
This changes the log line format for alembic so that the time (to the second) is printed with each log line, and also adds a log statement giving the time after all the migrations are complete. Since alembic prints out a log statement when starting a migration, this will let us look at the logs and know how long each migration took when deploying.