### PR TITLE
PDR / BigQuery schema fixes

### DIFF
--- a/rdr_service/dao/bq_hpo_dao.py
+++ b/rdr_service/dao/bq_hpo_dao.py
@@ -4,10 +4,8 @@ from sqlalchemy.sql import text
 
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
-from rdr_service.model.bq_hpo import BQHPOSchema, BQHPO
+from rdr_service.model.bq_hpo import BQHPOSchema, BQHPO, BQOrganizationTypeEnum, BQObsoleteStatusEnum
 from rdr_service.model.hpo import HPO
-from rdr_service.model.site_enums import ObsoleteStatus
-from rdr_service.participant_enums import OrganizationType
 
 
 
@@ -28,14 +26,15 @@ class BQHPOGenerator(BigQueryGenerator):
         with ro_dao.session() as ro_session:
             row = ro_session.execute(text('select * from hpo where hpo_id = :id'), {'id': hpo_id}).first()
             data = ro_dao.to_dict(row)
-            # TODO:  Tried convert_to_enum=True but does not handle null values gracefully.  Is there a better way to
-            # TODO: populate the new *_id fields vs. using the messages.Enum classes from participant_enums.py?
-            if data['is_obsolete']:
-                data['is_obsolete_id'] = int(ObsoleteStatus(data['is_obsolete']))
-                data['is_obsolete'] = str(ObsoleteStatus(data['is_obsolete']))
-            if data['organization_type']:
-                data['organization_type_id'] = int(OrganizationType(data['organization_type']))
-                data['organization_type'] = str(OrganizationType(data['organization_type']))
+            # TODO: convenience method in BQRecord that can use BQField fld_enum to do the _id field assignments?
+            is_obsolete = data['is_obsolete']
+            org_type = data['organization_type']
+            if is_obsolete:
+                data['is_obsolete_id'] = BQObsoleteStatusEnum(is_obsolete).value
+                data['is_obsolete'] = BQObsoleteStatusEnum(is_obsolete).name
+            if org_type:
+                data['organization_type_id'] = BQOrganizationTypeEnum(org_type).value
+                data['organization_type'] = BQOrganizationTypeEnum(org_type).name
             return BQRecord(schema=BQHPOSchema, data=data, convert_to_enum=convert_to_enum)
 
 

--- a/rdr_service/dao/bq_hpo_dao.py
+++ b/rdr_service/dao/bq_hpo_dao.py
@@ -29,12 +29,15 @@ class BQHPOGenerator(BigQueryGenerator):
             # TODO: convenience method in BQRecord that can use BQField fld_enum to do the _id field assignments?
             is_obsolete = data['is_obsolete']
             org_type = data['organization_type']
-            if is_obsolete:
-                data['is_obsolete_id'] = BQObsoleteStatusEnum(is_obsolete).value
-                data['is_obsolete'] = BQObsoleteStatusEnum(is_obsolete).name
-            if org_type:
-                data['organization_type_id'] = BQOrganizationTypeEnum(org_type).value
-                data['organization_type'] = BQOrganizationTypeEnum(org_type).name
+            if is_obsolete is not None:
+                obsolete_enum = BQObsoleteStatusEnum(is_obsolete)
+                data['is_obsolete_id'] = obsolete_enum.value
+                data['is_obsolete'] = obsolete_enum.name
+            if org_type is not None:
+                org_enum = BQOrganizationTypeEnum(org_type)
+                data['organization_type_id'] = org_enum.value
+                data['organization_type'] = org_enum.name
+
             return BQRecord(schema=BQHPOSchema, data=data, convert_to_enum=convert_to_enum)
 
 

--- a/rdr_service/dao/bq_organization_dao.py
+++ b/rdr_service/dao/bq_organization_dao.py
@@ -27,9 +27,10 @@ class BQOrganizationGenerator(BigQueryGenerator):
                 text('select * from organization where organization_id = :id'), {'id': organization_id}).first()
             data = ro_dao.to_dict(row)
             is_obsolete = data['is_obsolete']
-            if is_obsolete:
-                data['is_obsolete_id'] = BQObsoleteStatusEnum(is_obsolete).value
-                data['is_obsolete'] = BQObsoleteStatusEnum(is_obsolete).name
+            if is_obsolete is not None:
+                obsolete_enum = BQObsoleteStatusEnum(is_obsolete)
+                data['is_obsolete_id'] = obsolete_enum.value
+                data['is_obsolete'] = obsolete_enum.name
 
             return BQRecord(schema=BQOrganizationSchema, data=data, convert_to_enum=convert_to_enum)
 

