### PR TITLE
Remove spaces in notification

### DIFF
--- a/rdr_service/config/pub_sub_config_prod.json
+++ b/rdr_service/config/pub_sub_config_prod.json
@@ -94,7 +94,7 @@
       "topic_name": "genomic_data_files_upload",
       "topic_project": "all-of-us-rdr-prod",
       "payload_format": "JSON_API_V1",
-      "object_name_prefix": "Wgs_sample_raw_data/ SS_VCF_research/",
+      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
       "event_types": [
         "OBJECT_FINALIZE"
       ]
@@ -127,7 +127,7 @@
       "topic_name": "genomic_data_files_upload",
       "topic_project": "all-of-us-rdr-prod",
       "payload_format": "JSON_API_V1",
-      "object_name_prefix": "wgs_sample_raw_data/ ss_vcf_research/",
+      "object_name_prefix": "wgs_sample_raw_data/ss_vcf_research/",
       "event_types": [
         "OBJECT_FINALIZE"
       ]
@@ -160,7 +160,7 @@
       "topic_name": "genomic_data_files_upload",
       "topic_project": "all-of-us-rdr-prod",
       "payload_format": "JSON_API_V1",
-      "object_name_prefix": "Wgs_sample_raw_data/ SS_VCF_research/",
+      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
       "event_types": [
         "OBJECT_FINALIZE"
       ]

--- a/rdr_service/config/pub_sub_config_sandbox.json
+++ b/rdr_service/config/pub_sub_config_sandbox.json
@@ -57,7 +57,7 @@
       "topic_name": "genomic_data_files_upload",
       "topic_project": "all-of-us-rdr-sandbox",
       "payload_format": "JSON_API_V1",
-      "object_name_prefix": "Wgs_sample_raw_data/ SS_VCF_research/",
+      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
       "event_types": [
         "OBJECT_FINALIZE"
       ]


### PR DESCRIPTION
## Resolves *[ticket #]*
N/A

## Description of changes/additions
Need to remove the spaces in the notificiation configs. In testing on sandbox, found a bug in the notifications where only way to access child was add space in path. This PR is just for config changes, notifications have already been updated via `gsutil` in prod.

## Tests
- [] unit tests


