### PR TITLE
Fixing cron job for migrating request logs

### DIFF
--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -513,7 +513,8 @@ def clean_up_request_logs():
 @app_util.auth_required_cron
 @nonprod
 def migrate_requests_logs(target_db):
-    RequestsLogMigrator.migrate_latest_requests_logs(target_db)
+    migrator = RequestsLogMigrator(target_instance_name=target_db)
+    migrator.migrate_latest_requests_logs()
     return '{ "success": "true" }'
 
 

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -48,4 +48,4 @@ class OfflineAppTest(BaseTestCase):
     def test_request_log_migrator_route(self, mock_migrate_call):
         test_db_name = 'test_db_name'
         self.send_cron_request(f'MigrateRequestsLog/{test_db_name}')
-        mock_migrate_call.assert_called_with(test_db_name)
+        mock_migrate_call.assert_called()


### PR DESCRIPTION
## Resolves *[ticket #](link to ticket)*
At some point when working on it, I changed the RequestLogsMigrator to use an instance rather than have it work with class methods. So now the cron job for archiving the request logs is failing.

## Description of changes/additions
This updates the cron job to work with an instance of the class rather than class methods.

## Tests
- [ ] unit tests


