### PR TITLE
Adding interpreter directives to files that are missing them

### DIFF
--- a/ci/install_google_sdk.sh
+++ b/ci/install_google_sdk.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Install the Google Cloud SDK
 #

--- a/ci/install_mysql.sh
+++ b/ci/install_mysql.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # Install and configure mysql
 #

--- a/ci/run_upload_coverage_report.sh
+++ b/ci/run_upload_coverage_report.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source venv/bin/activate
 coverage xml -o report.xml
 bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r report.xml

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
+
 #
 # Install the python library requirements
 #
-
 python3 -m venv venv
 source venv/bin/activate
 export PYTHONPATH=`pwd`

--- a/rdr_service/tools/setup_vars.sh
+++ b/rdr_service/tools/setup_vars.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 READONLY_DB_USER=readonly
 RDR_DB_USER=rdr
 ALEMBIC_DB_USER=alembic


### PR DESCRIPTION
## Resolves *no ticket*
Some files are being flagged for not having the interpreter directive at the top.

## Description of changes/additions
This specifies the interpreter so it's clearer that they're meant to be run by bash.

## Tests
- [ ] unit tests


