### PR TITLE
[DA-2055] Adding code for validating Vibrent primary consent files

### DIFF
--- a/rdr_service/services/consent_files.py
+++ b/rdr_service/services/consent_files.py
@@ -1,0 +1,185 @@
+from abc import ABC, abstractmethod
+from dateutil import parser
+from geometry import Rect
+from google.cloud.storage.blob import Blob
+from io import BytesIO
+from pdfminer.high_level import extract_pages
+from pdfminer.layout import LTChar, LTFigure, LTImage, LTTextBox
+from typing import List
+
+
+class ConsentFile(ABC):
+    def __init__(self, pdf: 'Pdf'):
+        self.pdf = pdf
+
+    def get_signature_on_file(self):
+        signature_elements = self._get_signature_elements()
+        signature = None
+        for element in signature_elements:
+            first_child = Pdf.get_first_child_of_element(element)
+
+            if isinstance(first_child, LTChar):
+                possible_signature = ''
+                for char in element:
+                    possible_signature += char.get_text()
+                possible_signature = possible_signature.strip()
+                if possible_signature != '':
+                    signature = possible_signature
+                    break
+
+            elif isinstance(first_child, LTImage):
+                signature = True
+                break
+
+        return signature
+
+    def get_date_signed(self):
+        date_elements = self._get_date_elements()
+        for element in date_elements:
+            if isinstance(element, LTFigure):
+                date_str = ''
+                for char in element:
+                    date_str += char.get_text()
+                date_str = date_str.strip()
+                if date_str:
+                    return parser.parse(date_str).date()
+
+    @abstractmethod
+    def _get_signature_elements(self):
+        ...
+
+    @abstractmethod
+    def _get_date_elements(self):
+        ...
+
+
+class PrimaryConsentFile(ConsentFile, ABC):
+    def get_is_va_consent(self):
+        return self.pdf.get_page_number_of_text(['you will get care at a VA facility']) is not None
+
+
+class VibrentPrimaryConsentFile(PrimaryConsentFile):
+    def _get_signature_page(self):
+        return self.pdf.get_page_number_of_text([
+            'I freely and willingly choose',
+            'sign your full name'
+        ])
+
+    def _get_signature_elements(self):
+        signature_page = self._get_signature_page()
+        if signature_page is None:
+            return []
+
+        elements = self.pdf.get_elements_intersecting_box(
+            Rect.from_edges(left=125, right=500, bottom=155, top=160),
+            page=signature_page
+        )
+        if not elements:  # old style consent
+            elements = self.pdf.get_elements_intersecting_box(
+                Rect.from_edges(left=220, right=500, bottom=590, top=600), page=signature_page)
+
+        return elements
+
+    def _get_date_elements(self):
+        signature_page = self._get_signature_page()
+        if signature_page is None:
+            return []
+
+        elements = self.pdf.get_elements_intersecting_box(
+            Rect.from_edges(left=125, right=200, bottom=110, top=120),
+            page=signature_page
+        )
+        if not elements:  # old style consent
+            elements = self.pdf.get_elements_intersecting_box(
+                Rect.from_edges(left=110, right=200, bottom=570, top=580),
+                page=signature_page
+            )
+
+        return elements
+
+
+class Pdf:
+
+    def __init__(self, pages):
+        self.pages = pages
+
+    @classmethod
+    def from_google_storage_blob(cls, blob: Blob):
+        file_bytes = BytesIO(blob.download_as_string())
+        pages = extract_pages(file_bytes)
+        return Pdf(pages)
+
+    def get_elements_intersecting_box(self, search_box: Rect, page=0):
+        if page is None:
+            return []
+
+        elements = []
+        page = self.pages[page]
+        for element in page:
+            element_rect = Rect.from_edges(
+                left=element.x0,
+                right=element.x1,
+                bottom=element.y0,
+                top=element.y1
+            )
+            if element_rect.intersection(search_box) is not None:
+                elements.append(element)
+
+        return elements
+
+    def get_page_number_of_text(self, search_str_list: List[str]):
+        for page_number, page in enumerate(self.pages):
+            all_strings_found_in_page = True
+            for search_str in search_str_list:
+                if isinstance(search_str, str):
+                    string_found_in_page = self._is_string_in_page(search_str, page)
+                else:
+                    # Using tuples for translations
+                    string_found_in_page = False
+                    for search_str_translation in search_str:
+                        if self._is_string_in_page(search_str_translation, page):
+                            string_found_in_page = True
+                            break
+
+                if not string_found_in_page:
+                    all_strings_found_in_page = False
+                    break
+
+            if all_strings_found_in_page:
+                return page_number
+
+        return None
+
+    @classmethod
+    def get_first_child_of_element(cls, element):
+        try:
+            return list(element)[0]
+        except (IndexError, TypeError):
+            return None
+
+    def _is_string_in_page(self, search_str, page):
+        for element in page:
+            if self._is_text_in_layout_element(element, search_str):
+                return True
+
+        return False
+
+    def _is_text_in_layout_element(self, element, search_str):
+        if hasattr(element, 'get_text'):
+            if self._is_text_match(element.get_text(), search_str):
+                return True
+
+        if isinstance(element, LTTextBox):
+            for child_text in element:
+                if self._is_text_in_layout_element(child_text, search_str):
+                    return True
+
+        return False
+
+    @classmethod
+    def _is_text_match(cls, element_text, search_text):
+        return cls._get_text_for_comparison(search_text) in cls._get_text_for_comparison(element_text)
+
+    @classmethod
+    def _get_text_for_comparison(cls, text: str):
+        return ''.join(text.lower().split())

