### PR TITLE
[DA-2000] add_external_id_for_curation

### DIFF
--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -26,6 +26,7 @@ class SrcClean(Base):
     id = Column(BigInteger, autoincrement=True, primary_key=True)
     participant_id = Column(BigInteger)
     research_id = Column(BigInteger)
+    external_id = Column(BigInteger)
     survey_name = Column(String(200))
     date_of_survey = Column(DateTime)
     question_ppi_code = Column(String(200))

--- a/rdr_service/etl/raw_sql/finalize_cdm_data.sql
+++ b/rdr_service/etl/raw_sql/finalize_cdm_data.sql
@@ -1510,9 +1510,10 @@ WHERE cdm_meas.parent_id IS NOT NULL;
 DROP TABLE IF EXISTS cdm.pid_rid_mapping;
 CREATE TABLE cdm.pid_rid_mapping (
     participant_id              bigint,
-    research_id                 bigint
+    research_id                 bigint,
+    external_id                 bigint
 );
-INSERT INTO cdm.pid_rid_mapping SELECT DISTINCT participant_id, research_id FROM cdm.src_clean;
+INSERT INTO cdm.pid_rid_mapping SELECT DISTINCT participant_id, research_id, external_id FROM cdm.src_clean;
 
 -- -------------------------------------------------------------------
 -- Drop Temporary Tables

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -266,6 +266,7 @@ class CurationExportClass(ToolBase):
         column_map = {
             SrcClean.participant_id: Participant.participantId,
             SrcClean.research_id: Participant.researchId,
+            SrcClean.external_id: Participant.externalId,
             SrcClean.survey_name: module_code.value,
             SrcClean.date_of_survey: coalesce(QuestionnaireResponse.authored, QuestionnaireResponse.created),
             SrcClean.question_ppi_code: question_code.shortValue,


### PR DESCRIPTION
## Resolves *[DA-2000](https://precisionmedicineinitiative.atlassian.net/browse/DA-2000)*
Add external ID to curation `pid_rid_mapping` table

## Description of changes/additions
FitBit data is using PTSC pid which is the external id in RDR, this change adds the external id to curation table to help them map the FitBit data.

## Tests
- no test case


