### PR TITLE
[PDR QC] Ignore duplicate answers in same questionnaire response (PDR generators)

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -1358,7 +1358,7 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
                                 ON qq.questionnaire_id = q.questionnaire_id
             WHERE qr.questionnaire_response_id = :qr_id
             -- Order by question and calculated answer so any duplicates from the same response are adjacant
-            ORDER BY qra.question_id, 4
+            ORDER BY qra.question_id, answer
         """
 
         answers = OrderedDict()

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1360,7 +1360,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                                 ON qq.questionnaire_id = q.questionnaire_id
             WHERE qr.questionnaire_response_id = :qr_id
             -- Order by question and the calculated answer so duplicates can be caught when results are processed
-            ORDER BY qra.question_id, 4
+            ORDER BY qra.question_id, answer
         """
 
         answers = OrderedDict()

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1344,6 +1344,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         _answers_sql = """
             SELECT qr.questionnaire_id,
+                   qra.question_id,
                    qq.code_id,
                    (select c.value from code c where c.code_id = qq.code_id) as code_name,
                    COALESCE((SELECT c.value from code c where c.code_id = qra.value_code_id),
@@ -1357,7 +1358,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                                 ON qra.question_id = qq.questionnaire_question_id
                      INNER JOIN questionnaire q
                                 ON qq.questionnaire_id = q.questionnaire_id
-            WHERE qr.questionnaire_response_id = :qr_id;
+            WHERE qr.questionnaire_response_id = :qr_id
+            -- Order by question and the calculated answer so duplicates can be caught when results are processed
+            ORDER BY qra.question_id, 4
         """
 
         answers = OrderedDict()
@@ -1391,8 +1394,15 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 # Save parent record field values into data dict.
                 data = ro_dao.to_dict(row, result_proxy=results)
                 qnans = session.execute(_answers_sql, {'qr_id': row.questionnaire_response_id})
-                # Save answers into data dict.
+                # Save answers into data dict. Ignore duplicate answers to the same question from the same response
+                # (See: questionnaire_response_id 680418686 as an example)
+                last_question_id = None
+                last_answer = None
+                skipped_duplicates = 0
                 for qnan in qnans:
+                    if last_question_id == qnan.question_id and last_answer == qnan.answer:
+                        skipped_duplicates += 1
+                        continue
                     # For question codes with multiple responses, created comma-separated list of answers
                     if qnan.code_name in data:
                         data[qnan.code_name] += f',{qnan.answer}'
@@ -1410,6 +1420,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
                 # Insert data dict into answers list.
                 answers[row.questionnaire_response_id] = data
+                if skipped_duplicates:
+                    logging.warning('Questionnaire response {0} contained {1} duplicate answers. Please investigate' \
+                                    .format(row.questionnaire_response_id, skipped_duplicates))
 
         # Apply answers to data dict, response by response, until we reach the end or the specific response id.
         data = dict()

--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -16,8 +16,7 @@ from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
 from rdr_service.offline import update_ehr_status
 from rdr_service.participant_enums import EhrStatus
-from rdr_service.resource.generators.participant import ParticipantSummaryGenerator
-from tests.helpers.unittest_base import BaseTestCase
+from tests.helpers.unittest_base import BaseTestCase, PDRGeneratorTestMixin
 
 
 class UpdateEhrStatusMakeJobsTestCase(BaseTestCase):
@@ -86,7 +85,7 @@ class UpdateEhrStatusMakeJobsTestCase(BaseTestCase):
         self.assertEqual(job, None)
 
 
-class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
+class UpdateEhrStatusUpdatesTestCase(BaseTestCase, PDRGeneratorTestMixin):
     def setUp(self, **kwargs):
         # pylint: disable=unused-argument
         super(UpdateEhrStatusUpdatesTestCase, self).setUp()
@@ -160,8 +159,7 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
         self.assertEqual(latest_ehr_time, participant_summary.ehrUpdateTime)
 
         # Check generated data
-        gen = ParticipantSummaryGenerator()
-        ps_data = gen.make_resource(participant_id).get_data()
+        ps_data = self.make_participant_resource(participant_id)
         self.assertEqual(str(participant_summary.ehrStatus), ps_data['ehr_status'])
         self.assertEqual(participant_summary.ehrReceiptTime, ps_data['ehr_receipt'])
         self.assertEqual(participant_summary.ehrUpdateTime, ps_data['ehr_update'])
@@ -182,8 +180,7 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase):
         self.assertAlmostEquals(last_seen, record.lastSeen, delta=datetime.timedelta(seconds=1))
 
         # Check generated data.
