### PR TITLE
Setting minimum number of sandbox instances to 0

### DIFF
--- a/rdr_service/app_sandbox.yaml
+++ b/rdr_service/app_sandbox.yaml
@@ -1,0 +1,7 @@
+# app_base.yaml is concatenated to the beginning of this file for deployment.
+# https://cloud.google.com/appengine/docs/standard/
+instance_class: F4
+
+# Have 0 idle instances to reduce unneeded costs
+automatic_scaling:
+  min_idle_instances: 0

--- a/rdr_service/services/gcp_config.py
+++ b/rdr_service/services/gcp_config.py
@@ -117,6 +117,10 @@ GCP_SERVICE_CONFIG_MAP = OrderedDict({
                 'rdr_service/app_base.yaml',
                 'rdr_service/app_nonprod.yaml'
             ],
+            'sandbox': [
+                'rdr_service/app_base.yaml',
+                'rdr_service/app_sandbox.yaml'
+            ]
         },
         'offline': {
             'type': 'service',


### PR DESCRIPTION
## Resolves *no ticket*
Deploying to the Sandbox environment uses the `app_nonprod.yaml` file for configuring the Google App Engine settings for the project. `app_nonprod.yaml` sets the minimum number of instances to 2 (to make sure that Stable, Staging, and all the testing environments have servers ready to accept requests).

## Description of changes/additions
This creates a new configuration file to set the minimum number of instances on Sandbox to 0 so that servers aren't running when we don't need them.

## Tests
- [ ] unit tests