--- a/rdr_service/dao/bq_organization_dao.py
+++ b/rdr_service/dao/bq_organization_dao.py
@@ -4,6 +4,7 @@ from sqlalchemy.sql import text
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_organization import BQOrganizationSchema, BQOrganization
+from rdr_service.model.bq_site import BQObsoleteStatusEnum
 from rdr_service.model.organization import Organization
 
 
@@ -25,6 +26,11 @@ class BQOrganizationGenerator(BigQueryGenerator):
             row = ro_session.execute(
                 text('select * from organization where organization_id = :id'), {'id': organization_id}).first()
             data = ro_dao.to_dict(row)
+            is_obsolete = data['is_obsolete']
+            if is_obsolete:
+                data['is_obsolete_id'] = BQObsoleteStatusEnum(is_obsolete).value
+                data['is_obsolete'] = BQObsoleteStatusEnum(is_obsolete).name
+
             return BQRecord(schema=BQOrganizationSchema, data=data, convert_to_enum=convert_to_enum)
 
 

--- a/rdr_service/dao/bq_site_dao.py
+++ b/rdr_service/dao/bq_site_dao.py
@@ -32,18 +32,22 @@ class BQSiteGenerator(BigQueryGenerator):
             ds_status = data['digital_scheduling_status']
             enrolling_status = data['enrolling_status']
             is_obsolete = data['is_obsolete']
-            if site_status:
-                data['site_status'] = BQSiteStatus(site_status).name
-                data['site_status_id'] = BQSiteStatus(site_status).value
-            if ds_status:
-                data['digital_scheduling_status'] = BQDigitalSchedulingStatus(ds_status).name
-                data['digital_scheduling_status_id'] = BQDigitalSchedulingStatus(ds_status).value
-            if enrolling_status:
-                data['enrolling_status'] = BQEnrollingStatus(enrolling_status).name
-                data['enrolling_status_id'] = BQEnrollingStatus(enrolling_status).value
-            if is_obsolete:
-                data['is_obsolete'] = BQObsoleteStatusEnum(is_obsolete).name
-                data['is_obsolete_id'] = BQObsoleteStatusEnum(is_obsolete).value
+            if site_status is not None:
+                site_status_enum = BQSiteStatus(site_status)
+                data['site_status'] = site_status_enum.name
+                data['site_status_id'] = site_status_enum.value
+            if ds_status is not None:
+                ds_status_enum = BQDigitalSchedulingStatus(ds_status)
+                data['digital_scheduling_status'] = ds_status_enum.name
+                data['digital_scheduling_status_id'] = ds_status_enum.value
+            if enrolling_status is not None:
+                enroll_enum = BQEnrollingStatus(enrolling_status)
+                data['enrolling_status'] = enroll_enum.name
+                data['enrolling_status_id'] = enroll_enum.value
+            if is_obsolete is not None:
+                obsolete_enum = BQObsoleteStatusEnum(is_obsolete)
+                data['is_obsolete'] = obsolete_enum.name
+                data['is_obsolete_id'] = obsolete_enum.value
 
             return BQRecord(schema=BQSiteSchema, data=data, convert_to_enum=convert_to_enum)
 

