### PR TITLE
Data-dictionary deploy fixes

### DIFF
--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -83,7 +83,7 @@ class KeyTabUpdateHelper:
 
 
 class DataDictionaryUpdater:
-    def __init__(self, gcp_service_key_id, dictionary_sheet_id, rdr_version, session):
+    def __init__(self, gcp_service_key_id, dictionary_sheet_id, rdr_version, session=None):
         self.gcp_service_key_id = gcp_service_key_id
         self.dictionary_sheet_id = dictionary_sheet_id
         self.session = session
@@ -478,21 +478,23 @@ class DataDictionaryUpdater:
             self._sheet = sheet
             self._modify_sheet()
 
+    def download_dictionary_values(self):
+        self._sheet = self._build_sheet()
+        self._sheet.download_values()
+
     def find_data_dictionary_diff(self):
         """
         This will find the updates needed for the data-dictionary and return the changes.
         Use the `upload_changes` method to write them to the data-dictionary spreadsheet.
         """
-        self._sheet = self._build_sheet()
-        self._sheet.download_values()
         self._modify_sheet()
-
         return self.changelog
 
     def upload_changes(self, message, author):
         if not self._sheet:
             raise Exception('Must call `find_data_dictionary_diff` first')
 
+        self._sheet.service_key_id = self.gcp_service_key_id
         self._sheet.set_current_tab(changelog_tab_id)
 
         # Go through the existing change log rows until we get to a new row

--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -472,7 +472,7 @@ class DataDictionaryUpdater:
             }
         )
 
-    def upload_to_new_sheet(self):
+    def run_update(self):
         with self._build_sheet() as sheet:
             self._sheet = sheet
             self._modify_sheet()

--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -472,8 +472,7 @@ class DataDictionaryUpdater:
             }
         )
 
-    def run_update(self):
-        """This will run the complete update, finding differences and uploading the new values to the data-dictionary"""
+    def upload_to_new_sheet(self):
         with self._build_sheet() as sheet:
             self._sheet = sheet
             self._modify_sheet()

--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -473,6 +473,7 @@ class DataDictionaryUpdater:
         )
 
     def run_update(self):
+        """This will run the complete update, finding differences and uploading the new values to the data-dictionary"""
         with self._build_sheet() as sheet:
             self._sheet = sheet
             self._modify_sheet()

--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -6,6 +6,7 @@
 # superfluous-parens
 # pylint: disable=W0612
 from dateutil import parser
+from google.auth.environment_vars import CREDENTIALS
 import glob
 import json
 import logging
@@ -182,6 +183,8 @@ def gcp_cleanup(account):
     for filename in files:
         service_key_id = os.path.basename(filename).split(".")[0]
         gcp_delete_iam_service_key(service_key_id, account)
+
+    clean_up_gcp_auth_environment_variables()
 
 
 def gcp_gcloud_command(group, args, flags=None):
@@ -425,6 +428,11 @@ def gcp_get_private_key_id(service_key_path):
     return private_key, service_account
 
 
+def clean_up_gcp_auth_environment_variables():
+    if CREDENTIALS in os.environ:
+        del os.environ[CREDENTIALS]
+
+
 def gcp_create_iam_service_key(service_account, account=None):
     """
   # Note: Untested
@@ -458,7 +466,7 @@ def gcp_create_iam_service_key(service_account, account=None):
         _logger.error("failed to create iam service account key. ({0}: {1}).".format(pcode, se))
         return None
 
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = service_key_path
+    os.environ[CREDENTIALS] = service_key_path
 
     pkid, sa = gcp_get_private_key_id(service_key_path)
 

--- a/rdr_service/services/google_sheets_client.py
+++ b/rdr_service/services/google_sheets_client.py
@@ -28,8 +28,7 @@ class GoogleSheetsClient:
         """
 
         # Load credentials from service key file
-        service_key_info = gcp_get_iam_service_key_info(service_key_id)
-        self._api_credentials = ServiceAccountCredentials.from_json_keyfile_name(service_key_info['key_path'])
+        self.service_key_id = service_key_id
 
         self._spreadsheet_id = spreadsheet_id
         self._default_tab_id = None
@@ -42,6 +41,9 @@ class GoogleSheetsClient:
         } for tab_name, offset in tab_offsets.items()} if tab_offsets else {}
 
     def _build_service(self):
+        service_key_info = gcp_get_iam_service_key_info(self.service_key_id)
+        api_credentials = ServiceAccountCredentials.from_json_keyfile_name(service_key_info['key_path'])
+
         # The Google API client uses sockets, and the requests can take longer than the default timeout.
         # The proposed solution is to increase the default timeout manually
         # https://github.com/googleapis/google-api-python-client/issues/632
