### PR TITLE
[DA-2045] Adding cope vaccine survey to ppi count

### DIFF
--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -17,7 +17,8 @@
     "questionnaireOnCopeJuly",
     "questionnaireOnCopeNov",
     "questionnaireOnCopeDec",
-    "questionnaireOnCopeFeb"
+    "questionnaireOnCopeFeb",
+    "questionnaireOnCopeVaccineMinute1"
   ],
   "baseline_sample_test_codes": [
   	"1ED04",

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -707,6 +707,7 @@ class QuestionnaireResponseDao(BaseDao):
                         and participant_summary.questionnaireOnCopeVaccineMinute1 != QuestionnaireStatus.SUBMITTED:
                     participant_summary.questionnaireOnCopeVaccineMinute1 = QuestionnaireStatus.SUBMITTED
                     participant_summary.questionnaireOnCopeVaccineMinute1Authored = authored
+                    module_changed = True
 
         if module_changed:
             participant_summary.numCompletedBaselinePPIModules = count_completed_baseline_ppi_modules(

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -873,6 +873,7 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
         self.insert_codes()
         participant = self.data_generator.create_database_participant(participantId=1, biobankId=2)
         self._setup_participant()
+        num_completed_ppi_after_setup = self.participant_summary_dao.get(1).numCompletedPPIModules
 
         questionnaire = self._create_questionnaire(module_code=self.vaccine_1_survey_module_code)
         authored_date = datetime.datetime(2021, 3, 4)
@@ -888,6 +889,7 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
         ).one()
         self.assertEqual(QuestionnaireStatus.SUBMITTED, summary.questionnaireOnCopeVaccineMinute1)
         self.assertEqual(authored_date, summary.questionnaireOnCopeVaccineMinute1Authored)
+        self.assertEqual(num_completed_ppi_after_setup + 1, summary.numCompletedPPIModules)
 
         participant_res_data = self.make_participant_resource(participant.participantId)
         [vaccine_module_data] = self.get_generated_items(


### PR DESCRIPTION
## Resolves *[DA-2045](https://precisionmedicineinitiative.atlassian.net/browse/DA-2045)*
Adds the COPE vaccine survey to the ppi module count algorithm.

## Description of changes/additions
Sets `module_changed` to recalculate the count. And adds to the config for testing. I'll be updating the base-config as part of the ticket.

## Tests
- [x] unit tests


