### PR TITLE
Refactoring gcp_db_daemon

### DIFF
--- a/rdr_service/services/gcp_db_daemon.py
+++ b/rdr_service/services/gcp_db_daemon.py
@@ -45,12 +45,27 @@ def run():
                 RdrEnvironment.PTSC_3_TEST:     ProxyPortData(primary=9980, replica=9985)
             }
 
+            self.environments_to_activate = [RdrEnvironment.PROD, RdrEnvironment.STABLE, RdrEnvironment.STAGING]
+
+            if self._args.enable_sandbox:
+                self.environments_to_activate.append(RdrEnvironment.SANDBOX)
+            if self._args.enable_test:
+                self.environments_to_activate.append(RdrEnvironment.TEST)
+            if self._args.enable_care_evo:
+                self.environments_to_activate.append(RdrEnvironment.CAREEVO_TEST)
+            if self._args.enable_ptsc_1_test:
+                self.environments_to_activate.append(RdrEnvironment.PTSC_1_TEST)
+            if self._args.enable_ptsc_2_test:
+                self.environments_to_activate.append(RdrEnvironment.PTSC_2_TEST)
+            if self._args.enable_ptsc_3_test:
+                self.environments_to_activate.append(RdrEnvironment.PTSC_3_TEST)
+
         def _print_instance_line(self, project_name, db_type, port_number):
             project_name_display = f'{project_name}:'.ljust(30)
             _logger.info(f'    {project_name_display}{db_type.ljust(15)}-> tcp: {self.host}:{port_number}')
 
         def print_instances(self):
-            for environment in RdrEnvironment:
+            for environment in self.environments_to_activate:
                 proxy_port = self.environment_proxy_port_map[environment]
                 self._print_instance_line(environment.value, 'primary', proxy_port.primary)
                 if self._args.enable_replica and proxy_port.replica is not None:
