### PR TITLE
Returning 404 if parent aliquot not found

### DIFF
--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -388,12 +388,12 @@ class BiobankAliquotDao(BiobankDaoBase):
                 parent_aliquot = session.query(BiobankAliquot).filter(
                     BiobankAliquot.rlimsId == parent_rlims_id
                 ).one_or_none()
+                if parent_aliquot is None:
+                    raise NotFound(f'No parent specimen or aliquot found with ID {parent_rlims_id}')
+
                 parent_specimen = session.query(BiobankSpecimen).filter(
                     BiobankSpecimen.rlimsId == parent_aliquot.specimen_rlims_id
                 ).one_or_none()
-
-            if parent_aliquot is None:
-                raise NotFound(f'Unable to find specimen or aliquot with rlimsId {parent_rlims_id}')
 
             return parent_specimen, parent_aliquot
 

--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -1049,6 +1049,20 @@ class BiobankOrderApiTest(BaseTestCase):
             aliquot = session.query(BiobankAliquot).filter(BiobankAliquot.id == aliquot.id).one()
             self.assertEqual(updated_sample_type, aliquot.sampleType)
 
+    def test_aliquot_nesting_not_found_error(self):
+        """Return 404 if trying to PUT an aliquot as a child of another that doesn't exist"""
+        generic_aliquot_data = {
+            'sampleType': 'first sample',
+            'containerTypeID': 'tube'
+        }
+
+        # Try to upload an aliquot for an ID that doesn't exist, expecting a 404
+        self.send_put(
+            f'Biobank/specimens/does-not-exist/aliquots/new-aliquot',
+            generic_aliquot_data,
+            expected_status=404
+        )
+
     def _create_minimal_specimen_with_aliquot(self, rlims_id='sabrina', aliquot_rlims_id='salem'):
         payload = self.get_minimal_specimen_json(rlims_id)
         payload['aliquots'] = [{


### PR DESCRIPTION
## Resolves *no ticket*
When Biobank was running tests on this, we found that the server gives 500 if the parent can't be found (rather than returning a 404).

## Description of changes/additions
Returning 404 if the parent aliquot isn't found (rather than trying to access an attribute on it).

## Tests
- [x] unit tests


