### PR TITLE
[DA-2024] modify_public_metrics_cronjob

### DIFF
--- a/rdr_service/dao/metrics_cache_dao.py
+++ b/rdr_service/dao/metrics_cache_dao.py
@@ -500,30 +500,19 @@ class MetricsGenderCacheDao(BaseDao):
         }
         return operation_funcs[self.cache_type](buckets)
 
-    def copy_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
+    def update_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
         with self.session() as session:
-            copy_sql = """
-                INSERT INTO metrics_gender_cache
-                SELECT
-                :new_date_inserted_time as date_inserted,
-                type,
-                enrollment_status,
-                hpo_id,
-                hpo_name,
-                date,
-                gender_name,
-                gender_count,
-                participant_origin
-                FROM metrics_gender_cache
-                WHERE date_inserted = :last_date_inserted_time AND type = :type
-                AND date >= :start_date AND date <= :end_date
-            """
-            params = {'new_date_inserted_time': new_date_inserted_time,
-                      'last_date_inserted_time': last_date_inserted_time,
-                      'type': self.cache_type,
-                      'start_date': start_date,
-                      'end_date': end_date}
-            session.execute(copy_sql, params)
+            query = (
+                sqlalchemy
+                    .update(MetricsGenderCache)
+                    .where(and_(MetricsGenderCache.dateInserted == last_date_inserted_time,
+                           MetricsGenderCache.date >= start_date,
+                           MetricsGenderCache.date <= end_date,
+                           MetricsGenderCache.type == self.cache_type)
+                           )
+                    .values({MetricsGenderCache.dateInserted: new_date_inserted_time})
+            )
+            session.execute(query)
 
     def delete_old_records(self, n_days_ago=7):
         with self.session() as session:
@@ -919,30 +908,19 @@ class MetricsAgeCacheDao(BaseDao):
         }
         return operation_funcs[self.cache_type](buckets)
 
-    def copy_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
+    def update_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
         with self.session() as session:
-            copy_sql = """
-                INSERT INTO metrics_age_cache
-                SELECT
-                :new_date_inserted_time as date_inserted,
-                enrollment_status,
-                type,
-                hpo_id,
-                hpo_name,
-                date,
-                age_range,
-                age_count,
-                participant_origin
-                FROM metrics_age_cache
-                WHERE date_inserted = :last_date_inserted_time AND type = :type
-                AND date >= :start_date AND date <= :end_date
-            """
-            params = {'new_date_inserted_time': new_date_inserted_time,
-                      'last_date_inserted_time': last_date_inserted_time,
-                      'type': self.cache_type,
-                      'start_date': start_date,
-                      'end_date': end_date}
-            session.execute(copy_sql, params)
+            query = (
+                sqlalchemy
+                    .update(MetricsAgeCache)
+                    .where(and_(MetricsAgeCache.dateInserted == last_date_inserted_time,
+                                MetricsAgeCache.date >= start_date,
+                                MetricsAgeCache.date <= end_date,
+                                MetricsAgeCache.type == self.cache_type)
+                           )
+                    .values({MetricsAgeCache.dateInserted: new_date_inserted_time})
+            )
+            session.execute(query)
 
     def delete_old_records(self, n_days_ago=7):
         with self.session() as session:
@@ -1402,43 +1380,19 @@ class MetricsRaceCacheDao(BaseDao):
         }
         return operation_funcs[self.cache_type](buckets)
 
-    def copy_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
+    def update_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
         with self.session() as session:
-            copy_sql = """
-                INSERT INTO metrics_race_cache
-                SELECT
-                :new_date_inserted_time as date_inserted,
-                type,
-                registered_flag,
-                participant_flag,
-                consent_flag,
-                core_flag,
-                hpo_id,
-                hpo_name,
-                date,
-                american_indian_alaska_native,
-                asian,
-                black_african_american,
-                middle_eastern_north_african,
-                native_hawaiian_other_pacific_islander,
-                white,
-                hispanic_latino_spanish,
-                none_of_these_fully_describe_me,
-                prefer_not_to_answer,
-                multi_ancestry,
-                no_ancestry_checked,
-                participant_origin,
-                unset_no_basics
-                FROM metrics_race_cache
-                WHERE date_inserted = :last_date_inserted_time AND type = :type
-                AND date >= :start_date AND date <= :end_date
-            """
-            params = {'new_date_inserted_time': new_date_inserted_time,
-                      'last_date_inserted_time': last_date_inserted_time,
-                      'type': self.cache_type,
-                      'start_date': start_date,
-                      'end_date': end_date}
-            session.execute(copy_sql, params)
+            query = (
+                sqlalchemy
+                    .update(MetricsRaceCache)
+                    .where(and_(MetricsRaceCache.dateInserted == last_date_inserted_time,
+                                MetricsRaceCache.date >= start_date,
+                                MetricsRaceCache.date <= end_date,
+                                MetricsRaceCache.type == self.cache_type)
+                           )
+                    .values({MetricsRaceCache.dateInserted: new_date_inserted_time})
+            )
+            session.execute(query)
 
     def delete_old_records(self, n_days_ago=7):
         with self.session() as session:
@@ -2329,44 +2283,19 @@ class MetricsLifecycleCacheDao(BaseDao):
         }
         return operation_funcs[self.cache_type](buckets)
 
-    def copy_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
+    def update_historical_cache_data(self, new_date_inserted_time, last_date_inserted_time, start_date, end_date):
         with self.session() as session:
-            copy_sql = """
-                INSERT INTO metrics_lifecycle_cache
-                SELECT
-                :new_date_inserted_time as date_inserted,
-                enrollment_status,
-                type,
-                hpo_id,
-                hpo_name,
-                date,
-                registered,
-                consent_enrollment,
-                consent_complete,
-                ppi_basics,
-                ppi_overall_health,
-                ppi_lifestyle,
-                ppi_healthcare_access,
-                ppi_medical_history,
-                ppi_medications,
-                ppi_family_health,
-                ppi_baseline_complete,
-                retention_modules_eligible,
-                retention_modules_complete,
-                physical_measurement,
-                sample_received,
-                full_participant,
-                participant_origin
-                FROM metrics_lifecycle_cache
-                WHERE date_inserted = :last_date_inserted_time AND type = :type
-                AND date >= :start_date AND date <= :end_date
-            """
-            params = {'new_date_inserted_time': new_date_inserted_time,
-                      'last_date_inserted_time': last_date_inserted_time,
-                      'type': self.cache_type,
-                      'start_date': start_date,
-                      'end_date': end_date}
-            session.execute(copy_sql, params)
+            query = (
+                sqlalchemy
+                    .update(MetricsLifecycleCache)
+                    .where(and_(MetricsLifecycleCache.dateInserted == last_date_inserted_time,
+                                MetricsLifecycleCache.date >= start_date,
+                                MetricsLifecycleCache.date <= end_date,
+                                MetricsLifecycleCache.type == self.cache_type)
+                           )
+                    .values({MetricsLifecycleCache.dateInserted: new_date_inserted_time})
+            )
+            session.execute(query)
 
     def delete_old_records(self, n_days_ago=7):
         with self.session() as session:

--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -41,7 +41,7 @@ class ParticipantCountsOverTimeService(BaseDao):
         self.start_date = datetime.datetime.strptime("2017-05-30", "%Y-%m-%d").date()
         self.end_date = datetime.datetime.now().date() + datetime.timedelta(days=10)
         self.stage_number = MetricsCronJobStage.STAGE_ONE
-        self.cronjob_time = datetime.datetime.now()
+        self.cronjob_time = datetime.datetime.now().replace(microsecond=0)
 
     def init_tmp_table(self):
         with self.session() as session:
@@ -222,8 +222,8 @@ class ParticipantCountsOverTimeService(BaseDao):
             logging.info(f'No last success stage two found for {dao.table_name}, calculate new data for stage two')
             self.refresh_data_for_metrics_cache(dao)
         else:
-            dao.copy_historical_cache_data(self.cronjob_time, last_success_stage_two.dateInserted,
-                                           self.start_date, self.end_date)
+            dao.update_historical_cache_data(self.cronjob_time, last_success_stage_two.dateInserted,
+                                             self.start_date, self.end_date)
             status_dao.set_to_complete(dao.cache_type, dao.table_name, self.cronjob_time, self.stage_number)
             dao.delete_old_records(n_days_ago=30)
 

--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -152,22 +152,32 @@ class ParticipantCountsOverTimeService(BaseDao):
         self.end_date = end_date
         self.stage_number = stage_number
 