@@ -79,24 +94,8 @@ def run():
             Build all instances we are going to connect to
             :return: string
             """
-
-            environments_to_activate = [RdrEnvironment.PROD, RdrEnvironment.STABLE, RdrEnvironment.STAGING]
-
-            if self._args.enable_sandbox:
-                environments_to_activate.append(RdrEnvironment.SANDBOX)
-            if self._args.enable_test:
-                environments_to_activate.append(RdrEnvironment.TEST)
-            if self._args.enable_care_evo:
-                environments_to_activate.append(RdrEnvironment.CAREEVO_TEST)
-            if self._args.enable_ptsc_1_test:
-                environments_to_activate.append(RdrEnvironment.PTSC_1_TEST)
-            if self._args.enable_ptsc_2_test:
-                environments_to_activate.append(RdrEnvironment.PTSC_2_TEST)
-            if self._args.enable_ptsc_3_test:
-                environments_to_activate.append(RdrEnvironment.PTSC_3_TEST)
-
             instance_string_list = []
-            for environment in environments_to_activate:
+            for environment in self.environments_to_activate:
                 instance_string_list.extend(self._get_instance_arg_list_for_environment(environment))
 
             return ','.join(instance_string_list)

--- a/rdr_service/services/gcp_db_daemon.py
+++ b/rdr_service/services/gcp_db_daemon.py
@@ -8,7 +8,8 @@ import time
 
 from rdr_service.services.daemon import Daemon
 from rdr_service.services.gcp_config import RdrEnvironment
-from rdr_service.services.gcp_utils import gcp_activate_account, gcp_activate_sql_proxy, gcp_format_sql_instance
+from rdr_service.services.gcp_utils import build_gcp_instance_connection_name, gcp_activate_account,\
+    gcp_activate_sql_proxy
 from rdr_service.services.system_utils import is_valid_email, setup_logging, setup_i18n, which
 
 _logger = logging.getLogger("rdr_logger")
@@ -57,11 +58,18 @@ def run():
 
         def _get_instance_arg_list_for_environment(self, environment: RdrEnvironment):
             proxy_port = self.environment_proxy_port_map[environment]
-            instance_arg_list = [gcp_format_sql_instance(environment.value, proxy_port.primary)]
+            instance_arg_list = [build_gcp_instance_connection_name(
+                project_name=environment.value,
+                port=proxy_port.primary,
+                database_name='rdrmaindb'
+            )]
 
             if self._args.enable_replica and proxy_port.replica is not None:
                 instance_arg_list.append(
-                    gcp_format_sql_instance(environment.value, proxy_port.replica, replica=True)
+                    build_gcp_instance_connection_name(
+                        project_name=environment.value,
+                        port=proxy_port.replica,
+                        database_name='rdrbackupdb-a' if environment == RdrEnvironment.PROD else 'rdrbackupdb')
                 )
 
             return instance_arg_list

--- a/rdr_service/services/gcp_db_daemon.py
+++ b/rdr_service/services/gcp_db_daemon.py
@@ -1,14 +1,5 @@
-#
-# !!! This file is python 3.x compliant !!!
-#
-#
-
-# Note: disable specific pylint checks globally here.
-# superfluous-parens
-# pylint: disable=C0325
-
-
 import argparse
+from dataclasses import dataclass
 import logging
 import os
 import signal
@@ -16,12 +7,19 @@ import sys
 import time
 
 from rdr_service.services.daemon import Daemon
+from rdr_service.services.gcp_config import RdrEnvironment
 from rdr_service.services.gcp_utils import gcp_activate_account, gcp_activate_sql_proxy, gcp_format_sql_instance
 from rdr_service.services.system_utils import is_valid_email, setup_logging, setup_i18n, which
 
 _logger = logging.getLogger("rdr_logger")
-
 progname = "gcp-db-daemon"
+
+
+@dataclass
+class ProxyPortData:
+    """Class for bundling primary and replica proxy ports for an environment"""
+    primary: int
+    replica: int = None  # Not every environment has a replica db
 
 
 def run():
@@ -33,106 +31,67 @@ def run():
             self._args = kwargs.pop("args", None)
             super(SQLProxyDaemon, self).__init__(*args, **kwargs)
 
+            self.host = '127.0.0.1'
+            self.environment_proxy_port_map = {
+                RdrEnvironment.PROD:            ProxyPortData(primary=9900, replica=9905),
+                RdrEnvironment.STABLE:          ProxyPortData(primary=9910, replica=9915),
+                RdrEnvironment.STAGING:         ProxyPortData(primary=9920, replica=9925),
+                RdrEnvironment.SANDBOX:         ProxyPortData(primary=9930),
+                RdrEnvironment.TEST:            ProxyPortData(primary=9940, replica=9945),
+                RdrEnvironment.CAREEVO_TEST:    ProxyPortData(primary=9950, replica=9955),
+                RdrEnvironment.PTSC_1_TEST:     ProxyPortData(primary=9960, replica=9965),
+                RdrEnvironment.PTSC_2_TEST:     ProxyPortData(primary=9970, replica=9975),
+                RdrEnvironment.PTSC_3_TEST:     ProxyPortData(primary=9980, replica=9985)
+            }
+
+        def _print_instance_line(self, project_name, db_type, port_number):
+            project_name_display = f'{project_name}:'.ljust(30)
+            _logger.info(f'    {project_name_display}{db_type.ljust(15)}-> tcp: {self.host}:{port_number}')
+
         def print_instances(self):
+            for environment in RdrEnvironment:
+                proxy_port = self.environment_proxy_port_map[environment]
+                self._print_instance_line(environment.value, 'primary', proxy_port.primary)
+                if self._args.enable_replica and proxy_port.replica is not None:
+                    self._print_instance_line(environment.value, 'replica', proxy_port.replica)
 
-            _logger.info("    all-of_us-rdr-prod:     primary    -> tcp: 127.0.0.1:9900")
-            if self._args.enable_replica:
-                _logger.info("    all-of_us-rdr-prod:     replica    -> tcp: 127.0.0.1:9905")
+        def _get_instance_arg_list_for_environment(self, environment: RdrEnvironment):
+            proxy_port = self.environment_proxy_port_map[environment]
+            instance_arg_list = [gcp_format_sql_instance(environment.value, proxy_port.primary)]
 
-            _logger.info("    all-of_us-rdr-stable:   primary    -> tcp: 127.0.0.1:9910")
-            if self._args.enable_replica:
-                _logger.info("    all-of_us-rdr-stable:   replica    -> tcp: 127.0.0.1:9915")
+            if self._args.enable_replica and proxy_port.replica is not None:
+                instance_arg_list.append(
+                    gcp_format_sql_instance(environment.value, proxy_port.replica, replica=True)
+                )
 
-            _logger.info("    all-of_us-rdr-staging:  primary    -> tcp: 127.0.0.1:9920")
-            if self._args.enable_replica:
-                _logger.info("    all-of_us-rdr-staging:  replica    -> tcp: 127.0.0.1:9925")
+            return instance_arg_list
 
-            if self._args.enable_sandbox is True:
-                _logger.info("    all-of_us-rdr-sandbox:  primary    -> tcp: 127.0.0.1:9930")
-                # Sandbox does not currently have a replica enabled
-                # if self._args.enable_replica:
-                #   _logger.info('    all-of_us-rdr-sandbox:     replica    -> tcp: 127.0.0.1:9935')
-
-            if self._args.enable_test is True:
-                _logger.info("    pmi-drc-api-test:       primary    -> tcp: 127.0.0.1:9940")
-                if self._args.enable_replica:
-                    _logger.info("    pmi-drc-api-test:       replica    -> tcp: 127.0.0.1:9945")
-
-            if self._args.enable_care_evo is True:
-                _logger.info('    all-of-us-rdr-careevo-test:       primary    -> tcp: 127.0.0.1:9950')
-                if self._args.enable_replica:
-                    _logger.info('    all-of-us-rdr-careevo-test:       replica    -> tcp: 127.0.0.1:9955')
-
-            if self._args.enable_ptsc_1_test is True:
-                _logger.info('    all-of-us-rdr-ptsc-1-test:       primary    -> tcp: 127.0.0.1:9960')
-                if self._args.enable_replica:
-                    _logger.info('    all-of-us-rdr-ptsc-1-test:       replica    -> tcp: 127.0.0.1:9965')
-
-            if self._args.enable_ptsc_2_test is True:
-                _logger.info('    all-of-us-rdr-ptsc-2-test:       primary    -> tcp: 127.0.0.1:9970')
-                if self._args.enable_replica:
-                    _logger.info('    all-of-us-rdr-ptsc-2-test:       replica    -> tcp: 127.0.0.1:9975')
-
-            if self._args.enable_ptsc_3_test is True:
-                _logger.info('    all-of-us-rdr-ptsc-3-test:       primary    -> tcp: 127.0.0.1:9980')
-                if self._args.enable_replica:
-                    _logger.info('    all-of-us-rdr-ptsc-3-test:       replica    -> tcp: 127.0.0.1:9985')
-
-        def get_instances(self):
+        def get_instances_arg_str(self):
             """
