### PR TITLE
[DA-1956] Update to mayo clinic salivary kit payload 

### DIFF
--- a/rdr_service/api/mail_kit_order_api.py
+++ b/rdr_service/api/mail_kit_order_api.py
@@ -116,10 +116,15 @@ class MailKitOrderApi(UpdatableApi):
             self.dao.insert_biobank_order(p_id, merged_resource)
             self.dao.insert_mayolink_create_order_history(p_id, merged_resource, resource, response)
 
-        response = super(MailKitOrderApi, self).put(
-            bo_id, participant_id=p_id, skip_etag=True, resource=merged_resource
-        )
-        response[2]["Location"] = "/rdr/v1/SupplyDelivery/{}".format(bo_id)
+        response = super(MailKitOrderApi, self)\
+            .put(
+                bo_id,
+                participant_id=p_id,
+                skip_etag=True,
+                resource=merged_resource
+            )
+
+        response[2]["Location"] = f"/rdr/v1/SupplyDelivery/{bo_id}"
         response[2]['auth_user'] = resource['auth_user']
         if response[1] == 200:
             created_response = list(response)
@@ -167,7 +172,11 @@ class MailKitOrderApi(UpdatableApi):
             raise BadRequest("missing FHIR order document")
 
         method = self._lookup_resource_type_method(
-            {"SupplyRequest": self._put_supply_request, "SupplyDelivery": self._put_supply_delivery}, resource
+            {
+                "SupplyRequest": self._put_supply_request,
+                "SupplyDelivery": self._put_supply_delivery
+            },
+            resource
         )
         return method(resource, bo_id)
 

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -86,6 +86,7 @@ class MailKitOrderDao(UpdatableDao):
         collected_time_utc = parser.parse(fhir_resource.occurrenceDateTime).replace(tzinfo=_UTC)
         collected_time_central = collected_time_utc.astimezone(_US_CENTRAL)
 
+        # MayoLink api has strong opinions on what should be sent and the order of elements. Dont touch.
         order = {
             "order": {
                 "collected": str(collected_time_central),

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -115,6 +115,13 @@ class MailKitOrderDao(UpdatableDao):
                 "comments": "Salivary Kit Order, direct from participant",
             }
         }
+
+        if barcode and len(barcode) > 14:
+            client_fields = {"client_passthrough_fields": {
+                "field1": barcode
+            }}
+            order['order'].update(client_fields)
+            del order["order"]["number"]
         return order
 
     def to_client_json(self, model, for_update=False):
@@ -139,8 +146,7 @@ class MailKitOrderDao(UpdatableDao):
             result["participantId"] = to_client_participant_id(result["participantId"])
         return result
 
-    def from_client_json(
-        self, resource_json, id_=None, expected_version=None, participant_id=None, client_id=None
+    def from_client_json(self, resource_json, id_=None, expected_version=None, participant_id=None, client_id=None
     ):  # pylint: disable=unused-argument
         """Initial loading of the DV order table does not include all attributes."""
         fhir_resource = SimpleFhirR4Reader(resource_json)

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -86,7 +86,6 @@ class MailKitOrderDao(UpdatableDao):
         collected_time_utc = parser.parse(fhir_resource.occurrenceDateTime).replace(tzinfo=_UTC)
         collected_time_central = collected_time_utc.astimezone(_US_CENTRAL)
 
-        # MayoLink api has strong opinions on what should be sent and the order of elements. Dont touch.
         order = {
             "order": {
                 "collected": str(collected_time_central),
@@ -112,16 +111,17 @@ class MailKitOrderDao(UpdatableDao):
                 "physician": {"name": "None", "phone": None, "npi": None},  # must be a string value, not None.
                 "report_notes": fhir_resource.extension.get(url=DV_ORDER_URL).valueString,
                 "tests": [{"test": {"code": "1SAL2", "name": "PMI Saliva, FDA Kit", "comments": None}}],
-                "comments": "Salivary Kit Order, direct from participant",
             }
         }
 
-        if barcode and len(barcode) > 14:
+        if len(barcode) > 14:
+            del order["order"]["number"]
             client_fields = {"client_passthrough_fields": {
                 "field1": barcode
             }}
             order['order'].update(client_fields)
-            del order["order"]["number"]
+
+        order['order']['comments'] = "Salivary Kit Order, direct from participant"
         return order
 
     def to_client_json(self, model, for_update=False):

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -114,7 +114,7 @@ class MailKitOrderDao(UpdatableDao):
             }
         }
 
