### PR TITLE
Using Backoff to handle 502 errors when updating data-dictionary

### DIFF
--- a/rdr_service/services/google_sheets_client.py
+++ b/rdr_service/services/google_sheets_client.py
@@ -1,4 +1,6 @@
+import backoff
 from googleapiclient import discovery
+from googleapiclient.errors import HttpError
 from oauth2client.service_account import ServiceAccountCredentials
 import socket
 
@@ -85,6 +87,7 @@ class GoogleSheetsClient:
         })
         return tab_offset_data['offset_str']
 
+    @backoff.on_exception(backoff.constant, HttpError, max_tries=4, jitter=None, interval=30)
     def download_values(self):
         """
         Retrieve the values as they currently are in google drive.
@@ -243,6 +246,7 @@ class GoogleSheetsClient:
 
         return list(values_grid[row_index])
 
+    @backoff.on_exception(backoff.constant, HttpError, max_tries=4, jitter=None, interval=30)
     def upload_values(self):
         """
         Upload the local data to the google drive spreadsheet.


### PR DESCRIPTION
## Resolves *no ticket*
The Google Sheets API seems to frequently return a 502 error when trying to download the data-dictionary values. But if retried a few times the request will succeed.

## Description of changes/additions
This uses Backoff to retry the API after 30 seconds. It also adds a retry-loop to the upload, just in case.

## Tests
- [x] unit tests

Unit tests to make sure the backoff is set up correctly.


