### PR TITLE
[PDR fixes] Handles multiselect questionnaire responses (race/gender)

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -647,6 +647,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         # get TheBasics questionnaire response answers
         qnan = BQRecord(schema=None, data=qnans)  # use only most recent questionnaire.
         data = {}
+        # Turn a comma-separate list of answer codes for race and gender into their nested arrays
         if qnan.get('Race_WhatRaceEthnicity'):
             rl = list()
             for val in qnan.get('Race_WhatRaceEthnicity').split(','):
@@ -1406,7 +1407,12 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 qnans = session.execute(_answers_sql, {'qr_id': row.questionnaire_response_id})
                 # Save answers into data dict.
                 for qnan in qnans:
-                    data[qnan.code_name] = qnan.answer
+                    # For question codes with multiple responses, created comma-separated list of answers
+                    if qnan.code_name in data:
+                        data[qnan.code_name] += f',{qnan.answer}'
+                    else:
+                        data[qnan.code_name] = qnan.answer
+
                     # Special handling of GROR deprecated responses
                     if module == 'GROR' \
                        and data['questionnaire_id'] == _deprecated_gror_consent_questionnaire_id \

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -230,12 +230,15 @@ class BQPDRParticipantSummaryAllView(BQPDRParticipantSummaryView):
         ])
     )
 
-class BQPDRParticipantSummaryWithdrawnView(BQView):
-    __viewname__ = 'v_pdr_participant_withdrawn'
-    __viewdescr__ = 'PDR Participant Summary Withdrawn View'
-    __table__ = BQPDRParticipantSummary
-    __sql__ = BQPDRParticipantSummaryView.__sql__.replace('ps.withdrawal_status_id = 1',
-                                                          'ps.withdrawal_status_id != 1')
+# TODO:  This is now a custom view in PDR BigQuery (as of PDR-262).  Needs to be disabled here so it will not be
+# updated by migrate-bq tool.   Consider moving all custom views into our model?  Some (like this one) will have
+# extremely complicated SQL definitions, so unclear if that is a viable/best solution
+#class BQPDRParticipantSummaryWithdrawnView(BQView):
+#   __viewname__ = 'v_pdr_participant_withdrawn'
+#   __viewdescr__ = 'PDR Participant Summary Withdrawn View'
+#   __table__ = BQPDRParticipantSummary
+#   __sql__ = BQPDRParticipantSummaryView.__sql__.replace('ps.withdrawal_status_id = 1',
+#                                                         'ps.withdrawal_status_id != 1')
 
 
 class BQPDRPMView(BQView):
@@ -363,6 +366,9 @@ class BQPDRParticipantBiobankOrderView(BQView):
              nt.bbo_processed_site_id,
              nt.bbo_finalized_site,
              nt.bbo_finalized_site_id,
