### PR TITLE
[DA-2020] Remove A1 manifest validation from Slack alerts

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -63,7 +63,7 @@ class GenomicJobController:
         self.job_id = job_id
         self.job_run = None
         self.bucket_name = getSetting(bucket_name, default="")
-        self.sub_folder_name = getSetting(sub_folder_name, default="")
+        self.sub_folder_name = getSetting(sub_folder_name, default=sub_folder_name)
         self.sub_folder_tuple = sub_folder_tuple
         self.bucket_name_list = getSettingList(bucket_name_list, default=[])
         self.archive_folder_name = archive_folder_name

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -233,8 +233,8 @@ def gem_a2_manifest_workflow():
     Entrypoint for GEM A2 Workflow
     """
     with GenomicJobController(GenomicJob.GEM_A2_MANIFEST,
-                              bucket_name=config.GENOMIC_GEM_BUCKET_NAME) as controller:
-        controller.sub_folder_name = config.GENOMIC_GEM_A2_MANIFEST_SUBFOLDER
+                              bucket_name=config.GENOMIC_GEM_BUCKET_NAME,
+                              sub_folder_name=config.GENOMIC_GEM_A2_MANIFEST_SUBFOLDER) as controller:
         controller.reconcile_report_states(_genome_type=config.GENOME_TYPE_ARRAY)
         controller.run_general_ingestion_workflow()
 

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -234,6 +234,7 @@ def gem_a2_manifest_workflow():
     """
     with GenomicJobController(GenomicJob.GEM_A2_MANIFEST,
                               bucket_name=config.GENOMIC_GEM_BUCKET_NAME) as controller:
+        controller.sub_folder_name = config.GENOMIC_GEM_A2_MANIFEST_SUBFOLDER
         controller.reconcile_report_states(_genome_type=config.GENOME_TYPE_ARRAY)
         controller.run_general_ingestion_workflow()
 


### PR DESCRIPTION
## Resolves *[DA-2020](https://precisionmedicineinitiative.atlassian.net/browse/DA-2020)*


## Description of changes/additions
The A2 ingestion cron job was picking up the A1 manifest. The A2 job was failing the A1 manifest due to incorrect naming convention and then posting alerts to the Slack `#rdr-genomic-alerts` channel. This PR explicitly sets the `controller.sub_folder_name` in the A2 ingestion workflow so that it does not pick up the A1 manifest.

## Tests
- [] unit tests


