### PR TITLE
removing references of tmp duplication table from BQ and resource code

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import logging
-import MySQLdb
 import re
 
 from collections import OrderedDict
@@ -126,9 +125,6 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
     """
     Generate a Participant Summary BQRecord object
     """
-    # Temporary
-    cdm_db_exists = False
-
     ro_dao = None
     # Retrieve module and sample test lists from config.
     _baseline_modules = [mod.replace('questionnaireOn', '')
@@ -147,8 +143,6 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             self.ro_dao = BigQuerySyncDao(backup=True)
 
         with self.ro_dao.session() as ro_session:
-            # Temporary
-            self.cdm_db_exists = self._test_cdm_db_exists(ro_session)
             # prep participant info from Participant record
             summary = self._prep_participant(p_id, ro_session)
             # prep additional participant profile info
@@ -212,24 +206,6 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                 return BQRecord(schema=BQParticipantSummarySchema, data=json.loads(rec.resource),
                                 convert_to_enum=False)
         return None
-
-    def _test_cdm_db_exists(self, ro_session):
-        """
-        Temporary function to detect if the 'cdm' database and 'tmp_questionnaire_response' table exists.
-        :param ro_session: Readonly DAO session object
-        :return: True if 'cdm' database exists otherwise False.
-        """
-        sql = "SELECT * FROM cdm.tmp_questionnaire_response LIMIT 1"
-
-        try:
-            ro_session.execute(sql)
-            return True
-        except exc.ProgrammingError:
-            pass
-        except (exc.OperationalError, MySQLdb._exceptions.OperationalError):
-            logging.warning('Unexpected error found when checking for tmp_questionnaire_response table',
-                            exc_info=True)
-        return False
 
     def _prep_participant(self, p_id, ro_session):
         """
@@ -442,8 +418,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
 
         # PDR-178:  Retrieve both the processed (layered) answers result, and the raw responses. This allows us to
         # do some extra processing of the ConsentPII data without having to query all over again.
-        qnans, responses = self.get_module_answers(self.ro_dao, 'ConsentPII', p_id, return_responses=True,
-                                        cdm_db_exists=self.cdm_db_exists)
+        qnans, responses = self.get_module_answers(self.ro_dao, 'ConsentPII', p_id, return_responses=True)
         if not qnans:
             # return the minimum data required when we don't have the questionnaire data.
             return {'email': None, 'is_ghost_id': 0}
@@ -502,52 +477,20 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         :param ro_session: Readonly DAO session object
         :return: dict
         """
+        code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
+            filter(QuestionnaireResponse.questionnaireId ==
+                   QuestionnaireConcept.questionnaireId).label('codeId')
 
-        if not self.cdm_db_exists:
-            code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
-                filter(QuestionnaireResponse.questionnaireId ==
-                       QuestionnaireConcept.questionnaireId).label('codeId')
-
-            # Responses are sorted by authored date ascending and then created date descending
-            # This should result in a list where any replays of a response are adjacent (most recently created first)
-            query = ro_session.query(
-                    QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
-                    QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
-                    QuestionnaireResponse.status, code_id_query). \
-                join(QuestionnaireHistory). \
-                filter(QuestionnaireResponse.participantId == p_id). \
-                order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
-            #sql = self.ro_dao.query_to_text(query)
-            results = query.all()
-
-        # Temporary: Use raw sql instead to facilitate joining across databases to the cdm.tmp_questionnaire_response
-        # table where we have flagged duplicate response payloads sent by PTSC for filtering out during PDR data
-        # rebuilds.  See:  ROC-825
-        else:
-            # This SQL statement is based off of the query_to_text() output for the SQLAlchemy query above, and then
-            # modified to add the additional filtering when joined with cdm.temp_questionnaire_response (and match
-            # expected column names to what the SQLAlchemy query also returns)
-            _raw_sql = """
-                SELECT qr.questionnaire_response_id questionnaireResponseId,
-                       qr.authored,
-                       qr.created,
-                       qr.language,
-                       qh.external_id externalId,
-                       qr.status,
-                  (SELECT max(questionnaire_concept.code_id) AS max_1
-                   FROM questionnaire_concept
-                   WHERE qr.questionnaire_id = questionnaire_concept.questionnaire_id) AS `codeId`
-                FROM questionnaire_response qr
-                INNER JOIN questionnaire_history qh
-                      ON qh.questionnaire_id = qr.questionnaire_id
-                      AND qh.version = qr.questionnaire_version
-                LEFT OUTER JOIN cdm.tmp_questionnaire_response tqr
-                      ON qr.questionnaire_response_id = tqr.questionnaire_response_id
-                WHERE qr.participant_id = :pid
-                      AND (tqr.duplicate is NULL or tqr.duplicate = 0)
-                ORDER BY qr.authored, qr.created DESC;
-            """
-            results = ro_session.execute(_raw_sql, {'pid': p_id})
+        # Responses are sorted by authored date ascending and then created date descending
+        # This should result in a list where any replays of a response are adjacent (most recently created first)
+        query = ro_session.query(
+                QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
+                QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
+                QuestionnaireResponse.status, code_id_query). \
+            join(QuestionnaireHistory). \
+            filter(QuestionnaireResponse.participantId == p_id, QuestionnaireResponse.isDuplicate.is_(False)). \
+            order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
+        results = query.all()
 
         data = {
             'consent_cohort': BQConsentCohort.UNSET.name,
@@ -556,7 +499,6 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         modules = list()
         consents = list()
         consent_dt = None
-
 
         if results:
             # Track the last module/consent data dictionaries generated, so we can detect and omit replayed responses
@@ -595,8 +537,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                         data['consent_cohort'] = cohort.name
                         data['consent_cohort_id'] = cohort.value
 
-                    qnans = self.get_module_answers(self.ro_dao, module_name, p_id, row.questionnaireResponseId,
-                                                    cdm_db_exists=self.cdm_db_exists)
+                    qnans = self.get_module_answers(self.ro_dao, module_name, p_id, row.questionnaireResponseId)
                     if qnans:
                         qnan = BQRecord(schema=None, data=qnans)
                         consent = {
@@ -678,8 +619,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         :param ro_session: Readonly DAO session object
         :return: dict
         """
-        qnans = self.get_module_answers(self.ro_dao, 'TheBasics', p_id, return_responses=False,
-                                        cdm_db_exists=self.cdm_db_exists)
+        qnans = self.get_module_answers(self.ro_dao, 'TheBasics', p_id, return_responses=False)
         if not qnans or len(qnans) == 0:
             return {}
 
@@ -1355,7 +1295,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         return data
 
     @staticmethod
-    def get_module_answers(ro_dao, module, p_id, qr_id=None, return_responses=False, cdm_db_exists=False):
+    def get_module_answers(ro_dao, module, p_id, qr_id=None, return_responses=False):
         """
         Retrieve the questionnaire module answers for the given participant id.  This retrieves all responses to
         the module and applies/layers the answers from each response to the final data dict returned.
@@ -1364,7 +1304,6 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
         :param p_id: participant id.
         :param qr_id: questionnaire response id
         :param return_responses:  Return the responses (unlayered) in addition to the processed answer data
-        :param cdm_db_exists: Temporary arg.
         :return: dicts
         """
         _module_info_sql = """
@@ -1378,21 +1317,10 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
             FROM questionnaire_response qr
                     INNER JOIN questionnaire_concept qc on qr.questionnaire_id = qc.questionnaire_id
                     INNER JOIN questionnaire q on q.questionnaire_id = qc.questionnaire_id
+            WHERE qr.participant_id = :p_id and qc.code_id in (select c1.code_id from code c1 where c1.value = :mod)
+                AND qr.is_duplicate = FALSE
+            ORDER BY qr.created
         """
-        # Temporary
-        if cdm_db_exists:
-            _module_info_sql += """
-                LEFT OUTER JOIN cdm.tmp_questionnaire_response tqr
-                    ON qr.questionnaire_response_id = tqr.questionnaire_response_id
-                WHERE qr.participant_id = :p_id and qc.code_id in (select c1.code_id from code c1 where c1.value = :mod) AND
-                   (tqr.duplicate is null or tqr.duplicate = 0)
-                ORDER BY qr.created;
-            """
-        else:
-            _module_info_sql += """
-                WHERE qr.participant_id = :p_id and qc.code_id in (select c1.code_id from code c1 where c1.value = :mod)
-                ORDER BY qr.created;
-            """
 
         _answers_sql = """
             SELECT qr.questionnaire_id,

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import logging
-import MySQLdb
 import re
 
 from collections import OrderedDict
@@ -123,10 +122,6 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
     """
     Generate a Participant Summary Resource object
     """
-
-    # Temporary
-    cdm_db_exists = False
-
     ro_dao = None
     # Retrieve module and sample test lists from config.
     _baseline_modules = [mod.replace('questionnaireOn', '')
@@ -144,8 +139,6 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             self.ro_dao = ResourceDataDao(backup=True)
 
         with self.ro_dao.session() as ro_session:
-            # Temporary
-            self.cdm_db_exists = self._test_cdm_db_exists(ro_session)
             # prep participant info from Participant record
             summary = self._prep_participant(p_id, ro_session)
             # prep additional participant profile info
@@ -214,23 +207,6 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 return generators.ResourceRecordSet(schemas.ParticipantSchema, summary)
 
         return None
-
-    def _test_cdm_db_exists(self, ro_session):
-        """
-        Temporary function to detect if the 'cdm' database and 'tmp_questionnaire_response' table exists.
-        :param ro_session: Readonly DAO session object
-        :return: True if 'cdm' database exists otherwise False.
-        """
-        sql = "SELECT * FROM cdm.tmp_questionnaire_response LIMIT 1"
-        try:
-            ro_session.execute(sql)
-            return True
-        except exc.ProgrammingError:
-            pass
-        except (exc.OperationalError, MySQLdb._exceptions.OperationalError):
-            msg = 'Unexpected error found when checking for tmp_questionnaire_response table'
-            logging.warning(msg, exc_info=False)
-        return False
 
     def _prep_participant(self, p_id, ro_session):
         """
@@ -439,8 +415,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         # PDR-178:  Retrieve both the processed (layered) answers result, and the raw responses. This allows us to
         # do some extra processing of the ConsentPII data without having to query all over again.
-        qnans, responses = self.get_module_answers(self.ro_dao, 'ConsentPII', p_id, return_responses=True,
-                                                   cdm_db_exists=self.cdm_db_exists)
+        qnans, responses = self.get_module_answers(self.ro_dao, 'ConsentPII', p_id, return_responses=True)
         if not qnans:
             # return the minimum data required when we don't have the questionnaire data.
             return {'email': None, 'is_ghost_id': 0}
@@ -499,52 +474,21 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :param ro_session: Readonly DAO session object
         :return: dict
         """
+        code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
+            filter(QuestionnaireResponse.questionnaireId ==
+                   QuestionnaireConcept.questionnaireId).label('codeId')
 
-        if not self.cdm_db_exists:
-            code_id_query = ro_session.query(func.max(QuestionnaireConcept.codeId)). \
-                filter(QuestionnaireResponse.questionnaireId ==
-                       QuestionnaireConcept.questionnaireId).label('codeId')
-
-            # Responses are sorted by authored date ascending and then created date descending
-            # This should result in a list where any replays of a response are adjacent (most recently created first)
-            query = ro_session.query(
-                    QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
-                    QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
-                    QuestionnaireResponse.status, code_id_query). \
-                join(QuestionnaireHistory). \
-                filter(QuestionnaireResponse.participantId == p_id). \
-                order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
-            # sql = self.ro_dao.query_to_text(query)
-            results = query.all()
-
-        # Temporary: Use raw sql instead to facilitate joining across databases to the cdm.tmp_questionnaire_response
-        # table where we have flagged duplicate response payloads sent by PTSC for filtering out during PDR data
-        # rebuilds.  See:  ROC-825
-        else:
-            # This SQL statement is based off of the query_to_text() output for the SQLAlchemy query above, and then
-            # modified to add the additional filtering when joined with cdm.temp_questionnaire_response (and match
-            # expected column names to what the SQLAlchemy query also returns)
-            _raw_sql = """
-                 SELECT qr.questionnaire_response_id questionnaireResponseId,
-                        qr.authored,
-                        qr.created,
-                        qr.language,
-                        qh.external_id externalId,
-                        qr.status,
-                   (SELECT max(questionnaire_concept.code_id) AS max_1
-                    FROM questionnaire_concept
-                    WHERE qr.questionnaire_id = questionnaire_concept.questionnaire_id) AS `codeId`
-                 FROM questionnaire_response qr
-                 INNER JOIN questionnaire_history qh
-                       ON qh.questionnaire_id = qr.questionnaire_id
-                       AND qh.version = qr.questionnaire_version
-                 LEFT OUTER JOIN cdm.tmp_questionnaire_response tqr
-                       ON qr.questionnaire_response_id = tqr.questionnaire_response_id
-                 WHERE qr.participant_id = :pid
-                       AND (tqr.duplicate is NULL or tqr.duplicate = 0)
-                 ORDER BY qr.authored, qr.created DESC;
-             """
-            results = ro_session.execute(_raw_sql, {'pid': p_id})
+        # Responses are sorted by authored date ascending and then created date descending
+        # This should result in a list where any replays of a response are adjacent (most recently created first)
+        query = ro_session.query(
+                QuestionnaireResponse.questionnaireResponseId, QuestionnaireResponse.authored,
+                QuestionnaireResponse.created, QuestionnaireResponse.language, QuestionnaireHistory.externalId,
+                QuestionnaireResponse.status, code_id_query). \
+            join(QuestionnaireHistory). \
+            filter(QuestionnaireResponse.participantId == p_id, QuestionnaireResponse.isDuplicate.is_(False)). \
+            order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc())
+        # sql = self.ro_dao.query_to_text(query)
+        results = query.all()
 
         data = {
             'consent_cohort': BQConsentCohort.UNSET.name,
@@ -672,8 +616,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :param ro_session: Readonly DAO session object
         :return: dict
         """
-        qnans = self.get_module_answers(self.ro_dao, 'TheBasics', p_id, return_responses=False,
-                                        cdm_db_exists=self.cdm_db_exists)
+        qnans = self.get_module_answers(self.ro_dao, 'TheBasics', p_id, return_responses=False)
         if not qnans or len(qnans) == 0:
             return {}
 
@@ -1353,7 +1296,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         return data
 
     @staticmethod
-    def get_module_answers(ro_dao, module, p_id, qr_id=None, return_responses=False, cdm_db_exists=False):
+    def get_module_answers(ro_dao, module, p_id, qr_id=None, return_responses=False):
         """
         Retrieve the questionnaire module answers for the given participant id.  This retrieves all responses to
         the module and applies/layers the answers from each response to the final data dict returned.
@@ -1362,7 +1305,6 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :param p_id: participant id.
         :param qr_id: questionnaire response id
         :param return_responses:  Return the responses (unlayered) in addition to the processed answer data
-        :param cdm_db_exists: Temporary arg.
         :return: dicts
         """
         _module_info_sql = """
@@ -1377,21 +1319,10 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             FROM questionnaire_response qr
                     INNER JOIN questionnaire_concept qc on qr.questionnaire_id = qc.questionnaire_id
                     INNER JOIN questionnaire q on q.questionnaire_id = qc.questionnaire_id
+            WHERE qr.participant_id = :p_id and qc.code_id in (select c1.code_id from code c1 where c1.value = :mod)
+                AND qr.is_duplicate = FALSE
+            ORDER BY qr.created;
         """
-        # Temporary
-        if cdm_db_exists:
-            _module_info_sql += """
-                LEFT OUTER JOIN cdm.tmp_questionnaire_response tqr
-                    ON qr.questionnaire_response_id = tqr.questionnaire_response_id
-                WHERE qr.participant_id = :p_id and qc.code_id in (select c1.code_id from code c1 where c1.value = :mod) AND
-                   (tqr.duplicate is null or tqr.duplicate = 0)
-                ORDER BY qr.created;
-            """
-        else:
-            _module_info_sql += """
-                WHERE qr.participant_id = :p_id and qc.code_id in (select c1.code_id from code c1 where c1.value = :mod)
-                ORDER BY qr.created;
-            """
 
         _answers_sql = """
             SELECT qr.questionnaire_id,


### PR DESCRIPTION
## Partially Resolves [DA-1928](https://precisionmedicineinitiative.atlassian.net/browse/DA-1928)


This updates the BQ/resource code by removing references to the `tmp_questionnaire_response` table in the CDM database, replacing them with the new `questionnaire_response.is_duplicate` column.



## Description of changes/additions
In one case an if-block would use raw sql when needing to check the `tmp_questionnaire_response` table, and another query if the table didn't exist. The `is_duplicate` column will always be present, so the code is simplified to one query.

Another instance concatenates different WHERE statements depending on whether the table is present or not. The query was updated to always check the `is_duplicate` column.



## Tests
There don't seem to be tests in place yet for this behavior. Leaving adding them in for another time.


