### PR TITLE
Update compare-ingestion tool

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1119,10 +1119,10 @@ class GenomicGCValidationMetricsDao(UpsertableDao):
             return session.query(
                 functions.count(GenomicGCValidationMetrics.id)
             ).join(
-                GenomicManifestFile,
-                GenomicManifestFile.id == GenomicGCValidationMetrics.genomicFileProcessedId
+                GenomicFileProcessed,
+                GenomicFileProcessed.id == GenomicGCValidationMetrics.genomicFileProcessedId
             ).filter(
-                GenomicManifestFile.filePath == filepath,
+                GenomicFileProcessed.filePath == filepath,
                 GenomicGCValidationMetrics.ignoreFlag != 1
             ).one_or_none()
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1746,7 +1746,10 @@ class CompareRecordsClass(GenomicManifestBase):
         }
         _dict = {}
         for i, val in paths[manifest_type].items():
-            _dict[self.main_config[manifest_type]['headers'][i]] = val(path)[0]
+            if val(path):
+                _dict[self.main_config[manifest_type]['headers'][i]] = val(path)[0]
+
+        _dict['file_path'] = path
 
         self.data_rows.append(_dict)
         return self.data_rows
@@ -1764,7 +1767,7 @@ class CompareRecordsClass(GenomicManifestBase):
                 prefix = prefix.lower()
             files = self.gscp.list(bucket, prefix)
             all_files.extend(['{}/{}'.format(f.bucket.name, f.name) for f in files if files and '.csv' in f.name])
-        return
+        return all_files
 
     def output_records(self):
         manifest_type = self.args.manifest_type.lower()


### PR DESCRIPTION
## Resolves *no ticket*


## Description of changes/additions
This PR updates the genomic compare-ingestion tool. The AW2 query was modified to use `genomic_file_processed` and the output file now includes a column for the manifest file path. Some logic was modified to skip empty rows.

## Tests
- [] unit tests


