### PR TITLE
Setting up Safety check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,6 @@ commands:
           name: Code static analysis checks
           command: ci/full_static_analysis.sh
       - run:
-          name: Safety Check
-          command: source venv/bin/activate && safety check
-      - run:
           name: Check Licenses
           command : |
             export PYTHONPATH=$PYTHONPATH:`pwd`
@@ -43,6 +40,9 @@ commands:
       - run:
           name: Running Unittests
           command: ./ci/run_unittests.sh
+      - run:
+          name: Safety Check
+          command: source venv/bin/activate && safety check
 
   deploy-app-steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ commands:
       - run:
           name: Running Unittests
           command: ./ci/run_unittests.sh
+      - run:
+          name: Safety Check
+          command: safety check
 
   deploy-app-steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           command: ./ci/run_unittests.sh
       - run:
           name: Safety Check
-          command: safety check
+          command: source venv/bin/activate & safety check
 
   deploy-app-steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           command: ./ci/run_unittests.sh
       - run:
           name: Safety Check
-          command: source venv/bin/activate & safety check
+          command: source venv/bin/activate & python -m safety check
 
   deploy-app-steps:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ commands:
           name: Code static analysis checks
           command: ci/full_static_analysis.sh
       - run:
+          name: Safety Check
+          command: source venv/bin/activate && safety check
+      - run:
           name: Check Licenses
           command : |
             export PYTHONPATH=$PYTHONPATH:`pwd`
@@ -40,9 +43,6 @@ commands:
       - run:
           name: Running Unittests
           command: ./ci/run_unittests.sh
-      - run:
-          name: Safety Check
-          command: source venv/bin/activate & python -m safety check
 
   deploy-app-steps:
     parameters:

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -9,3 +9,5 @@ echo "PYTHONPATH=${PYTHONPATH}"
 pip install --upgrade pip
 pip install safety
 pip install -r requirements.txt
+
+safety check

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -9,5 +9,3 @@ echo "PYTHONPATH=${PYTHONPATH}"
 pip install --upgrade pip
 pip install safety
 pip install -r requirements.txt
-
-safety check

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -7,7 +7,7 @@
 alabaster==0.7.12         # via sphinx
 alembic==1.4.2            # via -r requirements.in
 aniso8601==8.0.0          # via flask-restful
-astroid==2.4.1            # via pylint
+astroid==2.5.2            # via pylint
 babel==2.8.0              # via sphinx
 backoff==1.10.0           # via -r requirements.in
 blinker==1.4              # via -r requirements.in

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -80,7 +80,7 @@ pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
 pycparser==2.20           # via cffi
 pygments==2.7.4           # via sphinx
 pyjwt==1.7.1              # via oauthlib
-pylint==2.5.2             # via -r requirements.in
+pylint==2.7.4             # via -r requirements.in
 pyopenssl==19.1.0         # via requests
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via alembic, faker
@@ -92,7 +92,7 @@ pyzmq==19.0.1             # via locust
 requests-oauthlib==1.3.0  # via jira
 requests-toolbelt==0.9.1  # via jira
 requests[security]==2.23.0  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
-rsa==4.1                  # via google-auth, oauth2client
+rsa==4.7.2                  # via google-auth, oauth2client
 sendgrid==6.3.1           # via -r requirements.in
 simplejson==3.17.0        # via -r requirements.in
 six==1.15.0               # via astroid, cryptography, flask-restful, geventhttpclient, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-python-cloud-debugger, google-resumable-media, grpcio, isodate, jira, oauth2client, packaging, pip-tools, protobuf, protorpc, pyopenssl, python-dateutil


### PR DESCRIPTION
## Resolves *no ticket*
We noticed that Safety was installed as part of the CI process but not used. Safety is a utility that can alert us if any libraries we're using have known vulnerabilities.

To get Safety passing, this also updates libraries that have vulnerabilities (and `asteroid` because pylint depends on a newer version of it).

## Description of changes/additions
This adds a step to the `test_commits_workflow` step that runs Safety. Circle-CI is all or nothing, it doesn't seem to offer a way of warning but still passing. If anything is outdated enough then the CI builds will finish with a failed status. I believe having this automatic warning system that packages should be updated is worth having to work around that. I've placed the check at the end of the build, so we'll still be able to decide to merge something when we see that the unit tests are passing.

## Tests
- [ ] unit tests

No unit tests since these are external libraries.

