### PR TITLE
Updating documentation for physical measurements

### DIFF
--- a/rdr_service/model/measurements.py
+++ b/rdr_service/model/measurements.py
@@ -22,19 +22,23 @@ class PhysicalMeasurements(Base):
     """ID of the participant that the physical measurements are for"""
     created = Column("created", UTCDateTime, nullable=False)
     final = Column("final", Boolean, nullable=False)
-    # The ID that these measurements are an amendment of (points from new to old)
+    """
+    A flag indicating whether the physical measurements have been amended. Set to 1/True when the
+    measurements are created, and then set to 0/False if the measurements are amended.
+    """
     amendedMeasurementsId = Column(
         "amended_measurements_id", Integer, ForeignKey("physical_measurements.physical_measurements_id")
     )
+    """The ID that these measurements are an amendment of (points from new to old)"""
     logPositionId = Column("log_position_id", Integer, ForeignKey("log_position.log_position_id"), nullable=False)
-    # The site that created the physical measurements.
     createdSiteId = Column("created_site_id", Integer, ForeignKey("site.site_id"))
-    # The username / email of the HealthPro user that created the physical measurements.
+    """The site that created the physical measurements."""
     createdUsername = Column("created_username", String(255))
-    # The site that finalized the physical measurements.
+    """The username / email of the HealthPro user that created the physical measurements."""
     finalizedSiteId = Column("finalized_site_id", Integer, ForeignKey("site.site_id"))
-    # The username / email of the HealthPro user that finalized the physical measurements.
+    """The site that finalized the physical measurements."""
     finalizedUsername = Column("finalized_username", String(255))
+    """The username / email of the HealthPro user that finalized the physical measurements."""
     logPosition = relationship("LogPosition")
     finalized = Column("finalized", UTCDateTime)
     """The time at which the physical measurements were finalized"""


### PR DESCRIPTION
This PR moves some comments describing the fields into docstrings so that they'll get into the ReadTheDocs documentation and the data-dictionary. This also adds a description for the `final` flag.