-        if len(barcode) > 14:
+        if barcode and len(barcode) > 14:
             del order["order"]["number"]
             client_fields = {"client_passthrough_fields": {
                 "field1": barcode

--- a/tests/api_tests/test_mail_kit_order_api.py
+++ b/tests/api_tests/test_mail_kit_order_api.py
@@ -180,7 +180,7 @@ class MailKitOrderApiTestPutSupplyRequest(MailKitOrderApiTestBase):
         orders = self.get_orders()
         self.assertEqual(1, len(orders))
         for i in orders:
-            self.assertEqual(i.barcode, "SABR90160121INA")
+            self.assertEqual(i.barcode, "SABR90160121IN")
             self.assertEqual(i.id, int(1))
             self.assertEqual(i.order_id, int(999999))
             self.assertEqual(i.biobankOrderId, "WEB1ABCD1234")

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -64,7 +64,7 @@ class MailKitOrderDaoTestBase(BaseTestCase):
             "rdr_service.dao.mail_kit_order_dao.MayoLinkApi", **{"return_value.post.return_value": self.mayolink_response}
         )
 
-        self.mayolinkapi_patcher_start = mayolinkapi_patcher.start()
+        self.mock_mayolinkapi = mayolinkapi_patcher.start()
         self.addCleanup(mayolinkapi_patcher.stop)
 
     def test_insert_biobank_order(self):
@@ -100,7 +100,7 @@ class MailKitOrderDaoTestBase(BaseTestCase):
         self.assertEqual(put_response["barcode"], version_one_barcode)
         self.assertEqual(put_response["order_id"], 999999)
 
-        mayo_order_payload = self.mayolinkapi_patcher_start.return_value.post.call_args.args[0]
+        mayo_order_payload = self.mock_mayolinkapi.return_value.post.call_args.args[0]
         mayo_order_payload = mayo_order_payload['order']
         mayo_payload_fields = ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests', 'comments']
 
@@ -133,7 +133,7 @@ class MailKitOrderDaoTestBase(BaseTestCase):
 
         self.assertEqual(put_response["barcode"], version_two_barcode)
 
-        mayo_order_payload = self.mayolinkapi_patcher_start.return_value.post.call_args.args[0]
+        mayo_order_payload = self.mock_mayolinkapi.return_value.post.call_args.args[0]
         mayo_order_payload = mayo_order_payload['order']
         mayo_payload_fields = ['collected', 'account', 'patient', 'physician', 'report_notes', 'tests', 'client_passthrough_fields','comments']
 

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -106,14 +106,11 @@ class MailKitOrderDaoTestBase(BaseTestCase):
         )
         location = payload.location.rsplit("/", 1)[-1]
         version_two_barcode = 'SABR901601##21IN'
-        # update barcode
         self.put_request['extension'][0]['valueString'] = version_two_barcode
-        # barcode inserted
         self.send_put(
             f"SupplyRequest/{location}",
             request_data=self.put_request
         )
-        # payload sent to mayo
         payload = self.send_post(
             "SupplyDelivery",
             request_data=self.post_delivery,
@@ -132,7 +129,6 @@ class MailKitOrderDaoTestBase(BaseTestCase):
             request_data=self.post_request,
             expected_status=http.client.CREATED
         )
-        #mailkitdao => send order => mayolinkapi
         payload = self.send_post(
             "SupplyDelivery",
             request_data=load_test_data_json("dv_order_api_post_supply_delivery_alt.json"),

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -63,7 +63,8 @@ class MailKitOrderDaoTestBase(BaseTestCase):
         mayolinkapi_patcher = mock.patch(
             "rdr_service.dao.mail_kit_order_dao.MayoLinkApi", **{"return_value.post.return_value": self.mayolink_response}
         )
-        mayolinkapi_patcher.start()
+
+        self.mock_patcher_start = mayolinkapi_patcher.start()
         self.addCleanup(mayolinkapi_patcher.stop)
 
     def test_insert_biobank_order(self):

--- a/tests/test-data/dv_order_api_put_supply_request.json
+++ b/tests/test-data/dv_order_api_put_supply_request.json
@@ -58,7 +58,7 @@
   "extension": [
     {
       "url": "http://joinallofus.org/fhir/barcode",
-      "valueString": "SABR90160121INA"
+      "valueString": "SABR90160121IN"
     },
     {
       "url": "http://joinallofus.org/fhir/order-type",


### PR DESCRIPTION
Need to update the payload that we send to the mayo clinic for salivary kits based on the barcode version for the order.

-- logic for updating payload based on barcode type
-- tests updated/added for testing payloads sent in `post` to MayoLinkAPI 