### PR TITLE
[DA-1966] Fixing file name for cron_test.yaml

### DIFF
--- a/rdr_service/services/gcp_config.py
+++ b/rdr_service/services/gcp_config.py
@@ -149,7 +149,7 @@ GCP_SERVICE_CONFIG_MAP = OrderedDict({
             ],
             'test': [
                 'rdr_service/cron_default.yaml',
-                'rdr_service/cron_test.yml'
+                'rdr_service/cron_test.yaml'
             ]
         },
         'queue': {


### PR DESCRIPTION
## Resolves *[DA-1966](https://precisionmedicineinitiative.atlassian.net/browse/DA-1966)*
Gets the cron job schedule working for the Test environment.

## Description of changes/additions
There was an error in PR #2385, this fixes the typo so the cron job gets scheduled.

## Tests
- [ ] unit tests


