### PR TITLE
DA-1993 AW4 pulling AW5 routes

### DIFF
--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -201,7 +201,7 @@ def aw4_array_manifest_workflow():
     """
     with GenomicJobController(GenomicJob.AW4_ARRAY_WORKFLOW,
                               bucket_name=config.DRC_BROAD_BUCKET_NAME,
-                              sub_folder_name=config.getSetting(config.DRC_BROAD_AW4_SUBFOLDERS[0])
+                              sub_folder_name=config.DRC_BROAD_AW4_SUBFOLDERS[0]
                               ) as controller:
         controller.run_general_ingestion_workflow()
 
@@ -212,7 +212,7 @@ def aw4_wgs_manifest_workflow():
     """
     with GenomicJobController(GenomicJob.AW4_WGS_WORKFLOW,
                               bucket_name=config.DRC_BROAD_BUCKET_NAME,
-                              sub_folder_name=config.getSetting(config.DRC_BROAD_AW4_SUBFOLDERS[1])
+                              sub_folder_name=config.DRC_BROAD_AW4_SUBFOLDERS[1],
                               ) as controller:
         controller.run_general_ingestion_workflow()
 


### PR DESCRIPTION
## Resolves *[ticket DA-1993]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-1993

## Description of changes/additions
In the genomic workflow when instantiating the path for picking up manifests for ingestions for the AW4s the subfolder was getting set to null,  and since the AW5s have the same naming convention and are in the same bucket it is pulling all files regardless of AW4 or AW5. So this PR fixes the subfolder discrepancy so that the AW4s will pull correct paths.

## Tests
- [x] unit tests


