### PR TITLE
[PDR fix] Correct handling of EHR consent expiration in PDR data

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -119,6 +119,16 @@ _withdrawal_aian_ceremony_status_map = {
 _deprecated_gror_consent_questionnaire_id = 415
 _deprecated_gror_consent_question_code_names = ('CheckDNA_Yes', 'CheckDNA_No', 'CheckDNA_NotSure')
 
+# The use case initially detected for these unlayered question codes was participants whose EHR consents
+# had expired and RDR received a payload with the EHRConsentPII_ConsentExpired hidden question code and
+# EHRConsentPII_ConsentExpired_Yes answer code; but then a renewed EHR Consent without that hidden question code
+# was subsequently received.  We don't want the EHRConsentPII_ConsentExpired_Yes value layered onto the new consent
+# See: get_module_answers() method
+_unlayered_question_codes = (
+    'EHRConsentPII_ConsentExpired'
+)
+
+
 class ParticipantSummaryGenerator(generators.BaseGenerator):
     """
     Generate a Participant Summary Resource object
@@ -1405,6 +1415,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # Apply answers to data dict, response by response, until we reach the end or the specific response id.
         data = dict()
         for questionnaire_response_id, qnans in answers.items():
+            # This "overwrites"/removes previous payload's answer codes for answers that should not be carried forward
+            # (layered) from previously processed responses if the question code was not in the more recent payload
+            for q_code in _unlayered_question_codes:
+                if q_code in data.keys() and q_code not in qnans.keys():
+                    del data[q_code]
+
             data.update(qnans)
             if qr_id and qr_id == questionnaire_response_id:
                 break

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -119,14 +119,13 @@ _withdrawal_aian_ceremony_status_map = {
 _deprecated_gror_consent_questionnaire_id = 415
 _deprecated_gror_consent_question_code_names = ('CheckDNA_Yes', 'CheckDNA_No', 'CheckDNA_NotSure')
 
-# The use case initially detected for these unlayered question codes was participants whose EHR consents
-# had expired and RDR received a payload with the EHRConsentPII_ConsentExpired hidden question code and
-# EHRConsentPII_ConsentExpired_Yes answer code; but then a renewed EHR Consent without that hidden question code
-# was subsequently received.  We don't want the EHRConsentPII_ConsentExpired_Yes value layered onto the new consent
-# See: get_module_answers() method
-_unlayered_question_codes = (
-    'EHRConsentPII_ConsentExpired'
-)
+# For cases where we don't want to carry forward previous answers if a subsequent response to the same module is a
+# partial.  For example, the only time we see the EHRConsentPII_ConsentExpired hidden question code / answer is for an
+# expired consent.   Don't want to carry the EHRConsentPII_ConsentExpired_Yes answer to a subsequent renewed consent
+# See: get_module_answers() method.
+_unlayered_question_codes_map = {
+    'EHRConsentPII': ['EHRConsentPII_ConsentExpired', ]
+}
 
 
 class ParticipantSummaryGenerator(generators.BaseGenerator):
@@ -296,7 +295,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # An additional check will be made later at the end of the participant summary data setup, after we've
         # added details like email and phone numbers to the summary data dict, in case they have fake participant
         # credentials but are not correctly flagged in the participant table
-        test_participant = p.isGhostId == 1 or p.isTestParticipant == 1 or hpo.name == TEST_HPO_NAME
+        test_participant = p.isGhostId == 1 or p.isTestParticipant == 1 or (hpo and hpo.name == TEST_HPO_NAME)
 
         data = {
             'participant_id': f'P{p_id}',
@@ -1414,10 +1413,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         # Apply answers to data dict, response by response, until we reach the end or the specific response id.
         data = dict()
+        unlayered_codes = _unlayered_question_codes_map.get(module, [])
         for questionnaire_response_id, qnans in answers.items():
-            # This "overwrites"/removes previous payload's answer codes for answers that should not be carried forward
-            # (layered) from previously processed responses if the question code was not in the more recent payload
-            for q_code in _unlayered_question_codes:
+            # This excludes the layering of prior answers to certain question codes if they do not exist in the more
+            # recent response
+            for q_code in unlayered_codes:
                 if q_code in data.keys() and q_code not in qnans.keys():
                     del data[q_code]
 

--- a/tests/dao_tests/test_bigquery_sync_dao.py
+++ b/tests/dao_tests/test_bigquery_sync_dao.py
@@ -221,9 +221,9 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
     def get_generated_items(item_list, item_key=None, item_value=None, sort_key=None):
         """
             Extracts requested items from a provided list of dicts (e.g., ps_json['consents'])
-            Returns a filtered list of dict entries that match the item name, sorted if requested
+            Returns a filtered list of dict entries that match the item key/value, sorted if requested
             Example:
-                get_items(ps_json['modules'], item_key='mod_module', item_value='OverallHealth',
+                get_generated_items(ps_json['modules'], item_key='mod_module', item_value='OverallHealth',
                                   sort_key='mod_authored')
         """
         if not (item_key and item_value and isinstance(item_list, list)):

--- a/tests/dao_tests/test_bigquery_sync_dao.py
+++ b/tests/dao_tests/test_bigquery_sync_dao.py
@@ -471,5 +471,4 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         # This field should be None for consent payloads that don't contain the expiration hidden question code
         self.assertIsNone(ehr_consents[2].get('consent_expired', ''))
 
-        self.assertIsNotNone(ps_json)
 


### PR DESCRIPTION
## Resolves *bug found during investigation of EHR consent expiration data*


## Description of changes/additions
PDR generators handle partial module responses by carrying forward previously submitted answers to question codes that were not sent in a subsequent payload.   This caused a problem with EHR consents because we carried forward the hidden `EHRConsentPII_ConsentExpired` question code and `EHRConsentPII_ConsentExpired_Yes` answer to a subsequent renewed EHR consent response.   This may have impacts on other PDR data elements, e.g., when `enrollment_status` is calculated.

In case we run into more cases like this, the fix will maintain a list of codes that should be "unlayered" for a given module. We will not carry prior answers to those forward to the next module response payload

Also did some minor refactoring of unit test helper routines used in validating output from the PDR data generators, and addressed what could be bug waiting to happen with building participant data if a participant is unpaired 
## Tests
- [x] unit tests
Added `test_ehr_consent_expired_and_renewed` test case to  verify the new logic around unlayered question codes


