### PR TITLE
fix_researcher_bq_sync

### DIFF
--- a/rdr_service/dao/bq_workbench_dao.py
+++ b/rdr_service/dao/bq_workbench_dao.py
@@ -91,7 +91,7 @@ def bq_workspace_update(_id, project_id=None, gen=None, w_dao=None):
 
     bqr = gen.make_bqrecord(_id)
     with w_dao.session() as w_session:
-        gen.save_bqrecord(_id, bqr, bqtable=BQRWBWorkspace, w_dao=w_dao,
+        gen.save_bqrecord(bqr.workspace_source_id, bqr, bqtable=BQRWBWorkspace, w_dao=w_dao,
                           w_session=w_session, project_id=project_id)
 
 
@@ -239,7 +239,7 @@ def bq_researcher_update(_id, project_id=None, gen=None, w_dao=None):
 
     bqr = gen.make_bqrecord(_id)
     with w_dao.session() as w_session:
-        gen.save_bqrecord(_id, bqr, bqtable=BQRWBResearcher, w_dao=w_dao,
+        gen.save_bqrecord(bqr.user_source_id, bqr, bqtable=BQRWBResearcher, w_dao=w_dao,
                           w_session=w_session, project_id=project_id)
 
 

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -928,6 +928,7 @@ class WorkbenchResearcherDao(UpdatableDao):
                 for attr_name in researcher.__dict__.keys():
                     if not attr_name.startswith('_') and attr_name != 'created':
                         setattr(exist, attr_name, getattr(researcher, attr_name))
+                researcher.id = exist.id
             else:
                 session.add(researcher)
             new_researchers.append(researcher)


### PR DESCRIPTION
## Resolves *[No ticket]*
Fix workbench researcher bigquery sync bug

## Description of changes/additions
1. For existing researchers, set id attribute for the bigquery sync cloud task.
2. Use source id for bigquery view pk id.(This is a new issue just found during debugging)

## Tests
Manually test on sandbox