-      Build all instances we are going to connect to
-      :return: string
-      """
+            Build all instances we are going to connect to
+            :return: string
+            """
 
-            instances = ""
+            environments_to_activate = [RdrEnvironment.PROD, RdrEnvironment.STABLE, RdrEnvironment.STAGING]
 
-            instances += gcp_format_sql_instance("all-of-us-rdr-prod", 9900) + ","
-            if self._args.enable_replica:
-                instances += gcp_format_sql_instance("all-of-us-rdr-prod", 9905, True) + ","
+            if self._args.enable_sandbox:
+                environments_to_activate.append(RdrEnvironment.SANDBOX)
+            if self._args.enable_test:
+                environments_to_activate.append(RdrEnvironment.TEST)
+            if self._args.enable_care_evo:
+                environments_to_activate.append(RdrEnvironment.CAREEVO_TEST)
+            if self._args.enable_ptsc_1_test:
+                environments_to_activate.append(RdrEnvironment.PTSC_1_TEST)
+            if self._args.enable_ptsc_2_test:
+                environments_to_activate.append(RdrEnvironment.PTSC_2_TEST)
+            if self._args.enable_ptsc_3_test:
+                environments_to_activate.append(RdrEnvironment.PTSC_3_TEST)
 
-            instances += gcp_format_sql_instance("all-of-us-rdr-stable", 9910) + ","
-            if self._args.enable_replica:
-                instances += gcp_format_sql_instance("all-of-us-rdr-stable", 9915, True) + ","
+            instance_string_list = []
+            for environment in environments_to_activate:
+                instance_string_list.extend(self._get_instance_arg_list_for_environment(environment))
 
