### PR TITLE
Fixing circular dependency in tool code

### DIFF
--- a/rdr_service/services/config_client.py
+++ b/rdr_service/services/config_client.py
@@ -1,0 +1,34 @@
+import json
+
+from rdr_service.config import GoogleCloudDatastoreConfigProvider
+
+
+class ConfigClient:
+    def __init__(self, gcp_env):
+        self.gcp_env = gcp_env
+
+    def _get_config(self, config_root, config_key='current_config'):
+        config_data_str, _ = self.gcp_env.get_latest_config_from_bucket(config_root, config_key)
+        if not config_data_str:
+            raise FileNotFoundError(f'Error: {config_root} configuration not found in bucket.')
+
+        return json.loads(config_data_str)
+
+    def get_server_config(self) -> dict:
+        """
+        Provides the config values from the server (including any values in the base config).
+        :return: A dictionary representing the config for the environment.
+        """
+        base_config = self._get_config('base-config')
+        proj_config = self._get_config(self.gcp_env.project)
+
+        config = {**base_config, **proj_config}
+
+        if self.gcp_env.project != 'localhost':
+            # insert the geocode key from 'pmi-drc-api-test' into this config.
+            cloud_datastore_provider = GoogleCloudDatastoreConfigProvider()
+            geocode_config = cloud_datastore_provider.load('geocode_key', project='pmi-drc-api-test')
+            if geocode_config:
+                config['geocode_api_key'] = [geocode_config['api_key']]
+
+        return config

--- a/rdr_service/tools/tool_libs/tool_base.py
+++ b/rdr_service/tools/tool_libs/tool_base.py
@@ -4,14 +4,14 @@ import sys
 from typing import Type
 
 from rdr_service.dao import database_factory
+from rdr_service.services.config_client import ConfigClient
 from rdr_service.services.system_utils import setup_logging, setup_i18n
 from rdr_service.tools.tool_libs import GCPProcessContext
-import rdr_service.tools.tool_libs.app_engine_manager as app_engine_manager
 
 logger = logging.getLogger("rdr_logger")
 
 
-class ToolBase(object):
+class ToolBase:
     def __init__(self, args, gcp_env=None, tool_name=None):
         self.args = args
         self.tool_cmd = tool_name
@@ -46,13 +46,8 @@ class ToolBase(object):
             return 1
 
     def get_server_config(self):
-        # The AppConfig class uses the git_project field from args when initializing,
-        # looks like it uses it as a root directory for other purposes.
-        self.args.git_project = self.gcp_env.git_project
-
-        # Get the server config
-        app_config_manager = app_engine_manager.AppConfigClass(self.args, self.gcp_env)
-        return app_config_manager.get_bucket_app_config()
+        client = ConfigClient(self.gcp_env)
+        return client.get_server_config()
 
     @staticmethod
     def get_session(database_name='rdr', alembic=False, **kwargs):

--- a/tests/helpers/tool_test_mixin.py
+++ b/tests/helpers/tool_test_mixin.py
@@ -7,13 +7,6 @@ from rdr_service.tools.tool_libs.tool_base import ToolBase
 class ToolTestMixin:
 
     @staticmethod
-    def _build_env():
-        gcp_env = mock.MagicMock()
-        gcp_env.project = 'localhost'
-
-        return gcp_env
-
-    @staticmethod
     def _build_args(args):
         args_obj = mock.MagicMock()
         if args is not None:
@@ -24,7 +17,9 @@ class ToolTestMixin:
 
     @classmethod
     def run_tool(cls, tool_class: Type[ToolBase], tool_args: dict = None, server_config: dict = None):
-        gcp_env = ToolTestMixin._build_env()
+        gcp_env = mock.MagicMock()
+        gcp_env.project = 'localhost'
+
         tool_args = ToolTestMixin._build_args(tool_args)
 
         with mock.patch.object(ToolBase, 'initialize_process_context') as mock_init_env,\

--- a/tests/helpers/tool_test_mixin.py
+++ b/tests/helpers/tool_test_mixin.py
@@ -1,28 +1,15 @@
 import mock
-import json
-import os
 from typing import Type
 
-import rdr_service
 from rdr_service.tools.tool_libs.tool_base import ToolBase
