### PR TITLE
[ROC-974] Only enforce constraints if awardee is not present.

### DIFF
--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -56,9 +56,10 @@ class ParticipantSummaryApi(BaseApi):
             return super(ParticipantSummaryApi, self)._query("participantId")
 
     def _make_query(self, check_invalid=True):
-        constraint_failed, message = self._check_constraints()
-        if constraint_failed:
-            raise BadRequest(f"{message}")
+        if not request.args.get("awardee"):
+            constraint_failed, message = self._check_constraints()
+            if constraint_failed:
+                raise BadRequest(f"{message}")
 
         query = super(ParticipantSummaryApi, self)._make_query(check_invalid)
         query.always_return_token = self._get_request_arg_bool("_sync")

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 import datetime
 import http.client
+from unittest import mock
+
 from mock import patch
 import threading
 import unittest
@@ -551,6 +553,20 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
         response_no_filter = self.send_get("ParticipantSummary")
         self.assertEqual(len(response_no_filter['entry']), num_summary)
+
+        constraint_method = "rdr_service.api.participant_summary_api.ParticipantSummaryApi._check_constraints"
+
+        # Test constraints called when no awardee param
+        with mock.patch(constraint_method) as constraint_mock:
+            constraint_mock.return_value = False, ""
+            self.send_get(f"ParticipantSummary?dateOfBirth={_date}&lastName={last_name}")
+
+            constraint_mock.assert_called()
+
+        # Test constraints not called when awardee param
+        with mock.patch(constraint_method) as constraint_mock:
+            self.send_get(f"ParticipantSummary?awardee=TEST&dateOfBirth={_date}&lastName={last_name}")
+            constraint_mock.assert_not_called()
 
         self.overwrite_test_user_roles([PTC])
 


### PR DESCRIPTION
## Resolves *[ROC-974](https://precisionmedicineinitiative.atlassian.net/browse/ROC-974)*


## Description of changes/additions
A recent update to the participant summary API required date of birth and last name parameters to be provided when Health Pro requested a participant look-up. This PR updates this requirement to only be enforced when the `awardee` parameter is not provided. Unit tests were updated as well to test the new behavior.

## Tests
- [] unit tests
- tests.api_tests.test_participant_summary_api.ParticipantSummaryApiTest.test_constraints_dob_and_lastname

