### PR TITLE
Checking for withdrawal before parsing questionnaire response

### DIFF
--- a/rdr_service/api/questionnaire_response_api.py
+++ b/rdr_service/api/questionnaire_response_api.py
@@ -7,6 +7,7 @@ from rdr_service.dao.bq_questionnaire_dao import bq_questionnaire_update_task
 from rdr_service.api.base_api import BaseApi
 from rdr_service.api_util import PTC, PTC_AND_HEALTHPRO
 from rdr_service.dao.code_dao import CodeDao
+from rdr_service.dao.participant_dao import ParticipantDao, raise_if_withdrawn
 from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao
 from rdr_service.model.code import Code, CodeType
 from rdr_service.model.participant import Participant
@@ -29,6 +30,10 @@ class QuestionnaireResponseApi(BaseApi):
 
     @app_util.auth_required(PTC)
     def post(self, p_id):
+        # Reject any questionnaire response POSTs for participants that are withdrawn
+        participant = ParticipantDao().get(p_id)
+        raise_if_withdrawn(participant)
+
         resp = super(QuestionnaireResponseApi, self).post(participant_id=p_id)
         if resp and 'id' in resp:
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -49,7 +49,7 @@ from rdr_service.code_constants import (
     COHORT_1_REVIEW_CONSENT_YES_CODE)
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.code_dao import CodeDao
-from rdr_service.dao.participant_dao import ParticipantDao, raise_if_withdrawn
+from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import (
     ParticipantGenderAnswersDao,
     ParticipantRaceAnswersDao,
@@ -477,11 +477,8 @@ class QuestionnaireResponseDao(BaseDao):
                 raise BadRequest(
                     f"Unable to find signed consent-for-enrollment file for participant"
                 )
-            raise_if_withdrawn(participant)
             participant_summary = ParticipantDao.create_summary_for_participant(participant)
             something_changed = True
-        else:
-            raise_if_withdrawn(participant_summary)
 
         # Fetch the codes for all questions and concepts
         codes = code_dao.get_with_ids(code_ids)

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -238,23 +238,6 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
         with self.assertRaises(BadRequest):
             self._insert_questionnaire_response(qr)
 
-    def test_insert_participant_withdrawn(self):
-        self.insert_codes()
-        p = Participant(participantId=1, biobankId=2, withdrawalStatus=WithdrawalStatus.NO_USE)
-        self.participant_dao.insert(p)
-        self._setup_questionnaire()
-        qr = self.data_generator._questionnaire_response(
-            questionnaireResponseId=1,
-            questionnaireId=1,
-            questionnaireVersion=1,
-            questionnaireSemanticVersion='V1',
-            participantId=1,
-            resource=QUESTIONNAIRE_RESPONSE_RESOURCE
-        )
-        qr.answers.extend(self._names_and_email_answers())
-        with self.assertRaises(Forbidden):
-            self._insert_questionnaire_response(qr)
-
     def test_insert_not_name_answers(self):
         self.insert_codes()
         p = Participant(participantId=1, biobankId=2)


### PR DESCRIPTION
The ceremony decision for Native American participants comes in a QuestionnaireResponse POST right before we also receive the Participant PUT for their withdrawal. On March 24th at 8:31:23.790 on stable we received and started processing the withdrawal QuestionnaireResponse POST for P894006518. Less than a second later, at 8:31:24.307, we received the withdrawal PUT request for the participant. The code finished with the PUT request at 8:31:24.600 and marked the participant as withdrawn while the POST for the questionnaire response was still being processed. Then at 8:31:24.967 the code processing the questionnaire response POST checked for whether the participant was withdrawn or not.

This moves the withdrawal check to the beginning of the QuestionnaireResponse processing so that we'll still save the QuestionnaireResponse even if the participant is marked as withdrawn before the response is fully parsed.