### PR TITLE
Removing logs for inspection unsupported errors

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -89,7 +89,9 @@ def log_api_request(log: RequestsLog = None, model_obj=None):
                 else:
                     log.fpk_alt_id = str(insp.identity[0])
 
-        except (NoInspectionAvailable, Exception):  # pylint: disable=broad-except
+        except NoInspectionAvailable:
+            pass  # Ignoring errors generated for model objects that can't be inspected (like the FHIR lib classes)
+        except Exception:  # pylint: disable=broad-except
             logging.error('Error setting request log data', exc_info=True)
 
     return save_raw_request_record(log)


### PR DESCRIPTION
## Resolves *no ticket*
Release 1.96.1 added some new log messages. One of them is for when `inspect` fails because there's "no inspection system" for the object.

## Description of changes/additions
This removes skips logging the message if that occurs, as the object likely isn't one of our models.

## Tests
- [ ] unit tests


