### PR TITLE
[ROC-943] - Changing biobank api endpoint to allow for nested aliquot creation

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -184,25 +184,6 @@ class BiobankSpecimenAttributeApi(BiobankSpecimenTargetedUpdateBase):
         return 200
 
 
-class BiobankAliquotTargetedUpdateBase(BiobankTargetedUpdateBase):
-    def __init__(self):
-        super(BiobankAliquotTargetedUpdateBase, self).__init__(BiobankAliquotDao())
-
-    def get_model_with_rlims_id(self, rlims_id, session):
-        try:
-            return self.dao.get_with_rlims_id(rlims_id, session)
-        except NoResultFound:
-            raise NotFound(f'No aliquot found for the given rlims_id: {rlims_id}')
-
-
-class BiobankAliquotStatusApi(BiobankStatusApiMixin, BiobankAliquotTargetedUpdateBase):
-    pass
-
-
-class BiobankAliquotDisposalApi(BiobankDisposalApiMixin, BiobankAliquotTargetedUpdateBase):
-    pass
-
-
 class BiobankAliquotApi(BiobankApiBase):
     def __init__(self):
         super(BiobankAliquotApi, self).__init__(BiobankAliquotDao())
@@ -229,6 +210,25 @@ class BiobankAliquotApi(BiobankApiBase):
     def _parse_aliquot_json(self, resource):
         resource['rlimsID'] = self.aliquot_rlims_id
         return self.dao.from_client_json(resource, parent_rlims_id=self.parent_rlims_id)
+
+
+class BiobankAliquotTargetedUpdateBase(BiobankTargetedUpdateBase):
+    def __init__(self):
+        super(BiobankAliquotTargetedUpdateBase, self).__init__(BiobankAliquotDao())
+
+    def get_model_with_rlims_id(self, rlims_id, session):
+        try:
+            return self.dao.get_with_rlims_id(rlims_id, session)
+        except NoResultFound:
+            raise NotFound(f'No aliquot found for the given rlims_id: {rlims_id}')
+
+
+class BiobankAliquotStatusApi(BiobankStatusApiMixin, BiobankAliquotTargetedUpdateBase):
+    pass
+
+
+class BiobankAliquotDisposalApi(BiobankDisposalApiMixin, BiobankAliquotTargetedUpdateBase):
+    pass
 
 
 class BiobankAliquotDatasetApi(BiobankAliquotTargetedUpdateBase):

--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -22,7 +22,7 @@ class BiobankSpecimenApi(BiobankApiBase):
         super().__init__(BiobankSpecimenDao(), get_returns_children=True)
 
     @auth_required(BIOBANK)
-    def put(self, *args, **kwargs):  # pylint: disable=unused-argument
+    def put(self, *_, **kwargs):
         resource = request.get_json(force=True)
 
         if 'rlims_id' in kwargs:
@@ -117,11 +117,9 @@ class BiobankTargetedUpdateBase(BiobankApiBase):
             return self._make_response(model)
 
     def get_model_with_rlims_id(self, rlims_id, session):
-        # pylint: disable=unused-argument
         raise NotImplementedError(f"get_model_with_rlims_id not implemented in {self.__class__}")
 
     def update_model(self, model, resource, session):
-        # pylint: disable=unused-argument
         raise NotImplementedError(f"update_model not implemented in {self.__class__}")
 
 
@@ -221,13 +219,14 @@ class BiobankAliquotApi(BiobankApiBase):
             super(BiobankAliquotApi, self).post()
         else:
             super(BiobankAliquotApi, self).put(aliquot_id, skip_etag=True)
-            # TODO: test the update too
 
     def _get_model_to_update(self, resource, id_, expected_version, participant_id=None):
-        resource['rlimsID'] = self.aliquot_rlims_id
-        return self.dao.from_client_json(resource, parent_rlims_id=self.parent_rlims_id)
+        return self._parse_aliquot_json(resource)
 
     def _get_model_to_insert(self, resource, participant_id=None):