-        gen = ParticipantSummaryGenerator()
-        ps_data = gen.make_resource(participant_id).get_data()
+        ps_data = self.make_participant_resource(participant_id)
         self.assertIsNotNone(ps_data['ehr_receipts'], f'PDR EHR receipt data not generated for pid {participant_id}')
 
         # Look for a matching dict entry in the ps_data['ehr_receipts'] list, since it may also contain other entries

--- a/tests/dao_tests/test_bigquery_sync_dao.py
+++ b/tests/dao_tests/test_bigquery_sync_dao.py
@@ -5,7 +5,6 @@ from rdr_service.clock import FakeClock
 from rdr_service import clock
 from rdr_service.code_constants import *
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
-from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGenerator
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderIdentifier, BiobankOrderedSample
@@ -14,10 +13,10 @@ from rdr_service.model.hpo import HPO
 from rdr_service.model.measurements import PhysicalMeasurements
 from rdr_service.model.site import Site
 from tests.test_data import load_measurement_json
-from tests.helpers.unittest_base import BaseTestCase, QuestionnaireTestMixin
+from tests.helpers.unittest_base import BaseTestCase, PDRGeneratorTestMixin
 
 
-class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
+class BigQuerySyncDaoTest(BaseTestCase, PDRGeneratorTestMixin):
     TIME_1 = datetime(2018, 9, 20, 5, 49, 11)
     TIME_2 = datetime(2018, 9, 24, 14, 21, 1)
     TIME_3 = datetime(2018, 9, 25, 12, 25, 30)
@@ -53,6 +52,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
             self.participant = self.create_participant(self.provider_link)
             self.participant_id = int(self.participant['participantId'].replace('P', ''))
             self.biobank_id = int(self.participant['biobankId'].replace('Z', ''))
+
 
     def create_participant(self, provider_link=None):
         if provider_link:
@@ -217,28 +217,11 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
 
         return biobank_order
 
-    @staticmethod
-    def get_generated_items(item_list, item_key=None, item_value=None, sort_key=None):
-        """
-            Extracts requested items from a provided list of dicts (e.g., ps_json['consents'])
-            Returns a filtered list of dict entries that match the item key/value, sorted if requested
-            Example:
-                get_generated_items(ps_json['modules'], item_key='mod_module', item_value='OverallHealth',
-                                  sort_key='mod_authored')
-        """
-        if not (item_key and item_value and isinstance(item_list, list)):
-            return item_list
-
-        items = list(filter(lambda x: x[item_key] == item_value, item_list))
-        if sort_key:
-            items = sorted(items, key=(lambda s: s[sort_key]))
-        return items
 
 
     def test_registered_participant_gen(self):
         """ Test a BigQuery after initial participant creation """
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
 
         self.assertIsNotNone(ps_json)
         self.assertEqual(ps_json['enrollment_status'], 'REGISTERED')
@@ -246,15 +229,14 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
     def test_interested_participant_gen(self):
         """ Basic Participant Creation Test"""
         self.send_consent(self.participant_id)
-
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
 
         self.assertIsNotNone(ps_json)
-        self.assertEqual(ps_json.sign_up_time, self.TIME_1)
-        self.assertEqual(ps_json.suspension_status, 'NOT_SUSPENDED')
-        self.assertEqual(ps_json.withdrawal_status, 'NOT_WITHDRAWN')
-        self.assertEqual(ps_json['enrollment_status'], 'PARTICIPANT')
+        self.assertEqual(ps_json.get('sign_up_time', None),
+                         self.TIME_1.strftime("%Y-%m-%dT%H:%M:%S"))
+        self.assertEqual(ps_json.get('suspension_status', None), 'NOT_SUSPENDED')
+        self.assertEqual(ps_json.get('withdrawn_status'), None, 'NOT_WITHDRAWN')
+        self.assertEqual(ps_json.get('enrollment_status', None), 'PARTICIPANT')
 
 
     def test_member_participant_status(self):
@@ -262,9 +244,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         # set up questionnaires to hit the calculate_max_core_sample_time in participant summary
         self.send_consent(self.participant_id)
         self._submit_ehrconsent(self.participant_id)
-
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
 
         self.assertIsNotNone(ps_json)
         self.assertEqual(ps_json['enrollment_status'], 'FULLY_CONSENTED')
@@ -286,11 +266,11 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
             self.bio_order = BiobankOrderDao().insert(
                 self._make_biobank_order(participantId=self.participant_id))
 
+
     def test_full_participant_status(self):
         """ Full Participant Test"""
         self._set_up_participant_data()
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
 
         self.assertIsNotNone(ps_json)
         self.assertEqual('COHORT_2', ps_json['consent_cohort'], 'Test is built assuming cohort 2')