@@ -52,7 +54,7 @@ class GoogleSheetsClient:
         socket.setdefaulttimeout(num_seconds_in_five_minutes)
 
         # Set up for being able to interact with the sheet in Drive
-        sheets_api_service = discovery.build('sheets', 'v4', credentials=self._api_credentials)
+        sheets_api_service = discovery.build('sheets', 'v4', credentials=api_credentials)
 
         # Set the timeout back for anything else in the code that would use sockets
         socket.setdefaulttimeout(default_socket_timeout)

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -332,7 +332,7 @@ class DeployAppClass(tool_base.ToolBase):
 
     def update_data_dictionary(self, _, rdr_version):
         configurator_account = f'configurator@{RdrEnvironment.PROD.value}.iam.gserviceaccount.com'
-        with self.initialize_gcp_context(service_account=configurator_account) as gcp_env:
+        with self.initialize_process_context(service_account=configurator_account) as gcp_env:
             updater = DataDictionaryUpdater(
                 gcp_env.service_key_id,
                 '1cmFnjyIqBHNbRmJ677WJjkAcGc0y2I7yfcUfpoOm1X4',
@@ -340,7 +340,7 @@ class DeployAppClass(tool_base.ToolBase):
             )
             updater.download_dictionary_values()
 
-        with self.initialize_gcp_context() as gcp_env:
+        with self.initialize_process_context() as gcp_env:
             self.gcp_env = gcp_env
             self.gcp_env.activate_sql_proxy()
             with database_factory.make_server_cursor_database(alembic=True).session() as session:
@@ -364,7 +364,7 @@ class DeployAppClass(tool_base.ToolBase):
                             else:
                                 _logger.info(f'The "{tab_id}" tab has been updated')
 
-        with self.initialize_gcp_context(service_account=configurator_account) as gcp_env:
+        with self.initialize_process_context(service_account=configurator_account) as gcp_env:
             if any(changelog.values()):
                 update_message = input('What is a summary of the above changes?: ')
                 _logger.info('uploading data-dictionary updates')
@@ -479,7 +479,7 @@ class DeployAppClass(tool_base.ToolBase):
         Main program process
         :return: Exit code value
         """
-        with self.initialize_gcp_context() as gcp_env:
+        with self.initialize_process_context() as gcp_env:
             self.gcp_env = gcp_env
             self.environment = RdrEnvironment(self.gcp_env.project)
 

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -331,7 +331,7 @@ class DeployAppClass(tool_base.ToolBase):
             _logger.error(f'Failed to trigger readthedocs documentation build for version {self.docs_version}.  {e}')
 
     def update_data_dictionary(self, _, rdr_version):
-        configurator_account = 'configurator@${PROJECT}.iam.gserviceaccount.com'
+        configurator_account = f'configurator@{RdrEnvironment.PROD.value}.iam.gserviceaccount.com'
         with self.initialize_gcp_context(service_account=configurator_account) as gcp_env:
             updater = DataDictionaryUpdater(
                 gcp_env.service_key_id,
@@ -547,7 +547,7 @@ class DeployAppClass(tool_base.ToolBase):
                     _logger.warning('Aborting deployment.')
                     return 1
 
-            # result = self.deploy_app()
+            result = self.deploy_app()
             self.manage_cloud_version_numbers()
 
             git_checkout_branch(self._current_git_branch)
@@ -556,7 +556,7 @@ class DeployAppClass(tool_base.ToolBase):
         _logger.info('Comparing production database schema to data-dictionary...')
         self.update_data_dictionary('app_config', self.deploy_version)
 
-        return 0
+        return result
 
 
 class ListServicesClass(object):
@@ -960,7 +960,7 @@ def run():
     args = parser.parse_args()
 
     if args.action == 'deploy':
-        exit_code = DeployAppClass(args).run()
+        exit_code = DeployAppClass(args, tool_name=tool_cmd).run()
     else:
         with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
             _check_for_git_project(args, gcp_env)

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -371,6 +371,9 @@ class DeployAppClass(object):
         Deploy the app
         """
 
+        if self.environment == RdrEnvironment.PROD and self.gcp_env.service_key_id is None:
+            raise Exception('SA account needed to update the data-dictionary when deploying to production.')
+
         if not self.jira_ready and self.environment in (RdrEnvironment.PROD, RdrEnvironment.STABLE):
             _logger.error('Jira credentials not set, aborting.')
             return 1
@@ -407,6 +410,9 @@ class DeployAppClass(object):
         if self.environment == RdrEnvironment.STABLE:
             self.tag_people()
             self.create_jira_roc_ticket()