+        return self._parse_aliquot_json(resource)
+
+    def _parse_aliquot_json(self, resource):
         resource['rlimsID'] = self.aliquot_rlims_id
         return self.dao.from_client_json(resource, parent_rlims_id=self.parent_rlims_id)
 

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -376,11 +376,11 @@ class BiobankAliquotDao(BiobankDaoBase):
                 BiobankSpecimen.rlimsId == parent_rlims_id
             ).one_or_none()
 
-        # If the direct parent is a specimen, give back that rlims_id and no parent aliquot
+        # If the direct parent is a specimen, give that back and no parent aliquot
         if parent_specimen:
             return parent_specimen, None
         else:
-            # The given rlims should be an aliquot then. So find the aliquot and give back the specimen and aliquot ids
+            # The given rlims should be an aliquot then. So find the aliquot and give back the aliquot and specimen
             if self.preloader:
                 parent_aliquot = self.preloader.get_object(BiobankAliquot(rlimsId=parent_rlims_id))
                 parent_specimen = self.preloader.get_object(BiobankSpecimen(rlimsId=parent_aliquot.specimen_rlims_id))
@@ -418,9 +418,6 @@ class BiobankAliquotDao(BiobankDaoBase):
 
     def from_client_json(self, resource, session=None, parent_rlims_id=None, specimen_rlims_id=None,
                          parent_aliquot_rlims_id=None, **_):
