### PR TITLE
Adding code coverage reports to Codacy

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+command_line = -m unittest discover -v -s tests
+branch = True
+source =
+    rdr_service
+omit=
+    # ignore fhir client libs
+    rdr_service/lib_fhir/*
+    rdr_service/alembic/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@ command_line = -m unittest discover -v -s tests
 branch = True
 source =
     rdr_service
-omit=
+omit =
     # ignore fhir client libs
     rdr_service/lib_fhir/*
     rdr_service/alembic/*

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -3,6 +3,6 @@
 #
 source venv/bin/activate
 export PYTHONPATH=$PYTHONPATH:`pwd`
-UNITTEST_FLAG=1 coverage run -m unittest
+UNITTEST_FLAG=1 coverage run -m unittest discover -v -s tests
 coverage xml -o report.xml
-bash <(curl -Ls https://coverage.codacy.com/com.get.sh) report -r report.xml
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r report.xml

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -3,4 +3,6 @@
 #
 source venv/bin/activate
 export PYTHONPATH=$PYTHONPATH:`pwd`
-UNITTEST_FLAG=1 python -m unittest discover -v -s tests
+UNITTEST_FLAG=1 coverage run -m unittest
+coverage xml -o report.xml
+bash <(curl -Ls https://coverage.codacy.com/com.get.sh) report -r report.xml


### PR DESCRIPTION
## Resolves *no ticket*
Codacy has the ability to display code coverage data, this sets CircleCI up to send coverage reports for tracking. I think with these settings, Codacy would only display the code coverage for the devel branch. I'm still trying to make sense of how it works and that might be easier when I can see them working for the devel branch.

## Description of changes/additions
`.coveragerc` is used to configure options for the coverage (such as branch detection) and is also picked up by Pycharm. `ci/run_unittests.sh` is modified to generate coverage reports for the unit tests while running them and then send the reports to Codacy (using an environment variable to associate it with the RDR project).

## Tests
- [ ] unit tests


