### PR TITLE
[DA-1928] Cron job flagging responses as duplicates

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -24,6 +24,11 @@ cron:
   schedule: 2 of month 00:00
   timezone: America/New_York
   target: offline
+- description: Mark any new duplicates of questionnaire responses as duplicates if they match previous groups of responses
+  url: /offline/FlagResponseDuplication
+  schedule: every day 03:00
+  timezone: America/New_York
+  target: offline
 - description: BigQuery Sync
   url: /offline/BigQuerySync
   timezone: America/New_York

--- a/rdr_service/services/response_duplication_detector.py
+++ b/rdr_service/services/response_duplication_detector.py
@@ -1,0 +1,58 @@
+import logging
+from sqlalchemy import and_, func, update
+from sqlalchemy.orm import aliased
+from typing import Type
+
+from rdr_service.dao.database_factory import get_database
+from rdr_service.model.questionnaire_response import QuestionnaireResponse
+
+
+class ResponseDuplicationDetector:
+    @classmethod
+    def _join_on_duplication(cls, newer_response: Type[QuestionnaireResponse],
+                             older_response: Type[QuestionnaireResponse]):
+        return and_(
+            newer_response.created > older_response.created,
+            newer_response.externalId == older_response.externalId,
+            newer_response.answerHash == older_response.answerHash
+        )
+
+    @classmethod
+    def flag_duplicate_responses(cls):
+        with get_database().session() as session:
+            older_duplicate = aliased(QuestionnaireResponse)
+            newer_duplicate = aliased(QuestionnaireResponse)
+            duplicated_response_ids = (
+                session.query(
+                    QuestionnaireResponse.questionnaireResponseId,
+                    func.group_concat(older_duplicate.questionnaireResponseId)
+                ).join(
+                    older_duplicate,
+                    and_(
+                        cls._join_on_duplication(QuestionnaireResponse, older_response=older_duplicate),
+                        older_duplicate.isDuplicate.is_(False)
+                    )
+                ).outerjoin(
+                    newer_duplicate,
+                    cls._join_on_duplication(newer_duplicate, older_response=QuestionnaireResponse)
+                ).filter(
+                    # We should use the newest duplicate, and mark the older ones with isDuplicate
+                    newer_duplicate.questionnaireResponseId.is_(None)
+                ).group_by(QuestionnaireResponse.questionnaireResponseId)
+            ).all()
+
+            questionnaire_ids_to_mark_as_duplicates = []
+            for latest_duplicate_response_id, previous_duplicate_ids_str in duplicated_response_ids:
+                previous_duplicate_ids = previous_duplicate_ids_str.split(',')
+                logging.warning(f'{previous_duplicate_ids} found as duplicates of {latest_duplicate_response_id}')
+
+                questionnaire_ids_to_mark_as_duplicates.extend(previous_duplicate_ids)
+
+            session.execute(
+                update(QuestionnaireResponse)
+                .where(QuestionnaireResponse.questionnaireResponseId.in_(questionnaire_ids_to_mark_as_duplicates))
+                .values({
+                    QuestionnaireResponse.isDuplicate: True
+                })
+            )
+            # TODO: index the externalId and answerHash column

--- a/rdr_service/services/response_duplication_detector.py
+++ b/rdr_service/services/response_duplication_detector.py
@@ -8,51 +8,68 @@ from rdr_service.model.questionnaire_response import QuestionnaireResponse
 
 
 class ResponseDuplicationDetector:
+    def __init__(self, duplication_threshold: int = 10):
+        """
+        Used to check the database for any new questionnaire response duplicates.
+
+        :param duplication_threshold: The number of matching responses needed in a group before any of them will be
+            considered duplicates. Defaults to 10.
+        """
+        self.duplication_threshold = duplication_threshold
+
     @classmethod
-    def _join_on_duplication(cls, newer_response: Type[QuestionnaireResponse],
-                             older_response: Type[QuestionnaireResponse]):
+    def _responses_are_duplicates(cls, newer_response: Type[QuestionnaireResponse],
+                                  older_response: Type[QuestionnaireResponse]):
         return and_(
             newer_response.created > older_response.created,
             newer_response.externalId == older_response.externalId,
-            newer_response.answerHash == older_response.answerHash
+            newer_response.answerHash == older_response.answerHash,
+            newer_response.participantId == older_response.participantId
         )
 
-    @classmethod
-    def flag_duplicate_responses(cls):
+    def flag_duplicate_responses(self):
         with get_database().session() as session:
