### PR TITLE
[ROC-969] Validating participant withdrawal status before making call to MayoLINK

### DIFF
--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -274,7 +274,7 @@ class MailKitOrderDao(UpdatableDao):
 
         return order
 
-    def insert_biobank_order(self, pid, resource):
+    def insert_biobank_order(self, pid, resource, session=None):
         obj = BiobankOrder()
         obj.participantId = int(pid)
         obj.created = clock.CLOCK.now()
@@ -284,10 +284,13 @@ class MailKitOrderDao(UpdatableDao):
         obj.orderOrigin = resource.get("orderOrigin")
         test = self.get(resource["id"])
         obj.mailKitOrders = [test]
-        bod = BiobankOrderDao()
         obj.samples = [BiobankOrderedSample(test="1SAL2", processingRequired=False, description="salivary pilot kit")]
         self._add_identifiers_and_main_id(obj, app_util.ObjectView(resource))
-        bod.insert(obj)
+        biobank_order_dao = BiobankOrderDao()
+        if session is None:
+            biobank_order_dao.insert(obj)
+        else:
+            biobank_order_dao.insert_with_session(session, obj)
 
     def insert_mayolink_create_order_history(self, pid, resource, request_payload, response_payload):
         mayolink_create_order_history = MayolinkCreateOrderHistory()


### PR DESCRIPTION
## Partially resolves *[ROC-969](https://precisionmedicineinitiative.atlassian.net/browse/ROC-969)*
When a participant is withdrawn, the BiobankOrderDao's `_update_participant_summary` method will raise an error. But that currently happens after a request has been made to the MayoLINK API for the order. Best case scenario is that this request is made once and not replayed. But with CE's retry logic we're sending MayoLINK multiple POST requests for the order.

## Description of changes/additions
This changes the code to check to see if the participant is withdrawn before making the MayoLINK API call. There are other validation scenarios that should be checked before calling MayoLINK. I'm still trying to get a sense of what would need to be validated when. But this can be implemented before then.

This loads the participant summary and locks it for updates (to make sure it isn't withdrawn before the request finishes). Then the request is processed as normal (unless the participant is wthdrawn), using the same session to later update the participant summary.

## Tests
- [x] unit tests