--- a/rdr_service/services/consent_files.py
+++ b/rdr_service/services/consent_files.py
@@ -14,33 +14,22 @@ class ConsentFile(ABC):
 
     def get_signature_on_file(self):
         signature_elements = self._get_signature_elements()
-        signature = None
         for element in signature_elements:
             first_child = Pdf.get_first_child_of_element(element)
 
             if isinstance(first_child, LTChar):
-                possible_signature = ''
-                for char in element:
-                    possible_signature += char.get_text()
-                possible_signature = possible_signature.strip()
+                possible_signature = ''.join([char_child.get_text() for char_child in element]).strip()
                 if possible_signature != '':
-                    signature = possible_signature
-                    break
+                    return possible_signature
 
             elif isinstance(first_child, LTImage):
-                signature = True
-                break
-
-        return signature
+                return True
 
     def get_date_signed(self):
         date_elements = self._get_date_elements()
         for element in date_elements:
             if isinstance(element, LTFigure):
-                date_str = ''
-                for char in element:
-                    date_str += char.get_text()
-                date_str = date_str.strip()
+                date_str = ''.join([char_child.get_text() for char_child in element]).strip()
                 if date_str:
                     return parser.parse(date_str).date()
 
@@ -67,8 +56,6 @@ class VibrentPrimaryConsentFile(PrimaryConsentFile):
 
     def _get_signature_elements(self):
         signature_page = self._get_signature_page()
-        if signature_page is None:
-            return []
 
         elements = self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=125, right=500, bottom=155, top=160),
@@ -82,8 +69,6 @@ class VibrentPrimaryConsentFile(PrimaryConsentFile):
 
     def _get_date_elements(self):
         signature_page = self._get_signature_page()
-        if signature_page is None:
-            return []
 
         elements = self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=125, right=200, bottom=110, top=120),

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -72,6 +72,7 @@ oauthlib[signedtoken]==3.1.0  # via jira, requests-oauthlib
 packaging==20.4           # via sphinx
 parameterized==0.7.4      # via -r requirements.in
 pbr==5.4.5                # via jira
+pdfminer.six==20201018
 # pip-tools==5.1.2          # via -r requirements.in
 protobuf==3.12.1          # via -r requirements.in, google-api-core, google-cloud-bigquery, googleapis-common-protos
 protorpc==0.12.0          # via -r requirements.in
@@ -97,6 +98,7 @@ requests-toolbelt==0.9.1  # via jira
 requests[security]==2.25.1  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
 rsa==4.7.2                  # via google-auth, oauth2client
 sendgrid==6.3.1           # via -r requirements.in
+simple-geometry==0.1.4  # geometry
 simplejson==3.17.0        # via -r requirements.in
 six==1.15.0               # via astroid, cryptography, flask-restful, geventhttpclient, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-python-cloud-debugger, google-resumable-media, grpcio, isodate, jira, oauth2client, packaging, pip-tools, protobuf, protorpc, pyopenssl, python-dateutil
 snowballstemmer==2.0.0    # via sphinx

