### PR TITLE
Upserting request logs to archive

### DIFF
--- a/rdr_service/offline/requests_log_migrator.py
+++ b/rdr_service/offline/requests_log_migrator.py
@@ -33,12 +33,12 @@ class RequestsLogMigrator:
             make_transient(request_log)
             postgresql_connection = cls._get_database_connection('rdrpostgresql')
             with postgresql_connection.session() as postgresql_session:
-                postgresql_session.add(request_log)
+                postgresql_session.merge(request_log)
 
             make_transient(request_log)
             mysql8_connection = cls._get_database_connection('rdrmysql8')
             with mysql8_connection.session() as mysql8_session:
-                mysql8_session.add(request_log)
+                mysql8_session.merge(request_log)
 
         finally:
             # Setting table name back to what it originally was


### PR DESCRIPTION
## Resolves *no ticket*
Test is seeing errors again. It looks as if somehow a task is attempting to migrate a request log twice, or multiple tasks are trying to migrate the same one. In any case there are errors that the request log can't be inserted because it already exists in the database.

## Description of changes/additions
This changes the insert to an upsert, letting the task update the existing request log if it already exists.

## Tests
- [ ] unit tests


