### PR TITLE
Fix RDR test_bigquery_sync_dao.py unittest

### DIFF
--- a/tests/dao_tests/test_bigquery_sync_dao.py
+++ b/tests/dao_tests/test_bigquery_sync_dao.py
@@ -378,7 +378,8 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
 
         # This verifies the module submitted status from the participant generator data for each of the GROR modules
         # Also checks that an external id key/value pair exists (but value likely None for test data modules)
-        gror_modules = self.get_generated_items(ps_json['modules'], item_key='mod_module', item_value='GROR')
+        gror_modules = self.get_generated_items(ps_json['modules'], item_key='mod_module', item_value='GROR',
+                                                sort_key='mod_authored')
         self.assertIn('mod_external_id', gror_modules[0])
         self.assertEqual('SUBMITTED', gror_modules[0]['mod_status'])
         self.assertEqual('SUBMITTED_NO_CONSENT', gror_modules[1]['mod_status'])


### PR DESCRIPTION
## Resolves *(no ticket)*


## Description of changes/additions
[PR #2372](https://github.com/all-of-us/raw-data-repository/pull/2372) refactored a helper method (renamed `get_generated_items()` ) in `dao_tests.test_bigquery_sync_dao.py`.  It used to sort results based on a hardcoded sort key, but now the caller must now pass in the key name to use for the sort.  Was causing random/intermittent failures in a test case that was not updated to specify a sort key, because the data returned was no longer predictably sorted.

## Tests
- [x] unit tests - Ran locally to confirm `test_participant_stays_core` case is passing with the updated `get_generated_items()` method call