-
-PROJECT_ROOT = os.path.dirname(os.path.dirname(rdr_service.__file__))
 
 
 class ToolTestMixin:
 
     @staticmethod
-    def _build_env(server_config):
-        if server_config is None:
-            server_config = {}
-
-        def construct_server_config_response(*_):
-            return json.dumps(server_config), 'test_server_config_file_name'
-
+    def _build_env():
         gcp_env = mock.MagicMock()
         gcp_env.project = 'localhost'
-        gcp_env.git_project = PROJECT_ROOT
-        gcp_env.get_latest_config_from_bucket = construct_server_config_response
 
         return gcp_env
 
@@ -37,11 +24,14 @@ class ToolTestMixin:
 
     @classmethod
     def run_tool(cls, tool_class: Type[ToolBase], tool_args: dict = None, server_config: dict = None):
-        gcp_env = ToolTestMixin._build_env(server_config)
+        gcp_env = ToolTestMixin._build_env()
         tool_args = ToolTestMixin._build_args(tool_args)
 
-        with mock.patch.object(ToolBase, 'initialize_process_context') as mock_init_env:
+        with mock.patch.object(ToolBase, 'initialize_process_context') as mock_init_env,\
+             mock.patch('rdr_service.services.config_client.ConfigClient.get_server_config') as mock_server_config:
+
             mock_init_env.return_value.__enter__.return_value = gcp_env
+            mock_server_config.return_value = server_config or {}
 
             tool_instance = tool_class(tool_args, gcp_env)
             return tool_instance.run_process()

--- a/tests/service_tests/test_config_client.py
+++ b/tests/service_tests/test_config_client.py
@@ -15,7 +15,7 @@ class ConfigClientTest(BaseTestCase):
         self.mock_gcp_env.project = self.test_environment_name
         self.config_client = ConfigClient(self.mock_gcp_env)
 
-    def _mock_config_data(self, base_config_data_str, test_config_data_str):
+    def _mock_server_config_data(self, base_config_data_str, test_config_data_str):
         def get_config_data(config_root, _):
             if config_root == self.test_environment_name:
                 return test_config_data_str, config_root
