### PR TITLE
[DA-2002] Add biobank prefix to biobank_id field, AW3 WGS

### DIFF
--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -64,7 +64,7 @@ class GenomicQueryClass:
             )),
             GenomicManifestTypes.AW3_WGS: (sqlalchemy.select(
                 [
-                    GenomicSetMember.biobankId,
+                    sqlalchemy.func.concat(get_biobank_id_prefix(), GenomicSetMember.biobankId),
                     GenomicSetMember.sampleId,
                     sqlalchemy.func.concat(get_biobank_id_prefix(),
                                            GenomicSetMember.biobankId, '_',

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -2952,6 +2952,8 @@ class GenomicPipelineTest(BaseTestCase):
             rows = list(csv_reader)
 
             self.assertEqual(1, len(rows))
+            self.assertEqual(f'{get_biobank_id_prefix()}{member.biobankId}',
+                             rows[0]['biobank_id'])
             self.assertEqual(f'{get_biobank_id_prefix()}{member.biobankId}_{member.sampleId}',
                              rows[0]['biobankidsampleid'])
             self.assertEqual(member.sexAtBirth, rows[0]['sex_at_birth'])


### PR DESCRIPTION
## Resolves *[DA-2002](https://precisionmedicineinitiative.atlassian.net/browse/DA-2002)*


## Description of changes/additions
This PR adds the Biobank prefix to the `biobank_id` field in the WGS AW3 manifest.

## Tests
- [] unit tests
- test_aw3_wgs_manifest_generation


