### PR TITLE
[DA-1995] Adding check for GROR to consent sync script

### DIFF
--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -178,21 +178,24 @@ def build_participant_query(session, org_ids, start_date=None, end_date=None, al
         participant_query = participant_query.filter(
             or_(
                 ParticipantSummary.consentForStudyEnrollmentTime.between(start_date, end_date),
-                ParticipantSummary.consentForElectronicHealthRecordsTime.between(start_date, end_date)
+                ParticipantSummary.consentForElectronicHealthRecordsTime.between(start_date, end_date),
+                ParticipantSummary.consentForGenomicsRORTime.between(start_date, end_date)
             )
         )
     elif start_date:
         participant_query = participant_query.filter(
             or_(
                 ParticipantSummary.consentForStudyEnrollmentTime > start_date,
-                ParticipantSummary.consentForElectronicHealthRecordsTime > start_date
+                ParticipantSummary.consentForElectronicHealthRecordsTime > start_date,
+                ParticipantSummary.consentForGenomicsRORTime > start_date
             )
         )
     elif end_date:
         participant_query = participant_query.filter(
             or_(
                 ParticipantSummary.consentForStudyEnrollmentTime < end_date,
-                ParticipantSummary.consentForElectronicHealthRecordsTime < end_date
+                ParticipantSummary.consentForElectronicHealthRecordsTime < end_date,
+                ParticipantSummary.consentForGenomicsRORTime < end_date
             )
         )
 


### PR DESCRIPTION
## Resolves *[DA-1995](https://precisionmedicineinitiative.atlassian.net/browse/DA-1995)*
The consent sync cron job will find all participants that have received EHR or Primary consent response times in the past month. But it's possible that a participant will delay giving GROR consent until later. If they give GROR consent and nothing else in a month, then the script wouldn't copy their consent files.

## Description of changes/additions
This adds a check for the GROR consent time to detect any participants that have only given GROR and need to have that file copied.

## Tests
- [x] unit tests