@@ -31,7 +31,7 @@ class ConfigClientTest(BaseTestCase):
         Test that the client builds config data from the base config file
         as well as the file for the specific environment.
         """
-        self._mock_config_data(
+        self._mock_server_config_data(
             base_config_data_str=json.dumps({
                 'base_setting': 'default'
             }),
@@ -49,7 +49,7 @@ class ConfigClientTest(BaseTestCase):
     def test_environment_settings_override_base(self):
         """Verify that the environment configs override values from the base file"""
         config_key = 'config_key_to_override'
-        self._mock_config_data(
+        self._mock_server_config_data(
             base_config_data_str=json.dumps({
                 config_key: 'default'
             }),

--- a/tests/service_tests/test_config_client.py
+++ b/tests/service_tests/test_config_client.py
@@ -1,0 +1,66 @@
+import json
+import mock
+
+from rdr_service.services.config_client import ConfigClient
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ConfigClientTest(BaseTestCase):
+    def setUp(self, **kwargs) -> None:
+        super(ConfigClientTest, self).setUp(**kwargs)
+
+        self.test_environment_name = 'test-project'
+
+        self.mock_gcp_env = mock.MagicMock()
+        self.mock_gcp_env.project = self.test_environment_name
+        self.config_client = ConfigClient(self.mock_gcp_env)
+
+    def _mock_config_data(self, base_config_data_str, test_config_data_str):
+        def get_config_data(config_root, _):
+            if config_root == self.test_environment_name:
+                return test_config_data_str, config_root
+            elif config_root == 'base-config':
+                return base_config_data_str, config_root
+
+            raise Exception(f'Unexpected config root "{config_root}"')
+
+        self.mock_gcp_env.get_latest_config_from_bucket.side_effect = get_config_data
+
+    def test_config_data_retrieved_for_environment(self):
+        """
+        Test that the client builds config data from the base config file
+        as well as the file for the specific environment.
+        """
+        self._mock_config_data(
+            base_config_data_str=json.dumps({
+                'base_setting': 'default'
+            }),
+            test_config_data_str=json.dumps({
+                'test_key': 'test_value'
+            })
+        )
+
+        test_config = self.config_client.get_server_config()
+        del test_config['geocode_api_key']  # Geocode API key purpose is unclear, ignoring it in the test for now
+        self.assertEqual({
+            'base_setting': 'default',
+            'test_key': 'test_value'
+        }, test_config)
+
+    def test_environment_settings_override_base(self):
+        """Verify that the environment configs override values from the base file"""
+        config_key = 'config_key_to_override'
+        self._mock_config_data(
+            base_config_data_str=json.dumps({
+                config_key: 'default'
+            }),
+            test_config_data_str=json.dumps({
+                config_key: 'new_value'
+            })
+        )
+
+        test_config = self.config_client.get_server_config()
+        del test_config['geocode_api_key']  # Geocode API key purpose is unclear, ignoring it in the test for now
+        self.assertEqual({
+            config_key: 'new_value'
+        }, test_config)

--- a/tests/service_tests/test_config_client.py
+++ b/tests/service_tests/test_config_client.py
@@ -9,7 +9,7 @@ class ConfigClientTest(BaseTestCase):
     def setUp(self, **kwargs) -> None:
         super(ConfigClientTest, self).setUp(**kwargs)
 
-        self.test_environment_name = 'test-project'
+        self.test_environment_name = 'localhost'
 
         self.mock_gcp_env = mock.MagicMock()
         self.mock_gcp_env.project = self.test_environment_name
@@ -41,7 +41,6 @@ class ConfigClientTest(BaseTestCase):
         )
 
         test_config = self.config_client.get_server_config()
-        del test_config['geocode_api_key']  # Geocode API key purpose is unclear, ignoring it in the test for now
         self.assertEqual({
             'base_setting': 'default',
             'test_key': 'test_value'
@@ -60,7 +59,6 @@ class ConfigClientTest(BaseTestCase):
         )
 
         test_config = self.config_client.get_server_config()
-        del test_config['geocode_api_key']  # Geocode API key purpose is unclear, ignoring it in the test for now
         self.assertEqual({
             config_key: 'new_value'
         }, test_config)

--- a/tests/tool_tests/test_codes_management.py
+++ b/tests/tool_tests/test_codes_management.py
@@ -1,16 +1,12 @@
 import mock
-import os
 from typing import List
 
-import rdr_service
 from rdr_service.model.code import Code, CodeType
 from rdr_service.model.survey import Survey, SurveyQuestion, SurveyQuestionType, SurveyQuestionOption
 from rdr_service.tools.tool_libs.codes_management import CodesSyncClass, DRIVE_EXPORT_FOLDER_ID,\
     EXPORT_SERVICE_ACCOUNT_NAME, REDCAP_PROJECT_KEYS
 from tests.helpers.unittest_base import BaseTestCase
 from tests.helpers.tool_test_mixin import ToolTestMixin
-
-PROJECT_ROOT = os.path.dirname(os.path.dirname(rdr_service.__file__))
 
 
 class CodesManagementTest(ToolTestMixin, BaseTestCase):

--- a/tests/tool_tests/test_cope_answers.py
+++ b/tests/tool_tests/test_cope_answers.py
@@ -1,15 +1,11 @@
 from collections import namedtuple
 import json
 import mock
-import os
 
-import rdr_service
 from rdr_service import config
 from rdr_service.tools.tool_libs.cope_answers import CopeAnswersClass
 from tests.helpers.unittest_base import BaseTestCase
 from tests.helpers.tool_test_mixin import ToolTestMixin
-
-PROJECT_ROOT = os.path.dirname(os.path.dirname(rdr_service.__file__))
 
 FakeFile = namedtuple('FakeFile', ['name', 'updated'])
 


### PR DESCRIPTION
## Resolves *no ticket*
There was a circular dependence between the `ToolBase` class and the `app_engine_manager` module: ToolBase needed to be able to get the server's config so used the `AppConfigClass`, and `DeployAppClass` is a subclass of `ToolBase`.

## Description of changes/additions
These changes move the functionality of downloading the server's config data into the `ConfigClient` class, getting rid of the circular dependence.

There was also code for inserting a geocode value into the config. I haven't tracked down the purpose of that yet, but it was moved into the shared functionality too.

## Tests
- [x] unit tests

New unit tests added to isolate the new class.


