### PR TITLE
[PDR-252] Add AIAN withdrawal ceremony decision to PDR participant data

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -72,7 +72,7 @@ RACE_NONE_OF_THESE_CODE = "WhatRaceEthnicity_RaceEthnicityNoneOfThese"
 
 WITHDRAWAL_CEREMONY_QUESTION_CODE = "withdrawalaianceremony"
 WITHDRAWAL_CEREMONY_YES = "withdrawalaianceremony_yes"
-WITHDRAWAL_CEREMONY_NO = "withdrawalaian_ceremony_no"
+WITHDRAWAL_CEREMONY_NO = "withdrawalaianceremony_no"
 
 # Consent answer codes
 CONSENT_PERMISSION_YES_CODE = "ConsentPermission_Yes"

--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -72,6 +72,7 @@ RACE_NONE_OF_THESE_CODE = "WhatRaceEthnicity_RaceEthnicityNoneOfThese"
 
 WITHDRAWAL_CEREMONY_QUESTION_CODE = "withdrawalaianceremony"
 WITHDRAWAL_CEREMONY_YES = "withdrawalaianceremony_yes"
+WITHDRAWAL_CEREMONY_NO = "withdrawalaian_ceremony_no"
 
 # Consent answer codes
 CONSENT_PERMISSION_YES_CODE = "ConsentPermission_Yes"
@@ -114,6 +115,8 @@ HEALTHCARE_ACCESS_MODULE = "HealthcareAccess"
 # A new survey was developed for November 2020
 COPE_MODULE = 'COPE'
 COPE_NOV_MODULE = 'cope_nov'
+COPE_DEC_MODULE = "cope_dec"
+COPE_FEB_MODULE = "cope_feb"
 GENETIC_ANCESTRY_MODULE = 'GeneticAncestry'
 
 # DVEHR ANSWERS
@@ -125,7 +128,6 @@ DVEHRSHARING_CONSENT_CODE_NOT_SURE = "DVEHRSharing_NotSure"
 GENETIC_ANCESTRY_CONSENT_CODE_YES = "ConsentAncestryTraits_Yes"
 GENETIC_ANCESTRY_CONSENT_CODE_NO = "ConsentAncestryTraits_No"
 GENETIC_ANCESTRY_CONSENT_CODE_NOT_SURE = "ConsentAncestryTraits_NotSure"
