### PR TITLE
add_bqsync_delay_for_workbench_sync

### DIFF
--- a/rdr_service/api/workbench_api.py
+++ b/rdr_service/api/workbench_api.py
@@ -39,10 +39,10 @@ class WorkbenchWorkspaceApi(BaseApi):
 
             if len(workspaces_payload['ids']) > 0:
                 self._task.execute('rebuild_research_workbench_table_records_task', payload=workspaces_payload,
-                                   in_seconds=5, queue='resource-rebuild')
+                                   in_seconds=15, queue='resource-rebuild')
             if len(workspace_users_payload['ids']) > 0:
                 self._task.execute('rebuild_research_workbench_table_records_task', payload=workspace_users_payload,
-                                   in_seconds=5, queue='resource-rebuild')
+                                   in_seconds=15, queue='resource-rebuild')
         return workspaces
 
 
@@ -70,8 +70,8 @@ class WorkbenchResearcherApi(BaseApi):
 
             if len(researchers_payload['ids']) > 0:
                 self._task.execute('rebuild_research_workbench_table_records_task', payload=researchers_payload,
-                                   in_seconds=5, queue='resource-rebuild')
+                                   in_seconds=15, queue='resource-rebuild')
             if len(affiliations_payload['ids']) > 0:
                 self._task.execute('rebuild_research_workbench_table_records_task', payload=affiliations_payload,
-                                   in_seconds=5, queue='resource-rebuild')
+                                   in_seconds=15, queue='resource-rebuild')
         return researchers


### PR DESCRIPTION
## Resolves *[No ticket]*
For the workbench sync process, we got BQ syncs error due the the duplicate database is not ready. Change the BQ sync delay from 5 secs to 15 secs. 

## Description of changes/additions
Change the BQ sync delay from 5 secs to 15 secs.

## Tests
- no test case