-            older_duplicate = aliased(QuestionnaireResponse)
-            newer_duplicate = aliased(QuestionnaireResponse)
+            older_duplicate = aliased(QuestionnaireResponse)  # joined as older responses to be updated as duplicates
+            newer_duplicate = aliased(QuestionnaireResponse)  # used to keep isDuplicate = 0 on the latest response
+            other_duplicate = aliased(QuestionnaireResponse)  # used to find the number of other duplicates there are
             duplicated_response_ids = (
                 session.query(
                     QuestionnaireResponse.questionnaireResponseId,
-                    func.group_concat(older_duplicate.questionnaireResponseId)
+                    func.group_concat(older_duplicate.questionnaireResponseId.distinct()),
+                    func.count(other_duplicate.questionnaireResponseId.distinct())
                 ).join(
                     older_duplicate,
                     and_(
-                        cls._join_on_duplication(QuestionnaireResponse, older_response=older_duplicate),
+                        self._responses_are_duplicates(QuestionnaireResponse, older_response=older_duplicate),
                         older_duplicate.isDuplicate.is_(False)
                     )
+                ).join(
+                    other_duplicate,
+                    self._responses_are_duplicates(QuestionnaireResponse, older_response=other_duplicate)
                 ).outerjoin(
                     newer_duplicate,
-                    cls._join_on_duplication(newer_duplicate, older_response=QuestionnaireResponse)
+                    self._responses_are_duplicates(newer_duplicate, older_response=QuestionnaireResponse)
                 ).filter(
                     # We should use the newest duplicate, and mark the older ones with isDuplicate
                     newer_duplicate.questionnaireResponseId.is_(None)
-                ).group_by(QuestionnaireResponse.questionnaireResponseId)
+                )
+                .group_by(QuestionnaireResponse.questionnaireResponseId)
             ).all()
 
             questionnaire_ids_to_mark_as_duplicates = []
-            for latest_duplicate_response_id, previous_duplicate_ids_str in duplicated_response_ids:
-                previous_duplicate_ids = previous_duplicate_ids_str.split(',')
-                logging.warning(f'{previous_duplicate_ids} found as duplicates of {latest_duplicate_response_id}')
+            for latest_duplicate_response_id, previous_duplicate_ids_str, duplication_count in duplicated_response_ids:
+                duplicates_needed = self.duplication_threshold - 1
+                if duplication_count >= duplicates_needed:  # duplicate_count doesn't count the latest response
+                    previous_duplicate_ids = previous_duplicate_ids_str.split(',')
+                    logging.warning(f'{previous_duplicate_ids} found as duplicates of {latest_duplicate_response_id}')
 
-                questionnaire_ids_to_mark_as_duplicates.extend(previous_duplicate_ids)
+                    questionnaire_ids_to_mark_as_duplicates.extend(previous_duplicate_ids)
 
-            session.execute(
-                update(QuestionnaireResponse)
-                .where(QuestionnaireResponse.questionnaireResponseId.in_(questionnaire_ids_to_mark_as_duplicates))
-                .values({
-                    QuestionnaireResponse.isDuplicate: True
-                })
-            )
-            # TODO: index the externalId and answerHash column
+            if questionnaire_ids_to_mark_as_duplicates:
+                session.execute(
+                    update(QuestionnaireResponse)
+                    .where(QuestionnaireResponse.questionnaireResponseId.in_(questionnaire_ids_to_mark_as_duplicates))
+                    .values({
+                        QuestionnaireResponse.isDuplicate: True
+                    })
+                )

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -118,6 +118,10 @@ class DataGenerator:
 
         if 'questionnaireResponseId' not in kwargs:
             kwargs['questionnaireResponseId'] = self.unique_questionnaire_response_id()
+        if 'questionnaireId' not in kwargs:
+            questionnaire = self.create_database_questionnaire_history()
+            kwargs['questionnaireId'] = questionnaire.questionnaireId
+            kwargs['questionnaireVersion'] = questionnaire.version
 
         return QuestionnaireResponse(**kwargs)
 

