### PR TITLE
Adding ability for tests to skip the database setup and reset

### DIFF
--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -20,6 +20,10 @@ from tests.helpers.unittest_base import BaseTestCase, PDRGeneratorTestMixin
 
 
 class UpdateEhrStatusMakeJobsTestCase(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     # pylint: disable=unused-argument
     def setUp(self, use_mysql=False, with_data=False, with_consent_codes=False):
         super(UpdateEhrStatusMakeJobsTestCase, self).setUp()

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -1332,6 +1332,9 @@ class QuestionnaireResponseDaoTest(BaseTestCase):
 
 
 class QuestionnaireResponseDaoCloudCheckTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
 
     def test_file_exists(self):
         consent_pdf_path = "/%s/Participant/somefile.pdf" % _FAKE_BUCKET['example']

--- a/tests/service_tests/test_config_client.py
+++ b/tests/service_tests/test_config_client.py
@@ -6,6 +6,10 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class ConfigClientTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     def setUp(self, **kwargs) -> None:
         super(ConfigClientTest, self).setUp(**kwargs)
 

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -6,6 +6,10 @@ from tests.service_tests.test_google_sheets_client import GoogleSheetsTestBase
 
 
 class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = True
+
     def setUp(self, **kwargs) -> None:
         super(DataDictionaryUpdaterTest, self).setUp(**kwargs)
 

--- a/tests/service_tests/test_gcp_logging.py
+++ b/tests/service_tests/test_gcp_logging.py
@@ -7,6 +7,10 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class GCPLoggingTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     def test_published_severity_level(self):
         """Ensure that the severity level used is the highest of the individual logs being published"""
 

--- a/tests/service_tests/test_google_sheets_client.py
+++ b/tests/service_tests/test_google_sheets_client.py
@@ -6,6 +6,10 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class GoogleSheetsTestBase(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     def setUp(self, **kwargs) -> None:
         super(GoogleSheetsTestBase, self).setUp(**kwargs)
 

--- a/tests/service_tests/test_redcap_client.py
+++ b/tests/service_tests/test_redcap_client.py
@@ -6,6 +6,9 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class CodesManagementTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
 
     def setUp(self, **kwargs):
         super(CodesManagementTest, self).setUp(**kwargs)

--- a/tests/test_app_util.py
+++ b/tests/test_app_util.py
@@ -30,6 +30,10 @@ def not_in_prod():
     pass
 
 class AppUtilTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     def setUp(self):
         super().setUp()
 

--- a/tests/test_date_app_util.py
+++ b/tests/test_date_app_util.py
@@ -5,6 +5,10 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class DateCollectionTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     @staticmethod
     def _build_simple_intersection(start_of_first, end_of_first, start_of_second, end_of_second):
         first = DateCollection()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -10,6 +10,10 @@ class TestEnvironment(BaseTestCase):
     """
     Test our python environment
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     def test_python_version(self):
         """ Make sure we are using Python 3.7 or higher """
         self.assertEqual(sys.version_info[0], 3)

--- a/tests/tool_tests/test_app_engine_manager.py
+++ b/tests/tool_tests/test_app_engine_manager.py
@@ -5,6 +5,10 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class AppEngineManagerTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
     def test_deploy_date_calculation(self):
         expected_release_date = 'Jan 21, 2021'
 


### PR DESCRIPTION
## Resolves *no ticket*
The unit tests can be quicker if they don't need to interact with the database, but there wasn't a way to specify that nothing needs to happen with the database for a set of tests.

## Description of changes/additions
This lets a test case class specify that it doesn't need to use or reset the database.

## Tests
Analyzed the performance locally with the Google Sheets tests. Previously each test was taking about 100 milliseconds and running the entire suite took about 8 seconds (that also includes time for setting up the mysql database and connecting to it). After this change each test took about 10 milliseconds and the entire set of tests ran in less than a quarter of a second.


