### PR TITLE
[ROC-947] Make filtering exception for inadvertently withdrawn participants

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -141,6 +141,8 @@ DATA_DICTIONARY_DOCUMENT_ID = "data_dictionary_document_id"
 
 RDR_SLACK_WEBHOOKS = "rdr_slack_webhooks"
 
+DECEASED_REPORT_FILTER_EXCEPTIONS = "deceased_report_filter_exceptions"
+
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}
 

--- a/tests/dao_tests/test_deceased_reports_dao.py
+++ b/tests/dao_tests/test_deceased_reports_dao.py
@@ -1,0 +1,33 @@
+
+from rdr_service.config import DECEASED_REPORT_FILTER_EXCEPTIONS
+from rdr_service.dao.deceased_report_dao import DeceasedReportDao
+from rdr_service.participant_enums import DeceasedReportStatus, WithdrawalStatus
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class DeceasedReportDaoTest(BaseTestCase):
+    def test_report_exceptions(self):
+        """
+        Some deceased participants have been inadvertently withdrawn. They have pending deceased reports, but since
+        they're withdrawn the reports don't display for approval. In order to get the pending reports approved,
+        and let us remove the withdrawal status without making the participant appear contactable, we needed a way
+        of making the pending reports visible even though the participants are withdrawn.
+        """
+
+        # Create a withdrawn participant with a report that is pending
+        participant = self.data_generator.create_database_participant(
+            withdrawalStatus=WithdrawalStatus.NO_USE
+        )
+        expected_report = self.data_generator.create_database_deceased_report(
+            participantId=participant.participantId,
+            status=DeceasedReportStatus.PENDING
+        )
+
+        # Set up participant as an exception to the report filters
+        self.temporarily_override_config_setting(DECEASED_REPORT_FILTER_EXCEPTIONS, [participant.participantId])
+
+        # Load the deceased reports and verify that the pending report is visible
+        dao = DeceasedReportDao()
+        actual_reports = dao.load_reports(participant_id=participant.participantId)
+        self.assertNotEmpty(actual_reports)
+        self.assertEqual(expected_report.id, actual_reports[0].id)


### PR DESCRIPTION
## Partially resolves *[ROC-947](https://precisionmedicineinitiative.atlassian.net/browse/ROC-947)*
There are a few participants that have been withdrawn but should have been marked as deceased instead. They currently have pending deceased reports, but since they're withdrawn those reports don't appear for approval.

## Description of changes/additions
This adds an exception for specific participant ids, letting the API show their deceased reports to have them approved. Once the reports are approved we'll be able to remove the withdrawal status for the participants without fear of them being contacted.

## Tests
- [x] unit tests