-        # if parent_rlims_id is None:
-        #     raise BadRequest("A parent rlims id is required for aliquots")
-
         if session is None:
             with self.session() as session:
                 aliquot_from_json = self._from_client_json_with_session(
@@ -500,9 +497,8 @@ class BiobankAliquotDao(BiobankDaoBase):
         return result
 
     @staticmethod
-    def get_with_rlims_id(rlims_id, session, allow_none=False):
-        query = session.query(BiobankAliquot).filter(BiobankAliquot.rlimsId == rlims_id)
-        return query.one_or_none() if allow_none else query.one()
+    def get_with_rlims_id(rlims_id, session):
+        return session.query(BiobankAliquot).filter(BiobankAliquot.rlimsId == rlims_id).one()
 
     def get_id_with_session(self, obj, session):
         if self.preloader and self.preloader.is_hydrated:

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -8,7 +8,7 @@ from rdr_service.dao.base_dao import UpdatableDao
 from rdr_service.dao.object_preloader import LoadingStrategy, ObjectPreloader
 from rdr_service.model.biobank_order import BiobankSpecimen, BiobankSpecimenAttribute, BiobankAliquot,\
     BiobankAliquotDataset, BiobankAliquotDatasetItem
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, NotFound
 
 
 class RlimsIdLoadingStrategy(LoadingStrategy):
@@ -363,23 +363,49 @@ class BiobankAliquotDao(BiobankDaoBase):
     def __init__(self, preloader=None):
         super().__init__(BiobankAliquot, preloader=preloader)
 
-    #pylint: disable=unused-argument
-    def from_client_json(self, resource, id_=None, expected_version=None, participant_id=None, client_id=None,
-                         specimen_rlims_id=None, parent_aliquot_rlims_id=None, session=None):
+    def _get_parent_ids(self, parent_rlims_id, session):
+        # See if the given parent_rlims_id is a specimen
+        if self.preloader:
+            parent_specimen = self.preloader.get_object(BiobankSpecimen(rlimsId=parent_rlims_id))
+        else:
+            parent_specimen = session.query(BiobankSpecimen).filter(
+                BiobankSpecimen.rlimsId == parent_rlims_id
+            ).one_or_none()
 
-        if specimen_rlims_id is None:
-            raise BadRequest("Specimen rlims id required for aliquots")
+        # If the direct parent is a specimen, give back that rlims_id and no parent aliquot
+        if parent_specimen:
+            return parent_specimen.rlimsId, None
+        else:
+            # The given rlims should be an aliquot then. So find the aliquot and give back the specimen and aliquot ids
+            if self.preloader:
+                parent_aliquot = self.preloader.get_object(BiobankAliquot(rlimsId=parent_rlims_id))
+            else:
+                parent_aliquot = session.query(BiobankAliquot).filter(
+                    BiobankAliquot.rlimsId == parent_rlims_id
+                ).one_or_none()
 
+            if parent_aliquot is None:
+                raise NotFound(f'Unable to find specimen or aliquot with rlimsId {parent_rlims_id}')
+
+            return parent_aliquot.specimen_rlims_id, parent_aliquot.rlimsId
+
+    def _from_client_json_with_session(self, resource, parent_rlims_id, session):
+        specimen_rlims_id, parent_aliquot_rlims_id = self._get_parent_ids(parent_rlims_id, session)
         aliquot = BiobankAliquot(rlimsId=resource['rlimsID'], specimen_rlims_id=specimen_rlims_id,
                                  parent_aliquot_rlims_id=parent_aliquot_rlims_id)
+        self.read_aliquot_data(aliquot, resource, specimen_rlims_id, session)
+        return aliquot
+
+    def from_client_json(self, resource, parent_rlims_id=None, session=None, **_):
+
+        if parent_rlims_id is None:
+            raise BadRequest("A parent rlims id is required for aliquots")
 
         if session is None:
             with self.session() as session:
-                self.read_aliquot_data(aliquot, resource, specimen_rlims_id, session)
+                return self._from_client_json_with_session(resource, parent_rlims_id, session)
         else:
-            self.read_aliquot_data(aliquot, resource, specimen_rlims_id, session)
-
-        return aliquot
+            return self._from_client_json_with_session(resource, parent_rlims_id, session)
 
     def read_aliquot_data(self, aliquot, resource, specimen_rlims_id, session):
         for client_field, model_field in [('sampleType', None),
@@ -440,8 +466,9 @@ class BiobankAliquotDao(BiobankDaoBase):
         return result
 
     @staticmethod
-    def get_with_rlims_id(rlims_id, session):
-        return session.query(BiobankAliquot).filter(BiobankAliquot.rlimsId == rlims_id).one()
+    def get_with_rlims_id(rlims_id, session, allow_none=False):
+        query = session.query(BiobankAliquot).filter(BiobankAliquot.rlimsId == rlims_id)
+        return query.one_or_none() if allow_none else query.one()
 
     def get_id_with_session(self, obj, session):
         if self.preloader and self.preloader.is_hydrated:

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -160,6 +160,10 @@ class BiobankDaoBase(UpdatableDao):
         with self.session() as session:
             return self.get_id_with_session(obj, session)
 
+    def get_etag(self, *_):
+        # Because the UpdatableApi class requires this when processing a PUT request
+        return None
+
 
 class BiobankSpecimenDao(BiobankDaoBase):
 
@@ -397,15 +401,16 @@ class BiobankAliquotDao(BiobankDaoBase):
         return aliquot
 
     def from_client_json(self, resource, parent_rlims_id=None, session=None, **_):
-
         if parent_rlims_id is None:
             raise BadRequest("A parent rlims id is required for aliquots")
 
         if session is None:
             with self.session() as session:
-                return self._from_client_json_with_session(resource, parent_rlims_id, session)
+                aliquot_from_json = self._from_client_json_with_session(resource, parent_rlims_id, session)
         else:
-            return self._from_client_json_with_session(resource, parent_rlims_id, session)
+            aliquot_from_json = self._from_client_json_with_session(resource, parent_rlims_id, session)
+
+        return aliquot_from_json
 
     def read_aliquot_data(self, aliquot, resource, specimen_rlims_id, session):
         for client_field, model_field in [('sampleType', None),

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -393,22 +393,38 @@ class BiobankAliquotDao(BiobankDaoBase):
 
             return parent_aliquot.specimen_rlims_id, parent_aliquot.rlimsId
 
-    def _from_client_json_with_session(self, resource, parent_rlims_id, session):
-        specimen_rlims_id, parent_aliquot_rlims_id = self._get_parent_ids(parent_rlims_id, session)
+    def _from_client_json_with_session(self, resource, session, parent_rlims_id=None, specimen_rlims_id=None,
+                                       parent_aliquot_rlims_id=None):
+        # If not given a parent_rlims_id, then the specimen_rlims_id is expected to be the parent
+        if parent_rlims_id is not None:
+            specimen_rlims_id, parent_aliquot_rlims_id = self._get_parent_ids(parent_rlims_id, session)
         aliquot = BiobankAliquot(rlimsId=resource['rlimsID'], specimen_rlims_id=specimen_rlims_id,
                                  parent_aliquot_rlims_id=parent_aliquot_rlims_id)
         self.read_aliquot_data(aliquot, resource, specimen_rlims_id, session)
         return aliquot
 
-    def from_client_json(self, resource, parent_rlims_id=None, session=None, **_):
-        if parent_rlims_id is None:
-            raise BadRequest("A parent rlims id is required for aliquots")
+    def from_client_json(self, resource, session=None, parent_rlims_id=None, specimen_rlims_id=None,
+                         parent_aliquot_rlims_id=None, **_):
+        # if parent_rlims_id is None:
+        #     raise BadRequest("A parent rlims id is required for aliquots")
 
         if session is None:
             with self.session() as session:
-                aliquot_from_json = self._from_client_json_with_session(resource, parent_rlims_id, session)
+                aliquot_from_json = self._from_client_json_with_session(
+                    resource,
+                    session,
+                    parent_rlims_id=parent_rlims_id,
+                    specimen_rlims_id=specimen_rlims_id,
+                    parent_aliquot_rlims_id=parent_aliquot_rlims_id
+                )
         else:
-            aliquot_from_json = self._from_client_json_with_session(resource, parent_rlims_id, session)
+            aliquot_from_json = self._from_client_json_with_session(
+                resource,
+                session,
+                parent_rlims_id=parent_rlims_id,
+                specimen_rlims_id=specimen_rlims_id,
+                parent_aliquot_rlims_id=parent_aliquot_rlims_id
+            )
 
         return aliquot_from_json
 

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -25,9 +25,10 @@ from rdr_service.api import metrics_ehr_api
 from rdr_service.api.awardee_api import AwardeeApi
 from rdr_service.api.bigquery_participant_summary_api import BQParticipantSummaryApi
 from rdr_service.api.biobank_order_api import BiobankOrderApi
-from rdr_service.api.biobank_specimen_api import BiobankSpecimenApi, BiobankSpecimenStatusApi,\
-    BiobankSpecimenDisposalApi, BiobankSpecimenAttributeApi, BiobankSpecimenAliquotApi, BiobankAliquotStatusApi,\
-    BiobankAliquotDisposalApi, BiobankAliquotDatasetApi
+from rdr_service.api.biobank_specimen_api import BiobankAliquotApi, BiobankAliquotDatasetApi,\
+    BiobankAliquotDisposalApi, BiobankAliquotStatusApi, BiobankSpecimenApi, BiobankSpecimenAttributeApi,\
+    BiobankSpecimenDisposalApi, BiobankSpecimenStatusApi
+
 from rdr_service.api.check_ppi_data_api import check_ppi_data
 from rdr_service.api.data_gen_api import DataGenApi, SpecDataGenApi
 from rdr_service.api.deceased_report_api import DeceasedReportApi, DeceasedReportReviewApi
@@ -258,8 +259,8 @@ api.add_resource(
     )
 
 api.add_resource(
-    BiobankSpecimenAliquotApi,
-    API_PREFIX + "Biobank/specimens/<string:rlims_id>/aliquots/<string:aliquot_rlims_id>",
+    BiobankAliquotApi,
+    API_PREFIX + "Biobank/specimens/<string:parent_rlims_id>/aliquots/<string:rlims_id>",
     endpoint="biobank.parent_aliquot",
     methods=["PUT"],
     )

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -1042,11 +1042,9 @@ class BiobankOrderApiTest(BaseTestCase):
 
         # Make an update to the aliquot and make sure the API modifies the existing aliquot
         updated_sample_type = 'new updated sample type'
-        from tests.helpers.diagnostics import LoggingDatabaseActivity
-        with LoggingDatabaseActivity():
-            self.send_put(f'Biobank/specimens/{parent_rlims_id}/aliquots/{child_rlims_id}', {
-                'sampleType': updated_sample_type
-            })
+        self.send_put(f'Biobank/specimens/{parent_rlims_id}/aliquots/{child_rlims_id}', {
+            'sampleType': updated_sample_type
+        })
         with self.dao.session() as session:
             aliquot = session.query(BiobankAliquot).filter(BiobankAliquot.id == aliquot.id).one()
             self.assertEqual(updated_sample_type, aliquot.sampleType)

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -1040,6 +1040,17 @@ class BiobankOrderApiTest(BaseTestCase):
         self.assertEqual(parent_rlims_id, aliquot.parent_aliquot_rlims_id)
         self.assertEqual(specimen.rlimsId, aliquot.specimen_rlims_id)
 
+        # Make an update to the aliquot and make sure the API modifies the existing aliquot
+        updated_sample_type = 'new updated sample type'
+        from tests.helpers.diagnostics import LoggingDatabaseActivity
+        with LoggingDatabaseActivity():
+            self.send_put(f'Biobank/specimens/{parent_rlims_id}/aliquots/{child_rlims_id}', {
+                'sampleType': updated_sample_type
+            })
+        with self.dao.session() as session:
+            aliquot = session.query(BiobankAliquot).filter(BiobankAliquot.id == aliquot.id).one()
+            self.assertEqual(updated_sample_type, aliquot.sampleType)
+
     def _create_minimal_specimen_with_aliquot(self, rlims_id='sabrina', aliquot_rlims_id='salem'):
         payload = self.get_minimal_specimen_json(rlims_id)
         payload['aliquots'] = [{

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -1019,6 +1019,27 @@ class BiobankOrderApiTest(BaseTestCase):
         self.assertEqual('updated', aliquot['sampleType'])
         self.assertEqual('tube', aliquot['containerTypeID'])
 
+    def test_simplified_aliquot_nesting(self):
+        """The aliquots endpoint should allow for defining a new aliquot as a child of an existing aliquot"""
+        generic_aliquot_data = {
+            'sampleType': 'first sample',
+            'containerTypeID': 'tube'
+        }
+
+        # Create a parent aliquot to test with
+        specimen = self.data_generator.create_database_biobank_specimen()
+        parent_rlims_id = 'parent_aliquot'
+        self.send_put(f'Biobank/specimens/{specimen.rlimsId}/aliquots/{parent_rlims_id}', generic_aliquot_data)
+
+        # Create another aliquot that is nested within the first aliquot (specimen -> aliquot -> aliquot)
+        child_rlims_id = 'child_aliquot'
+        self.send_put(f'Biobank/specimens/{parent_rlims_id}/aliquots/{child_rlims_id}', generic_aliquot_data)
+
+        # Verify that the aliquot was successfully created and has the correct nesting structure
+        aliquot = self.session.query(BiobankAliquot).filter(BiobankAliquot.rlimsId == child_rlims_id).one()
+        self.assertEqual(parent_rlims_id, aliquot.parent_aliquot_rlims_id)
+        self.assertEqual(specimen.rlimsId, aliquot.specimen_rlims_id)
+
     def _create_minimal_specimen_with_aliquot(self, rlims_id='sabrina', aliquot_rlims_id='salem'):
         payload = self.get_minimal_specimen_json(rlims_id)
         payload['aliquots'] = [{


### PR DESCRIPTION
## Resolves *[ROC-943](https://precisionmedicineinitiative.atlassian.net/browse/ROC-943)*
The Biobank is expecting the /Biobank/specimen/<rlims_id>/aliquots/<rlims_id> endpoint to be able to also nest aliquots within aliquots.

## Description of changes/additions
These changes rename the class to `BiobankAliquotApi` to better reflect what it handles. And the endpoint is updated to receive a parent_rlims_id to reflect that it could be an rlims_id for an aliquot too. The DAO functionality is updated to determine if the given rlims_id is an aliquot or if it's a specimen, and then set the parent ids accordingly.

Note: I'm realizing that the Specimen API and DAO classes are getting frustrating to follow. I plan on refactoring them to abstract out some of the concepts (like preloading) and make the logic easier to follow.

## Tests
- [x] additional unit tests for newly expected behavior

Previous unit tests cover the ways we are aware of the API being used.