--- a/rdr_service/model/bq_organization.py
+++ b/rdr_service/model/bq_organization.py
@@ -14,7 +14,9 @@ class BQOrganizationSchema(BQSchema):
     external_id = BQField('external_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.REQUIRED)
     # Human readable display name for the organization, e.g. University of Wisconsin, Madison
     display_name = BQField('display_name', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
-    is_obsolete = BQField('is_obsolete', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
+    is_obsolete = BQField('is_obsolete', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE,
+                          fld_enum=BQObsoleteStatusEnum)
+    is_obsolete_id = BQField('is_obsolete_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
                           fld_enum=BQObsoleteStatusEnum)
 
 

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -181,6 +181,7 @@ class BQPatientStatusSchema(BQSchema):
     organization_id = BQField('organization_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     site = BQField('site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     site_id = BQField('site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    patient_status_history_id = BQField('patient_status_history_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQEhrReceiptSchema(BQSchema):
@@ -190,6 +191,8 @@ class BQEhrReceiptSchema(BQSchema):
     file_timestamp = BQField('file_timestamp', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
     first_seen = BQField('first_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     last_seen = BQField('last_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    participant_ehr_receipt_id = BQField('participant_ehr_receipt_id', BQFieldTypeEnum.INTEGER,
+                                         BQFieldModeEnum.NULLABLE)
 
 
 class BQParticipantSummarySchema(BQSchema):

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -117,6 +117,8 @@ class BQPhysicalMeasurements(BQSchema):
     pm_finalized_site = BQField('pm_finalized_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     pm_finalized_site_id = BQField('pm_finalized_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     pm_finalized = BQField('pm_finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    pm_physical_measurements_id = BQField('pm_physical_measurements_id', BQFieldTypeEnum.INTEGER,
+                                         BQFieldModeEnum.NULLABLE)
 
 
 class BQBiobankSampleSchema(BQSchema):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -48,6 +48,8 @@ class BQPDREhrReceiptSchema(BQSchema):
     file_timestamp = BQField('file_timestamp', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
     first_seen = BQField('first_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     last_seen = BQField('last_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    participant_ehr_receipt_id = BQField('participant_ehr_receipt_id', BQFieldTypeEnum.INTEGER,
+                                         BQFieldModeEnum.NULLABLE)
 
 
 class BQPDRParticipantSummarySchema(BQSchema):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -21,6 +21,9 @@ class BQPDRPhysicalMeasurements(BQSchema):
     pm_status = BQField('pm_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     pm_status_id = BQField('pm_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     pm_finalized = BQField('pm_finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    pm_physical_measurements_id = BQField('pm_physical_measurements_id', BQFieldTypeEnum.INTEGER,
+                                         BQFieldModeEnum.NULLABLE)
+
 
 # TODO:  Deprecate use of this class and add these fields to the BQBiobankOrderSchema
 class BQPDRBiospecimenSchema(BQSchema):
@@ -37,6 +40,7 @@ class BQPDRBiospecimenSchema(BQSchema):
     biosp_baseline_tests_confirmed = BQField('biosp_baseline_tests_confirmed',
                                              BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
+
 class BQPDREhrReceiptSchema(BQSchema):
     """
     PDR Participant EHR Receipt Histories
@@ -44,6 +48,7 @@ class BQPDREhrReceiptSchema(BQSchema):
     file_timestamp = BQField('file_timestamp', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
     first_seen = BQField('first_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     last_seen = BQField('last_seen', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
 
 class BQPDRParticipantSummarySchema(BQSchema):
     """
@@ -212,6 +217,7 @@ class BQPDRParticipantSummaryView(BQView):
         ])
     )
 
+
 class BQPDRParticipantSummaryAllView(BQPDRParticipantSummaryView):
     __viewname__ = 'v_pdr_participant_all'
     __viewdescr__ = 'PDR Participant Summary All View'
@@ -238,10 +244,11 @@ class BQPDRParticipantSummaryAllView(BQPDRParticipantSummaryView):
         ])
     )
 
+
 # TODO:  This is now a custom view in PDR BigQuery (as of PDR-262).  Needs to be disabled here so it will not be
 # updated by migrate-bq tool.   Consider moving all custom views into our model?  Some (like this one) will have
 # extremely complicated SQL definitions, so unclear if that is a viable/best solution
-#class BQPDRParticipantSummaryWithdrawnView(BQView):
+# class BQPDRParticipantSummaryWithdrawnView(BQView):
 #   __viewname__ = 'v_pdr_participant_withdrawn'
 #   __viewdescr__ = 'PDR Participant Summary Withdrawn View'
 #   __table__ = BQPDRParticipantSummary
@@ -343,6 +350,7 @@ class BQPDRBioSpecView(BQView):
       WHERE ps.rn = 1 and ps.test_participant != 1
   """
 
+
 class BQPDRPatientStatuesView(BQView):
     __viewname__ = 'v_pdr_participant_patient_status'
     __viewdescr__ = 'PDR Participant Patient Status View'
@@ -356,6 +364,7 @@ class BQPDRPatientStatuesView(BQView):
       ) ps cross join unnest(patient_statuses) as nt
       WHERE ps.rn = 1 and ps.test_participant != 1
   """
+
 
 class BQPDRParticipantBiobankOrderView(BQView):
     __viewname__ = 'v_pdr_participant_biobank_order'
@@ -387,6 +396,7 @@ class BQPDRParticipantBiobankOrderView(BQView):
         WHERE ps.rn = 1 and ps.test_participant != 1
     """
 
+
 class BQPDRParticipantBiobankSampleView(BQView):
     __viewname__ = 'v_pdr_participant_biobank_sample'
     __viewdescr__ = 'PDR Participant Biobank Sample Details view'
@@ -414,6 +424,7 @@ class BQPDRParticipantBiobankSampleView(BQView):
             ) ps cross join unnest(biobank_orders) as bbo, unnest(bbo.bbo_samples) as nt
             WHERE ps.rn = 1 and ps.test_participant != 1
     """
+
 
 class BQPDREhrReceiptView(BQView):
     __viewname__ = 'v_pdr_participant_ehr_receipt'

--- a/rdr_service/model/bq_site.py
+++ b/rdr_service/model/bq_site.py
@@ -79,6 +79,7 @@ class BQSiteSchema(BQSchema):
                           fld_enum=BQObsoleteStatusEnum)
     is_obsolete_id = BQField('is_obsolete_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE,
                              fld_enum=BQObsoleteStatusEnum)
+    site_type = BQField('site_type', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
 
 class BQSite(BQTable):
     """ Organization Site BigQuery Table """

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -820,7 +820,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 pm_status = PhysicalMeasurementsStatus(row.status) if row.status else PhysicalMeasurementsStatus.UNSET
 
             pm_list.append({
-                'physical_measurement_id': row.physicalMeasurementsId,
+                'physical_measurements_id': row.physicalMeasurementsId,
                 'status': str(pm_status),
                 'status_id': int(pm_status),
                 'created': row.created,

--- a/rdr_service/resource/schemas/organization.py
+++ b/rdr_service/resource/schemas/organization.py
@@ -5,6 +5,7 @@
 from marshmallow import validate
 
 from rdr_service.resource import Schema, fields
+from rdr_service.resource.schemas.site import ObsoleteStatusEnum
 from rdr_service.resource.constants import SchemaID
 
 
@@ -17,7 +18,8 @@ class OrganizationSchema(Schema):
     external_id = fields.String(validate=validate.Length(max=80))
     # Human readable display name for the organization, e.g. University of Wisconsin, Madison
     display_name = fields.String(validate=validate.Length(max=255))
-    is_obsolete = fields.Boolean()
+    is_obsolete = fields.EnumString(enum=ObsoleteStatusEnum)
+    is_obsolete_id = fields.EnumInteger(enum=ObsoleteStatusEnum)
 
     class Meta:
         schema_id = SchemaID.organization

--- a/rdr_service/resource/schemas/site.py
+++ b/rdr_service/resource/schemas/site.py
@@ -43,6 +43,7 @@ class SiteSchema(Schema):
 
     site_id = fields.Int32(required=False)
     site_name = fields.String(validate=validate.Length(max=255))
+    site_type = fields.String(validate=validate.Length(max=255))
     # The Google group for the site; this is a unique key used externally.
     google_group = fields.String(validate=validate.Length(max=255))
     mayolink_client_number = fields.Int32(required=False)

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -801,7 +801,7 @@ class SiteResourceClass(object):
             else:
                 _logger.warning(f'Unknown table {table}.  Skipping rebuild for {table}')
 
-        return 1
+        return 0
 
 def get_id_list(fname):
     """

--- a/tests/resource_tests/schema_tests/test_resource_schemas.py
+++ b/tests/resource_tests/schema_tests/test_resource_schemas.py
@@ -33,10 +33,8 @@ bq_field_exclusions = {
 
 # Fields from the resource schemas that do not exist in the BQ schema
 rsc_field_exclusions = {
-    'EhrReceiptSchema': ['participant_ehr_receipt_id'],
     'HPOSchema': list(rschemas.HPOSchema.Meta.pii_fields),
-    'PatientStatusSchema':
-        list(rschemas.participant.PatientStatusSchema.Meta.pii_fields) + ['patient_status_history_id'],
+    'PatientStatusSchema': list(rschemas.participant.PatientStatusSchema.Meta.pii_fields),
     'GenomicManifestFileSchema': _default_exclusions,
     'GenomicManifestFeedbackSchema': _default_exclusions,
     'GenomicGCValidationMetricsSchema': _default_exclusions,

--- a/tests/resource_tests/schema_tests/test_resource_schemas.py
+++ b/tests/resource_tests/schema_tests/test_resource_schemas.py
@@ -37,7 +37,6 @@ rsc_field_exclusions = {
     'HPOSchema': list(rschemas.HPOSchema.Meta.pii_fields),
     'PatientStatusSchema':
         list(rschemas.participant.PatientStatusSchema.Meta.pii_fields) + ['patient_status_history_id'],
-    'PhysicalMeasurementsSchema': ['physical_measurements_id'],
     'GenomicManifestFileSchema': _default_exclusions,
     'GenomicManifestFeedbackSchema': _default_exclusions,
     'GenomicGCValidationMetricsSchema': _default_exclusions,


### PR DESCRIPTION
## Resolves *issues from PR #2455 ,  [PDR-319](https://precisionmedicineinitiative.atlassian.net/browse/PDR-319)*


## Description of changes/additions
Resolves additional PDR schema cleanup and issues found from PR #2455  in PDR testing for RDR 1.96.1 release 
Adds a primary key field (pm_physical_measurements_id) to the PDR PhysicalMeasurements BQ schemas
Adds new site_type field to the BQSiteSchema for PDR-319
Updates migrate-bq tool to produce more useful details on schema changes found during --dry-run  
Updates resource tool to allow manual PDR rebuilds of the hpo, site, and organization tables
Adds id fields from PatientStatusSchema and ParticipantEhrReceiptSchema resource schemas to BQ schemas

## Tests
Existing unit tests and manual tests in sandbox to verify PDR migrations and resource tool data rebuilds