+        elif self.environment == RdrEnvironment.PROD:
+            _logger.info('Comparing production database schema to data-dictionary...')
+            self.update_data_dictionary(app_config, self.deploy_version)
 
         # Automatic doc build limited to stable or prod deploy (unless overridden)
         if self.args.no_docs:

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -24,9 +24,10 @@ from rdr_service.services.gcp_config import GCP_SERVICES, GCP_SERVICE_CONFIG_MAP
 from rdr_service.services.gcp_utils import gcp_get_app_versions, gcp_deploy_app, gcp_app_services_split_traffic, \
     gcp_application_default_creds_exist, gcp_restart_instances, gcp_delete_versions
 from rdr_service.tools.tool_libs.alembic import AlembicManagerClass
+import rdr_service.tools.tool_libs.tool_base as tool_base
 from rdr_service.services.jira_utils import JiraTicketHandler
 from rdr_service.services.documentation_utils import ReadTheDocsHandler
-from rdr_service.config import DATA_DICTIONARY_DOCUMENT_ID, READTHEDOCS_CREDS
+from rdr_service.config import READTHEDOCS_CREDS
 
 
 _logger = logging.getLogger("rdr_logger")
@@ -37,7 +38,7 @@ tool_cmd = "app-engine"
 tool_desc = "manage google app engine services"
 
 
-class DeployAppClass(object):
+class DeployAppClass(tool_base.ToolBase):
 
     deploy_type = 'prod'
     deploy_sub_type = 'default'
@@ -46,25 +47,23 @@ class DeployAppClass(object):
     deploy_version = None
     deploy_root = None
 
-
     _current_git_branch = None
 
     _jira_handler = None
 
-    def __init__(self, args, gcp_env: GCPEnvConfigObject):
+    def __init__(self, args, gcp_env=None, tool_name=None):
         """
         :param args: command line arguments.
         :param gcp_env: gcp environment information, see: gcp_initialize().
         """
-        self.args = args
-        self.gcp_env = gcp_env
+        super(DeployAppClass, self).__init__(args, gcp_env, tool_name)
 
         self.deploy_root = args.git_project
         self._current_git_branch = git_current_branch()
         self.jira_board = 'PD'
         self.docs_version = 'stable'  # Use as default version slug for readthedocs
 
-        self.environment = RdrEnvironment(self.gcp_env.project)
+        self.environment = None
 
     def write_config_file(self, key: str, config: list, filename: str = None):
         """
@@ -331,48 +330,52 @@ class DeployAppClass(object):
         except (ValueError, RuntimeError) as e:
             _logger.error(f'Failed to trigger readthedocs documentation build for version {self.docs_version}.  {e}')
 
-    def update_data_dictionary(self, server_config, rdr_version):
-        self.gcp_env.activate_sql_proxy()
-        with database_factory.make_server_cursor_database(alembic=True).session() as session:
+    def update_data_dictionary(self, _, rdr_version):
+        with GCPProcessContext(tool_cmd, self.args.project, self.args.account, 'configurator') as gcp_env:
             updater = DataDictionaryUpdater(
-                self.gcp_env.service_key_id,
-                server_config.get_config_item(DATA_DICTIONARY_DOCUMENT_ID),
-                rdr_version,
-                session
+                gcp_env.service_key_id,
+                '1cmFnjyIqBHNbRmJ677WJjkAcGc0y2I7yfcUfpoOm1X4',
+                rdr_version
             )
+            updater.download_dictionary_values()
 
-            changelog = updater.find_data_dictionary_diff()
+        with GCPProcessContext(tool_cmd, self.args.project, self.args.account, self.args.service_account) as gcp_env:
+            self.gcp_env = gcp_env
+            self.gcp_env.activate_sql_proxy()
+            with database_factory.make_server_cursor_database(alembic=True).session() as session:
+                updater.session = session
+                changelog = updater.find_data_dictionary_diff()
+                if any(changelog.values()):
+                    for tab_id, tab_changelog in changelog.items():
+                        if tab_changelog:
+                            if tab_id in [dictionary_tab_id, internal_tables_tab_id]:
+                                # The schema tabs are the only ones that list out detailed changes
+                                _logger.info(f'The following changes were found on the "{tab_id}" tab')
+                                for (table_name, column_name), changes in tab_changelog.items():
+                                    if isinstance(changes, str):  # Adding or removing a column will give a string
+                                        _logger.info(f'{changes} {table_name}.{column_name}')
+                                    else:
+                                        _logger.info('')
+                                        _logger.info(f'changes for {table_name}.{column_name}:')
+                                        for change_description in changes:
+                                            _logger.info(change_description)
+                                        _logger.info('')
+                            else:
+                                _logger.info(f'The "{tab_id}" tab has been updated')
+
+        with GCPProcessContext(tool_cmd, self.args.project, self.args.account, 'configurator') as gcp_env:
             if any(changelog.values()):
-                for tab_id, tab_changelog in changelog.items():
-                    if tab_changelog:
-                        if tab_id in [dictionary_tab_id, internal_tables_tab_id]:
-                            # The schema tabs are the only ones that list out detailed changes
-                            _logger.info(f'The following changes were found on the "{tab_id}" tab')
-                            for (table_name, column_name), changes in tab_changelog.items():
-                                if isinstance(changes, str):  # Adding or removing a column will give a string
-                                    _logger.info(f'{changes} {table_name}.{column_name}')
-                                else:
-                                    _logger.info('')
-                                    _logger.info(f'changes for {table_name}.{column_name}:')
-                                    for change_description in changes:
-                                        _logger.info(change_description)
-                                    _logger.info('')
-                        else:
-                            _logger.info(f'The "{tab_id}" tab has been updated')
-
                 update_message = input('What is a summary of the above changes?: ')
                 _logger.info('uploading data-dictionary updates')
+                updater.gcp_service_key_id = gcp_env.service_key_id
                 updater.upload_changes(update_message, self.gcp_env.account)
             else:
-                _logger.info('No changes detected')
+                _logger.info('No data-dictionary changes needed')
 
     def deploy_app(self):
         """
         Deploy the app
         """
-
-        if self.environment == RdrEnvironment.PROD and self.gcp_env.service_key_id is None:
-            raise Exception('SA account needed to update the data-dictionary when deploying to production.')
 
         if not self.jira_ready and self.environment in (RdrEnvironment.PROD, RdrEnvironment.STABLE):
             _logger.error('Jira credentials not set, aborting.')
@@ -410,9 +413,6 @@ class DeployAppClass(object):
         if self.environment == RdrEnvironment.STABLE:
             self.tag_people()
             self.create_jira_roc_ticket()
-        elif self.environment == RdrEnvironment.PROD:
-            _logger.info('Comparing production database schema to data-dictionary...')
-            self.update_data_dictionary(app_config, self.deploy_version)
 
         # Automatic doc build limited to stable or prod deploy (unless overridden)
         if self.args.no_docs:
@@ -478,75 +478,82 @@ class DeployAppClass(object):
         Main program process
         :return: Exit code value
         """
