### PR TITLE
Changing the db character set in a few more places

### DIFF
--- a/rdr_service/tools/setup_local_vars.sh
+++ b/rdr_service/tools/setup_local_vars.sh
@@ -13,5 +13,5 @@ function set_local_db_connection_string {
   then
     DB_USER=$1
   fi
-  export DB_CONNECTION_STRING="mysql+mysqldb://${DB_USER}:${RDR_PASSWORD}@127.0.0.1/?charset=utf8"
+  export DB_CONNECTION_STRING="mysql+mysqldb://${DB_USER}:${RDR_PASSWORD}@127.0.0.1/?charset=utf8mb4"
 }

--- a/rdr_service/tools/tool_libs/__init__.py
+++ b/rdr_service/tools/tool_libs/__init__.py
@@ -178,7 +178,7 @@ class GCPEnvConfigObject(object):
         # If localhost project, just point to the local instance of mysql.
         if (project and project == 'localhost') or (self.project and self.project == 'localhost'):
             passwd = 'root' if user == 'root' else 'rdr!pwd'
-            os.environ['DB_CONNECTION_STRING'] = f'mysql+mysqldb://{user}:{passwd}@127.0.0.1:3306/rdr?charset=utf8'
+            os.environ['DB_CONNECTION_STRING'] = f'mysql+mysqldb://{user}:{passwd}@127.0.0.1:3306/rdr?charset=utf8mb4'
             return 1
 
         _logger.debug("Starting google sql proxy...")
@@ -192,7 +192,7 @@ class GCPEnvConfigObject(object):
             time.sleep(6)  # allow time for sql connection to be made.
             cfg_user = 'root' if user == 'root' else 'rdr'
             passwd = db_config[f'{cfg_user}_db_password']
-            os.environ['DB_CONNECTION_STRING'] = f'mysql+mysqldb://{user}:{passwd}@127.0.0.1:{port}/rdr?charset=utf8'
+            os.environ['DB_CONNECTION_STRING'] = f'mysql+mysqldb://{user}:{passwd}@127.0.0.1:{port}/rdr?charset=utf8mb4'
             return self._sql_proxy_process.pid
 
         _logger.error('Failed to activate sql proxy.')

--- a/rdr_service/tools/tool_libs/setup_local_db.py
+++ b/rdr_service/tools/tool_libs/setup_local_db.py
@@ -95,7 +95,7 @@ class SetupLocalDB:  # pylint: disable=too-many-instance-attributes
         if user:
             self.db_user = user
 
-        self.db_connection_string = f"mysql+mysqldb://{self.db_user}:{self.rdr_password}@127.0.0.1/?charset=utf8"
+        self.db_connection_string = f"mysql+mysqldb://{self.db_user}:{self.rdr_password}@127.0.0.1/?charset=utf8mb4"
         os.environ['DB_CONNECTION_STRING'] = self.db_connection_string
 
     def set_connection_info(self):


### PR DESCRIPTION
## Resolves *no ticket*
The db_config.json file is modified and the charset is set back to `utf8` when setting up the local database. There were also a few other places that the charset was still `utf8`.

## Description of changes/additions
`setup_local_vars.sh` is used by `setup_local_database.sh` and modifies the db_config.json file which kept appear as a changed file for me.

There are a few other places that the connection string still has just `utf8`. This updates the tool classes to use the `utf8mb4` charset instead.

## Tests
- [ ] unit tests

I'm not really sure how I would unit test this.