--- a/tests/service_tests/test_response_duplication_detector.py
+++ b/tests/service_tests/test_response_duplication_detector.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+import mock
+
+from rdr_service.services.response_duplication_detector import ResponseDuplicationDetector
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ResponseDuplicationDetectorTests(BaseTestCase):
+    def test_duplicates_are_marked(self):
+        """Any responses found to be a duplicate of another should have isDuplicate set (except the most recent one)"""
+
+        # Create some responses, some that are duplicates of each other
+        participant = self.data_generator.create_database_participant()
+        one = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId='one',
+            answerHash='badbeef',
+            authored=datetime(2021, 2, 1),
+            created=datetime(2021, 3, 1)
+        )
+        duplicate_of_one = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId=one.externalId,
+            answerHash=one.answerHash,
+            authored=one.authored,
+            created=datetime(2021, 3, 2)
+        )
+        another_duplicate_of_one = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId=one.externalId,
+            answerHash=one.answerHash,
+            authored=datetime.now(),  # Sometimes the authored date can shift when duplications happen,
+            created=datetime(2021, 3, 3)
+        )
+        # Some repetitions should be accepted, such as updates to contact information through the ConsentPII.
+        # These updates will come as responses that share the identifier of the original, but have different answers.
+        two = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId=one.externalId,
+            answerHash='0ddba11',
+            authored=datetime.now(),
+            created=datetime(2021, 3, 4)
+        )
+
+        from tests.helpers.diagnostics import LoggingDatabaseActivity
+        with LoggingDatabaseActivity():
+            ResponseDuplicationDetector.flag_duplicate_responses()
+
+        # Reload responses in the current session so we can get the updated info on the isDuplicate field
+        self.session.refresh(one)
+        self.session.refresh(duplicate_of_one)
+        self.session.refresh(another_duplicate_of_one)
+        self.session.refresh(two)
+
+        # Check that the isDuplicate flags were set correctly
+        self.assertTrue(one.isDuplicate)
+        self.assertTrue(duplicate_of_one.isDuplicate)
+        self.assertFalse(another_duplicate_of_one.isDuplicate)
+        self.assertFalse(two.isDuplicate)
+
+    @mock.patch('rdr_service.services.response_duplication_detector.logging')
+    def test_duplicates_are_not_reprocessed(self, mock_logging):
+        """Responses that are already known to be duplicates shouldn't be updated every time"""
+
+        participant = self.data_generator.create_database_participant()
+        first_response = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId='one',
+            answerHash='badbeef',
+            created=datetime(2021, 3, 1),
+            isDuplicate=True
+        )
+        another_response = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId=first_response.externalId,
+            answerHash=first_response.answerHash,
+            created=datetime(2021, 3, 2)
+        )
+        new_response = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId=first_response.externalId,
+            answerHash=first_response.answerHash,
+            created=datetime(2021, 3, 3)
+        )
+
+        ResponseDuplicationDetector.flag_duplicate_responses()
+
+        # Check that only one response was marked as a duplicate
+        mock_logging.warning.assert_called_with(
+            f"['{another_response.questionnaireResponseId}'] "
+            f"found as duplicates of {new_response.questionnaireResponseId}"
+        )

--- a/tests/service_tests/test_response_duplication_detector.py
+++ b/tests/service_tests/test_response_duplication_detector.py
@@ -1,11 +1,22 @@
 from datetime import datetime
 import mock
 
+from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.services.response_duplication_detector import ResponseDuplicationDetector
 from tests.helpers.unittest_base import BaseTestCase
 
 
 class ResponseDuplicationDetectorTests(BaseTestCase):
+    def _make_duplicate_of(self, response: QuestionnaireResponse, **kwargs):
+        response_params = {
+            'participantId': response.participantId,
+            'externalId': response.externalId,
+            'answerHash': response.answerHash,
+            'authored': response.authored
+        }
+        response_params.update(**kwargs)
+        return self.data_generator.create_database_questionnaire_response(**response_params)
+
     def test_duplicates_are_marked(self):
         """Any responses found to be a duplicate of another should have isDuplicate set (except the most recent one)"""
 
@@ -18,17 +29,12 @@ class ResponseDuplicationDetectorTests(BaseTestCase):
             authored=datetime(2021, 2, 1),
             created=datetime(2021, 3, 1)
         )