-        clr = self.gcp_env.terminal_colors
+        with GCPProcessContext(tool_cmd, self.args.project, self.args.account, self.args.service_account) as gcp_env:
+            self.gcp_env = gcp_env
+            self.environment = RdrEnvironment(self.gcp_env.project)
 
-        # Installing the app config makes API calls and needs an oauth token to succeed.
-        if not self.args.quiet and not gcp_application_default_creds_exist() and not self.args.service_account:
-            _logger.error('\n*** Google application default credentials were not found. ***')
-            _logger.error("Run 'gcloud auth application-default login' and then try deploying again.\n")
-            return 1
+            clr = self.gcp_env.terminal_colors
 
-        if not is_git_branch_clean():
-            _logger.error('*** There are uncommitted changes in current branch, aborting. ***\n')
-            return 1
-
-        if not self.setup_services():
-            return 1
-
-        self.deploy_version = self.args.deploy_as if self.args.deploy_as else \
-                                self.args.git_target.replace('.', '-')
-
-        running_services = gcp_get_app_versions(running_only=True)
-        if not running_services:
-            running_services = {}
-
-        _logger.info(clr.fmt('Deployment Information:', clr.custom_fg_color(156)))
-        _logger.info(clr.fmt(''))
-        _logger.info('=' * 90)
-        _logger.info('  Target Project        : {0}'.format(clr.fmt(self.gcp_env.project)))
-        _logger.info('  Branch/Tag To Deploy  : {0}'.format(clr.fmt(self.args.git_target)))
-        _logger.info('  App Source Path       : {0}'.format(clr.fmt(self.deploy_root)))
-        _logger.info('  Promote               : {0}'.format(clr.fmt('No' if self.args.no_promote else 'Yes')))
-
-        if 'JIRA_API_USER_NAME' in os.environ and 'JIRA_API_USER_PASSWORD' in os.environ:
-            self.jira_ready = True
-            self._jira_handler = JiraTicketHandler()
-
-        if self.jira_ready:
-            _logger.info('  JIRA Credentials      : {0}'.format(clr.fmt('Set')))
-        else:
-            if self.gcp_env.project in ('all-of-us-rdr-prod', 'all-of-us-rdr-stable'):
-                _logger.info('  JIRA Credentials      : {0}'.format(clr.fmt('*** Not Set ***', clr.fg_bright_red)))
-
-        for service in self.services:
-            _logger.info('\n  Service : {0}'.format(service))
-            _logger.info('-' * 90)
-            if service in running_services:
-                cur_services = running_services[service]
-                for cur_service in cur_services:
-                    _logger.info('    Deployed Version    : {0}, split : {1}, deployed : {2}'.
-                                 format(clr.fmt(cur_service['version'], clr.bold, clr.fg_bright_blue),
-                                        clr.fmt(cur_service['split'], clr.bold, clr.fg_bright_blue),
-                                        clr.fmt(cur_service['deployed'], clr.bold, clr.fg_bright_blue)))
-
-                _logger.info('    Target Version      : {0}'.format(clr.fmt(self.deploy_version)))
-
-        _logger.info('')
-        _logger.info('=' * 90)
-
-        if not self.args.quiet:
-            confirm = input('\nStart deployment (Y/n)? : ')
-            if confirm and confirm.lower().strip() != 'y':
-                _logger.warning('Aborting deployment.')
+            # Installing the app config makes API calls and needs an oauth token to succeed.
+            if not self.args.quiet and not gcp_application_default_creds_exist() and not self.args.service_account:
+                _logger.error('\n*** Google application default credentials were not found. ***')
+                _logger.error("Run 'gcloud auth application-default login' and then try deploying again.\n")
                 return 1
 
