### PR TITLE
Upgrading google-auth so it's compatible with the new version of rsa

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 job_defaults: &job_defaults
   docker:
-    - image: circleci/python:3.7.7
+    - image: circleci/python:3.7.5
   working_directory: ~/all-of-us/raw-data-repository
   parallelism: 1
   shell: /bin/bash --login

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 job_defaults: &job_defaults
   docker:
-    - image: circleci/python:3.7.5
+    - image: circleci/python:3.7.7
   working_directory: ~/all-of-us/raw-data-repository
   parallelism: 1
   shell: /bin/bash --login

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -7,5 +7,5 @@ source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
 pip install --upgrade pip
-pip install -r requirements.txt
 pip install safety
+pip install -r requirements.txt

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -6,6 +6,5 @@ python3 -m venv venv
 source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
-pip install --upgrade pip
 pip install -r requirements.txt
 pip install safety

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -6,5 +6,5 @@ python3 -m venv venv
 source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
-pip install --exists-action=w -r requirements.txt
+pip install --exists-action=w --no-cache-dir -r requirements.txt
 pip install safety

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -6,5 +6,6 @@ python3 -m venv venv
 source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
+pip install --upgrade pip
 pip install -r requirements.txt
 pip install safety

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -6,5 +6,6 @@ python3 -m venv venv
 source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
-pip install --exists-action=w --no-cache-dir -r requirements.txt
+pip install --upgrade pip
+pip install -r requirements.txt
 pip install safety

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -6,5 +6,5 @@ python3 -m venv venv
 source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
-pip install -q -r requirements.txt
+pip install --exists-action=w -r requirements.txt
 pip install safety

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -33,7 +33,7 @@ geventhttpclient==1.4.2   # via locust
 google-api-core[grpc]==1.17.0  # via google-api-python-client, google-cloud-bigquery, google-cloud-core, google-cloud-datastore, google-cloud-firestore, google-cloud-logging, google-cloud-tasks
 google-api-python-client==1.8.3  # via -r requirements.in, google-python-cloud-debugger
 google-auth-httplib2==0.0.3  # via google-api-python-client, google-python-cloud-debugger
-google-auth==1.28.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-bigquery, google-cloud-storage, google-python-cloud-debugger
+google-auth==1.15.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-bigquery, google-cloud-storage, google-python-cloud-debugger
 google-cloud-bigquery==1.24.0  # via -r requirements.in
 google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-datastore, google-cloud-firestore, google-cloud-logging, google-cloud-storage
 google-cloud-datastore==1.12.0  # via -r requirements.in

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -33,7 +33,7 @@ geventhttpclient==1.4.2   # via locust
 google-api-core[grpc]==1.17.0  # via google-api-python-client, google-cloud-bigquery, google-cloud-core, google-cloud-datastore, google-cloud-firestore, google-cloud-logging, google-cloud-tasks
 google-api-python-client==1.8.3  # via -r requirements.in, google-python-cloud-debugger
 google-auth-httplib2==0.0.3  # via google-api-python-client, google-python-cloud-debugger
-google-auth==1.15.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-bigquery, google-cloud-storage, google-python-cloud-debugger
+google-auth==1.28.0       # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-bigquery, google-cloud-storage, google-python-cloud-debugger
 google-cloud-bigquery==1.24.0  # via -r requirements.in
 google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-datastore, google-cloud-firestore, google-cloud-logging, google-cloud-storage
 google-cloud-datastore==1.12.0  # via -r requirements.in


### PR DESCRIPTION
When the rsa library was updated the pip install started throwing a warning that google auth was incompatible (google-auth 1.15.0 depends on rsa's version being >=3.1.4 and <4.1). CircleCI and Google builds were continuing to work, but ReadTheDocs builds were failing (https://readthedocs.org/projects/all-of-us-raw-data-repository/builds/13396770/).

This PR updates google-auth to the latest version (1.28.0, https://pypi.org/project/google-auth). And it adds a step in the Circle-CI process to upgrade pip. Using the newer version of pip will error out rather than warn about the incompatibility and install anyway (https://app.circleci.com/pipelines/github/all-of-us/raw-data-repository/2840/workflows/b062d515-06ef-4987-8c1b-dc2dded96d3d/jobs/10573).

It also installs the requirements file last so that Circle-CI fails on the install step if installing the requirements fails.