### PR TITLE
Fixing problem in response validation code

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -252,10 +252,10 @@ class ResponseValidator:
                 else:
                     self._check_answer_has_expected_data_type(answer, survey_question, questionnaire_question)
 
-                if survey_question.codeId in question_codes_answered:
-                    logging.error(f'Too many answers given for {survey_question.code.value}')
-                elif survey_question.questionType != SurveyQuestionType.CHECKBOX:
-                    question_codes_answered.add(survey_question.codeId)
+                    if survey_question.codeId in question_codes_answered:
+                        logging.error(f'Too many answers given for {survey_question.code.value}')
+                    elif survey_question.questionType != SurveyQuestionType.CHECKBOX:
+                        question_codes_answered.add(survey_question.codeId)
 
 
 class QuestionnaireResponseDao(BaseDao):
@@ -342,8 +342,11 @@ class QuestionnaireResponseDao(BaseDao):
                 semantic version {questionnaire_response.questionnaireSemanticVersion} is not found"
             )
 
-        answer_validator = ResponseValidator(questionnaire_history, session)
-        answer_validator.check_response(questionnaire_response)
+        try:
+            answer_validator = ResponseValidator(questionnaire_history, session)
+            answer_validator.check_response(questionnaire_response)
+        except (AttributeError, ValueError, TypeError, LookupError):
+            logging.error('Code error encountered when validating the response', exc_info=True)
 
         questionnaire_response.created = clock.CLOCK.now()
         if not questionnaire_response.authored:


### PR DESCRIPTION
There is a Survey structure defined for ConsentPII and it was constructed from the code parenting that we had in place (before the Redcap projects). But there's one question code that wasn't present in the spreadsheets that the codes were synced from, so it didn't have a parent set and it doesn't show up as a question for the survey. The validation code has a check to see if the question was found, but then went on to try to access things on it even if it was found to be None. That's fixed (moved some of the validation logic that uses the question definition into the block that is only reached when the question was found).

All of this is to try to validate the questionnaire response and doesn't affect anything else. So even if it crashes, the response should still be stored (at least for now). So this PR also adds a try-catch to capture failures that could happen in the validation code.