### PR TITLE
Unit test logging updates

### DIFF
--- a/tests/helpers/diagnostics.py
+++ b/tests/helpers/diagnostics.py
@@ -1,0 +1,11 @@
+import logging
+
+
+class LoggingDatabaseActivity:
+    def __enter__(self):
+        self._sqlalchemy_logger = logging.getLogger('sqlalchemy.engine')
+        self._original_log_level = self._sqlalchemy_logger.level  # Store the level so it can be restored later
+        self._sqlalchemy_logger.setLevel(logging.INFO)  # INFO will print all SQL run against the database
+
+    def __exit__(self, *_):
+        self._sqlalchemy_logger.setLevel(self._original_log_level)

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -398,6 +398,7 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
 
         logger = logging.getLogger()
         stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
         logger.addHandler(stream_handler)
 
         # Change this to logging.ERROR when you want to see API server errors.


### PR DESCRIPTION
This doesn't need to be merged for the release.

This makes two updates for unit test logging. The first is to add the timestamp to logs that are printed during unit tests. It could be helpful in general, but came to mind when I thought of the second change.

The other change is to add the LoggingDatabaseActivity context manager. Any code run within a `with LoggingDatabaseActivity()` block will print the SQL that is run against the database. There could be other applications for it, but I plan on using it when working on tests to verify the raw SQL generated by the ORM and to see how many queries are being generated from lazy loading.