### PR TITLE
Setting target for postgres archive cron job test

### DIFF
--- a/rdr_service/cron_test.yaml
+++ b/rdr_service/cron_test.yaml
@@ -7,3 +7,4 @@
   url: /offline/MigrateRequestsLog/rdrpostgresql
   timezone: America/New_York
   schedule: every day 1:00
+  target: offline


### PR DESCRIPTION
## Resolves *no ticket*
I missed the 'target' keyword when scheduling the archive cron job for postgres. So it was trying to run it in the main app and getting a 404.

## Description of changes/additions
Sets the target to offline so the job will run in the offline service's version of the app.

## Tests
- [ ] unit tests


