### PR TITLE
Setting up cron job on test

### DIFF
--- a/rdr_service/cron_test.yaml
+++ b/rdr_service/cron_test.yaml
@@ -1,0 +1,9 @@
+- description: Migrate RequestsLog to MySQL 8
+  url: /offline/MigrateRequestsLog/rdrmysql8
+  timezone: America/New_York
+  schedule: every tuesday 22:00
+  target: offline
+- description: Migrate RequestsLog to PostgreSQL
+  url: /offline/MigrateRequestsLog/rdrpostgresql
+  timezone: America/New_York
+  schedule: every wednesday 22:00

--- a/rdr_service/cron_test.yaml
+++ b/rdr_service/cron_test.yaml
@@ -1,9 +1,9 @@
 - description: Migrate RequestsLog to MySQL 8
   url: /offline/MigrateRequestsLog/rdrmysql8
   timezone: America/New_York
-  schedule: every tuesday 22:00
+  schedule: every day 22:00
   target: offline
 - description: Migrate RequestsLog to PostgreSQL
   url: /offline/MigrateRequestsLog/rdrpostgresql
   timezone: America/New_York
-  schedule: every wednesday 22:00
+  schedule: every day 1:00

--- a/rdr_service/offline/requests_log_migrator.py
+++ b/rdr_service/offline/requests_log_migrator.py
@@ -1,0 +1,5 @@
+
+class RequestsLogMigrator:
+    @classmethod
+    def migrate_latest_requests_logs(cls, _):
+        ...

--- a/rdr_service/services/gcp_config.py
+++ b/rdr_service/services/gcp_config.py
@@ -146,6 +146,10 @@ GCP_SERVICE_CONFIG_MAP = OrderedDict({
             'sandbox': [
                 'rdr_service/cron_default.yaml',
                 'rdr_service/cron_sandbox.yaml'
+            ],
+            'test': [
+                'rdr_service/cron_default.yaml',
+                'rdr_service/cron_test.yml'
             ]
         },
         'queue': {

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -64,7 +64,7 @@ class DeployAppClass(ToolBase):
         self.jira_board = 'PD'
         self.docs_version = 'stable'  # Use as default version slug for readthedocs
 
-        self.environment = None
+        self.environment = RdrEnvironment(self.args.project)
 
     def write_config_file(self, key: str, config: list, filename: str = None):
         """
@@ -127,7 +127,7 @@ class DeployAppClass(ToolBase):
                 config = service['default']
 
             # check to see if we are deploying this service.
-            if service['type'] == 'service'and key not in self.services:
+            if service['type'] == 'service' and key not in self.services:
                 continue
 
             config_file = self.write_config_file(key, config, service.get('config_file', None))
@@ -165,6 +165,8 @@ class DeployAppClass(ToolBase):
                 self.deploy_sub_type = 'sandbox'
             elif 'stable' in self.gcp_env.project:
                 self.deploy_sub_type = 'stable'
+            elif 'drc-api-test' in self.gcp_env.project:  # TODO: replace subtype references with environment
+                self.deploy_sub_type = 'test'
         else:
             self.docs_version = 'latest'  # readthedocs version slug for production releases
 
@@ -480,7 +482,6 @@ class DeployAppClass(ToolBase):
         """
         with self.initialize_process_context() as gcp_env:
             self.gcp_env = gcp_env
-            self.environment = RdrEnvironment(self.gcp_env.project)
 
             _check_for_git_project(self.args, self.gcp_env)
 

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -11,6 +11,14 @@ class OfflineAppTest(BaseTestCase):
         self.offline_test_client = app.test_client()
         self.url_prefix = OFFLINE_PREFIX
 
+    def send_cron_request(self, path):
+        self.send_get(
+            path,
+            test_client=self.offline_test_client,
+            prefix=self.url_prefix,
+            headers={'X-Appengine-Cron': True}
+        )
+
     def test_offline_http_exceptions_get_logged(self):
         """Make sure HTTPException are logged when thrown"""
 
@@ -35,3 +43,9 @@ class OfflineAppTest(BaseTestCase):
 
             traceback = error_log_call.args[0]
             self.assertIn('throw_exception', traceback, "Traceback should show where the error was raised")
+
+    @mock.patch('rdr_service.offline.requests_log_migrator.RequestsLogMigrator.migrate_latest_requests_logs')
+    def test_request_log_migrator_route(self, mock_migrate_call):
+        test_db_name = 'test_db_name'
+        self.send_cron_request(f'MigrateRequestsLog/{test_db_name}')
+        mock_migrate_call.assert_called_with(test_db_name)


### PR DESCRIPTION
## Work for *[DA-1966](https://precisionmedicineinitiative.atlassian.net/browse/DA-1966)*
Listed in the ticket are some different ways of migrating the RequestsLogs. One of them we try should probably be with a nightly or weekly cron job. This PR sets one up for nightly so that we have several data points to use when analyzing performance. To keep the PR small (and because I'm not done with it yet) the guts of the class that does the migrator will be in a later PR.

## Description of changes/additions
This sets up the ability to deploy cron jobs to just Test and also schedules a run of a place holder class that will migrate RequestsLogs as a cron job.

## Tests
- [x] unit tests

Unit test added to check the setup for the new cron job route (and I did end up needing it, because I wasn't reading the request argument correctly the first time).

Pseudo-tested the deploy changes by walking through it in a debugger (stopping before it would actually deploy).