+             nt.bbo_finalized_time,
+             nt.bbo_finalized_status,
+             nt.bbo_finalized_status_id,
              nt.bbo_tests_ordered,
              nt.bbo_tests_stored
         FROM (

--- a/rdr_service/offline/bigquery_sync.py
+++ b/rdr_service/offline/bigquery_sync.py
@@ -70,7 +70,7 @@ def dispatch_participant_rebuild_tasks(pid_list, batch_size=100, project_id=GAE_
         count += 1
 
         if count == batch_size:
-            payload = {'batch': batch}
+            payload = {'batch': batch, 'build_participant_summary': True, 'build_modules': True}
 
             if build_locally:
                 batch_rebuild_participants_task(payload, project_id=project_id)
@@ -85,7 +85,7 @@ def dispatch_participant_rebuild_tasks(pid_list, batch_size=100, project_id=GAE_
 
     # send last batch if needed.
     if count:
-        payload = {'batch': batch}
+        payload = {'batch': batch, 'build_participant_summary': True, 'build_modules': True}
         batch_count += 1
         if build_locally:
             batch_rebuild_participants_task(payload, project_id=project_id)

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -644,6 +644,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # get TheBasics questionnaire response answers
         qnan = BQRecord(schema=None, data=qnans)  # use only most recent questionnaire.
         data = {}
+        # Turn comma-separated list of answer codes for race and gender into their nested arrays
         if qnan.get('Race_WhatRaceEthnicity'):
             rl = list()
             for val in qnan.get('Race_WhatRaceEthnicity').split(','):
@@ -1407,7 +1408,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 qnans = session.execute(_answers_sql, {'qr_id': row.questionnaire_response_id})
                 # Save answers into data dict.
                 for qnan in qnans:
-                    data[qnan.code_name] = qnan.answer
+                    # For question codes with multiple responses, created comma-separated list of answers
+                    if qnan.code_name in data:
+                        data[qnan.code_name] += f',{qnan.answer}'
+                    else:
+                        data[qnan.code_name] = qnan.answer
+
                     # Special handling of GROR deprecated responses
                     if module == 'GROR' \
                         and data['questionnaire_id'] == _deprecated_gror_consent_questionnaire_id \

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -38,8 +38,8 @@ def batch_rebuild_participants_task(payload, project_id=None):
     # This is intended to improve performance/efficiency for targeted PDR rebuilds which may only affect (for example)
     # the participant summary data but do not require all the module response data to be rebuilt (or vice versa)
     # TODO: Pass a list of specific modules to build (empty if skipping all modules) instead of a flag
-    build_participant_summary = payload['build_participant_summary'] if 'build_participant_summary' in payload else True
-    build_modules = payload['build_modules'] if 'build_modules' in payload else True
+    build_participant_summary = payload.get('build_participant_summary', True)
+    build_modules = payload.get('build_modules', True)
 
     logging.info(f'Start time: {datetime.utcnow()}, batch size: {len(batch)}')
     # logging.info(json.dumps(batch, indent=2))
@@ -50,7 +50,7 @@ def batch_rebuild_participants_task(payload, project_id=None):
 
     for item in batch:
         p_id = item['pid']
-        patch_data = item['patch'] if 'patch' in item else None
+        patch_data = item.get('patch', None)
         count += 1
 
         if build_participant_summary:

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -140,7 +140,10 @@ class ParticipantResourceClass(object):
             count += 1
 
             if count == batch_size:
-                payload = {'batch': batch}
+                payload = {'batch': batch,
+                           'build_modules': not self.args.no_modules,
+                           'build_participant_summary': not self.args.modules_only
+                           }
 
                 if self.gcp_env.project == 'localhost':
                     batch_rebuild_participants_task(payload)
@@ -163,7 +166,10 @@ class ParticipantResourceClass(object):
 
         # send last batch if needed.
         if count:
-            payload = {'batch': batch}
+            payload = {'batch': batch,
+                       'build_modules': not self.args.no_modules,
+                       'build_participant_summary': not self.args.modules_only
+                       }
             batch_count += 1
             if self.gcp_env.project == 'localhost':
                 batch_rebuild_participants_task(payload)
@@ -512,7 +518,7 @@ class EHRReceiptClass(object):
             count += 1
 
             if count == batch_size:
-                payload = {'batch': batch}
+                payload = {'batch': batch, 'build_participant_summary': True, 'build_modules': False}
 
                 if self.gcp_env.project == 'localhost':
                     batch_rebuild_participants_task(payload)
@@ -535,7 +541,7 @@ class EHRReceiptClass(object):
 
         # send last batch if needed.
         if count:
-            payload = {'batch': batch}
+            payload = {'batch': batch, 'build_participant_summary': True, 'build_modules': False}
             batch_count += 1
             if self.gcp_env.project == 'localhost':
                 batch_rebuild_participants_task(payload)


### PR DESCRIPTION
This is a high priority fix needed to kick off a local rebuild of participants with multiple race/gender selections, which were lost in this weekend's PDR data rebuild because of recent deprecation of the stored procedure that processed TheBasics survey responses in the generators.  We were only returning the last of the multiselect answer codes.

Also includes some misc model changes to address issues found after the most recent `migrate-bq --names all` tool run. Changes:

* Fix nested data construction after switching from stored procedure to new SQL logic to get TheBasics module answers
  Note:  `get_module_answers()` is also used to retrieve responses for other modules besides TheBasics, so unchanged code could see different data (comma-separated strings) returned now.  I believe all the use cases for this method still check out ok, but am looking for additional review in case I missed something
  
* Disable BQ model definition for `v_pdr_participant_withdrawn` (is now a custom view in BigQuery, manually managed)
* Add new fields to `v_pdr_participant_biobank_order` view (missed in 1.91.1 release, but migration was run against prod already to add these new fields to the view)