### PR TITLE
[DA-2014] managing data-ops service account keys

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -149,6 +149,7 @@ DAYS_TO_DELETE_KEYS = "days_to_delete_keys"
 
 # service accounts exception from key deletion
 SERVICE_ACCOUNTS_WITH_LONG_LIVED_KEYS = "service_accounts_with_long_lived_keys"
+DATA_OPS_SERVICE_ACCOUNTS_TO_MANAGE = "data_ops_service_accounts_to_manage"
 
 CONSENT_SYNC_BUCKETS = "consent_sync_buckets"
 


### PR DESCRIPTION
## Resolves *[DA-2014](https://precisionmedicineinitiative.atlassian.net/browse/DA-2014)*
This sets up a way for the `DeleteOldKeys` cron job to delete keys for pre-approved service accounts in the data-ops project. In PD-6202 we discussed that the awardee accounts were already being managed by the sysadmins, but the RDR team was getting requests to delete accounts for other accounts. The agreed upon approach is to use a managed list of accounts in the data-ops project to delete their keys but not for any other accounts.

## Description of changes/additions
This PR adds another call for managing the service account keys for the data-ops project in Prod. If a service account is in the managed list, then any keys that are older than 3 days will be deleted.

## Tests
- [x] unit tests