-
 
 BIOBANK_TESTS = [
     "1ED10",

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -24,13 +24,16 @@ from rdr_service.code_constants import (
     CONSENT_COPE_NO_CODE,
     CONSENT_COPE_DEFERRED_CODE,
     CABOR_SIGNATURE_QUESTION_CODE,
-    PMI_SKIP_CODE
+    PMI_SKIP_CODE,
+    WITHDRAWAL_CEREMONY_YES,
+    WITHDRAWAL_CEREMONY_NO
 )
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_pdr_participant_summary import BQPDRParticipantSummary
 from rdr_service.model.bq_participant_summary import BQParticipantSummarySchema, BQStreetAddressTypeEnum, \
     BQModuleStatusEnum, BQParticipantSummary, COHORT_1_CUTOFF, COHORT_2_CUTOFF, BQConsentCohort
+from rdr_service.model.code import Code
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.ehr import ParticipantEhrReceipt
 from rdr_service.model.hpo import HPO
@@ -41,10 +44,10 @@ from rdr_service.model.participant_cohort_pilot import ParticipantCohortPilot
 # TODO:  Using participant_summary as a workaround.  Replace with new participant_profile when it's available
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory
-from rdr_service.model.questionnaire_response import QuestionnaireResponse
+from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
     SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus, DeceasedStatus, \
-    DeceasedReportStatus, QuestionnaireResponseStatus, EnrollmentStatus, OrderStatus
+    DeceasedReportStatus, QuestionnaireResponseStatus, EnrollmentStatus, OrderStatus, WithdrawalAIANCeremonyStatus
 from rdr_service.resource.helpers import DateCollection
 
 
@@ -101,6 +104,15 @@ _consent_answer_status_map = {
     'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE,
     'PMI_Skip': BQModuleStatusEnum.UNSET,
 }
+
+# PDR-252:  When RDR starts accepting QuestionnaireResponse payloads for withdrawal screens, AIAN participants
+# will be given options for a last rites ceremony for their biobank samples.  Map answer codes to the status enum value
+# included with the PDR participant data
+_withdrawal_aian_ceremony_status_map = {
+    WITHDRAWAL_CEREMONY_YES: WithdrawalAIANCeremonyStatus.REQUESTED,
+    WITHDRAWAL_CEREMONY_NO: WithdrawalAIANCeremonyStatus.DECLINED
+}
+
 
 # See hotfix ticket ROC-447 / backfill ticket ROC-475.  The first GROR consent questionnaire was immediately
 # deprecated and replaced by a revised consent questionnaire.  Early GROR consents (~200) already received
@@ -257,6 +269,23 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         withdrawal_reason = WithdrawalReason(p.withdrawalReason if p.withdrawalReason else 0)
         suspension_status = SuspensionStatus(p.suspensionStatus)
 
+        # PDR-252:  The AIAN withdrawal ceremony decision needs to be made available to PDR.
+        # Find the most recently authored answer that matches one of the possible answer codes
+        # TODO:  When RDR implements manifests from biobank, update to look for completed ceremony notifications and
+        # set status to WithdrawalAIAINCeremonyStatus.COMPLETED
+        withdrawal_aian_ceremony_status = WithdrawalAIANCeremonyStatus.UNSET
+        code_filter = Code.value.in_([WITHDRAWAL_CEREMONY_NO, WITHDRAWAL_CEREMONY_YES])
+        ceremony_response = ro_session.query(Code.value).\
+            join(QuestionnaireResponseAnswer, QuestionnaireResponseAnswer.valueCodeId == Code.codeId).\
+            join(QuestionnaireResponse,
+                 QuestionnaireResponse.questionnaireResponseId == QuestionnaireResponseAnswer.questionnaireResponseId).\
+            filter(code_filter, QuestionnaireResponse.participantId == p_id).\
+            order_by(desc(QuestionnaireResponse.authored)).one_or_none()
+
+        if ceremony_response:
+            withdrawal_aian_ceremony_status = \
+                _withdrawal_aian_ceremony_status_map.get(ceremony_response.value, WithdrawalAIANCeremonyStatus.UNSET)
+
         # The cohort_2_pilot_flag field values in participant_summary were set via a one-time backfill based on a
         # list of participant IDs provided by PTSC and archived in the participant_cohort_pilot table.  See:
         # https://precisionmedicineinitiative.atlassian.net/browse/DA-1622
@@ -290,6 +319,8 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             'withdrawal_time': p.withdrawalTime,
             'withdrawal_authored': p.withdrawalAuthored,
             'withdrawal_reason_justification': p.withdrawalReasonJustification,
+            'withdrawal_aian_ceremony_status': str(withdrawal_aian_ceremony_status),
+            'withdrawal_aian_ceremony_status_id': int(withdrawal_aian_ceremony_status),
 
             'suspension_status': str(suspension_status),
             'suspension_status_id': int(suspension_status),
@@ -305,7 +336,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             'deceased_status_id':  int(deceased_status),
             'deceased_authored': deceased_authored,
             # TODO:  Enable this field definition in the BQ model if it's determined it should be included in PDR
-            'date_of_death': deceased_date_of_death
+            'date_of_death': deceased_date_of_death,
         }
 
 

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -43,7 +43,7 @@ from rdr_service.model.participant import Participant
 from rdr_service.model.participant_cohort_pilot import ParticipantCohortPilot
 # TODO:  Using participant_summary as a workaround.  Replace with new participant_profile when it's available
 from rdr_service.model.participant_summary import ParticipantSummary
-from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory
+from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory, QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
     SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus, DeceasedStatus, \
@@ -271,14 +271,15 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
 
         # PDR-252:  The AIAN withdrawal ceremony decision needs to be made available to PDR.
         # Find the most recently authored answer that matches one of the possible answer codes