-        duplicate_of_one = self.data_generator.create_database_questionnaire_response(
-            participantId=participant.participantId,
-            externalId=one.externalId,
-            answerHash=one.answerHash,
-            authored=one.authored,
+        duplicate_of_one = self._make_duplicate_of(
+            response=one,
             created=datetime(2021, 3, 2)
         )
-        another_duplicate_of_one = self.data_generator.create_database_questionnaire_response(
-            participantId=participant.participantId,
-            externalId=one.externalId,
-            answerHash=one.answerHash,
+        another_duplicate_of_one = self._make_duplicate_of(
+            response=one,
             authored=datetime.now(),  # Sometimes the authored date can shift when duplications happen,
             created=datetime(2021, 3, 3)
         )
@@ -42,9 +48,8 @@ class ResponseDuplicationDetectorTests(BaseTestCase):
             created=datetime(2021, 3, 4)
         )
 
-        from tests.helpers.diagnostics import LoggingDatabaseActivity
-        with LoggingDatabaseActivity():
-            ResponseDuplicationDetector.flag_duplicate_responses()
+        detector = ResponseDuplicationDetector(duplication_threshold=2)
+        detector.flag_duplicate_responses()
 
         # Reload responses in the current session so we can get the updated info on the isDuplicate field
         self.session.refresh(one)
@@ -70,23 +75,52 @@ class ResponseDuplicationDetectorTests(BaseTestCase):
             created=datetime(2021, 3, 1),
             isDuplicate=True
         )
-        another_response = self.data_generator.create_database_questionnaire_response(
-            participantId=participant.participantId,
-            externalId=first_response.externalId,
-            answerHash=first_response.answerHash,
+        another_response = self._make_duplicate_of(
+            response=first_response,
             created=datetime(2021, 3, 2)
         )
-        new_response = self.data_generator.create_database_questionnaire_response(
-            participantId=participant.participantId,
-            externalId=first_response.externalId,
-            answerHash=first_response.answerHash,
+        new_response = self._make_duplicate_of(
+            response=first_response,
             created=datetime(2021, 3, 3)
         )
 
-        ResponseDuplicationDetector.flag_duplicate_responses()
+        detector = ResponseDuplicationDetector(duplication_threshold=2)
+        detector.flag_duplicate_responses()
 
         # Check that only one response was marked as a duplicate
         mock_logging.warning.assert_called_with(
             f"['{another_response.questionnaireResponseId}'] "
             f"found as duplicates of {new_response.questionnaireResponseId}"
         )
+
+    @mock.patch('rdr_service.services.response_duplication_detector.logging')
+    def test_detection_threshold(self, mock_logging):
+        """Responses should only be marked as duplicates if there are a specific number of them"""
+
+        # Create a detector that will only mark responses as duplicates if there are 8 of them
+        detector = ResponseDuplicationDetector(duplication_threshold=8)
+
+        # Create a response and 6 more instances of it (totalling 7 duplicates)
+        participant = self.data_generator.create_database_participant()
+        first_response = self.data_generator.create_database_questionnaire_response(
+            participantId=participant.participantId,
+            externalId='one',
+            answerHash='badbeef',
+            created=datetime(2021, 3, 1)
+        )
+        self._make_duplicate_of(response=first_response, created=datetime(2021, 3, 2))
+        self._make_duplicate_of(response=first_response, created=datetime(2021, 3, 3))
+        self._make_duplicate_of(response=first_response, created=datetime(2021, 3, 4))
+        self._make_duplicate_of(response=first_response, created=datetime(2021, 3, 5))
+        self._make_duplicate_of(response=first_response, created=datetime(2021, 3, 6))
+        self._make_duplicate_of(response=first_response, created=datetime(2021, 3, 7))
+
+        # Check that nothing is marked as a duplicate of anything else
+        detector.flag_duplicate_responses()
+        mock_logging.warning.assert_not_called()
+
+        # Make one more duplicate and make sure the duplication is found
+        latest_duplicate = self._make_duplicate_of(response=first_response, created=datetime(2021, 3, 8))
+        detector.flag_duplicate_responses()
+        warning_log = mock_logging.warning.call_args[0][0]
+        self.assertTrue(warning_log.endswith(f'] found as duplicates of {latest_duplicate.questionnaireResponseId}'))


### PR DESCRIPTION
## Partially Resolves *[DA-1928](https://precisionmedicineinitiative.atlassian.net/browse/DA-1928)*
One more follow up PR will be made to create a quick tool for backfilling the answer hash values for the QuestionnaireResponses we already have in the database.



## Description of changes/additions
This adds a new class to be used for flagging questionnaire responses that are replays of each other. It follows the previous algorithm used: no responses are marked unless there are 10 or more duplicates, the latest response is left unmarked (`isDuplicate = 0`) so that we'll use the last one received. This is also configured to run as a cron job, so won't update any questionnaire responses that are already known as duplicates.

This also saves the MD5 digest of the answers json for comparison.



## Tests
- [x] unit tests for the newly added class


