### PR TITLE
[DA-1961] Additional needs_ceremony_disposal indicators

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -329,7 +329,7 @@ def _query_and_write_withdrawal_report(exporter, file_path, report_cover_range, 
                     (ceremony_answer_subquery.c.value == WITHDRAWAL_CEREMONY_YES, 'Y'),
                     (ceremony_answer_subquery.c.value == WITHDRAWAL_CEREMONY_NO, 'N'),
                 ], else_=(
-                    case([(_participant_has_answer(RACE_QUESTION_CODE, RACE_AIAN_CODE), 'Y')], else_='N')
+                    case([(_participant_has_answer(RACE_QUESTION_CODE, RACE_AIAN_CODE), 'U')], else_='NA')
                 )
             ).label('needs_disposal_ceremony'),
             Participant.participantOrigin.label('participant_origin')

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -529,12 +529,12 @@ class BiobankSamplesPipelineTest(BaseTestCase):
         return participant
 
     def assert_participant_in_report_rows(self, participant: Participant, rows, withdrawal_str,
-                                          as_native_american: bool, needs_ceremony: bool):
+                                          as_native_american: bool, needs_ceremony_indicator: str):
         self.assertIn((
             f'Z{participant.biobankId}',
             withdrawal_str,
             'Y' if as_native_american else 'N',
-            'Y' if needs_ceremony else 'N',
+            needs_ceremony_indicator,
             participant.participantOrigin
         ), rows)
 
@@ -589,28 +589,28 @@ class BiobankSamplesPipelineTest(BaseTestCase):
                 rows_written,
                 withdrawal_iso_str,
                 as_native_american=False,
-                needs_ceremony=False
+                needs_ceremony_indicator='NA'
             )
             self.assert_participant_in_report_rows(
                 ceremony_native_american_participant,
                 rows_written,
                 withdrawal_iso_str,
                 as_native_american=True,
-                needs_ceremony=True
+                needs_ceremony_indicator='Y'
             )
             self.assert_participant_in_report_rows(
                 native_american_participant_without_answer,
                 rows_written,
                 withdrawal_iso_str,
                 as_native_american=True,
-                needs_ceremony=True
+                needs_ceremony_indicator='U'
             )
             self.assert_participant_in_report_rows(
                 no_ceremony_native_american_participant,
                 rows_written,
                 withdrawal_iso_str,
                 as_native_american=True,
-                needs_ceremony=False
+                needs_ceremony_indicator='N'
             )
 
         # Test PDR BigQuery and resource participant summary data generators


### PR DESCRIPTION
## Resolves *[DA-1961](https://precisionmedicineinitiative.atlassian.net/browse/DA-1961)*
For clarity, we need to provide additional options for `needs_ceremony_disposal` in the withdrawal manifest for the biobank.

## Description of changes/additions
This still provides `Y` or `N` if the participant answered the question and requested or declined the ceremony. But it changes the indicator to `NA` if the participant does not identify as Native American, or `U` if they do and we don't have a yes or no answer from them.

## Tests
- [x] unit tests have been updated to check for the additional indicators


