### PR TITLE
Activating debugger in resource service

### DIFF
--- a/rdr_service/activate_debugger.py
+++ b/rdr_service/activate_debugger.py
@@ -1,0 +1,7 @@
+import os
+if os.getenv('GAE_ENV', '').startswith('standard'):
+    try:
+        import googleclouddebugger
+        googleclouddebugger.enable()
+    except ImportError:
+        pass

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -2,17 +2,11 @@
 
 This defines the APIs and the handlers for the APIs. All responses are JSON.
 """
-import os
-if os.getenv('GAE_ENV', '').startswith('standard'):
-    try:
-        import googleclouddebugger
-        googleclouddebugger.enable()
-    except ImportError:
-        pass
+# pylint: disable=unused-import
+import rdr_service.activate_debugger
 
 import logging
 
-# pylint: disable=unused-import
 from flask import got_request_exception, Response
 from flask_restful import Api
 from sqlalchemy.exc import DBAPIError

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -1,14 +1,7 @@
 """The main API definition file for endpoints that trigger MapReduces and batch tasks."""
-import os
+import rdr_service.activate_debugger  # pylint: disable=unused-import
 
 from rdr_service.genomic_enums import GenomicJob
-
-if os.getenv('GAE_ENV', '').startswith('standard'):
-    try:
-        import googleclouddebugger
-        googleclouddebugger.enable()
-    except ImportError:
-        pass
 
 import json
 import logging

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -1,5 +1,7 @@
 """The main API definition file for endpoints that trigger MapReduces and batch tasks."""
 
+import rdr_service.activate_debugger  # pylint: disable=unused-import
+
 from flask import Flask, got_request_exception
 from flask_restful import Api
 from sqlalchemy.exc import DBAPIError


### PR DESCRIPTION
## Resolves *no ticket*
The Cloud Debugger isn't currently active for the Resource service.

## Description of changes/additions
This adds the activation code for the debugger to the Resource main.py file. This also moves the activation code into a separate module to try to make it a little cleaner.

## Tests
- [ ] unit tests


