### PR TITLE
Fix for when aligned_q30_bases is set to blank string

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -668,6 +668,13 @@ class GenomicFileIngester:
         except KeyError:
             pass
 
+        # Convert blank alignedq30bases to none
+        try:
+            if row['alignedq30bases'] == '':
+                row['alignedq30bases'] = None
+        except KeyError:
+            pass
+
         # Validate and clean contamination data
         try:
             row['contamination'] = float(row['contamination'])


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR sets empty string values to `None` for the `aligned_q30_bases` field in the AW2 manifest. This fixes a recently occurring error where this field is provided as an empty string.

## Tests
- [] No unit tests were updated