-        # TODO:  When RDR implements manifests from biobank, update to look for completed ceremony notifications and
-        # set status to WithdrawalAIAINCeremonyStatus.COMPLETED
+        # TODO:  When RDR implements manifests from biobank, must determine how to track ceremony completion for PDR.
+        #  May be a separate flag field?
         withdrawal_aian_ceremony_status = WithdrawalAIANCeremonyStatus.UNSET
         code_filter = Code.value.in_([WITHDRAWAL_CEREMONY_NO, WITHDRAWAL_CEREMONY_YES])
         ceremony_response = ro_session.query(Code.value).\
             join(QuestionnaireResponseAnswer, QuestionnaireResponseAnswer.valueCodeId == Code.codeId).\
             join(QuestionnaireResponse,
                  QuestionnaireResponse.questionnaireResponseId == QuestionnaireResponseAnswer.questionnaireResponseId).\
+            join(QuestionnaireQuestion.questionnaireQuestionId == QuestionnaireResponseAnswer.questionId).\
             filter(code_filter, QuestionnaireResponse.participantId == p_id).\
             order_by(desc(QuestionnaireResponse.authored)).one_or_none()
 

--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -25,6 +25,7 @@ from rdr_service.code_constants import (
     CONSENT_COPE_DEFERRED_CODE,
     CABOR_SIGNATURE_QUESTION_CODE,
     PMI_SKIP_CODE,
+    WITHDRAWAL_CEREMONY_QUESTION_CODE,
     WITHDRAWAL_CEREMONY_YES,
     WITHDRAWAL_CEREMONY_NO
 )
@@ -270,22 +271,28 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         suspension_status = SuspensionStatus(p.suspensionStatus)
 
         # PDR-252:  The AIAN withdrawal ceremony decision needs to be made available to PDR.
-        # Find the most recently authored answer that matches one of the possible answer codes
-        # TODO:  When RDR implements manifests from biobank, must determine how to track ceremony completion for PDR.
-        #  May be a separate flag field?
-        withdrawal_aian_ceremony_status = WithdrawalAIANCeremonyStatus.UNSET
-        code_filter = Code.value.in_([WITHDRAWAL_CEREMONY_NO, WITHDRAWAL_CEREMONY_YES])
+        # Find the most recently authored answer to the withdrawal ceremony question
+        # TODO:  When RDR implements manifests from biobank, must determine how to track ceremony completion for PDR and
+        #  align with RDR for data quality checks.  May be tracked separately from ceremony decision in RDR to account
+        # for AIAN participants who withdrew before being offered ceremony yet were included in  ceremony by default?
+        ceremony_question_code = ro_session.query(Code.codeId).filter(Code.value == WITHDRAWAL_CEREMONY_QUESTION_CODE)
+        answer_code_filter = Code.value.in_([WITHDRAWAL_CEREMONY_NO, WITHDRAWAL_CEREMONY_YES])
         ceremony_response = ro_session.query(Code.value).\
-            join(QuestionnaireResponseAnswer, QuestionnaireResponseAnswer.valueCodeId == Code.codeId).\
+            join(QuestionnaireResponseAnswer,
+                 QuestionnaireResponseAnswer.valueCodeId == Code.codeId).\
             join(QuestionnaireResponse,
                  QuestionnaireResponse.questionnaireResponseId == QuestionnaireResponseAnswer.questionnaireResponseId).\
-            join(QuestionnaireQuestion.questionnaireQuestionId == QuestionnaireResponseAnswer.questionId).\
-            filter(code_filter, QuestionnaireResponse.participantId == p_id).\
+            join(QuestionnaireQuestion,
+                 QuestionnaireResponseAnswer.questionId == QuestionnaireQuestion.questionnaireQuestionId).\
+            filter(QuestionnaireResponse.participantId == p_id,
+                   QuestionnaireQuestion.codeId == ceremony_question_code, answer_code_filter).\
             order_by(desc(QuestionnaireResponse.authored)).one_or_none()
 
         if ceremony_response:
             withdrawal_aian_ceremony_status = \
                 _withdrawal_aian_ceremony_status_map.get(ceremony_response.value, WithdrawalAIANCeremonyStatus.UNSET)
