### PR TITLE
Updating vulnerable cloud function packages

### DIFF
--- a/rdr_service/gcloud_functions/requirements.txt
+++ b/rdr_service/gcloud_functions/requirements.txt
@@ -26,7 +26,7 @@ google-resumable-media==1.1.0  # via aou-cloud, google-cloud-bigquery, google-cl
 googleapis-common-protos[grpc]==1.52.0  # via aou-cloud, google-api-core, grpc-google-iam-v1
 grpc-google-iam-v1==0.12.3  # via aou-cloud, google-cloud-tasks
 grpcio==1.33.1            # via aou-cloud, google-api-core, googleapis-common-protos, grpc-google-iam-v1
-httplib2==0.18.1          # via aou-cloud, google-api-python-client, google-auth-httplib2
+httplib2==0.19.1          # via aou-cloud, google-api-python-client, google-auth-httplib2
 idna==2.10                # via aou-cloud, requests
 libcst==0.3.13            # via google-cloud-tasks
 mypy-extensions==0.4.3    # via typing-inspect
@@ -39,9 +39,9 @@ pyasn1==0.4.8             # via aou-cloud, pyasn1-modules, rsa
 pycparser==2.20           # via cffi
 python-dateutil==2.8.1    # via -r requirements.in, aou-cloud
 pytz==2020.1              # via aou-cloud, google-api-core, google-cloud-firestore
-pyyaml==5.3.1             # via aou-cloud, google-python-cloud-debugger, libcst
+pyyaml==5.4.1             # via aou-cloud, google-python-cloud-debugger, libcst
 requests==2.24.0          # via aou-cloud, google-api-core, google-cloud-storage
-rsa==4.6                  # via aou-cloud, google-auth
+rsa==4.7.2                  # via aou-cloud, google-auth
 six==1.15.0               # via aou-cloud, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-bigquery, google-python-cloud-debugger, google-resumable-media, grpcio, protobuf, python-dateutil
 typing-extensions==3.7.4.3  # via libcst, typing-inspect
 typing-inspect==0.6.0     # via libcst

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -48,7 +48,7 @@ greenlet==0.4.15          # via gevent
 grpc-google-iam-v1==0.12.3  # via google-cloud-tasks
 grpcio==1.29.0            # via google-api-core, googleapis-common-protos, grpc-google-iam-v1
 gunicorn==20.0.4          # via -r requirements.in
-httplib2==0.19.0          # via google-api-python-client, google-auth-httplib2, oauth2client
+httplib2==0.19.1          # via google-api-python-client, google-auth-httplib2, oauth2client
 idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 isodate==0.6.0            # via fhirclient
@@ -88,7 +88,7 @@ python-dateutil==2.8.1    # via alembic, faker
 python-editor==1.0.4      # via alembic
 python-http-client==3.2.7  # via sendgrid
 pytz==2020.1              # via babel, flask-restful, google-api-core, google-cloud-firestore
-pyyaml==5.4             # via google-python-cloud-debugger
+pyyaml==5.4.1             # via google-python-cloud-debugger
 pyzmq==19.0.1             # via locust
 requests-oauthlib==1.3.0  # via jira
 requests-toolbelt==0.9.1  # via jira


### PR DESCRIPTION
## Resolves *no ticket*
I just got Admin access for the repository and saw that dependabot is showing security vulnerability warnings for the gcloud_functions requirements file. But it can't automatically create PRs for that requirements file because it can't access the `python-aou-cloud-services` repository.

## Description of changes/additions
This satisfies the warnings that dependabot is giving, and upgrades the relevant packages in the main requirements file to the latest as well.

## Tests
- [ ] unit tests