@@ -304,25 +284,20 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         self.send_consent(p_id, authored=self.TIME_1)
         self._submit_ehrconsent(p_id, response_time=self.TIME_1)
 
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(p_id)
-
+        ps_json = self.make_bq_participant_summary(p_id)
         self.assertIsNotNone(ps_json)
         self.assertEqual(ps_json['enrollment_status'], 'FULLY_CONSENTED')
 
         # send ehr consent expired response
         self._submit_ehrconsent_expired(p_id, response_time=self.TIME_2)
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(p_id)
+        ps_json = self.make_bq_participant_summary(p_id)
         self.assertIsNotNone(ps_json)
         # downgrade FULLY_CONSENTED to PARTICIPANT
         self.assertEqual(ps_json['enrollment_status'], 'PARTICIPANT')
 
     def test_ehr_consent_expired_for_core_participant(self):
         self._set_up_participant_data(fake_time=self.TIME_1)
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
-
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertIsNotNone(ps_json)
         self.assertEqual('COHORT_2', ps_json['consent_cohort'], 'Test is built assuming cohort 2')
         self.assertEqual(ps_json['pm'][0]['pm_finalized_site'], 'hpo-site-monroeville')
@@ -331,16 +306,14 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
 
         # send ehr consent expired response
         self._submit_ehrconsent_expired(self.participant_id, response_time=self.TIME_3)
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertIsNotNone(ps_json)
         # once CORE, always CORE
         self.assertEqual(ps_json['enrollment_status'], 'CORE_PARTICIPANT')
 
     def test_cohort_3_without_gror(self):
         self._set_up_participant_data(fake_time=datetime(2020, 6, 1))
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
 
         self.assertIsNotNone(ps_json)
         self.assertEqual('COHORT_3', ps_json['consent_cohort'], 'Test is built assuming cohort 3')
@@ -349,9 +322,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
     def test_cohort_3_with_gror(self):
         self._set_up_participant_data(fake_time=datetime(2020, 6, 1))
         self._submit_genomics_ror(self.participant_id)
-
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
 
         self.assertIsNotNone(ps_json)
         self.assertEqual('COHORT_3', ps_json['consent_cohort'], 'Test is built assuming cohort 3')
@@ -363,8 +334,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
                                   consent_response=CONSENT_GROR_YES_CODE,
                                   response_time=datetime(2020, 7, 1))
 
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertEqual('COHORT_3', ps_json['consent_cohort'], 'Test is built assuming cohort 3')
         self.assertEqual('CORE_PARTICIPANT', ps_json['enrollment_status'],
                          'Test is built assuming participant starts as core')
@@ -373,7 +343,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         self._submit_genomics_ror(self.participant_id,
                                   consent_response=CONSENT_GROR_NO_CODE,
                                   response_time=datetime(2020, 9, 1))
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertEqual('CORE_PARTICIPANT', ps_json['enrollment_status'])
 
         # This verifies the module submitted status from the participant generator data for each of the GROR modules
@@ -390,8 +360,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         # If EHR consent is changed to No, they should remain Core
         self._set_up_participant_data(skip_ehr=True)
 
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertEqual('COHORT_2', ps_json['consent_cohort'],
                          'Test is built assuming cohort 2 (and that GROR consent is not required for Core status')
         self.assertNotEqual('CORE_PARTICIPANT', ps_json['enrollment_status'],
@@ -402,7 +371,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
                                 response_code=CONSENT_PERMISSION_YES_CODE,
                                 response_time=datetime(2019, 2, 14))
         self._submit_dvehrconsent(self.participant_id, response_time=datetime(2019, 4, 1))
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertEqual('CORE_PARTICIPANT', ps_json['enrollment_status'],
                          'Test is built assuming participant achieves Core status')
 
@@ -410,7 +379,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         self._submit_ehrconsent(self.participant_id,
                                 response_code=CONSENT_PERMISSION_NO_CODE,
                                 response_time=datetime(2019, 7, 1))
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertEqual('CORE_PARTICIPANT', ps_json['enrollment_status'])
 
         # This verifies the module submitted status from the participant generator data for ehr modules
@@ -426,8 +395,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         # No on EHR should supersede a yes on DV_EHR.
         self._set_up_participant_data(skip_ehr=True)
 
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertEqual('COHORT_2', ps_json['consent_cohort'],
                          'Test is built assuming cohort 2 (and that GROR consent is not required for Core status')
 
@@ -435,7 +403,7 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
                                 response_code=CONSENT_PERMISSION_NO_CODE,
                                 response_time=datetime(2019, 2, 14))
         self._submit_dvehrconsent(self.participant_id, response_time=datetime(2019, 4, 1))