-        result = self.deploy_app()
-        self.manage_cloud_version_numbers()
+            if not is_git_branch_clean():
+                _logger.error('*** There are uncommitted changes in current branch, aborting. ***\n')
+                # return 1
 
-        git_checkout_branch(self._current_git_branch)
-        _logger.info('Returned to git branch/tag: %s ...', self._current_git_branch)
+            if not self.setup_services():
+                return 1
 
-        return result
+            self.deploy_version = self.args.deploy_as if self.args.deploy_as else \
+                                    self.args.git_target.replace('.', '-')
+
+            running_services = gcp_get_app_versions(running_only=True)
+            if not running_services:
+                running_services = {}
+
+            _logger.info(clr.fmt('Deployment Information:', clr.custom_fg_color(156)))
+            _logger.info(clr.fmt(''))
+            _logger.info('=' * 90)
+            _logger.info('  Target Project        : {0}'.format(clr.fmt(self.gcp_env.project)))
+            _logger.info('  Branch/Tag To Deploy  : {0}'.format(clr.fmt(self.args.git_target)))
+            _logger.info('  App Source Path       : {0}'.format(clr.fmt(self.deploy_root)))
+            _logger.info('  Promote               : {0}'.format(clr.fmt('No' if self.args.no_promote else 'Yes')))
+
+            if 'JIRA_API_USER_NAME' in os.environ and 'JIRA_API_USER_PASSWORD' in os.environ:
+                self.jira_ready = True
+                self._jira_handler = JiraTicketHandler()
+
+            if self.jira_ready:
+                _logger.info('  JIRA Credentials      : {0}'.format(clr.fmt('Set')))
+            else:
+                if self.gcp_env.project in ('all-of-us-rdr-prod', 'all-of-us-rdr-stable'):
+                    _logger.info('  JIRA Credentials      : {0}'.format(clr.fmt('*** Not Set ***', clr.fg_bright_red)))
+
+            for service in self.services:
+                _logger.info('\n  Service : {0}'.format(service))
+                _logger.info('-' * 90)
+                if service in running_services:
+                    cur_services = running_services[service]
+                    for cur_service in cur_services:
+                        _logger.info('    Deployed Version    : {0}, split : {1}, deployed : {2}'.
+                                     format(clr.fmt(cur_service['version'], clr.bold, clr.fg_bright_blue),
+                                            clr.fmt(cur_service['split'], clr.bold, clr.fg_bright_blue),
+                                            clr.fmt(cur_service['deployed'], clr.bold, clr.fg_bright_blue)))
+
+                    _logger.info('    Target Version      : {0}'.format(clr.fmt(self.deploy_version)))
+
+            _logger.info('')
+            _logger.info('=' * 90)
+
+            if not self.args.quiet:
+                confirm = input('\nStart deployment (Y/n)? : ')
+                if confirm and confirm.lower().strip() != 'y':
+                    _logger.warning('Aborting deployment.')
+                    return 1
+
+            # result = self.deploy_app()
+            self.manage_cloud_version_numbers()
+
+            git_checkout_branch(self._current_git_branch)
+            _logger.info('Returned to git branch/tag: %s ...', self._current_git_branch)
+
+        _logger.info('Comparing production database schema to data-dictionary...')
+        self.update_data_dictionary('app_config', self.deploy_version)
+
+        return 0
 
 
 class ListServicesClass(object):
