### PR TITLE
Adding some log lines for server monitoring

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -89,10 +89,8 @@ def log_api_request(log: RequestsLog = None, model_obj=None):
                 else:
                     log.fpk_alt_id = str(insp.identity[0])
 
-        except NoInspectionAvailable:
-            pass
-        except Exception:  # pylint: disable=broad-except
-            pass
+        except (NoInspectionAvailable, Exception):  # pylint: disable=broad-except
+            logging.error('Error setting request log data', exc_info=True)
 
     return save_raw_request_record(log)
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -124,6 +124,8 @@ class ResponseValidator:
         self.survey = self._get_survey_for_questionnaire_history(questionnaire_history)
         if self.survey is not None:
             self._code_to_question_map = self._build_code_to_question_map()
+            if self.survey.redcapProjectId is not None:
+                logging.info('Validating imported survey')
 
         # Get the skip code id
         self.skip_code_id = self.session.query(Code.codeId).filter(Code.value == PMI_SKIP_CODE).scalar()


### PR DESCRIPTION
## Resolves *no ticket*
There are a few warnings that need to be cleaned up in the response validation and I haven't been able to get to them yet. But I want to make sure to still be able to check the validation of responses that we have imported from Redcap. Adding a log line for that will help with filtering out the ones I haven't been able to get to yet.

Codacy also picked up on some exceptions that were being passed when creating the RequestsLog record. This adds a log statement for them in case there's something there we would want to know about.


## Tests
- [ ] unit tests


