### PR TITLE
Cache client id for the request

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -111,7 +111,7 @@ def get_oauth_id():
     retries = 5
     use_tokeninfo_endpoint = False
 
-    if GLOBAL_CLIENT_ID_KEY in flask.g:
+    if flask.g and GLOBAL_CLIENT_ID_KEY in flask.g:
         return getattr(flask.g, GLOBAL_CLIENT_ID_KEY)
 
     while retries:
@@ -143,7 +143,8 @@ def get_oauth_id():
                         logging.error('UserInfo endpoint did not return the email')
                         use_tokeninfo_endpoint = True
                     else:
-                        setattr(flask.g, GLOBAL_CLIENT_ID_KEY, user_email)
+                        if flask.g:
+                            setattr(flask.g, GLOBAL_CLIENT_ID_KEY, user_email)
                         return user_email
                 else:
                     logging.info(f"Oauth failure: {response.content} (status: {response.status_code})")

--- a/tests/test_app_util.py
+++ b/tests/test_app_util.py
@@ -365,8 +365,8 @@ class AppUtilTest(BaseTestCase):
 
     @mock.patch('rdr_service.app_util.GAE_PROJECT', 'definitely_the_server')
     @mock.patch('rdr_service.app_util.requests')
-    def test_caching_oauth_token_validation(self, mock_requests):
-        """Make sure we only call Google's API once per request for getting the user-info for the API token."""
+    def test_caching_user_info(self, mock_requests):
+        """Make sure we only call Google's API once per request for getting the user info for the API token."""
         auth_api_response = mock.MagicMock()
         auth_api_response.status_code = 200
 


### PR DESCRIPTION
## Resolves *no ticket*
Each request that the API receives can potentially make several requests to Google's UserInfo (or TokenInfo) API to retrieve the client's email based on the authenticating token. ParticipantSummary requests appear to be making 4 separate requests (taking about 40 ms each time). This uses Flask's global storage to cache the client's email so that it will only be retrieved from Google once per request. Flask's global storage is reset for each request, so new requests to a thread that already had an email in the global storage will request the new email for the new request.

## Description of changes/additions
If the client ID is already in the global storage then `get_oauth_id` will return that. Otherwise it is requested from Google's API and then saved in the global storage before being returned.

## Tests
- [x] unit tests