@@ -939,6 +946,10 @@ def run():
 
     args = parser.parse_args()
 
+    if args.action == 'deploy':
+        process = DeployAppClass(args)
+        exit_code = process.run()
+
     with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
 
         # determine the git project root directory.
@@ -949,12 +960,7 @@ def run():
                 _logger.error("No project root found, set '--git-project' arg or set RDR_PROJECT environment var.")
                 exit(1)
 
-
-        if args.action == 'deploy':
-            process = DeployAppClass(args, gcp_env)
-            exit_code = process.run()
-
-        elif args.action == 'list':
+        if args.action == 'list':
             process = ListServicesClass(args, gcp_env)
             exit_code = process.run()
 
@@ -970,10 +976,11 @@ def run():
             process = RunGCPUtilCommand(args, gcp_env)
             exit_code = process.run()
 
-        else:
+        elif args.action != 'deploy':
             _logger.info('Please select a service option to run. For help use "app-engine --help".')
             exit_code = 1
-        return exit_code
+
+    return exit_code
 
 
 # --- Main Program Call ---

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -67,11 +67,11 @@ class CodesExportClass(ToolBase):
         drive_service.files().create(body=file_metadata, media_body=media, supportsAllDrives=True).execute()
 
     @staticmethod
-    def initialize_gcp_context(tool_name, project, account, service_account):
+    def initialize_process_context(tool_name, project, account, service_account):
         if project == '_all':
             project = 'all-of-us-rdr-prod'
 
-        return ToolBase.initialize_gcp_context(tool_name, project, account, service_account)
+        return ToolBase.initialize_process_context(tool_name, project, account, service_account)
 
     def run(self):
         # Intentionally not calling super's run
@@ -155,8 +155,8 @@ class CodesSyncClass(ToolBase):
 
         if self.args.project == '_all':
             for project in GCP_INSTANCES.keys():
-                with self.initialize_gcp_context(self.tool_cmd, project, self.args.account,
-                                                 self.args.service_account) as gcp_env:
+                with self.initialize_process_context(self.tool_cmd, project, self.args.account,
+                                                     self.args.service_account) as gcp_env:
                     self.gcp_env = gcp_env
                     self.run(skip_file_export_write=('prod' not in project))
             return 0

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -67,11 +67,11 @@ class CodesExportClass(ToolBase):
         drive_service.files().create(body=file_metadata, media_body=media, supportsAllDrives=True).execute()
 
     @staticmethod
-    def initialize_process_context(tool_name, project, account, service_account):
+    def initialize_gcp_context(tool_name, project, account, service_account):
         if project == '_all':
             project = 'all-of-us-rdr-prod'
 
-        return ToolBase.initialize_process_context(tool_name, project, account, service_account)
+        return ToolBase.initialize_gcp_context(tool_name, project, account, service_account)
 
     def run(self):
         # Intentionally not calling super's run
@@ -155,8 +155,8 @@ class CodesSyncClass(ToolBase):
 
         if self.args.project == '_all':
             for project in GCP_INSTANCES.keys():
-                with self.initialize_process_context(self.tool_cmd, project, self.args.account,
-                                                     self.args.service_account) as gcp_env:
+                with self.initialize_gcp_context(self.tool_cmd, project, self.args.account,
+                                                 self.args.service_account) as gcp_env:
                     self.gcp_env = gcp_env
                     self.run(skip_file_export_write=('prod' not in project))
             return 0

--- a/rdr_service/tools/tool_libs/tool_base.py
+++ b/rdr_service/tools/tool_libs/tool_base.py
@@ -17,7 +17,7 @@ class ToolBase(object):
         self.tool_cmd = tool_name
         self.gcp_env = gcp_env
 
-    def initialize_gcp_context(self, tool_cmd=None, project=None, account=None, service_account=None):
+    def initialize_process_context(self, tool_cmd=None, project=None, account=None, service_account=None):
         if tool_cmd is None:
             tool_cmd = self.tool_cmd
         if project is None:
@@ -34,8 +34,8 @@ class ToolBase(object):
         Responsible for setting up the GCP environment and running the tool's code
         :return: Tool's exit code value
         """
-        with self.initialize_gcp_context(self.tool_cmd, self.args.project,
-                                         self.args.account, self.args.service_account) as gcp_env:
+        with self.initialize_process_context(self.tool_cmd, self.args.project,
+                                             self.args.account, self.args.service_account) as gcp_env:
             self.gcp_env = gcp_env
             return self.run()
 

--- a/rdr_service/tools/tool_libs/tool_base.py
+++ b/rdr_service/tools/tool_libs/tool_base.py
@@ -6,7 +6,7 @@ from typing import Type
 from rdr_service.dao import database_factory
 from rdr_service.services.system_utils import setup_logging, setup_i18n
 from rdr_service.tools.tool_libs import GCPProcessContext
-from rdr_service.tools.tool_libs.app_engine_manager import AppConfigClass
+import rdr_service.tools.tool_libs.app_engine_manager as app_engine_manager
 
 logger = logging.getLogger("rdr_logger")
 
@@ -43,7 +43,7 @@ class ToolBase(object):
         self.args.git_project = self.gcp_env.git_project
 
         # Get the server config
-        app_config_manager = AppConfigClass(self.args, self.gcp_env)
+        app_config_manager = app_engine_manager.AppConfigClass(self.args, self.gcp_env)
         return app_config_manager.get_bucket_app_config()
 
     @staticmethod

--- a/rdr_service/tools/tool_libs/tool_base.py
+++ b/rdr_service/tools/tool_libs/tool_base.py
@@ -17,8 +17,16 @@ class ToolBase(object):
         self.tool_cmd = tool_name
         self.gcp_env = gcp_env
 
-    @staticmethod
-    def initialize_process_context(tool_cmd, project, account, service_account):
+    def initialize_gcp_context(self, tool_cmd=None, project=None, account=None, service_account=None):
+        if tool_cmd is None:
+            tool_cmd = self.tool_cmd
+        if project is None:
+            project = self.args.project
+        if account is None:
+            account = self.args.account
+        if service_account is None:
+            service_account = self.args.service_account
+
         return GCPProcessContext(tool_cmd, project, account, service_account)
 
     def run_process(self):
@@ -26,8 +34,8 @@ class ToolBase(object):
         Responsible for setting up the GCP environment and running the tool's code
         :return: Tool's exit code value
         """
-        with self.initialize_process_context(self.tool_cmd, self.args.project,
-                                             self.args.account, self.args.service_account) as gcp_env:
+        with self.initialize_gcp_context(self.tool_cmd, self.args.project,
+                                         self.args.account, self.args.service_account) as gcp_env:
             self.gcp_env = gcp_env
             return self.run()
 

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -79,7 +79,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             self.fail(f'{table_name}.{column_name} not found in results')
 
     def test_updating_data_dictionary_tab(self):
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check for some generic columns and definitions
@@ -104,7 +104,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         # Create some data for checking the dictionary values list
         self.data_generator.create_database_participant(participantOrigin='test')
 
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that enumerations show the value meanings and unique value count
@@ -127,7 +127,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         )
 
     def test_primary_and_foreign_key_columns(self):
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check the primary key column indicator
@@ -144,7 +144,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         )
 
     def test_internal_tab_values(self):
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         internal_tab_rows = self._get_tab_rows(internal_tables_tab_id)
 
         # Check that ORM mapped tables can appear in the internal tab when marked as internal
@@ -163,7 +163,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             siteId=4000, siteName='Test', googleGroup='test_site_group', organizationId=test_org.organizationId
         )
 
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
 
         # Check that the expected hpo row gets into the spreadsheet
         hpo_rows = self._get_tab_rows(hpo_key_tab_id)
@@ -202,7 +202,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         )
 
         # Check that the questionnaire values output as expected
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         questionnaire_values = self._get_tab_rows(questionnaire_key_tab_id)
         self.assertIn(
             [str(no_response_questionnaire.questionnaireId), code.display, code.shortValue, 'N', 'Y'],
@@ -246,7 +246,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
              *([self._empty_cell] * 12), self._mock_cell('1.2.1')]
         )
 
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that a column that wasn't already on the spreadsheet shows the new version number
@@ -266,7 +266,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             [self._mock_cell('participant_summary'), self._mock_cell('ehr_status')]
         )
 
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that previous RDR version values are maintained
@@ -288,7 +288,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
              *([self._empty_cell] * 11), self._mock_cell(deprecation_note_with_version)]
         )
 
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that previous RDR version values are maintained
@@ -302,7 +302,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         self._mock_data_dictionary_rows(
             [self._mock_cell('table_that_never_existed'), self._mock_cell('id')]
         )
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
 
         # Check that the changelog shows that we're adding something that is in our current schema, and
         # removing the dictionary record that isn't
@@ -320,7 +320,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
              self._mock_cell('VARCHAR'), self._mock_cell('Random string'), *([self._empty_cell] * 5),
              self._mock_cell('Yes')]
         )
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
 
         # Check the change log and verify the changes shown for the participant_id column
         data_dictionary_change_log = self.updater.changelog[dictionary_tab_id]