+        else:
+            withdrawal_aian_ceremony_status = WithdrawalAIANCeremonyStatus.UNSET
 
         # The cohort_2_pilot_flag field values in participant_summary were set via a one-time backfill based on a
         # list of participant IDs provided by PTSC and archived in the participant_cohort_pilot table.  See:

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -295,8 +295,6 @@ class BQParticipantSummarySchema(BQSchema):
     deceased_authored = BQField('deceased_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     deceased_status = BQField('deceased_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     deceased_status_id = BQField('deceased_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-    # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR
-    # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
 
     # PDR-178:  Add cabor_authored to align with RDR consent_for_cabor / consent_for_cabor_authored
     cabor_authored = BQField('cabor_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
@@ -304,6 +302,16 @@ class BQParticipantSummarySchema(BQSchema):
 
     # PDR-236:  Support for new RDR participant_summary.enrollment_core_minus_pm_time field in PDR data
     enrollment_core_minus_pm = BQField('enrollment_core_minus_pm', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
+    # PDR-252:  Need to provide AIAN withdrawal ceremony status in PDR data
+    withdrawal_aian_ceremony_status = \
+        BQField('withdrawal_aian_ceremony_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    withdrawal_aian_ceremony_status_id = \
+        BQField('withdrawal_aian_ceremony_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+
+    # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR. Add to
+    # end of field list if enabled later
+    # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
 
 
 class BQParticipantSummary(BQTable):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -155,8 +155,6 @@ class BQPDRParticipantSummarySchema(BQSchema):
     deceased_authored = BQField('deceased_authored', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     deceased_status = BQField('deceased_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     deceased_status_id = BQField('deceased_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-    # TODO:  Exclude date of death initially in case it constitutes PII, determine if it is needed in PDR
-    # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
 
     # PDR-178:  CABoR details.  This is part of ConsentPII, but for various reasons the easiest way to align with
     # RDR CABoR tracking is to surface the appropriate authored date here.  Presence of a date (vs. null/None also
@@ -166,6 +164,16 @@ class BQPDRParticipantSummarySchema(BQSchema):
 
     # PDR-236:  Support for new RDR participant_summary.enrollment_core_minus_pm_time field in PDR data
     enrollment_core_minus_pm = BQField('enrollment_core_minus_pm', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
+    # PDR-252:  Need to provide AIAN withdrawal ceremony status
+    withdrawal_aian_ceremony_status = \
+        BQField('withdrawal_aian_ceremony_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    withdrawal_aian_ceremony_status_id = \
+        BQField('withdrawal_aian_ceremony_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+
+    # TODO:  Exclude date of death initially in case it constitutes PII.  Add to end of field list if it is
+    # enabled later
+    # date_of_death = BQField('date_of_death', BQFieldTypeEnum.DATE, BQFieldModeEnum.NULLABLE)
 
 
 class BQPDRParticipantSummary(BQTable):

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -387,12 +387,11 @@ class WithdrawalReason(messages.Enum):
 # initial requirements to include this information in RDR GET API responses
 class WithdrawalAIANCeremonyStatus(messages.Enum):
     """Whether an AIAN participant requested a last rites ceremony for their samples when withdrawing.
-     If value is UNSET it means that a participant was not presented with or did not indicate a ceremony choice. """
+     UNSET indicates no response exists (question did not apply or AIAN participant never submitted a valid response)"""
 
     UNSET = 0
     DECLINED = 1
     REQUESTED = 2
-    COMPLETED = 3
 
 
 class ConsentExpireStatus(messages.Enum):

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -383,6 +383,17 @@ class WithdrawalReason(messages.Enum):
     DUPLICATE = 2
     TEST = 3
 
+# PDR-252:  This information will initially be required in PDR data for providing metrics.  There are no
+# initial requirements to include this information in RDR GET API responses
+class WithdrawalAIANCeremonyStatus(messages.Enum):
+    """Whether an AIAN participant requested a last rites ceremony for their samples when withdrawing.
+     If value is UNSET it means that a participant was not presented with or did not indicate a ceremony choice. """
+
+    UNSET = 0
+    DECLINED = 1
+    REQUESTED = 2
+    COMPLETED = 3
+
 
 class ConsentExpireStatus(messages.Enum):
     UNSET = 0

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -25,13 +25,16 @@ from rdr_service.code_constants import (
     CONSENT_COPE_NO_CODE,
     CONSENT_COPE_DEFERRED_CODE,
     CABOR_SIGNATURE_QUESTION_CODE,
-    PMI_SKIP_CODE
+    PMI_SKIP_CODE,
+    WITHDRAWAL_CEREMONY_YES,
+    WITHDRAWAL_CEREMONY_NO
 )
 from rdr_service.dao.resource_dao import ResourceDataDao
 # TODO: Replace BQRecord here with a Resource alternative.
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_participant_summary import BQStreetAddressTypeEnum, \
     BQModuleStatusEnum, COHORT_1_CUTOFF, COHORT_2_CUTOFF, BQConsentCohort
+from rdr_service.model.code import Code
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.ehr import ParticipantEhrReceipt
 from rdr_service.model.hpo import HPO
@@ -42,10 +45,10 @@ from rdr_service.model.participant_cohort_pilot import ParticipantCohortPilot
 # TODO:  Using participant_summary as a workaround.  Replace with new participant_profile when it's available
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory
-from rdr_service.model.questionnaire_response import QuestionnaireResponse
+from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.participant_enums import EnrollmentStatusV2, WithdrawalStatus, WithdrawalReason, SuspensionStatus, \
     SampleStatus, BiobankOrderStatus, PatientStatusFlag, ParticipantCohortPilotFlag, EhrStatus, DeceasedStatus, \
-    DeceasedReportStatus, QuestionnaireResponseStatus, EnrollmentStatus, OrderStatus
+    DeceasedReportStatus, QuestionnaireResponseStatus, EnrollmentStatus, OrderStatus, WithdrawalAIANCeremonyStatus
 from rdr_service.resource import generators, schemas
 from rdr_service.resource.constants import SchemaID
 
@@ -98,6 +101,14 @@ _consent_answer_status_map = {
     'ConsentAncestryTraits_Yes': BQModuleStatusEnum.SUBMITTED,
     'ConsentAncestryTraits_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE
+}
+
+# PDR-252:  When RDR starts accepting QuestionnaireResponse payloads for withdrawal screens, AIAN participants
+# will be given options for a last rites ceremony for their biobank samples.  Map answer codes to the status enum value
+# included with the PDR participant data
+_withdrawal_aian_ceremony_status_map = {
+    WITHDRAWAL_CEREMONY_YES: WithdrawalAIANCeremonyStatus.REQUESTED,
+    WITHDRAWAL_CEREMONY_NO: WithdrawalAIANCeremonyStatus.DECLINED
 }
 
 # See hotfix ticket ROC-447 / backfill ticket ROC-475.  The first GROR consent questionnaire was immediately
@@ -259,6 +270,22 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         withdrawal_reason = WithdrawalReason(p.withdrawalReason if p.withdrawalReason else 0)
         suspension_status = SuspensionStatus(p.suspensionStatus)
 
+
+        # PDR-252:  The AIAN withdrawal ceremony decision needs to be made available to PDR.  Look for the latest
+        # authored answer code, if one exists
+        withdrawal_aian_ceremony_status = WithdrawalAIANCeremonyStatus.UNSET
+        code_filter = Code.value.in_([WITHDRAWAL_CEREMONY_NO, WITHDRAWAL_CEREMONY_YES])
+        ceremony_response = ro_session.query(Code.value).\
+            join(QuestionnaireResponseAnswer, QuestionnaireResponseAnswer.valueCodeId == Code.codeId).\
+            join(QuestionnaireResponse,
+                 QuestionnaireResponse.questionnaireResponseId == QuestionnaireResponseAnswer.questionnaireResponseId).\
+            filter(code_filter, QuestionnaireResponse.participantId == p_id).\
+            order_by(desc(QuestionnaireResponse.authored)).one_or_none()
+
+        if ceremony_response:
+            withdrawal_aian_ceremony_status = \
+                _withdrawal_aian_ceremony_status_map.get(ceremony_response.value, WithdrawalAIANCeremonyStatus.UNSET)
+
         # The cohort_2_pilot_flag field values in participant_summary were set via a one-time backfill based on a
         # list of participant IDs provided by PTSC and archived in the participant_cohort_pilot table.  See:
         # https://precisionmedicineinitiative.atlassian.net/browse/DA-1622
@@ -291,6 +318,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             'withdrawal_time': p.withdrawalTime,
             'withdrawal_authored': p.withdrawalAuthored,
             'withdrawal_reason_justification': p.withdrawalReasonJustification,
+            'withdrawal_aian_ceremony_status': str(withdrawal_aian_ceremony_status),
+            'withdrawal_aian_ceremony_status_id': int(withdrawal_aian_ceremony_status),
 
             'suspension_status': str(suspension_status),
             'suspension_status_id': int(suspension_status),

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -8,7 +8,8 @@ from marshmallow import validate
 
 from rdr_service.participant_enums import QuestionnaireStatus, ParticipantCohort, Race, GenderIdentity, \
     PhysicalMeasurementsStatus, OrderStatus, EnrollmentStatusV2, EhrStatus, WithdrawalStatus, WithdrawalReason, \
-    SuspensionStatus, QuestionnaireResponseStatus, DeceasedStatus, ParticipantCohortPilotFlag
+    SuspensionStatus, QuestionnaireResponseStatus, DeceasedStatus, ParticipantCohortPilotFlag, \
+    WithdrawalAIANCeremonyStatus
 from rdr_service.resource import Schema, fields
 from rdr_service.resource.constants import SchemaID
 
@@ -234,6 +235,12 @@ class ParticipantSchema(Schema):
     withdrawal_reason = fields.EnumString(enum=WithdrawalReason)
     withdrawal_reason_id = fields.EnumInteger(enum=WithdrawalReason)
     withdrawal_reason_justification = fields.Text()
+    # PDR-252:  Must include AIAN ceremony decision in PDR data
+    withdrawal_aian_ceremony_status = fields.EnumString(enum=WithdrawalAIANCeremonyStatus)
+    withdrawal_aian_ceremony_status_id = fields.EnumInteger(enum=WithdrawalAIANCeremonyStatus)
+    suspension_status = fields.EnumString(enum=SuspensionStatus)
+    suspension_status_id = fields.EnumInteger(enum=SuspensionStatus)
+    suspension_time = fields.DateTime()
     suspension_status = fields.EnumString(enum=SuspensionStatus)
     suspension_status_id = fields.EnumInteger(enum=SuspensionStatus)
     suspension_time = fields.DateTime()

--- a/rdr_service/resource/schemas/pdr_participant.py
+++ b/rdr_service/resource/schemas/pdr_participant.py
@@ -6,7 +6,7 @@ from marshmallow import validate
 
 from rdr_service.participant_enums import ParticipantCohort, PhysicalMeasurementsStatus, \
     EnrollmentStatusV2, EhrStatus, WithdrawalStatus, WithdrawalReason, \
-    SuspensionStatus, DeceasedStatus, ParticipantCohortPilotFlag
+    SuspensionStatus, DeceasedStatus, ParticipantCohortPilotFlag, WithdrawalAIANCeremonyStatus
 from rdr_service.resource import Schema, fields
 from rdr_service.resource.schemas.participant import RaceSchema, GenderSchema, ModuleStatusSchema, ConsentSchema, \
     PatientStatusSchema, BiobankOrderSchema, EHRReceiptSchema
@@ -93,6 +93,9 @@ class PDRParticipantSchema(Schema):
     withdrawal_reason = fields.EnumString(enum=WithdrawalReason)
     withdrawal_reason_id = fields.EnumInteger(enum=WithdrawalReason)
     withdrawal_reason_justification = fields.Text()
+    # PDR-252:  Must include AIAN ceremony decision in PDR data
+    withdrawal_aian_ceremony_status = fields.EnumString(enum=WithdrawalAIANCeremonyStatus)
+    withdrawal_aian_ceremony_status_id = fields.EnumInteger(enum=WithdrawalAIANCeremonyStatus)
     suspension_status = fields.EnumString(enum=SuspensionStatus)
     suspension_status_id = fields.EnumInteger(enum=SuspensionStatus)
     suspension_time = fields.DateTime()


### PR DESCRIPTION
Kenny provided first review while the dev branch was still being finalized (before going OOO).  Feedback from that has been incorporated, to align more closely with RDR logic.

RDR does not need to expose the ceremony decision / status right now except for including a Y/N column in a CSV manifest file sent to the biobank.   For PDR requirements, I've created an enum to reflect specific choices (whether a ceremony was DECLINED or REQUESTED) and include that with the participant data, similar to other existing status (enum-derived) fields.

I also modified unit tests involving withdrawal ceremony choices in order to validate the PDR/resource generators as part of the tests.