### PR TITLE
Fix for google api networking issues

### DIFF
--- a/rdr_service/services/google_sheets_client.py
+++ b/rdr_service/services/google_sheets_client.py
@@ -45,7 +45,7 @@ class GoogleSheetsClient:
         # The Google API client uses sockets, and the requests can take longer than the default timeout.
         # The proposed solution is to increase the default timeout manually
         # https://github.com/googleapis/google-api-python-client/issues/632
-        # The socket seems to be created when calling discover.build, so this temporarily increases the timout for
+        # The socket seems to be created when calling discover.build, so this temporarily increases the timeout for
         # new sockets when the Google service creates its socket.
         default_socket_timeout = socket.getdefaulttimeout()
         num_seconds_in_five_minutes = 300
@@ -54,7 +54,7 @@ class GoogleSheetsClient:
         # Set up for being able to interact with the sheet in Drive
         sheets_api_service = discovery.build('sheets', 'v4', credentials=self._api_credentials)
 
-        # Set the timout back for anything else in the code that would use sockets
+        # Set the timeout back for anything else in the code that would use sockets
         socket.setdefaulttimeout(default_socket_timeout)
 
         return sheets_api_service

--- a/tests/dao_tests/test_participant_dao.py
+++ b/tests/dao_tests/test_participant_dao.py
@@ -597,7 +597,7 @@ class ParticipantDaoTest(BaseTestCase):
         self.assertEqual(ep.organizationId, p2.organizationId)
 
     @mock.patch('rdr_service.dao.base_dao.logging')
-    def test_inserts_retry_after_lock_wait_timout(self, mock_logging):
+    def test_inserts_retry_after_lock_wait_timeout(self, mock_logging):
         """
         Check to make sure inserts will retry when encountering a lock wait timeout error.
         Any dao should be able to do this, but this test uses ParticipantDao
@@ -607,7 +607,7 @@ class ParticipantDaoTest(BaseTestCase):
         self.session.execute('set global innodb_lock_wait_timeout = 1')
         self.session.query(Participant).with_for_update().all()
 
-        # Use the error logging to know when the lock timout was triggered,
+        # Use the error logging to know when the lock timeout was triggered,
         # unlock the participant table after the first failure
         mock_logging.warning.side_effect = lambda *_, **__: self.session.commit()
 


### PR DESCRIPTION
This addresses two issues I've noticed with using the google API:
- Sometimes we'll get a timeout when trying to download the current data-dictionary. Increasing python's socket timeout fixes that.
- If comparing the data-dictionary to the database schema takes too long (or if I take a while to respond to the command line prompt for what the changes were) then we can get a broken pipe error when trying to upload the values. That seems to be related to the google API dropping the idle connection. Using the API library to build the connection right before it's needed resolves that problem.