### PR TITLE
[ROC-920] update workspace active project number algorithm

### DIFF
--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -460,11 +460,11 @@ class WorkbenchWorkspaceDao(UpdatableDao):
             count_query = (session.query(distinct(WorkbenchWorkspaceApproved.workspaceSourceId))
                            .join(WorkbenchWorkspaceUser, WorkbenchResearcher, WorkbenchInstitutionalAffiliations)
                            .filter(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
-                                   WorkbenchWorkspaceApproved.status == 1,
+                                   WorkbenchWorkspaceApproved.status == int(WorkbenchWorkspaceStatus.ACTIVE),
                                    WorkbenchInstitutionalAffiliations.isVerified == 1,
                                    or_(WorkbenchWorkspaceUser.isCreator == 1,
                                        and_(
-                                           WorkbenchWorkspaceUser.role == 3,
+                                           WorkbenchWorkspaceUser.role == int(WorkbenchWorkspaceUserRole.OWNER),
                                            WorkbenchWorkspaceApproved.id.notin_(subquery)
                                        )),
                                    or_(WorkbenchWorkspaceApproved.modified < sequest_hours_ago,

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -459,10 +459,7 @@ class WorkbenchWorkspaceDao(UpdatableDao):
             )
             count_query = (session.query(distinct(WorkbenchWorkspaceApproved.workspaceSourceId))
                            .join(WorkbenchWorkspaceUser, WorkbenchResearcher, WorkbenchInstitutionalAffiliations)
-                           .filter(WorkbenchWorkspaceUser.workspaceId == WorkbenchWorkspaceApproved.id,
-                                   WorkbenchWorkspaceUser.researcherId == WorkbenchResearcher.id,
-                                   WorkbenchInstitutionalAffiliations.researcherId == WorkbenchResearcher.id,
-                                   WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
+                           .filter(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
                                    WorkbenchWorkspaceApproved.status == 1,
                                    WorkbenchInstitutionalAffiliations.isVerified == 1,
                                    or_(WorkbenchWorkspaceUser.isCreator == 1,

--- a/tests/api_tests/test_workspace_audit_and_research_directory_api.py
+++ b/tests/api_tests/test_workspace_audit_and_research_directory_api.py
@@ -206,19 +206,22 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
                            ]}
                        ],
-                       'workspaceOwner': [{'userId': 1, 'userName': 'given name 2 family name 2',
-                                           'degree': ['PHD', 'MPH'],
-                                           'affiliations': [{'institution': 'institution2',
-                                                             'role': 'institution role 2',
-                                                             'isVerified': None,
-                                                             'nonAcademicAffiliation': 'UNSET'},
-                                                            {'institution': 'institution22',
-                                                             'role': 'institution role 22',
-                                                             'isVerified': None,
-                                                             'nonAcademicAffiliation': 'INDUSTRY'},
-                                                            {'institution': 'verified institution',
-                                                             'role': 'verified institution role 1',
-                                                             'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}]}],
+                       'workspaceOwner': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1',
+                            'degree': ['PHD', 'MPH'],
+                            'affiliations': [{'institution': 'institution1', 'role': 'institution role 1',
+                                              'isVerified': None, 'nonAcademicAffiliation': 'INDUSTRY'},
+                                             {'institution': 'display name', 'role': 'verified institution role 1',
+                                              'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}]},
+                           {'userId': 1, 'userName': 'given name 2 family name 2',
+                            'degree': ['PHD', 'MPH'],
+                            'affiliations': [{'institution': 'institution2', 'role': 'institution role 2',
+                                              'isVerified': None, 'nonAcademicAffiliation': 'UNSET'},
+                                             {'institution': 'institution22', 'role': 'institution role 22',
+                                              'isVerified': None, 'nonAcademicAffiliation': 'INDUSTRY'},
+                                             {'institution': 'verified institution',
+                                              'role': 'verified institution role 1', 'isVerified': True,
+                                              'nonAcademicAffiliation': 'UNSET'}]}],
                        'hasVerifiedInstitution': True,
                        'excludeFromPublicDirectory': False, 'ethicalLegalSocialImplications': True,
                        'reviewRequested': False, 'diseaseFocusedResearch': True,
@@ -354,19 +357,22 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
                            ]}
                        ],
-                       'workspaceOwner': [{'userId': 1, 'userName': 'given name 2 family name 2',
-                                           'degree': ['PHD', 'MPH'],
-                                           'affiliations': [{'institution': 'institution2',
-                                                             'role': 'institution role 2',
-                                                             'isVerified': None,
-                                                             'nonAcademicAffiliation': 'UNSET'},
-                                                            {'institution': 'institution22',
-                                                             'role': 'institution role 22',
-                                                             'isVerified': None,
-                                                             'nonAcademicAffiliation': 'INDUSTRY'},
-                                                            {'institution': 'verified institution',
-                                                             'role': 'verified institution role 1',
-                                                             'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}]}],
+                       'workspaceOwner': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
+                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
+                                 'nonAcademicAffiliation': 'INDUSTRY'},
+                                {'institution': 'display name', 'role': 'verified institution role 1',
+                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
+                            ]},
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [{'institution': 'institution2', 'role': 'institution role 2',
+                                              'isVerified': None, 'nonAcademicAffiliation': 'UNSET'},
+                                             {'institution': 'institution22', 'role': 'institution role 22',
+                                              'isVerified': None, 'nonAcademicAffiliation': 'INDUSTRY'},
+                                             {'institution': 'verified institution',
+                                              'role': 'verified institution role 1', 'isVerified': True,
+                                              'nonAcademicAffiliation': 'UNSET'}]}],
                        'hasVerifiedInstitution': True,
                        'excludeFromPublicDirectory': False, 'ethicalLegalSocialImplications': True,
                        'reviewRequested': False, 'diseaseFocusedResearch': True,
@@ -419,19 +425,22 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
                            ]}
                        ],
-                       'workspaceOwner': [{'userId': 1, 'userName': 'given name 2 family name 2',
-                                           'degree': ['PHD', 'MPH'],
-                                           'affiliations': [{'institution': 'institution2',
-                                                             'role': 'institution role 2',
-                                                             'isVerified': None,
-                                                             'nonAcademicAffiliation': 'UNSET'},
-                                                            {'institution': 'institution22',
-                                                             'role': 'institution role 22',
-                                                             'isVerified': None,
-                                                             'nonAcademicAffiliation': 'INDUSTRY'},
-                                                            {'institution': 'verified institution',
-                                                             'role': 'verified institution role 1',
-                                                             'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}]}],
+                       'workspaceOwner': [
+                           {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [
+                                {'institution': 'institution1', 'role': 'institution role 1', 'isVerified': None,
+                                 'nonAcademicAffiliation': 'INDUSTRY'},
+                                {'institution': 'display name', 'role': 'verified institution role 1',
+                                 'isVerified': True, 'nonAcademicAffiliation': 'UNSET'}
+                            ]},
+                           {'userId': 1, 'userName': 'given name 2 family name 2', 'degree': ['PHD', 'MPH'],
+                            'affiliations': [{'institution': 'institution2', 'role': 'institution role 2',
+                                              'isVerified': None, 'nonAcademicAffiliation': 'UNSET'},
+                                             {'institution': 'institution22', 'role': 'institution role 22',
+                                              'isVerified': None, 'nonAcademicAffiliation': 'INDUSTRY'},
+                                             {'institution': 'verified institution',
+                                              'role': 'verified institution role 1', 'isVerified': True,
+                                              'nonAcademicAffiliation': 'UNSET'}]}],
                        'hasVerifiedInstitution': True,
                        'excludeFromPublicDirectory': False, 'ethicalLegalSocialImplications': True,
                        'reviewRequested': False, 'diseaseFocusedResearch': True,
@@ -710,11 +719,11 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         sequest_hours_ago = now - timedelta(hours=24)
         with FakeClock(sequest_hours_ago):
             self.send_post('workbench/directory/workspaces', request_data=request_json)
-        result = self.send_get('researchHub/projectDirectory')
-        self.assertEqual(len(result['data']), 2)
+        result = self.send_get('researchHub/projectDirectory?status=ACTIVE')
+        self.assertEqual(len(result['data']), 1)
         # test search by project purpose
         result = self.send_get('researchHub/projectDirectory?projectPurpose=controlSet')
-        self.assertEqual(result['totalActiveProjects'], 2)
+        self.assertEqual(result['totalActiveProjects'], 1)
         self.assertEqual(result['totalMatchedRecords'], 1)
         self.assertEqual(len(result['data']), 1)
         # test search by multiple project purpose
@@ -728,7 +737,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         self.assertEqual(len(result['data']), 1)
         # test search by generalized parameter workspaceLike
         result = self.send_get('researchHub/projectDirectory?workspaceLike=str')
-        self.assertEqual(result['totalActiveProjects'], 2)
+        self.assertEqual(result['totalActiveProjects'], 1)
         self.assertEqual(result['totalMatchedRecords'], 2)
         self.assertEqual(len(result['data']), 2)
         result = self.send_get('researchHub/projectDirectory?workspaceLike=string2')
@@ -750,7 +759,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         self.assertEqual(len(result['data']), 1)
         # test search by user id
         result = self.send_get('researchHub/projectDirectory?userId=1&userRole=owner')
-        self.assertEqual(result['totalActiveProjects'], 2)
+        self.assertEqual(result['totalActiveProjects'], 1)
         self.assertEqual(result['totalMatchedRecords'], 1)
         self.assertEqual(len(result['data']), 1)
         result = self.send_get('researchHub/projectDirectory?userId=1&userRole=member')
@@ -759,7 +768,7 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         self.assertEqual(len(result['data']), 2)
         # test page and page size
         result = self.send_get('researchHub/projectDirectory?page=1&pageSize=1')
-        self.assertEqual(result['totalActiveProjects'], 2)
+        self.assertEqual(result['totalActiveProjects'], 1)
         self.assertEqual(result['totalMatchedRecords'], 2)
         self.assertEqual(len(result['data']), 1)
         result = self.send_get('researchHub/projectDirectory?page=2&pageSize=1')


### PR DESCRIPTION
1. change active workspace number algorithm: 
Add the following criteria: `active` and `has verified institution`.

2. fix bug for multiple owners case:
Workspace allows to have multiple owns. When calculate workspace verified institution, if a workspace has creator info, then use creator info; if no creator info, we need to go through each owners, any of them has verified institution, the workspace will be marked as `has verified institution`.
