### PR TITLE
[DA-2019] Support withdrawal module response data in PDR

### DIFF
--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -5,9 +5,12 @@ from sqlalchemy import text
 
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
-from rdr_service.model.bq_questionnaires import BQPDRTheBasics, BQPDRConsentPII, BQPDRLifestyle, \
-    BQPDROverallHealth, BQPDRDVEHRSharing, BQPDREHRConsentPII, BQPDRFamilyHistory, \
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb
+from rdr_service.model.bq_questionnaires import (
+    BQPDRTheBasics, BQPDRConsentPII, BQPDRLifestyle,
+    BQPDROverallHealth, BQPDRDVEHRSharing, BQPDREHRConsentPII, BQPDRFamilyHistory,
+    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb,
+    BQPDRStopParticipating, BQPDRWithdrawalIntro
+)
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.participant_enums import QuestionnaireResponseStatus, TEST_HPO_NAME
 
@@ -108,7 +111,10 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
             'COPE': BQPDRCOPEMay,
             'cope_nov': BQPDRCOPENov,
             'cope_dec': BQPDRCOPEDec,
-            'cope_feb': BQPDRCOPEFeb
+            'cope_feb': BQPDRCOPEFeb,
+            # There are two different module id codes in use for the withdrawal survey
+            'withdrawal_intro': BQPDRWithdrawalIntro,
+            'StopParticipating': BQPDRStopParticipating
         }
         table = table_map.get(module_id, None)
         if table is None:

--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -9,7 +9,7 @@ from rdr_service.model.bq_questionnaires import (
     BQPDRTheBasics, BQPDRConsentPII, BQPDRLifestyle,
     BQPDROverallHealth, BQPDRDVEHRSharing, BQPDREHRConsentPII, BQPDRFamilyHistory,
     BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb,
-    BQPDRStopParticipating, BQPDRWithdrawalIntro
+    BQPDRStopParticipating, BQPDRWithdrawalIntro, BQPDRCOPEVaccine1
 )
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.participant_enums import QuestionnaireResponseStatus, TEST_HPO_NAME
@@ -112,6 +112,7 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
             'cope_nov': BQPDRCOPENov,
             'cope_dec': BQPDRCOPEDec,
             'cope_feb': BQPDRCOPEFeb,
+            'cope_vaccine1': BQPDRCOPEVaccine1,
             # There are two different module id codes in use for the withdrawal survey
             'withdrawal_intro': BQPDRWithdrawalIntro,
             'StopParticipating': BQPDRStopParticipating

--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -21,6 +21,7 @@ BQ_TABLES = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPENov'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEDec'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEFeb'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEVaccine1'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRWithdrawalIntro'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRStopParticipating'),
 
@@ -75,6 +76,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPENovView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEDecView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEFebView'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEVaccine1View'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRWithdrawalView'),
 
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherView'),

--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -21,6 +21,8 @@ BQ_TABLES = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPENov'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEDec'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEFeb'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRWithdrawalIntro'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRStopParticipating'),
 
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummary'),
 
@@ -73,6 +75,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPENovView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEDecView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEFebView'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRWithdrawalView'),
 
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherView'),
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherGenderView'),

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -635,6 +635,24 @@ class BQPDRCOPEFebView(BQView):
     __pk_id__ = ['participant_id', 'questionnaire_response_id']
     _show_created = True
 
+class BQPDRCOPEVaccine1Schema(_BQModuleSchema):
+    """ COPE Vaccine Survey 1 (initial) """
+    _module = 'cope_vaccine1'
+    _excluded_fields = ()
+
+class BQPDRCOPEVaccine1(BQTable):
+    """ COPE Vaccine 1 BigQuery Table """
+    __tablename__ = 'pdr_mod_cope_vaccine1'
+    __schema__ = BQPDRCOPEVaccine1Schema
+
+class BQPDRCOPEVaccine1View(BQView):
+    """ PDR COPE Vaccine1 BigQuery View """
+    __viewname__ = 'v_pdr_mod_cope_vaccine1'
+    __viewdescr__ = 'PDR COPE Vaccine1 Module View'
+    __table__ = BQPDRCOPEVaccine1
+    __pk_id__ = ['participant_id', 'questionnaire_response_id']
+    _show_created = True
+
 # Note:  the StopParticipating and withdrawal_intro module codes are used for similar surveys that contain the
 # same survey questions.
 class BQPDRWithdrawalIntroSchema(_BQModuleSchema):

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -25,9 +25,11 @@ from rdr_service.dao.bq_genomics_dao import bq_genomic_set_update, bq_genomic_se
 from rdr_service.dao.bq_workbench_dao import bq_workspace_update, bq_workspace_user_update, \
     bq_institutional_affiliations_update, bq_researcher_update
 from rdr_service.dao.resource_dao import ResourceDataDao
-from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb, BQPDRFamilyHistory, \
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory
+from rdr_service.model.bq_questionnaires import (
+    BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth,
+    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb, BQPDRFamilyHistory,
+    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRWithdrawalIntro, BQPDRStopParticipating
+)
 from rdr_service.model.participant import Participant
 from rdr_service.offline.bigquery_sync import batch_rebuild_participants_task
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
@@ -92,7 +94,9 @@ class ParticipantResourceClass(object):
                     BQPDRCOPEFeb,
                     BQPDRFamilyHistory,
                     BQPDRPersonalMedicalHistory,
-                    BQPDRHealthcareAccess
+                    BQPDRHealthcareAccess,
+                    BQPDRStopParticipating,
+                    BQPDRWithdrawalIntro
                 )
 
                 for module in modules:

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -28,7 +28,8 @@ from rdr_service.dao.resource_dao import ResourceDataDao
 from rdr_service.model.bq_questionnaires import (
     BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth,
     BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb, BQPDRFamilyHistory,
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRWithdrawalIntro, BQPDRStopParticipating
+    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRWithdrawalIntro, BQPDRStopParticipating,
+    BQPDRCOPEVaccine1
 )
 from rdr_service.model.participant import Participant
 from rdr_service.offline.bigquery_sync import batch_rebuild_participants_task
@@ -92,6 +93,7 @@ class ParticipantResourceClass(object):
                     BQPDRCOPENov,
                     BQPDRCOPEDec,
                     BQPDRCOPEFeb,
+                    BQPDRCOPEVaccine1,
                     BQPDRFamilyHistory,
                     BQPDRPersonalMedicalHistory,
                     BQPDRHealthcareAccess,


### PR DESCRIPTION
## Resolves *[DA-2019](https://precisionmedicineinitiative.atlassian.net/browse/DA-2019)*


## Description of changes/additions
Add the withdrawal survey response data to PDR questionnaire data generators.  PTSC used a different module code (`StopParticipating`) than CE (`withdrawal_intro`) for the withdrawal questionnaire.  To minimize impact on the existing BQ model / questionnaire data generator design, both withdrawal modules will have their own `pdr_mod_*` base table in BigQuery, but there will be a single custom BigQuery `v_pdr_mod_withdrawal` view that combines the data for analysts to query a single source.

Also pre-enabling support in PDR for the COPE Vaccine survey (cope_vaccine1 module)  that launches June 3.  (No migrations will be applied until end-to-end testing starts)

## Tests
PDR data was generated in stable for several participants with withdrawal questionnaire responses.  New BQ tables/view were created with `migrate-bq` tool in  stable BigQuery and confirmed the data was synced by the existing `BigQuerySync` cron job.