### PR TITLE
[ROC-914] keep PM time in PS when cancel a PM

### DIFF
--- a/tests/dao_tests/test_physical_measurements_dao.py
+++ b/tests/dao_tests/test_physical_measurements_dao.py
@@ -287,10 +287,10 @@ class PhysicalMeasurementsDaoTest(BaseTestCase):
 
         summary = ParticipantSummaryDao().get(self.participant.participantId)
         self.assertEqual(summary.physicalMeasurementsStatus, PhysicalMeasurementsStatus.CANCELLED)
-        self.assertEqual(summary.physicalMeasurementsTime, None)
-        self.assertEqual(summary.physicalMeasurementsFinalizedTime, None)
+        self.assertNotEqual(summary.physicalMeasurementsTime, None)
+        self.assertNotEqual(summary.physicalMeasurementsFinalizedTime, None)
         self.assertEqual(summary.physicalMeasurementsCreatedSiteId, 1)
-        self.assertEqual(summary.physicalMeasurementsFinalizedSiteId, None)
+        self.assertEqual(summary.physicalMeasurementsFinalizedSiteId, 2)
 
         with FakeClock(TIME_3):
             measurements = self.dao.insert(self._make_physical_measurements(physicalMeasurementsId=2))


### PR DESCRIPTION
We want to keep the `physicalMeasurementsTime` , `physicalMeasurementsFinalizedTime` and `physicalMeasurementsFinalizedSiteId` in participant summary even when the PM has been cancelled.