-        ps_json = gen.make_bqrecord(self.participant_id)
+        ps_json = self.make_bq_participant_summary(self.participant_id)
         self.assertEqual('PARTICIPANT', ps_json['enrollment_status'])
 
     def test_ehr_consent_expired_and_renewed(self):
@@ -446,8 +414,8 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         self._submit_ehrconsent(self.participant_id,
                                 response_code=CONSENT_PERMISSION_YES_CODE,
                                 response_time=self.TIME_3)
-        gen = BQParticipantSummaryGenerator()
-        ps_json = gen.make_bqrecord(self.participant_id)
+
+        ps_json = self.make_bq_participant_summary(self.participant_id)
 
         self.assertIsNotNone(ps_json)
         ehr_consents = self.get_generated_items(ps_json['consents'], item_key='consent_module',
@@ -456,18 +424,21 @@ class BigQuerySyncDaoTest(BaseTestCase, QuestionnaireTestMixin):
         # Confirm a total of three EHR Consent responses
         self.assertEqual(len(ehr_consents), 3)
         # Verify the initial EHR consent details (sent by _set_up_participant_data)
-        self.assertEqual(ehr_consents[0].get('consent_module_authored', None), self.TIME_1)
+        self.assertEqual(ehr_consents[0].get('consent_module_authored', None),
+                         self.TIME_1.strftime("%Y-%m-%dT%H:%M:%S"))
         self.assertEqual(ehr_consents[0].get('consent_value', None), CONSENT_PERMISSION_YES_CODE)
         # This field should be None for consent payloads that don't contain the expiration hidden question code
         self.assertIsNone(ehr_consents[0].get('consent_expired', ''))
 
         # Verify the expired consent response details (contains the hidden expiration question code / answer value)
-        self.assertEqual(ehr_consents[1].get('consent_module_authored', None), self.TIME_2)
+        self.assertEqual(ehr_consents[1].get('consent_module_authored', None),
+                         self.TIME_2.strftime("%Y-%m-%dT%H:%M:%S"))
         self.assertEqual(ehr_consents[1].get('consent_value', None), CONSENT_PERMISSION_NO_CODE)
         self.assertEqual(ehr_consents[1].get('consent_expired', None), EHR_CONSENT_EXPIRED_YES)
 
         # Verify the last EHR consent renewal;  'consent_expired' value should not be carried forward from last consent
-        self.assertEqual(ehr_consents[2].get('consent_module_authored', None), self.TIME_3)
+        self.assertEqual(ehr_consents[2].get('consent_module_authored', None),
+                         self.TIME_3.strftime("%Y-%m-%dT%H:%M:%S"))
         self.assertEqual(ehr_consents[2].get('consent_value', None), CONSENT_PERMISSION_YES_CODE)
         # This field should be None for consent payloads that don't contain the expiration hidden question code
         self.assertIsNone(ehr_consents[2].get('consent_expired', ''))

--- a/tests/resource_tests/generator_tests/test_participant_enrollment.py
+++ b/tests/resource_tests/generator_tests/test_participant_enrollment.py
@@ -12,7 +12,6 @@ from rdr_service.model.site import Site
 from tests.helpers.unittest_base import BaseTestCase, BiobankTestMixin, PDRGeneratorTestMixin
 from tests.test_data import load_measurement_json
 
-# The BaseTestCase includes the QuestionnaireTestMixin, CodebookTestMixin, and PDRGeneratorTestMixin by default
 class ParticipantEnrollmentTest(BaseTestCase, BiobankTestMixin, PDRGeneratorTestMixin):
     TIME_1 = datetime(2018, 9, 20, 5, 49, 11)
     TIME_2 = datetime(2018, 9, 24, 14, 21, 1)


### PR DESCRIPTION
## Related to *[PDR-248](https://precisionmedicineinitiative.atlassian.net/browse/PDR-248) (partial fix)*

## Description of changes/additions
While investigating deltas between PDR and RDR consent counts: found several GROR `questionnaire_response` payloads in RDR that had duplication of question and answer codes in the JSON data (See: `questionnaire_response_id` 680418686).  

In the PDR generators the duplicate answers became a comma-separated list (e.g., 'CheckDNA_Yes,CheckDNA_Yes') which no longer matched any recognized consent answer codes used to determine consent status, so status ended up SUBMITTED_INVALID.

Added logic to ignore duplicate question/answer values from the same response in the generators, in case there are any additional payloads with the same issue.


## Tests
- [x] unit tests - Added `test_gror_consent_with_duplicate_answers`

Added `PDRGeneratorTestMixin` to integrate the BigQuery and resource generators into the test class and simplify verifying generator data during unit tests.   Refactored existing tests that were already doing some PDR generator output validation and moved other helper methods into the Mixin class.


