### PR TITLE
[DA-1928] Backfill tool for questionnaire response answer digest

### DIFF
--- a/rdr_service/tools/tool_libs/backfill_answer_hash.py
+++ b/rdr_service/tools/tool_libs/backfill_answer_hash.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+import json
+
+from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao
+from rdr_service.model.questionnaire_response import QuestionnaireResponse
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase, logger
+
+tool_cmd = 'answer-hash-backfill'
+tool_desc = 'Backfill the answer digest for responses'
+
+
+class DigestBackfillTool(ToolBase):
+    def run(self):
+        super(DigestBackfillTool, self).run()
+
+        latest_id = -10
+        with self.get_session() as session:
+            found_responses = True
+            while found_responses:
+                found_responses = False
+                questionnaire_response_query = session.query(
+                    QuestionnaireResponse
+                ).filter(
+                    QuestionnaireResponse.questionnaireResponseId > latest_id,
+                    QuestionnaireResponse.answerHash.is_(None)
+                ).order_by(QuestionnaireResponse.questionnaireResponseId).limit(2500)
+
+                for response in questionnaire_response_query:
+                    found_responses = True
+
+                    answer_hash = QuestionnaireResponseDao.calculate_answer_hash(json.loads(response.resource))
+                    response.answerHash = answer_hash
+
+                    latest_id = response.questionnaireResponseId
+
+                if found_responses:
+                    logger.info(f'got to {latest_id}')
+                    logger.info(datetime.now())
+                    logger.info('committing')
+                    session.commit()
+
+
+def run():
+    return cli_run(tool_cmd, tool_desc, DigestBackfillTool)


### PR DESCRIPTION
## Resolves *[DA-1928](https://precisionmedicineinitiative.atlassian.net/browse/DA-1928)*
This does not need to get into the release.

This wraps up the work for DA-1928 by creating a temporary tool for backfilling the answer hash values for existing responses. I'll run this on Prod after the release is deployed (but before the cron job runs to mark duplicates).

## Description of changes/additions
Loads the responses in batches and uses the existing code from the DAO to find the answer digest for them.

## Tests
- [ ] unit tests

No unit tests since this will be temporary code to be run once. I've tested this locally by checking a few digests that it creates for Sandbox.


