### PR TITLE
[DA-2055] Parsing Cabor, EHR, and GROR for Vibrent

### DIFF
--- a/rdr_service/services/consent_files.py
+++ b/rdr_service/services/consent_files.py
@@ -47,6 +47,10 @@ class PrimaryConsentFile(ConsentFile, ABC):
         return self.pdf.get_page_number_of_text(['you will get care at a VA facility']) is not None
 
 
+class CaborConsentFile(ConsentFile, ABC):
+    ...
+
+
 class VibrentPrimaryConsentFile(PrimaryConsentFile):
     def _get_signature_page(self):
         return self.pdf.get_page_number_of_text([
@@ -81,6 +85,14 @@ class VibrentPrimaryConsentFile(PrimaryConsentFile):
             )
 
         return elements
+
+
+class VibrentCaborConsentFile(CaborConsentFile):
+    def _get_signature_elements(self):
+        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=200, right=400, bottom=110, top=115))
+
+    def _get_date_elements(self):
+        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=520, right=570, bottom=110, top=115))
 
 
 class Pdf:

--- a/rdr_service/services/consent_files.py
+++ b/rdr_service/services/consent_files.py
@@ -51,6 +51,10 @@ class CaborConsentFile(ConsentFile, ABC):
     ...
 
 
+class EhrConsentFile(ConsentFile, ABC):
+    ...
+
+
 class VibrentPrimaryConsentFile(PrimaryConsentFile):
     def _get_signature_page(self):
         return self.pdf.get_page_number_of_text([
@@ -93,6 +97,14 @@ class VibrentCaborConsentFile(CaborConsentFile):
 
     def _get_date_elements(self):
         return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=520, right=570, bottom=110, top=115))
+
+
+class VibrentEhrConsentFile(EhrConsentFile):
+    def _get_signature_elements(self):
+        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=130, right=250, bottom=160, top=165), page=6)
+
+    def _get_date_elements(self):
+        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=130, right=250, bottom=110, top=115), page=6)
 
 
 class Pdf:

--- a/rdr_service/services/consent_files.py
+++ b/rdr_service/services/consent_files.py
@@ -4,7 +4,7 @@ from geometry import Rect
 from google.cloud.storage.blob import Blob
 from io import BytesIO
 from pdfminer.high_level import extract_pages
-from pdfminer.layout import LTChar, LTFigure, LTImage, LTTextBox
+from pdfminer.layout import LTChar, LTCurve, LTFigure, LTImage, LTTextBox
 from typing import List
 
 
@@ -53,6 +53,20 @@ class CaborConsentFile(ConsentFile, ABC):
 
 class EhrConsentFile(ConsentFile, ABC):
     ...
+
+
+class GrorConsentFile(ConsentFile, ABC):
+    def is_confirmation_selected(self):
+        for element in self._get_confirmation_check_elements():
+            for child in element:
+                if isinstance(child, LTCurve):
+                    return True
+
+        return False
+
+    @abstractmethod
+    def _get_confirmation_check_elements(self):
+        ...
 
 
 class VibrentPrimaryConsentFile(PrimaryConsentFile):
@@ -105,6 +119,17 @@ class VibrentEhrConsentFile(EhrConsentFile):
 
     def _get_date_elements(self):
         return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=130, right=250, bottom=110, top=115), page=6)
+
+
+class VibrentGrorConsentFile(GrorConsentFile):
+    def _get_signature_elements(self):
+        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=150, right=400, bottom=155, top=160), page=9)
+
+    def _get_date_elements(self):
+        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=130, right=400, bottom=110, top=115), page=9)
+
+    def _get_confirmation_check_elements(self):
+        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=70,  right=73, bottom=475, top=478), page=9)
 
 
 class Pdf:

--- a/tests/service_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/test_consent_file_parsing.py
@@ -26,6 +26,12 @@ class ConsentFileParsingTest(BaseTestCase):
             self.assertEqual(consent_example.expected_signature, consent_file.get_signature_on_file())
             self.assertEqual(consent_example.expected_sign_date, consent_file.get_date_signed())
 
