### PR TITLE
[PDR Fix] Biobank sample pipeline may not trigger PDR data updates

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -87,10 +87,10 @@ def upsert_from_latest_csv():
         csv_reader = csv.DictReader(csv_file, delimiter="\t")
         written = _upsert_samples_from_csv(csv_reader)
 
-    ts = clock.CLOCK.now()
+    since_ts = clock.CLOCK.now()
     dao = ParticipantSummaryDao()
     dao.update_from_biobank_stored_samples()
-    update_bigquery_sync_participants(ts, dao)
+    update_bigquery_sync_participants(since_ts, dao)
 
     return written, timestamp
 

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -247,12 +247,13 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
         bqs_recs = self.session.query(BigQuerySync).filter(
             BigQuerySync.tableId == 'pdr_participant',
             BigQuerySync.pk_id.in_((on_site_1sal2_participant_id, mail_kit_1sal2_participant_id,
-                                   no_order_1sal2_participant_id))
+                                    no_order_1sal2_participant_id))
         ).all()
 
         # Establish when the participant_summary record updates were completed
         max_ps_modified_ts = max(ts for ts in
-                    [on_site_summary.lastModified, mail_kit_summary.lastModified, no_order_summary.lastModified])
+                                 [on_site_summary.lastModified, mail_kit_summary.lastModified,
+                                  no_order_summary.lastModified])
 
         # Confirm that the bigquery_sync records were built after participant_summary changes
         # (except for the no_order_summary pid)


### PR DESCRIPTION
## Resolves:  Biobank sample pipeline may not trigger PDR data updates  *[no ticket]*


## Description of changes/additions

Two issues that were not properly rebuilding `bigquery_sync` participant data after state changes in participant's RDR data due to biobank sample pipeline activity:

1. `update_bigquery_sync_participants()` was being called with a  timestamp reflecting local system time, which was used to query against the UTC timestamps in the RDR to find recently updated records.   (May be okay in production if GAE instances are set to UTC  but unsure if there are conditions where a different local TZ could be in effect)

2. The pipeline logic updated the `participant_summary` table but was looking for recently modified `participant` table records for the PDR data rebuild.   This would miss participants whose biobank details were updated by the pipeline job

## Tests
- [x] unit tests
Updated `cron_job_tests.test_biobank_samples_pipeline.test_end_to_end` to test for the expected `bigquery_sync` table changes
