### PR TITLE
[DA-1986] Updating number of Gunicorn workers and threads

### DIFF
--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -12,7 +12,7 @@ max_requests_jitter = 50
 if os.getenv('GAE_ENV', '').startswith('standard'):
     _port = os.environ.get('PORT', 8081)
     workers = multiprocessing.cpu_count()
-    threads = multiprocessing.cpu_count() * 16
+    threads = workers * 16
 
 
 bind = "0.0.0.0:{0}".format(_port)

--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -12,7 +12,7 @@ max_requests_jitter = 50
 if os.getenv('GAE_ENV', '').startswith('standard'):
     _port = os.environ.get('PORT', 8081)
     workers = multiprocessing.cpu_count()
-    threads = workers * 16
+    threads = multiprocessing.cpu_count() * 16
 
 
 bind = "0.0.0.0:{0}".format(_port)


### PR DESCRIPTION
## Resolves *[DA-1986](https://precisionmedicineinitiative.atlassian.net/browse/DA-1986)*
The servers don't seem limited by CPU or any other resources. It just looks like there weren't enough Gunicorn workers/threads to accept and process the incoming requests.

## Description of changes/additions
This updates the Gunicorn configuration code to reduce the number of workers (to potentially avoid overhead from process swapping and benefit from having more memory available for each worker) as well as increasing the number of threads per worker.

Each instance has 2 CPU cores. So previously the code would set up each instance with 4 workers and 4 threads per worker (so 16 threads capable of accepting requests per instance). This updates the code to run with 2 workers (significantly helping memory, but not required since threads share memory) and 32 threads per worker. So now each instance will have 64 threads capable of processing requests.

## Tests
- [ ] unit tests

This was load tested on Sandbox. The increased number of threads allows the server to handle a number of requests that would cause the original settings to drop requests.


