### PR TITLE
[ROC-974] Changing awardee constraint condition to hpoId

### DIFF
--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -56,7 +56,7 @@ class ParticipantSummaryApi(BaseApi):
             return super(ParticipantSummaryApi, self)._query("participantId")
 
     def _make_query(self, check_invalid=True):
-        if not request.args.get("awardee"):
+        if not request.args.get("hpoId"):
             constraint_failed, message = self._check_constraints()
             if constraint_failed:
                 raise BadRequest(f"{message}")

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -565,7 +565,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
         # Test constraints not called when awardee param
         with mock.patch(constraint_method) as constraint_mock:
-            self.send_get(f"ParticipantSummary?awardee=TEST&dateOfBirth={_date}&lastName={last_name}")
+            self.send_get(f"ParticipantSummary?hpoId=TEST&dateOfBirth={_date}&lastName={last_name}")
             constraint_mock.assert_not_called()
 
         self.overwrite_test_user_roles([PTC])


### PR DESCRIPTION
## Resolves *[ROC-974](https://precisionmedicineinitiative.atlassian.net/browse/ROC-974)*


## Description of changes/additions
HealthPro uses the `hpoId` not `awardee` parameter when lookup up participants in the participant summary API. This PR updates the constraints to only be enforced when the `hpoId` parameter is not present.

## Tests
- [] unit tests