--- a/tests/service_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/test_consent_file_parsing.py
@@ -1,0 +1,271 @@
+from dataclasses import dataclass
+from datetime import date
+import mock
+from pdfminer.layout import LTChar, LTFigure, LTImage, LTTextBoxHorizontal, LTTextLineHorizontal
+from typing import List
+
+from rdr_service.services import consent_files
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ConsentFileParsingTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(ConsentFileParsingTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def test_vibrent_primary_consent(self):
+        for consent_example in self._get_vibrent_primary_test_data():
+            consent_file = consent_example.file
+            self.assertEqual(consent_example.expected_signature, consent_file.get_signature_on_file())
+            self.assertEqual(consent_example.expected_sign_date, consent_file.get_date_signed())
+            self.assertEqual(consent_example.expected_to_be_va_file, consent_file.get_is_va_consent())
+
+    def _get_vibrent_primary_test_data(self) -> List['PrimaryConsentTestData']:
+        """
+        Builds a list of PDFs that represent the different layouts of Vibrent's primary consent
+        that have been encountered. Add to this if the code incorrectly parses any Vibrent primary pdf
+        """
+        test_data = []
+
+        # reusable elements usually expected on the signature page
+        description_elements = [
+            self._build_pdf_element(
+                cls=LTTextBoxHorizontal,
+                children=[
+                    self._build_pdf_element(
+                        cls=LTTextLineHorizontal,
+                        text='understand the information in this form. All of my questions\n'
+                    ),
+                    self._build_pdf_element(
+                        cls=LTTextLineHorizontal,
+                        text='have been answered. I freely and willingly choose to take part in\n'
+                    ),
+                    self._build_pdf_element(
+                        cls=LTTextLineHorizontal,
+                        text='the All of Us Research Program.\n'
+                    )
+                ]
+            ),
+            self._build_pdf_element(
+                cls=LTTextBoxHorizontal,
+                children=[
+                    self._build_pdf_element(cls=LTTextLineHorizontal, text='Sign Your Full Name: \n')
+                ]
+            )
+        ]
+
+        # Build basic file with signature of Test Name and signing date of August 17, 2019
+        pdf = self._build_pdf(pages=[
+            [
+                *description_elements,
+                self._build_form_element(text='Test Name', bbox=(116.734, 147.229, 517.202, 169.229)),
+                self._build_form_element(text='Aug 17, 2019', bbox=(116.167, 97.3622, 266.167, 119.362))
+            ]
+        ])
+        test_data.append(
+            PrimaryConsentTestData(
+                file=consent_files.VibrentPrimaryConsentFile(pdf),
+                expected_signature='Test Name',
+                expected_sign_date=date(2019, 8, 17)
+            )
+        )
+
+        # Build an older style of primary layout, with signature box higher up on the page
+        pdf = self._build_pdf(pages=[
+            [
+                *description_elements,
+                self._build_form_element(text='Nick', bbox=(116, 585, 517, 605)),
+                self._build_form_element(text='Dec 25, 2017', bbox=(116, 565, 266, 585))
+            ]
+        ])
+        test_data.append(
+            PrimaryConsentTestData(
+                file=consent_files.VibrentPrimaryConsentFile(pdf),
+                expected_signature='Nick',
+                expected_sign_date=date(2017, 12, 25)
+            )
+        )
+
+        # Build basic VA primary file
+        pdf = self._build_pdf(pages=[
+            [
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(cls=LTTextLineHorizontal, text='you will get care at a VA facility')
+                    ]
+                )
+            ]
+        ])
+        test_data.append(
+            PrimaryConsentTestData(
+                file=consent_files.VibrentPrimaryConsentFile(pdf),
+                expected_signature=None,
+                expected_sign_date=None,
+                expected_to_be_va_file=True
+            )
+        )
+
+        # Build file with an empty text element instead of a signature and date
+        pdf = self._build_pdf(pages=[
+            [
+                *description_elements,
+                self._build_form_element(text='', bbox=(116.16, 147.48, 521.16, 171.240)),
+                self._build_form_element(text='', bbox=(116.167, 97.3622, 266.167, 119.362))
+            ]
+        ])
+        test_data.append(
+            PrimaryConsentTestData(
+                file=consent_files.VibrentPrimaryConsentFile(pdf),
+                expected_signature=None,
+                expected_sign_date=None
+            )
+        )
+
+        # Build consent with an image instead of a typed signature
+        pdf = self._build_pdf(pages=[
+            [
+                *description_elements,
+                self._build_form_element(
+                    bbox=(200.0, 125.0, 400.0, 191.595),
+                    children=[
+                        self._build_pdf_element(cls=LTImage, bbox=(200.0, 125.0, 400.0, 191.595))
+                    ]
+                ),
+                self._build_form_element(text='December 7, 2018', bbox=(116.167, 97.3622, 266.167, 119.362))
+            ]
+        ])
+        test_data.append(
+            PrimaryConsentTestData(
+                file=consent_files.VibrentPrimaryConsentFile(pdf),
+                expected_signature=True,
+                expected_sign_date=date(2018, 12, 7)
+            )
+        )
+
+        # Build older style consent with different signature description formatting
+        pdf = self._build_pdf(pages=[
+            [
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(
+                            cls=LTTextLineHorizontal,
+                            text='this form. All of my questions have been answered. I freely and\n'
+                        ),
+                        self._build_pdf_element(
+                            cls=LTTextLineHorizontal,
+                            text='willingly choose to take part in the All of Us Research Program.\n'
+                        ),
+                    ]
+                ),
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(
+                            cls=LTTextLineHorizontal,
+                            children=[
+                                self._build_pdf_element(LTTextLineHorizontal, text='Sign Your \n'),
+                                self._build_pdf_element(LTTextLineHorizontal, text='Full Name: \n')
+                            ]
+                        )
+                    ]
+                ),
+                self._build_form_element(text='2018 Participant', bbox=(116.16, 147.48, 521.16, 171.24)),
+                self._build_form_element(text='Feb 19, 2018', bbox=(116.16, 96.84, 521.16, 120.6))
+            ]
+        ])
+        test_data.append(
+            PrimaryConsentTestData(
+                file=consent_files.VibrentPrimaryConsentFile(pdf),
+                expected_signature='2018 Participant',
+                expected_sign_date=date(2018, 2, 19)
+            )
+        )
+
+        return test_data
+
+    @classmethod
+    def _build_pdf(cls, pages) -> consent_files.Pdf:
+        """
+        Builds a consent_files.Pdf object
+        :param pages A list where each item represents a page,
+            and each item is a list of pdf elements for what should be on that page
+        """
+        page_mocks = []
+        for page_elements in pages:
+            page_mock = mock.MagicMock()
+            page_mock.__iter__.return_value = page_elements
+            page_mocks.append(page_mock)
+
+        return consent_files.Pdf(pages=page_mocks)
+
+    def _build_pdf_element(self, cls, text: str = None, children: list = None, bbox=None):
+        """Create a generic pdf element to add to the page"""
+        element = mock.MagicMock(spec=cls)
+        self._set_bbox(bbox, element)
+
+        if children:
+            element.__iter__.return_value = children
+
+        if hasattr(element, 'get_text'):
+            if text is None:
+                get_text_result = ''.join([child.get_text() for child in children])
+            else:
+                get_text_result = text
+            element.get_text.return_value = get_text_result
+
+        return element
+
+    def _build_form_element(self, bbox, text: str = None, children: list = None):
+        """
+        Form elements don't have a get_text method, and (at least with the Vibrent PDFs) any text within them is
+        laid out character by character
+        """
+        element = mock.MagicMock(spec=LTFigure)
+        self._set_bbox(bbox, element)
+
+        if children:
+            element.__iter__.return_value = children
+        else:
+            char_list = []
+            for char_str in text:
+                char_element = mock.MagicMock(spec=LTChar)
+                char_element.get_text.return_value = char_str
+                char_list.append(char_element)
+            if text == '':
+                char_element = mock.MagicMock(spec=LTChar)
+                char_element.get_text.return_value = ''
+                char_list.append(char_element)
+            element.__iter__.return_value = char_list
+
+        return element
+
+    def _set_bbox(self, bbox, element_mock):
+        """Set the data for a PDF element's bounding box on the Mock object"""
+        if not bbox:
+            left, bottom = self.fake.random_int(), self.fake.random_int()
+            right, top = self.fake.random_int() + left, self.fake.random_int() + bottom
+            bbox = (left, bottom, right, top)
+
+        (x0, y0, x1, y1) = bbox
+        element_mock.x0 = x0
+        element_mock.y0 = y0
+        element_mock.x1 = x1
+        element_mock.y1 = y1
+        element_mock.width = x1-x0
+        element_mock.height = y1-y0
+        element_mock.bbox = bbox
+
+
+@dataclass
+class ConsentTestData:
+    file: consent_files.ConsentFile
+    expected_signature: str or bool  # Text of the signature, or True if it's an image
+    expected_sign_date: date or None
+
+
+@dataclass
+class PrimaryConsentTestData(ConsentTestData):
+    file: consent_files.PrimaryConsentFile
+    expected_to_be_va_file: bool = False