+    def test_vibrent_ehr_consent(self):
+        for consent_example in self._get_vibrent_ehr_test_data():
+            consent_file = consent_example.file
+            self.assertEqual(consent_example.expected_signature, consent_file.get_signature_on_file())
+            self.assertEqual(consent_example.expected_sign_date, consent_file.get_date_signed())
+
     def _get_vibrent_primary_test_data(self) -> List['PrimaryConsentTestData']:
         """
         Builds a list of PDFs that represent the different layouts of Vibrent's primary consent
@@ -207,6 +213,23 @@ class ConsentFileParsingTest(BaseTestCase):
         )
 
         return [basic_cabor_case]
+
+    def _get_vibrent_ehr_test_data(self) -> List['ConsentTestData']:
+        five_empty_pages = [[], [], [], [], [], []]  # The EHR signature is expected to be on the 7th page
+        basic_ehr_pdf = self._build_pdf(pages=[
+            *five_empty_pages,
+            [
+                self._build_form_element(text='Test ehr', bbox=(125, 150, 450, 180)),
+                self._build_form_element(text='Dec 21, 2019', bbox=(125, 100, 450, 130))
+            ]
+        ])
+        basic_ehr_case = ConsentTestData(
+            file=consent_files.VibrentEhrConsentFile(basic_ehr_pdf),
+            expected_signature='Test ehr',
+            expected_sign_date=date(2019, 12, 21)
+        )
+
+        return [basic_ehr_case]
 
     @classmethod
     def _build_pdf(cls, pages) -> consent_files.Pdf:

--- a/tests/service_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/test_consent_file_parsing.py
@@ -20,6 +20,12 @@ class ConsentFileParsingTest(BaseTestCase):
             self.assertEqual(consent_example.expected_sign_date, consent_file.get_date_signed())
             self.assertEqual(consent_example.expected_to_be_va_file, consent_file.get_is_va_consent())
 
+    def test_vibrent_cabor_consent(self):
+        for consent_example in self._get_vibrent_cabor_test_data():
+            consent_file = consent_example.file
+            self.assertEqual(consent_example.expected_signature, consent_file.get_signature_on_file())
+            self.assertEqual(consent_example.expected_sign_date, consent_file.get_date_signed())
+
     def _get_vibrent_primary_test_data(self) -> List['PrimaryConsentTestData']:
         """
         Builds a list of PDFs that represent the different layouts of Vibrent's primary consent
@@ -184,6 +190,23 @@ class ConsentFileParsingTest(BaseTestCase):
         )
 
         return test_data
+
+    def _get_vibrent_cabor_test_data(self) -> List['ConsentTestData']:
+        """Builds a list of PDFs that represent the different layouts of Vibrent's CaBOR consent"""
+
+        basic_cabor_pdf = self._build_pdf(pages=[
+            [
+                self._build_form_element(text='Test cabor', bbox=(116, 100, 517, 140)),
+                self._build_form_element(text='April 27, 2020', bbox=(500, 100, 600, 140))
+            ]
+        ])
+        basic_cabor_case = ConsentTestData(
+            file=consent_files.VibrentCaborConsentFile(basic_cabor_pdf),
+            expected_signature='Test cabor',
+            expected_sign_date=date(2020, 4, 27)
+        )
+
+        return [basic_cabor_case]
 
     @classmethod
     def _build_pdf(cls, pages) -> consent_files.Pdf:


### PR DESCRIPTION
## Resolves *[DA-2055](https://precisionmedicineinitiative.atlassian.net/browse/DA-2055)*
This finishes out the rest of the Vibrent consent file parsing for now by adding classes and tests for Cabor, EHR, and GROR. The next PR will create factory classes that return specific consent files for a participant.

## Description of changes/additions
Adds classes that represent and extract data from Cabor, EHR, and GROR files.

## Tests
- [x] unit tests


