### PR TITLE
[PDR fix] Disable BQPDRParticipantSummaryWithdrawnView as a managed view

### DIFF
--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -48,7 +48,8 @@ BQ_VIEWS = [
     # PDR Views
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummaryView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummaryAllView'),
-    ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummaryWithdrawnView'),
+    # Disabling BQPDRParticipantSummaryWithdrawnView as a managed view;  is now a custom/manually managed view in BQ
+    # ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummaryWithdrawnView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRPMView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRGenderView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRRaceView'),


### PR DESCRIPTION
## Resolves *exception in migrate-bq tool (no related ticket)*


## Description of changes/additions
This removes `BQPDRParticipantSummaryWithdrawnView` from the `BQ_VIEWS` list.   See previous [PR #2319](https://github.com/all-of-us/raw-data-repository/pull/2319) which commented out the view definition in the model pending decision on whether to bring all BigQuery view definitions into our model source code.   The `migrate-bq` tool would throw an exception if run with  `--names all ` because the` BQ_VIEWS` list still referenced the disabled view

## Tests
- Manually tested in local environment (don't have unit tests for `migrate-bq` tool)


