### PR TITLE
Fix AW2 contamination non-float bug

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -677,8 +677,19 @@ class GenomicFileIngester:
                 row['contamination'] = 0
 
         except ValueError:
-            logging.error(f'contamination must be a number for sample_id: {row["sampleid"]}')
-            return GenomicSubProcessResult.ERROR
+            if row['processingstatus'].lower() != 'pass':
+                return row
+
+            _message = f'contamination must be a number for sample_id: {row["sampleid"]}'
+
+            self.controller.create_incident(source_job_run_id=self.job_run_id,
+                                            source_file_processed_id=self.file_obj.id,
+                                            code=GenomicIncidentCode.DATA_VALIDATION_FAILED.name,
+                                            message=_message,
+                                            biobank_id=member.biobankId,
+                                            sample_id=row['sampleid'],
+                                            )
+
 
         # Calculate contamination_category
         contamination_value = float(row['contamination'])

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -997,7 +997,7 @@ class GenomicFileIngester:
                 row_copy = self.prep_aw2_row_attributes(row_copy, member)
 
                 if row_copy == GenomicSubProcessResult.ERROR:
-                    return GenomicSubProcessResult.ERROR
+                    continue
 
                 # check whether metrics object exists for that member
                 existing_metrics_obj = self.metrics_dao.get_metrics_by_member_id(member.id)

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -690,6 +690,7 @@ class GenomicFileIngester:
                                             sample_id=row['sampleid'],
                                             )
 
+            return GenomicSubProcessResult.ERROR
 
         # Calculate contamination_category
         contamination_value = float(row['contamination'])
@@ -994,6 +995,9 @@ class GenomicFileIngester:
 
             if member is not None:
                 row_copy = self.prep_aw2_row_attributes(row_copy, member)
+
+                if row_copy == GenomicSubProcessResult.ERROR:
+                    return GenomicSubProcessResult.ERROR
 
                 # check whether metrics object exists for that member
                 existing_metrics_obj = self.metrics_dao.get_metrics_by_member_id(member.id)

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -209,6 +209,7 @@ class GenomicIncidentCode(messages.Enum):
     UNABLE_TO_FIND_MEMBER = 2
     MISSING_FILES = 3
     FILE_VALIDATION_FAILED = 4
+    DATA_VALIDATION_FAILED = 5
 
 
 class GenomicIncidentStatus(messages.Enum):

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -3342,7 +3342,7 @@ class GenomicPipelineTest(BaseTestCase):
         new_record = deepcopy(metrics_record_2)
         metrics_record_2.ignoreFlag = 1
 
-        new_record.id = 3
+        new_record.id = 4
         new_record.contamination = '0.1346'
 
         with self.metrics_dao.session() as session:
@@ -3733,7 +3733,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(0, incident.slack_notification)
             self.assertIsNone(incident.slack_notification_date)
 
-        self.assertEqual(2, len(incidents))
+        self.assertEqual(3, len(incidents))
         self.assertEqual("1", incidents[0].biobank_id)
         self.assertEqual("1001", incidents[0].sample_id)
         self.assertEqual(2, incidents[0].source_job_run_id)

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -370,8 +370,8 @@ class GenomicPipelineTest(BaseTestCase):
                 self.assertEqual('0', gc_metrics[1].contamination)
 
     def test_ingest_specific_aw2_file(self):
-        self._create_fake_datasets_for_gc_tests(2, arr_override=True,
-                                                array_participants=(1, 2),
+        self._create_fake_datasets_for_gc_tests(3, arr_override=True,
+                                                array_participants=(1, 3),
                                                 genomic_workflow_state=GenomicWorkflowState.AW1)
 
         self._update_test_sample_ids()

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,3 +1,4 @@
 Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Processing Status,Notes
 T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Pass,This sample passed
 T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Pass,This sample passed
+T3,1003,T3_1993,10003,10003_R01C02,0.3456789012,True,,Fail,This sample failed


### PR DESCRIPTION
## Resolves *No ticket*

## Description of changes/additions
This PR fixes a bug in the AW2 ingestion workflow when `contamination` is not supplied. The RDR must allow `contamination` to be a non-float in cases where `processing_status` is not `pass`. Previously, the code was returning a `GenomicSubprocessResult` object, but this is not correct. Now the code is returning the `row` object when `contamination` is a non-float and the `processing_status` is not `pass`. When the `processing_status` is `pass`, and the `contamination` value is a non-float, the code writes a `genomic_incident` record.

## Tests
- [] test_ingest_specific_aw2_file
- [] test_aw2_genomic_incident_inserted
- [] test_aw2f_manifest_generation_e2e


