### PR TITLE
[DA-1970] AW2 Ingestion Reports on Slack

### DIFF
--- a/rdr_service/genomic/genomic_data_quality_components.py
+++ b/rdr_service/genomic/genomic_data_quality_components.py
@@ -151,7 +151,7 @@ class ReportingComponent(GenomicDataQualityComponentBase):
         :return: string
         """
         # Report title
-        report_string = display_name + '\n'
+        report_string = "```" + display_name + '\n'
 
         # Header row
         report_string += "    ".join(data.keys())
@@ -160,5 +160,7 @@ class ReportingComponent(GenomicDataQualityComponentBase):
         for row in data.fetchall():
             report_string += "    ".join(tuple(map(str, row)))
             report_string += "\n"
+
+        report_string += "```"
 
         return report_string

--- a/rdr_service/genomic/genomic_data_quality_components.py
+++ b/rdr_service/genomic/genomic_data_quality_components.py
@@ -146,6 +146,7 @@ class ReportingComponent(GenomicDataQualityComponentBase):
     def format_report(self, display_name, data):
         """
         Converts the report query ResultProxy object to tab-delimited string
+        :param display_name: string
         :param data: ResultProxy
         :return: string
         """

--- a/rdr_service/genomic/genomic_data_quality_components.py
+++ b/rdr_service/genomic/genomic_data_quality_components.py
@@ -69,6 +69,9 @@ class ReportingComponent(GenomicDataQualityComponentBase):
         return self.get_report_data(report_def)
 
     def set_report_parameters(self, **kwargs):
+        # Default Report Name
+        display_name = self.get_report_display_name()
+
         # Set report level (SUMMARY, DETAIL, etc)
         try:
             report_level = kwargs['report_level']
@@ -90,7 +93,17 @@ class ReportingComponent(GenomicDataQualityComponentBase):
         except KeyError:
             time_frame = self.controller.job.name[0]
 
-        return report_level, report_target, time_frame
+        return report_level, report_target, time_frame, display_name
+
+    def get_report_display_name(self):
+
+        job_name_list = self.controller.job.name.split('_')
+
+        display_name = job_name_list[0].capitalize() + " "
+        display_name += job_name_list[-1].capitalize() + " "
+        display_name += job_name_list[1].capitalize()
+
+        return display_name
 
     def get_report_def(self, level, target, time_frame):
         """
@@ -130,16 +143,17 @@ class ReportingComponent(GenomicDataQualityComponentBase):
 
         return result
 
-    @staticmethod
-    def format_report(data):
+    def format_report(self, display_name, data):
         """
         Converts the report query ResultProxy object to tab-delimited string
         :param data: ResultProxy
         :return: string
         """
+        # Report title
+        report_string = display_name + '\n'
 
         # Header row
-        report_string = "    ".join(data.keys())
+        report_string += "    ".join(data.keys())
         report_string += "\n"
 
         for row in data.fetchall():

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1092,13 +1092,13 @@ class DataQualityJobController:
 
         rc = ReportingComponent(self)
 
-        report_level, report_target, time_frame = rc.set_report_parameters(**kwargs)
+        report_level, report_target, time_frame, display_name = rc.set_report_parameters(**kwargs)
 
         report_data = rc.generate_report_data(level=report_level,
                                               target=report_target,
                                               time_frame=time_frame)
 
-        report_string = rc.format_report(report_data)
+        report_string = rc.format_report(display_name, report_data)
 
         # Send report to slack #rdr-genomics channel
         if kwargs.get('slack') is True:

--- a/tests/cron_job_tests/test_genomic_data_quality_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_data_quality_pipeline.py
@@ -184,7 +184,8 @@ class GenomicDataQualityReportTest(BaseTestCase):
         with DataQualityJobController(GenomicJob.DAILY_SUMMARY_REPORT_INGESTIONS) as controller:
             report_output = controller.execute_workflow()
 
-        expected_report = "record_count    ingested_count    incident_count    "
+        expected_report = "Daily Ingestions Summary\n"
+        expected_report += "record_count    ingested_count    incident_count    "
         expected_report += "file_type    gc_site_id    genome_type    file_path\n"
         expected_report += "1    0    0    aw1    rdr    aou_wgs    "
         expected_report += "test-bucket/AW1_wgs_sample_manifests/RDR_AoU_SEQ_PKG-2104-026571.csv"

--- a/tests/cron_job_tests/test_genomic_data_quality_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_data_quality_pipeline.py
@@ -224,14 +224,14 @@ class GenomicDataQualityReportTest(BaseTestCase):
         with DataQualityJobController(GenomicJob.DAILY_SUMMARY_REPORT_INGESTIONS) as controller:
             report_output = controller.execute_workflow()
 
-        expected_report = "Daily Ingestions Summary\n"
+        expected_report = "```Daily Ingestions Summary\n"
         expected_report += "record_count    ingested_count    incident_count    "
         expected_report += "file_type    gc_site_id    genome_type    file_path\n"
         expected_report += "1    0    0    aw1    rdr    aou_wgs    "
         expected_report += f"{aw1_manifest_path}\n"
         expected_report += "1    0    0    aw2    rdr    aou_wgs    "
         expected_report += f"{aw2_manifest_path}"
-        expected_report += "\n"
+        expected_report += "\n```"
 
         self.assertEqual(expected_report, report_output)
 


### PR DESCRIPTION
## Resolves *[DA-1970](https://precisionmedicineinitiative.atlassian.net/browse/DA-1970)*


## Description of changes/additions
This PR extends the daily ingestion report workflow to include the AW2 ingestion workflow. The following changes were made:
- The report query was expanded since the AW2 data is ingested into `genomic_gc_validation_metrics`. 
- The report string was also modified to include a display name. 
- The reporting unit test was expanded to also include AW2 ingestion.

## Tests
- [x] test_daily_ingestion_summary


