### PR TITLE
Fixing cloud debugger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -r requirements_base.txt
 
 mysqlclient==1.4.6        # via -r requirements.in
+google-python-cloud-debugger


### PR DESCRIPTION
The debugger was working previously (in sandbox at least). But it looks `google-cloud-debugger` isn't available by default on the environments anymore. Adding it back to the requirements.txt file to get the Cloud Debugger working again.

https://cloud.google.com/debugger/docs/setup/python?authuser=1#python_37_or_python_38