### PR TITLE
[DA-1979] Adding check for 7 days in Genomic Incidents

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1544,7 +1544,7 @@ class GenomicFileValidator:
             slack = True
             invalid_message = f"File structure of {filename} is not valid."
             if missing_fields:
-                invalid_message += ' Missing fields: {}'.format(missing_fields)
+                invalid_message += f' Missing fields: {missing_fields}'
                 if len(missing_fields) == len(expected):
                     slack = False
             self.controller.create_incident(
@@ -1566,16 +1566,18 @@ class GenomicFileValidator:
         :param filename: passed to each name rule as 'fn'
         :return: boolean
         """
-        filename_components = [x.lower() for x in filename.split('/')[-1].split("_")]
+        if self.job_id in [GenomicJob.BB_RETURN_MANIFEST]:
+            filename_components = [x.lower() for x in filename.split('/')[-1].split("-")]
+        else:
+            filename_components = [x.lower() for x in filename.split('/')[-1].split("_")]
 
         # Naming Rule Definitions
         def bb_result_name_rule():
             """Biobank to DRC Result name rule"""
-            bb_filename_components = [x.lower() for x in filename.split('/')[-1].split("-")]
             return (
-                bb_filename_components[0] == 'genomic' and
-                bb_filename_components[1] == 'manifest' and
-                bb_filename_components[2] in ('aou_array', 'aou_wgs') and
+                filename_components[0] == 'genomic' and
+                filename_components[1] == 'manifest' and
+                filename_components[2] in ('aou_array', 'aou_wgs') and
                 filename.lower().endswith('csv')
             )
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -870,7 +870,7 @@ class GenomicJobController:
         incident = None
         message = kwargs.get('message', None)
         created_incident = self.incident_dao.get_by_message(message) if message else None
-        today = datetime.utcnow()
+        today = clock.CLOCK.now()
 
         if created_incident and (today.date() - created_incident.created.date()).days <= num_days:
             return

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -899,15 +899,35 @@ class GenomicPipelineTest(BaseTestCase):
 
         self.assertIsNotNone(current_incidents_with_message)
 
-        genomic_pipeline.ingest_genomic_centers_metrics_files()
+        today_plus_6 = datetime.datetime.utcnow() \
+                            + datetime.timedelta(days=6)
 
-        all_incidents = self.incident_dao.get_all()
-        count = 0
-        for incident in all_incidents:
-            if incident.message == message:
-                count += 1
+        # run the GC Metrics Ingestion workflow + 6 days same bad file
+        with clock.FakeClock(today_plus_6):
+            genomic_pipeline.ingest_genomic_centers_metrics_files()
 
-        self.assertEqual(count, 1)
+            all_incidents = self.incident_dao.get_all()
+            count = 0
+            for incident in all_incidents:
+                if incident.message == message:
+                    count += 1
+
+            self.assertEqual(count, 1)
+
+        today_plus_8 = datetime.datetime.utcnow() \
+                           + datetime.timedelta(days=8)
+
+        # run the GC Metrics Ingestion workflow + 8 days same bad file
+        with clock.FakeClock(today_plus_8):
+            genomic_pipeline.ingest_genomic_centers_metrics_files()
+
+            all_incidents = self.incident_dao.get_all()
+            count = 0
+            for incident in all_incidents:
+                if incident.message == message:
+                    count += 1
+
+            self.assertEqual(count, 2)
 
     def test_gc_metrics_ingestion_no_files(self):
         # run the GC Metrics Ingestion workflow


### PR DESCRIPTION
## Resolves *[ticket DA-1979]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-1979

## Description of changes/additions
-- Added time constraint of 7 days to check for before creating new incidents/slack alerts

## Tests
- [x] unit tests