--- a/tests/service_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/test_consent_file_parsing.py
@@ -27,7 +27,7 @@ class ConsentFileParsingTest(BaseTestCase):
         """
         test_data = []
 
-        # reusable elements usually expected on the signature page
+        # elements that usually appear on the signature page
         description_elements = [
             self._build_pdf_element(
                 cls=LTTextBoxHorizontal,
@@ -58,8 +58,8 @@ class ConsentFileParsingTest(BaseTestCase):
         pdf = self._build_pdf(pages=[
             [
                 *description_elements,
-                self._build_form_element(text='Test Name', bbox=(116.734, 147.229, 517.202, 169.229)),
-                self._build_form_element(text='Aug 17, 2019', bbox=(116.167, 97.3622, 266.167, 119.362))
+                self._build_form_element(text='Test Name', bbox=(116, 147, 517, 169)),
+                self._build_form_element(text='Aug 17, 2019', bbox=(116, 97, 266, 119))
             ]
         ])
         test_data.append(
@@ -110,8 +110,8 @@ class ConsentFileParsingTest(BaseTestCase):
         pdf = self._build_pdf(pages=[
             [
                 *description_elements,
-                self._build_form_element(text='', bbox=(116.16, 147.48, 521.16, 171.240)),
-                self._build_form_element(text='', bbox=(116.167, 97.3622, 266.167, 119.362))
+                self._build_form_element(text='', bbox=(116, 147, 521, 171)),
+                self._build_form_element(text='', bbox=(116, 97, 266, 119))
             ]
         ])
         test_data.append(
@@ -127,12 +127,12 @@ class ConsentFileParsingTest(BaseTestCase):
             [
                 *description_elements,
                 self._build_form_element(
-                    bbox=(200.0, 125.0, 400.0, 191.595),
+                    bbox=(200, 125, 400, 191),
                     children=[
-                        self._build_pdf_element(cls=LTImage, bbox=(200.0, 125.0, 400.0, 191.595))
+                        self._build_pdf_element(cls=LTImage, bbox=(200, 125, 400, 191))
                     ]
                 ),
-                self._build_form_element(text='December 7, 2018', bbox=(116.167, 97.3622, 266.167, 119.362))
+                self._build_form_element(text='December 7, 2018', bbox=(116, 97, 266, 119))
             ]
         ])
         test_data.append(
@@ -171,8 +171,8 @@ class ConsentFileParsingTest(BaseTestCase):
                         )
                     ]
                 ),
-                self._build_form_element(text='2018 Participant', bbox=(116.16, 147.48, 521.16, 171.24)),
-                self._build_form_element(text='Feb 19, 2018', bbox=(116.16, 96.84, 521.16, 120.6))
+                self._build_form_element(text='2018 Participant', bbox=(116, 147, 521, 171)),
+                self._build_form_element(text='Feb 19, 2018', bbox=(116, 96, 521, 120))
             ]
         ])
         test_data.append(


### PR DESCRIPTION
## Partially resolves *[DA-2055](https://precisionmedicineinitiative.atlassian.net/browse/DA-2055)*
There's going to be alot of code for setting up a system for validating consent PDF files. I'll try to keep the PRs relatively small. This first one sets up a framework for testing how the files are parsed, and adds a few classes for working with PDF files.

There isn't anything yet in the code that depends on these classes. That will be added in one of the last PRs for this work (when setting up a nightly cron job for validating new consents).

## Description of changes/additions
This introduces a few different classes to provide functionality for working with the PDF files. The PDF data itself will be parsed by the pdfminer.six library and the `Pdf` class will extend it a bit by adding some convenience methods. The `ConsentFile` abstract base class provides generic methods and functionality needed for all consent files (parsing signatures and dates), but (since each file type is different) the base class relies on subclasses to find the PDF elements that give the elements to retrieve data from. Eventually this validation code will be extended to check CE files as well, so the `PrimaryConsentFile` class holds functionality common to both (checking for VA consent wording). Then the `VibrentPrimaryConsentFile` class encapsulates the functionality specific for where to find elements on the Primary consent files from Vibrent.

## Tests
- [x] unit tests

There are several possible formats for the consent file and we may need to extend the code to work with more in the future. So the tests are set up to check for all layout found so far and allow for adding more to be checked as we find them.


