### PR TITLE
Truncating incident message if it will cause errors

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1585,3 +1585,11 @@ class GenomicIncidentDao(UpdatableDao):
             ).filter(
                 GenomicIncident.source_file_processed_id == file_id
             ).all()
+
+    def insert(self, incident: GenomicIncident) -> GenomicIncident:
+        maximum_message_length = GenomicIncident.message.type.length
+        if len(incident.message) > maximum_message_length:
+            logging.warning('Truncating incident message when storing (too many characters for database column)')
+            incident.message = incident.message[:maximum_message_length]
+
+        return super(GenomicIncidentDao, self).insert(incident)

--- a/tests/genomics_tests/test_genomic_job_controller.py
+++ b/tests/genomics_tests/test_genomic_job_controller.py
@@ -1,0 +1,26 @@
+import mock
+from rdr_service.genomic.genomic_job_controller import GenomicIncident, GenomicJobController
+
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class GenomicJobControllerTest(BaseTestCase):
+    def test_incident_with_long_message(self):
+        """Make sure the length of incident messages doesn't cause issues when recording them"""
+        incident_message = "1" * (GenomicIncident.message.type.length + 20)
+        mock_slack_handler = mock.MagicMock()
+
+        job_controller = GenomicJobController(job_id=1)
+        job_controller.genomic_alert_slack = mock_slack_handler
+        job_controller.create_incident(message=incident_message, slack=True)
+
+        # Double check that the incident was saved successfully, with part of the message
+        incident: GenomicIncident = self.session.query(GenomicIncident).one()
+        self.assertTrue(incident_message.startswith(incident.message))
+
+        # Make sure Slack received the full message
+        mock_slack_handler.send_message_to_webhook.assert_called_with(
+            message_data={
+                'text': incident_message
+            }
+        )


### PR DESCRIPTION
## Resolves *no ticket*
Some errors are coming up in the logs. If there are too many missing files, then the genomics incident message fails to save to the database and prevents slack messages from being sent.

## Description of changes/additions
This adds a check to the incident DAO and truncates the message if it would be too big for the database.

## Tests
- [x] unit tests

Added test for the new behavior. The test tries to create an incident that wouldn't fit in the table unless the truncation happens. It's also import to make sure Slack receives the full message, so the test also checks to make sure that happens.

