### PR TITLE
More formatting changes for Jira release ticket

### DIFF
--- a/rdr_service/services/jira_utils.py
+++ b/rdr_service/services/jira_utils.py
@@ -225,10 +225,8 @@ class JiraTicketHandler:
         #args = ['git', 'log', f'{git_tag}..', '--pretty=format:"%h||%aN, %ad||%s"']
         # They want pretty, we'll give them pretty !
         args = ['git', 'log', f'{deployed_tag}..{target_tag}', '--graph', '--decorate',
-                "--format=format:'%C(bold blue)%h%C(reset) - %C(bold green)(%ar)%C(reset) "
-                "%C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(bold yellow)%d%C(reset)'"]
-        # pylint: disable=unused-variable
-        code, so, se = run_external_program(args=args)
+                "--format=format:'%C(white)%s%C(reset) %C(dim white)- %an%C(reset)%C(bold yellow)%d%C(reset)'"]
+        code, so, _ = run_external_program(args=args)
 
         if code != 0:
             return None

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -191,20 +191,16 @@ class DeployAppClass(object):
             deployed_version = resp.get('version_id', 'unknown').replace('-', '.')
 
         if not descr:
-            notes = self._jira_handler.get_release_notes_since_tag(deployed_version, self.args.git_target)
-            descr = "h1. Release Notes for {0}\nh2.deployed to {1}, listing changes since {2}:\n{3}".format(
-                self.args.git_target,
-                self.gcp_env.project,
-                deployed_version,
-                notes
-            )
-
             circle_ci_url = '<CircleCI URL>'
             if 'CIRCLE_BUILD_URL' in os.environ:
                 circle_ci_url = os.environ.get('CIRCLE_BUILD_URL')
+            change_log = self._jira_handler.get_release_notes_since_tag(deployed_version, self.args.git_target)
 
             today = datetime.datetime.today()
-            descr = descr + f"""
+            descr = descr + f"""h1. Release Notes for {self.args.git_target}
+            h2.deployed to {self.gcp_env.project}, listing changes since {deployed_version}:
+            {change_log}
+
             h3. Change Management Description
             System: All of Us DRC, Raw Data Repository (RDR)
             Developers: Robert Abram, Yu Wang, Josh Kanuch, Kenny Skaggs, Peggy Bertsch, Darryl Tharpe


### PR DESCRIPTION
I could be wrong, but I didn't think they'd need the commit hashes or time that the PR's were merged in the change description. I've been removing them when making the tickets and they haven't complained yet. This PR removes them from the change list when creating the Jira ticket. This also changes some formatting to try to get the start of the "Change Management" section to not be treated as a continuation of the bullet points in the git log lines.