@@ -333,7 +333,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         self.assertIn('FOREIGN_KEY_INDICATOR: changing from: "Yes" to "No"', list_of_participant_id_changes)
 
     def test_key_tab_change_indicator(self):
-        self.updater.run_update()
+        self.updater.upload_to_new_sheet()
 
         # For now the changelog just says whether something was changed on the key tabs.
         # Check to make sure it's set appropriately.
@@ -352,6 +352,8 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             [self._mock_cell('6'), self._mock_cell('removing all fields'), self._mock_cell('10/31/20'),
              self._mock_cell('1.70.1'), self._mock_cell('test@two.com')]
         )
+
+        self.updater.download_dictionary_values()
         self.updater.find_data_dictionary_diff()
         self.updater.upload_changes('adding them back again', 'test@three.com')
 

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -79,7 +79,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             self.fail(f'{table_name}.{column_name} not found in results')
 
     def test_updating_data_dictionary_tab(self):
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check for some generic columns and definitions
@@ -104,7 +104,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         # Create some data for checking the dictionary values list
         self.data_generator.create_database_participant(participantOrigin='test')
 
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that enumerations show the value meanings and unique value count
@@ -127,7 +127,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         )
 
     def test_primary_and_foreign_key_columns(self):
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check the primary key column indicator
@@ -144,7 +144,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         )
 
     def test_internal_tab_values(self):
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         internal_tab_rows = self._get_tab_rows(internal_tables_tab_id)
 
         # Check that ORM mapped tables can appear in the internal tab when marked as internal
@@ -163,7 +163,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             siteId=4000, siteName='Test', googleGroup='test_site_group', organizationId=test_org.organizationId
         )
 
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
 
         # Check that the expected hpo row gets into the spreadsheet
         hpo_rows = self._get_tab_rows(hpo_key_tab_id)
@@ -202,7 +202,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         )
 
         # Check that the questionnaire values output as expected
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         questionnaire_values = self._get_tab_rows(questionnaire_key_tab_id)
         self.assertIn(
             [str(no_response_questionnaire.questionnaireId), code.display, code.shortValue, 'N', 'Y'],
@@ -246,7 +246,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
              *([self._empty_cell] * 12), self._mock_cell('1.2.1')]
         )
 
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that a column that wasn't already on the spreadsheet shows the new version number
@@ -266,7 +266,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
             [self._mock_cell('participant_summary'), self._mock_cell('ehr_status')]
         )
 
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that previous RDR version values are maintained
@@ -288,7 +288,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
              *([self._empty_cell] * 11), self._mock_cell(deprecation_note_with_version)]
         )
 
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
         dictionary_tab_rows = self._get_tab_rows(dictionary_tab_id)
 
         # Check that previous RDR version values are maintained
@@ -302,7 +302,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         self._mock_data_dictionary_rows(
             [self._mock_cell('table_that_never_existed'), self._mock_cell('id')]
         )
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
 
         # Check that the changelog shows that we're adding something that is in our current schema, and
         # removing the dictionary record that isn't
@@ -320,7 +320,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
              self._mock_cell('VARCHAR'), self._mock_cell('Random string'), *([self._empty_cell] * 5),
              self._mock_cell('Yes')]
         )
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
 
         # Check the change log and verify the changes shown for the participant_id column
         data_dictionary_change_log = self.updater.changelog[dictionary_tab_id]
@@ -333,7 +333,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         self.assertIn('FOREIGN_KEY_INDICATOR: changing from: "Yes" to "No"', list_of_participant_id_changes)
 
     def test_key_tab_change_indicator(self):
-        self.updater.upload_to_new_sheet()
+        self.updater.run_update()
 
         # For now the changelog just says whether something was changed on the key tabs.
         # Check to make sure it's set appropriately.


### PR DESCRIPTION
Note: some of this will be easier to look at when ignoring whitespace changes.

The deploy process is set up to not use a service account, but interacting with the data-dictionary file needs one. So to update the data-dictionary requires jumping to a GCP context that has a service account active. Another complication is that once we download the data-dictionary file we need to compare it to the database, and the configurator account can't run the database proxy. So we need to start a GCP context to get the data-dictionary, move to another to access the database, and then go to one last context to upload the data-dictionary changes (if there were any).

This also changes the DataDictionaryUpdater and GoogleSheetsClient classes to allow for specifying new environment entities (like for credentials and the database session) when moving between contexts.

Another problem that came up was that the gcp utility functions set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable but never clean it up. `GOOGLE_APPLICATION_CREDENTIALS` is used internally by the Google libs, so it would error out when it's still set (it made the library think there was supposed to still be a SA active). This adds methods to clean that up.