### PR TITLE
Fixing issues in questionnaire response validation

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -211,7 +211,7 @@ class ResponseValidator:
         elif question_definition.questionType in (SurveyQuestionType.TEXT, SurveyQuestionType.NOTES):
             if question_definition.validation is None and answer.valueString is None:
                 logging.warning(f'No valueString answer given for text-based question {question_code_value}')
-            elif question_definition.validation is not None:
+            elif question_definition.validation is not None and question_definition.validation != '':
                 if question_definition.validation.startswith('date'):
                     if answer.valueDate is None:
                         logging.warning(f'No valueDate answer given for date-based question {question_code_value}')
@@ -220,7 +220,7 @@ class ResponseValidator:
                             answer.valueDate,
                             question_definition.validation_min,
                             question_definition.validation_max,
-                            parser.parse,
+                            lambda validation_str: parser.parse(validation_str).date(),
                             question_code_value
                         )
                 elif question_definition.validation == 'integer':

--- a/tests/dao_tests/test_response_validator.py
+++ b/tests/dao_tests/test_response_validator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 import mock
 from typing import Dict, List
 
@@ -273,9 +273,9 @@ class ResponseValidatorTest(BaseTestCase):
                 )
             },
             answers={
-                date_question_code: QuestionnaireResponseAnswer(valueDate=datetime(2020, 7, 4)),
+                date_question_code: QuestionnaireResponseAnswer(valueDate=date(2020, 7, 4)),
                 integer_question_code: QuestionnaireResponseAnswer(valueInteger=11),
-                broken_date_question_code: QuestionnaireResponseAnswer(valueDate=datetime(2020, 7, 4)),
+                broken_date_question_code: QuestionnaireResponseAnswer(valueDate=date(2020, 7, 4)),
                 broken_integer_question_code: QuestionnaireResponseAnswer(valueInteger=11),
             }
         )
@@ -285,7 +285,7 @@ class ResponseValidatorTest(BaseTestCase):
 
         mock_logging.warning.assert_has_calls([
             mock.call(
-                f'Given answer "2020-07-04 00:00:00" is less than expected min '
+                f'Given answer "2020-07-04" is less than expected min '
                 f'"2020-09-01" for question {date_question_code.value}'
             ),
             mock.call(


### PR DESCRIPTION
## Resolves *no ticket*
This takes care of two issues coming up when validating responses. One is when comparing date values for questionnaire response answers. The unit tests created them as Datetime objects, but they're loaded in FHIR as Date objects and can't be compared to Datetimes. The other issue is that some validation strings are empty strings and were being logged as unrecognized.

## Description of changes/additions
This updates the code to parse validation string dates as Date objects, and ignore validation strings that are empty strings.

## Tests
- [x] unit tests


