### PR TITLE
DA-1990 Remove DRC Contamination AW4(array)

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -297,7 +297,6 @@ class GenomicFileIngester:
 
             ingestion_type = ingestion_config[self.job_id]['method']
             return ingestion_type(data_to_ingest)
-
         else:
             logging.info("No data to ingest.")
             return GenomicSubProcessResult.NO_FILES
@@ -844,12 +843,12 @@ class GenomicFileIngester:
 
                 if metrics:
                     metrics.drcSexConcordance = row_copy['drcsexconcordance']
-                    metrics.drcContamination = row_copy['drccontamination']
 
                     if self.job_id == GenomicJob.AW4_ARRAY_WORKFLOW:
                         metrics.drcCallRate = row_copy['drccallrate']
 
                     elif self.job_id == GenomicJob.AW4_WGS_WORKFLOW:
+                        metrics.drcContamination = row_copy['drccontamination']
                         metrics.drcMeanCoverage = row_copy['drcmeancoverage']
                         metrics.drcFpConcordance = row_copy['drcfpconcordance']
 
@@ -1454,7 +1453,6 @@ class GenomicFileValidator:
             "researchid",
             "qcstatus",
             "drcsexconcordance",
-            "drccontamination",
             "drccallrate",
         )
 

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -296,12 +296,8 @@ class GenomicFileIngester:
             }
 
             ingestion_type = ingestion_config[self.job_id]['method']
+            return ingestion_type(data_to_ingest)
 
-            if self.job_id in [GenomicJob.AW1_MANIFEST, GenomicJob.AW1F_MANIFEST]:
-                gc_site_id = self._get_site_from_aw1()
-                return ingestion_type(data_to_ingest, gc_site_id)
-            else:
-                return ingestion_type(data_to_ingest)
         else:
             logging.info("No data to ingest.")
             return GenomicSubProcessResult.NO_FILES
@@ -388,7 +384,7 @@ class GenomicFileIngester:
             "call_rate": "callrate",
         }
 
-    def _ingest_aw1_manifest(self, data, _site):
+    def _ingest_aw1_manifest(self, data):
         """
         AW1 ingestion method: Updates the GenomicSetMember with AW1 data
         If the row is determined to be a control sample,
@@ -398,6 +394,7 @@ class GenomicFileIngester:
         :return: result code
         """
         _state = GenomicWorkflowState.AW0
+        _site = self._get_site_from_aw1()
 
         for row in data['rows']:
             row_copy = dict(zip([key.lower().replace(' ', '').replace('_', '')

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -3149,15 +3149,14 @@ class GenomicPipelineTest(BaseTestCase):
             metrics = self.metrics_dao.get_metrics_by_member_id(member.id)
 
             self.assertIsNotNone(metrics.drcSexConcordance)
-            self.assertIsNotNone(metrics.drcContamination)
             self.assertIsNotNone(metrics.drcCallRate)
 
+            self.assertIsNone(metrics.drcContamination)
             self.assertIsNone(metrics.drcMeanCoverage)
             self.assertIsNone(metrics.drcFpConcordance)
 
             if member.id in (1, 2):
                 self.assertEqual(2, member.aw4ManifestJobRunID)
-                self.assertEqual('0', metrics.drcContamination)
                 self.assertEqual('0.99689185', metrics.drcCallRate)
             if member.id == 1:
                 self.assertEqual('TRUE', metrics.drcSexConcordance)
@@ -3214,9 +3213,10 @@ class GenomicPipelineTest(BaseTestCase):
         for member in self.member_dao.get_all():
             metrics = self.metrics_dao.get_metrics_by_member_id(member.id)
 
+            self.assertIsNone(metrics.drcCallRate)
+
             self.assertIsNotNone(metrics.drcSexConcordance)
             self.assertIsNotNone(metrics.drcContamination)
-            self.assertIsNone(metrics.drcCallRate)
             self.assertIsNotNone(metrics.drcMeanCoverage)
             self.assertIsNotNone(metrics.drcFpConcordance)
 

--- a/tests/test-data/AoU_DRCB_GEN_2020-07-11-00-00-00.csv
+++ b/tests/test-data/AoU_DRCB_GEN_2020-07-11-00-00-00.csv
@@ -1,3 +1,3 @@
-biobank_id,sample_id,sex_at_birth,site_id,red_idat_path,red_idat_md5_path,green_idat_path,green_idat_md5_path,vcf_path,vcf_index_path,research_id,QC_status,drc_sex_concordance,drc_contamination,drc_call_rate
-1,1001,f,BI,1234_1_Red.idat,1234_1_Red.idat.md5sum,1234_1_Grn.idat,1234_1_Grn.idat.md5sum,1234_1_vcf.gz,1234_1_vcf.gz.tbi,109001,PASS,TRUE,0,0.99689185
-2,1002,f,BI,1234_2_Red.idat,1234_2_Red.idat.md5sum,1234_2_Grn.idat,1234_2_Grn.idat.md5sum,1234_2_vcf.gz,1234_2_vcf.gz.tbi,109002,FAIL,FALSE,0,0.99689185
+biobank_id,sample_id,sex_at_birth,site_id,red_idat_path,red_idat_md5_path,green_idat_path,green_idat_md5_path,vcf_path,vcf_index_path,research_id,QC_status,drc_sex_concordance,drc_call_rate
+1,1001,f,BI,1234_1_Red.idat,1234_1_Red.idat.md5sum,1234_1_Grn.idat,1234_1_Grn.idat.md5sum,1234_1_vcf.gz,1234_1_vcf.gz.tbi,109001,PASS,TRUE,0.99689185
+2,1002,f,BI,1234_2_Red.idat,1234_2_Red.idat.md5sum,1234_2_Grn.idat,1234_2_Grn.idat.md5sum,1234_2_vcf.gz,1234_2_vcf.gz.tbi,109002,FAIL,FALSE,0.99689185


### PR DESCRIPTION
## Resolves *[ticket DA-1990]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-1990

## Description of changes/additions
There was a discrepancy in the original ticket AC that the DRC contamination value needed to be ingested from AW4(array) but this value should only be expected from AW4(wgs). 

## Tests
- [x] unit tests


