### PR TITLE
Allowing for multiple head migrations

### DIFF
--- a/rdr_service/tools/generate_schema.sh
+++ b/rdr_service/tools/generate_schema.sh
@@ -20,4 +20,4 @@ then
 fi
 
 (source tools/set_path.sh; cd ${APP_DIR};
- alembic revision --autogenerate -m "$1")
+ alembic revision --autogenerate -m "$1" --head heads)

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -382,7 +382,7 @@ class DeployAppClass(object):
 
         # Run database migration
         _logger.info('Applying database migrations...')
-        alembic = AlembicManagerClass(self.args, self.gcp_env, ['upgrade', 'head'])
+        alembic = AlembicManagerClass(self.args, self.gcp_env, ['upgrade', 'heads'])
         if alembic.run() != 0:
             _logger.warning('Deploy process stopped.')
             return 1

--- a/rdr_service/tools/upgrade_database.sh
+++ b/rdr_service/tools/upgrade_database.sh
@@ -51,7 +51,7 @@ fi
 
 if [ -z "${REVISION}" ]
 then
-  REVISION=head
+  REVISION=heads
 fi
 
 if [ "${PROJECT}" -o "${INSTANCE}" ]


### PR DESCRIPTION
## Resolves *no ticket*
This addresses the issue we've had with needing to make sure any migrations we're merging are the only head migration file being deployed (a "head" migration being any migration that doesn't have any other migrations indicating it as a down revision).

Alembic allows for having multiple head migrations, it just needs to have some specificity around what to do with them in different contexts.

## Description of changes/additions
The primary issue we've seen is when two PRs with migrations both get merged and introduce two head migrations to devel. That fails to deploy because the command used for deploying to Test upgrades the database to the `head` migration, causing alembic to error out because there's not just one head. Changing it to upgrade to `heads` in the app_engine_manager.py file gets around that and will apply all head migrations.

A similar situation results when trying to set up the local database using the upgrade_database.sh tool. Specifying `heads` there allows for multiple head revisions as well.

Another problem that can come up is creating a new migration file when there are multiple heads. When alembic autogenerates a revision with only one head then it will automatically pick that as the down revision, but if there are multiple then it would throw an error. Specifying `--head heads` in the generate_schema.sh tool lets alembic know that the down revision for the new migration should be all the head migration files that exist.

## Tests
Tested locally by creating two head migrations that have the same down revision and using setup_local_database.sh to apply them locally, deploying them to sandbox (they've been rolled back there), and generating a new migration file that should use them both as down revisions.


