### PR TITLE
[DA-1969] Proof of concept for Pub Sub notifications on multiple buckets

### DIFF
--- a/rdr_service/gcloud_functions/genomic_manifest_generic_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_manifest_generic_function/main.py
@@ -2,7 +2,6 @@
 # This file is subject to the terms and conditions defined in the
 # file 'LICENSE', which is part of this source code package.
 #
-import base64
 import logging
 import sys
 
@@ -67,6 +66,8 @@ def get_deploy_args(gcp_env):
     _project_suffix = gcp_env.project.split('-')[-1]
 
     # Customize args here
+    if _project_suffix == "sandbox":
+        pass
 
     args = [function_name]
     for arg in deploy_args:

--- a/rdr_service/tools/tool_libs/deploy_func.py
+++ b/rdr_service/tools/tool_libs/deploy_func.py
@@ -28,6 +28,7 @@ tool_cmd = "deploy-func"
 tool_desc = "Deploy gcloud function"
 cloud_functions_dir = "gcloud_functions"
 
+
 class DeployFunctionClass(object):
     def __init__(self, args, gcp_env: GCPEnvConfigObject, project_path, func_path):
         """


### PR DESCRIPTION
## Resolves *[DA-1969](https://precisionmedicineinitiative.atlassian.net/browse/DA-1969)*


## Description of changes/additions
This PR modifies the generic ingestion cloud function as a proof of concept that a Pub/Sub event can trigger a single cloud function from multiple buckets.

## Tests
- [] unit tests
No unit tests. Testing was completed on Sandbox.