+        # For public metrics job, calculate new result for stage one, and copy history result for stage two
+        if stage_number == MetricsCronJobStage.STAGE_ONE:
+            self.refresh_data_for_metrics_cache(MetricsLifecycleCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+            logging.info("Refresh MetricsLifecycleCache for Public Metrics API done.")
+            self.refresh_data_for_metrics_cache(MetricsGenderCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+            logging.info("Refresh MetricsGenderCache for Public Metrics API done.")
+            self.refresh_data_for_metrics_cache(MetricsAgeCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+            logging.info("Refresh MetricsAgeCache for Public Metrics API done.")
+            self.refresh_data_for_metrics_cache(MetricsRaceCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+            logging.info("Refresh MetricsRaceCache for Public Metrics API done.")
+        elif stage_number == MetricsCronJobStage.STAGE_TWO:
+            self.refresh_data_for_public_metrics_cache_stage_two(
+                MetricsLifecycleCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+            self.refresh_data_for_public_metrics_cache_stage_two(
+                MetricsGenderCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+            self.refresh_data_for_public_metrics_cache_stage_two(
+                MetricsAgeCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+            self.refresh_data_for_public_metrics_cache_stage_two(
+                MetricsRaceCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
+
         self.refresh_data_for_metrics_cache(MetricsEnrollmentStatusCacheDao())
         logging.info("Refresh MetricsEnrollmentStatusCache done.")
-        self.refresh_data_for_metrics_cache(MetricsGenderCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
-        logging.info("Refresh MetricsGenderCache for Public Metrics API done.")
-        self.refresh_data_for_metrics_cache(MetricsAgeCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
-        logging.info("Refresh MetricsAgeCache for Public Metrics API done.")
-        self.refresh_data_for_metrics_cache(MetricsRaceCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
-        logging.info("Refresh MetricsRaceCache for Public Metrics API done.")
         self.refresh_data_for_metrics_cache(MetricsRegionCacheDao())
         logging.info("Refresh MetricsRegionCache done.")
         self.refresh_data_for_metrics_cache(MetricsLanguageCacheDao())
         logging.info("Refresh MetricsLanguageCache done.")
-        self.refresh_data_for_metrics_cache(MetricsLifecycleCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API))
-        logging.info("Refresh MetricsLifecycleCache for Public Metrics API done.")
-
-        # Cron job for METRICS_V2_API will be retired soon
         self.refresh_data_for_metrics_cache(MetricsGenderCacheDao(MetricsCacheType.METRICS_V2_API))
         logging.info("Refresh MetricsGenderCache for Metrics2API done.")
         self.refresh_data_for_metrics_cache(MetricsAgeCacheDao(MetricsCacheType.METRICS_V2_API))
@@ -201,6 +211,21 @@ class ParticipantCountsOverTimeService(BaseDao):
         status_dao.set_to_complete(dao.cache_type, dao.table_name, self.cronjob_time, self.stage_number)
         if self.stage_number == MetricsCronJobStage.STAGE_TWO:
             dao.delete_old_records()
+
+    def refresh_data_for_public_metrics_cache_stage_two(self, dao):
+        if self.stage_number != MetricsCronJobStage.STAGE_TWO:
+            return
+        status_dao = MetricsCacheJobStatusDao()
+        last_success_stage_two = status_dao.get_last_complete_stage_two_data_inserted_time(dao.table_name,
+                                                                                           dao.cache_type)
+        if not last_success_stage_two:
+            logging.info(f'No last success stage two found for {dao.table_name}, calculate new data for stage two')
+            self.refresh_data_for_metrics_cache(dao)
+        else:
+            dao.copy_historical_cache_data(self.cronjob_time, last_success_stage_two.dateInserted,
+                                           self.start_date, self.end_date)
+            status_dao.set_to_complete(dao.cache_type, dao.table_name, self.cronjob_time, self.stage_number)
+            dao.delete_old_records(n_days_ago=30)
 
     def insert_cache_by_hpo(self, dao, hpo_id):
         sql_arr = dao.get_metrics_cache_sql(hpo_id)

--- a/rdr_service/offline/participant_counts_over_time.py
+++ b/rdr_service/offline/participant_counts_over_time.py
@@ -1,16 +1,17 @@
 import datetime
 import logging
 
+from rdr_service import clock
 from rdr_service.dao.participant_counts_over_time_service import ParticipantCountsOverTimeService
 from rdr_service.participant_enums import MetricsCronJobStage
 
 
 def calculate_participant_metrics():
-    stage_one_start_date = datetime.datetime.now().date() - datetime.timedelta(days=30)
-    stage_one_end_date = datetime.datetime.now().date() + datetime.timedelta(days=10)
+    stage_one_start_date = clock.CLOCK.now().date() - datetime.timedelta(days=30)
+    stage_one_end_date = clock.CLOCK.now().date() + datetime.timedelta(days=10)
     # the first participant is registered at 2017-05-31
     stage_two_start_date = datetime.datetime.strptime("2017-05-30", "%Y-%m-%d").date()
-    stage_two_end_date = datetime.datetime.now().date() - datetime.timedelta(days=31)
+    stage_two_end_date = clock.CLOCK.now().date() - datetime.timedelta(days=31)
 
     # call metrics functions
     service = ParticipantCountsOverTimeService()

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -36,6 +36,8 @@ from tests.helpers.unittest_base import BaseTestCase
 from tests.helpers.mysql_helper_data import PITT_HPO_ID
 
 TIME_1 = datetime.datetime(2017, 12, 31)
+TIME_2 = datetime.datetime(2018, 1, 15)
+TIME_3 = datetime.datetime(2018, 2, 10)
 
 
 def _questionnaire_response_url(participant_id):
@@ -805,7 +807,12 @@ class PublicMetricsApiTest(BaseTestCase):
             )
         )
 
-        calculate_participant_metrics()
+        with FakeClock(TIME_2):
+            calculate_participant_metrics()
+
+        # test copy historical cache for stage two
+        with FakeClock(TIME_3):
+            calculate_participant_metrics()
 
         qs = "&stratification=GENDER_IDENTITY" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -1085,7 +1092,6 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
     def test_public_metrics_get_age_range_api(self):
-
         dob1 = datetime.date(1978, 10, 10)
         dob2 = datetime.date(1988, 10, 10)
         dob3 = datetime.date(1988, 10, 10)
@@ -1136,7 +1142,12 @@ class PublicMetricsApiTest(BaseTestCase):
         p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
         self._insert(p_ghost, "Ghost", "G", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time1, dob=dob3)
 
-        calculate_participant_metrics()
+        with FakeClock(TIME_2):
+            calculate_participant_metrics()
+
+        # test copy historical cache for stage two
+        with FakeClock(TIME_3):
+            calculate_participant_metrics()
 
         qs = "&stratification=AGE_RANGE" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -1698,8 +1709,12 @@ class PublicMetricsApiTest(BaseTestCase):
         setup_participant(self.time2, [RACE_AIAN_CODE], self.az_provider_link)
         setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
 
+        with FakeClock(TIME_2):
+            calculate_participant_metrics()
 
-        calculate_participant_metrics()
+        # test copy historical cache for stage two
+        with FakeClock(TIME_3):
+            calculate_participant_metrics()
 
         qs = "&stratification=RACE" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -2144,7 +2159,12 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time1,
         )
 
-        calculate_participant_metrics()
+        with FakeClock(TIME_2):
+            calculate_participant_metrics()
+
+        # test copy historical cache for stage two
+        with FakeClock(TIME_3):
+            calculate_participant_metrics()
 
         qs1 = "&stratification=LIFECYCLE" "&endDate=2018-01-03"
 
@@ -2367,7 +2387,12 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time1,
         )
 
-        calculate_participant_metrics()
+        with FakeClock(TIME_2):
+            calculate_participant_metrics()
+
+        # test copy historical cache for stage two
+        with FakeClock(TIME_3):
+            calculate_participant_metrics()
 
         qs = "&stratification=PRIMARY_CONSENT" "&startDate=2017-12-31" "&endDate=2018-01-08"
 


### PR DESCRIPTION
## Resolves *[DA-2024](https://precisionmedicineinitiative.atlassian.net/browse/DA-2024)*
1. Calculate public metrics cache for stage one(recent 30 days) with the latest production data.
2. Reuse the public metics historical cache for stage two(from 2017.5 to 30 days ago).
3. No change for metric cache of health pro dashboard.

## Description of changes/additions
For public metrics, we don't need to recalculate the withdrawal, test, ghost count for the historical data, the logic is straightforward and easy now. But this change still follow the current design, because the public metrics shares the logic with healthPro dashboard metrics. Once the healthPro dashboard retired(maybe in two weeks), we need to refactor the design and use a simple way to calculate the public metrics.

## Tests
- [x] unit tests


