### PR TITLE
[ROC-969] Modifying biobank withdrawal report criteria

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -346,6 +346,7 @@ def _query_and_write_withdrawal_report(exporter, file_path, report_cover_range, 
                 BiobankStoredSample.created >= earliest_report_date
             )
         )
+        .distinct()
     )
 
     exporter.run_export(file_path, withdrawal_report_query, backup=True)

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -11,7 +11,7 @@ import os
 import pytz
 from sqlalchemy import case
 from sqlalchemy.orm import aliased, Query
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, or_
 from sqlalchemy.sql.functions import concat
 
 from rdr_service import clock, config
@@ -33,7 +33,8 @@ from rdr_service.model.questionnaire import QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.offline.bigquery_sync import dispatch_participant_rebuild_tasks
 from rdr_service.offline.sql_exporter import SqlExporter
-from rdr_service.participant_enums import BiobankOrderStatus, OrganizationType, get_sample_status_enum_value
+from rdr_service.participant_enums import BiobankOrderStatus, OrganizationType, get_sample_status_enum_value,\
+    WithdrawalStatus
 
 # Format for dates in output filenames for the reconciliation report.
 _FILENAME_DATE_FORMAT = "%Y-%m-%d"
@@ -319,6 +320,7 @@ def _query_and_write_withdrawal_report(exporter, file_path, report_cover_range, 
     (as biobank samples for Native Americans are disposed of differently)
     """
     ceremony_answer_subquery = _participant_answer_subquery(WITHDRAWAL_CEREMONY_QUESTION_CODE)
+    earliest_report_date = now - datetime.timedelta(days=report_cover_range)
     withdrawal_report_query = (
         Query([
             concat(get_biobank_id_prefix(), Participant.biobankId).label('biobank_id'),
@@ -336,11 +338,13 @@ def _query_and_write_withdrawal_report(exporter, file_path, report_cover_range, 
         ])
         .select_from(Participant)
         .outerjoin(ceremony_answer_subquery, ceremony_answer_subquery.c.participant_id == Participant.participantId)
+        .join(BiobankStoredSample, BiobankStoredSample.biobankId == Participant.biobankId)
         .filter(
-            Participant.withdrawalTime >= now - datetime.timedelta(days=report_cover_range),
-            Query(BiobankStoredSample).filter(
-                BiobankStoredSample.biobankId == Participant.biobankId
-            ).exists()
+            Participant.withdrawalStatus != WithdrawalStatus.NOT_WITHDRAWN,
+            or_(
+                Participant.withdrawalTime >= earliest_report_date,
+                BiobankStoredSample.created >= earliest_report_date
+            )
         )
     )
 

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -492,7 +492,8 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
 
     def _create_participant(self, is_native_american=False, requests_ceremony=None, withdrawal_time=datetime.utcnow()):
         participant = self.data_generator.create_database_participant(
-            withdrawalTime=withdrawal_time
+            withdrawalTime=withdrawal_time,
+            withdrawalStatus=WithdrawalStatus.NO_USE
         )
 
         # Withdrawal report only includes participants that have stored samples

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -439,7 +439,8 @@ class DataGenerator:
         if 'biobankStoredSampleId' not in kwargs:
             kwargs['biobankStoredSampleId'] = self.unique_biobank_stored_sample_id()
 
-        for field, default in [('biobankOrderIdentifier', self.faker.pystr())]:
+        for field, default in [('biobankOrderIdentifier', self.faker.pystr()),
+                               ('test', self.faker.pystr(4))]:
             if field not in kwargs:
                 kwargs[field] = default
 


### PR DESCRIPTION
## Partially Resolves *[ROC-969](https://precisionmedicineinitiative.atlassian.net/browse/ROC-969)*
The Biobank relies on the withdrawal manifest to let them know what DNA samples need to be disposed. They found at least one participant that had sent a saliva kit by mail and then immediately withdrew. The sample wasn't processed until more than 10 days after the participant withdrew, so this participant never appeared on a withdrawal manifest and the biobank wasn't made aware that the sample could be disposed.

## Description of changes/additions
This PR updates the withdrawal manifest query to include any participants that have had samples reported recently. That way if the Biobank processes a sample for the withdrawn participant, we'll let them know about the withdrawal even when the withdrawal time is outside the 10 day window.

## Tests
- [x] unit tests

Unit test for checking the withdrawn participant appears on the report even when their withdrawal is outside the time window.