-            instances += gcp_format_sql_instance("all-of-us-rdr-staging", 9920) + ","
-            if self._args.enable_replica:
-                instances += gcp_format_sql_instance("all-of-us-rdr-staging", 9925, True) + ","
-
-            if self._args.enable_sandbox is True:
-                instances += gcp_format_sql_instance("all-of-us-rdr-sandbox", 9930) + ","
-                # Sandbox does not currently have a replica enabled
-                # if self._args.enable_replica:
-                #   instances += gcp_format_sql_instance('all-of-us-rdr-sandbox', 9935, True) + ','
-
-            if self._args.enable_test is True:
-                instances += gcp_format_sql_instance("pmi-drc-api-test", 9940) + ","
-                if self._args.enable_replica:
-                    instances += gcp_format_sql_instance("pmi-drc-api-test", 9945, True) + ","
-
-            if self._args.enable_care_evo is True:
-                instances += gcp_format_sql_instance('all-of-us-rdr-careevo-test', 9950) + ','
-                if self._args.enable_replica:
-                    instances += gcp_format_sql_instance('all-of-us-rdr-careevo-test', 9955, True) + ','
-
-            if self._args.enable_ptsc_1_test is True:
-                instances += gcp_format_sql_instance('all-of-us-rdr-ptsc-1-test', 9960) + ','
-                if self._args.enable_replica:
-                    instances += gcp_format_sql_instance('all-of-us-rdr-ptsc-1-test', 9965, True) + ','
-
-            if self._args.enable_ptsc_2_test is True:
-                instances += gcp_format_sql_instance('all-of-us-rdr-ptsc-2-test', 9970) + ','
-                if self._args.enable_replica:
-                    instances += gcp_format_sql_instance('all-of-us-rdr-ptsc-2-test', 9975, True) + ','
-
-            if self._args.enable_ptsc_3_test is True:
-                instances += gcp_format_sql_instance('all-of-us-rdr-ptsc-3-test', 9980) + ','
-                if self._args.enable_replica:
-                    instances += gcp_format_sql_instance('all-of-us-rdr-ptsc-3-test', 9985, True) + ','
-
-            # remove trailing comma
-            instances = instances[:-1]
-
-            return instances
+            return ','.join(instance_string_list)
 
         def run(self):
             """
@@ -149,7 +108,7 @@ def run():
                 _logger.error("failed to set authentication account, aborting.")
                 return 1
 
-            po_proxy = gcp_activate_sql_proxy(self.get_instances())
+            po_proxy = gcp_activate_sql_proxy(self.get_instances_arg_str())
             if not po_proxy:
                 _logger.error("cloud_sql_proxy process failed, aborting.")
                 return 1

--- a/rdr_service/services/gcp_db_daemon.py
+++ b/rdr_service/services/gcp_db_daemon.py
@@ -18,13 +18,13 @@ progname = "gcp-db-daemon"
 
 @dataclass
 class DatabaseProxy:
+    """Class for bundling primary and replica proxy ports for an environment"""
     name: str
     port: int
 
 
 @dataclass
-class ProxyPortData:
-    """Class for bundling primary and replica proxy ports for an environment"""
+class ProxyData:
     primary: DatabaseProxy
     replica: DatabaseProxy = None  # Not every environment has a replica db
 
@@ -40,40 +40,41 @@ def run():
 
             self.host = '127.0.0.1'
             self.environment_proxy_port_map = {
-                RdrEnvironment.PROD:            ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9900),
-                                                    replica=DatabaseProxy(name='rdrbackupdb-a', port=9905)
-                                                ),
-                RdrEnvironment.STABLE:          ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9910),
-                                                    replica=DatabaseProxy(name='rdrbackupdb', port=9915)
-                                                ),
-                RdrEnvironment.STAGING:         ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9920),
-                                                    replica=DatabaseProxy(name='rdrbackupdb', port=9925)
-                                                ),
-                RdrEnvironment.SANDBOX:         ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9930)),
-                RdrEnvironment.TEST:            ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9940),
-                                                    replica=DatabaseProxy(name='rdrbackupdb', port=9945)
-                                                ),
-                RdrEnvironment.CAREEVO_TEST:    ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9950),
-                                                    replica=DatabaseProxy(name='rdrbackupdb', port=9955)
-                                                ),
-                RdrEnvironment.PTSC_1_TEST:     ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9960),
-                                                    replica=DatabaseProxy(name='rdrbackupdb', port=9965)
-                                                ),
-                RdrEnvironment.PTSC_2_TEST:     ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9970),
-                                                    replica=DatabaseProxy(name='rdrbackupdb', port=9975)
-                                                ),
-                RdrEnvironment.PTSC_3_TEST:     ProxyPortData(
-                                                    primary=DatabaseProxy(name='rdrmaindb', port=9980),
-                                                    replica=DatabaseProxy(name='rdrbackupdb', port=9985)
-                                                )
+                RdrEnvironment.PROD:ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9900),
+                    replica=DatabaseProxy(name='rdrbackupdb-a', port=9905)
+                ),
+                RdrEnvironment.STABLE: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9910),
+                    replica=DatabaseProxy(name='rdrbackupdb', port=9915)
+                ),
+                RdrEnvironment.STAGING: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9920),
+                    replica=DatabaseProxy(name='rdrbackupdb', port=9925)
+                ),
+                RdrEnvironment.SANDBOX: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9930)
+                ),
+                RdrEnvironment.TEST: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9940),
+                    replica=DatabaseProxy(name='rdrbackupdb', port=9945)
+                ),
+                RdrEnvironment.CAREEVO_TEST: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9950),
+                    replica=DatabaseProxy(name='rdrbackupdb', port=9955)
+                ),
+                RdrEnvironment.PTSC_1_TEST: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9960),
+                    replica=DatabaseProxy(name='rdrbackupdb', port=9965)
+                ),
+                RdrEnvironment.PTSC_2_TEST: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9970),
+                    replica=DatabaseProxy(name='rdrbackupdb', port=9975)
+                ),
+                RdrEnvironment.PTSC_3_TEST: ProxyData(
+                    primary=DatabaseProxy(name='rdrmaindb', port=9980),
+                    replica=DatabaseProxy(name='rdrbackupdb', port=9985)
+                )
             }
 
             self.environments_to_activate = [RdrEnvironment.PROD, RdrEnvironment.STABLE, RdrEnvironment.STAGING]
@@ -115,7 +116,8 @@ def run():
                     build_gcp_instance_connection_name(
                         project_name=environment.value,
                         port=proxy_data.replica.port,
-                        database_name=proxy_data.replica.name)
+                        database_name=proxy_data.replica.name
+                    )
                 )
 
             return instance_arg_list

--- a/rdr_service/services/gcp_utils.py
+++ b/rdr_service/services/gcp_utils.py
@@ -588,6 +588,10 @@ def gcp_format_sql_instance(project, port=3320, replica=False):
     return instance
 
 
+def build_gcp_instance_connection_name(project_name, port, database_name, location='us-central1'):
+    return f'{project_name}:{location}:{database_name}=tcp:{port}'
+
+
 def gcp_activate_sql_proxy(instances):
     """
   Call cloud_sql_proxy to make a connection to the given instance.


### PR DESCRIPTION
## Resolves *no ticket*
In order to make connections to new databases for testing out Mysql 8 and Postgres we'll want to add new ports for them in the proxy connection setup. To make that easier I refactored the gcp_db_daemon code so that it will be simpler to set up new ports.

## Description of changes/additions
The methods `print_instances` and `get_instances` (renamed to `get_instances_arg_str`) both had information about the port numbers being used for each environment (for the primary and replica databases). This moves the port number information into a mapping dictionary (`environment_proxy_port_map`). The SQL database instance name is also set up in the dictionary. `build_gcp_instance_connection_name` is also added to help with different database names.

The `print_instances` method previously printed out all the connection information, even if those environments were activated. This updates it to only print out the ports that were activated.

## Tests
- [ ] unit tests

No unit tests were created and there don't seem to be any. But I've tested locally by comparing instance connection name lists sent to cloud_sql_proxy, making sure they're identical before and after these changes.
