### PR TITLE
[DA-2056] Cron jobs for managing consent validation

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -1,4 +1,14 @@
 cron:
+- description: Validate the previous day's consent files
+  url: /offline/ValidateConsentFiles
+  schedule: every day 02:00
+  timezone: America/New_York
+  target: offline
+- description: Check for any corrections to invalid consent files
+  url: /offline/CorrectConsentFiles
+  schedule: 7, 14, 21, 28 of month 20:00
+  timezone: America/New_York
+  target: offline
 - description: Sync site bucket consent files
   url: /offline/SyncConsentFiles
   schedule: 1 of month 00:00

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -1,0 +1,31 @@
+
+from sqlalchemy import or_
+
+from rdr_service.dao.base_dao import BaseDao
+from rdr_service.model.participant_summary import ParticipantSummary
+
+
+class ConsentDao(BaseDao):
+    def get_participants_with_consents_in_range(self, start_date, end_date=None):
+        with self.session() as session:
+            query = session.query(ParticipantSummary)
+            if end_date is None:
+                query = query.filter(
+                    or_(
+                        ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored >= start_date,
+                        ParticipantSummary.consentForCABoRAuthored >= start_date,
+                        ParticipantSummary.consentForElectronicHealthRecordsAuthored >= start_date,
+                        ParticipantSummary.consentForGenomicsRORAuthored >= start_date
+                    )
+                )
+            else:
+                query = query.filter(
+                    or_(
+                        ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored.between(start_date, end_date),
+                        ParticipantSummary.consentForCABoRAuthored.between(start_date, end_date),
+                        ParticipantSummary.consentForElectronicHealthRecordsAuthored.between(start_date, end_date),
+                        ParticipantSummary.consentForGenomicsRORAuthored.between(start_date, end_date)
+                    )
+                )
+            summaries = query.all()
+            return summaries

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -2,6 +2,7 @@
 from sqlalchemy import or_
 
 from rdr_service.dao.base_dao import BaseDao
+from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus
 from rdr_service.model.participant_summary import ParticipantSummary
 
 
@@ -29,3 +30,9 @@ class ConsentDao(BaseDao):
                 )
             summaries = query.all()
             return summaries
+
+    def get_files_needing_correction(self):
+        with self.session() as session:
+            return session.query(ConsentFile).filter(
+                ConsentFile.sync_status == ConsentSyncStatus.NEEDS_CORRECTING
+            ).all()

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -1,3 +1,4 @@
+from typing import List
 
 from sqlalchemy import or_
 
@@ -31,8 +32,13 @@ class ConsentDao(BaseDao):
             summaries = query.all()
             return summaries
 
-    def get_files_needing_correction(self):
+    def get_files_needing_correction(self) -> List[ConsentFile]:
         with self.session() as session:
             return session.query(ConsentFile).filter(
                 ConsentFile.sync_status == ConsentSyncStatus.NEEDS_CORRECTING
             ).all()
+
+    def batch_update_consent_files(self, consent_files: List[ConsentFile]):
+        with self.session() as session:
+            for file_record in consent_files:
+                session.merge(file_record)

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -10,7 +10,7 @@ from rdr_service.model.participant_summary import ParticipantSummary
 class ConsentDao(BaseDao):
     def get_participants_with_consents_in_range(self, start_date, end_date=None) -> List[ParticipantSummary]:
         with self.session() as session:
-            query = session.query(ParticipantSummary)
+            query = session.query(ParticipantSummary).filter(ParticipantSummary.participantOrigin == 'vibrent')
             if end_date is None:
                 query = query.filter(
                     or_(

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -8,7 +8,7 @@ from rdr_service.model.participant_summary import ParticipantSummary
 
 
 class ConsentDao(BaseDao):
-    def get_participants_with_consents_in_range(self, start_date, end_date=None):
+    def get_participants_with_consents_in_range(self, start_date, end_date=None) -> List[ParticipantSummary]:
         with self.session() as session:
             query = session.query(ParticipantSummary)
             if end_date is None:
@@ -42,3 +42,9 @@ class ConsentDao(BaseDao):
         with self.session() as session:
             for file_record in consent_files:
                 session.merge(file_record)
+
+    def get_validation_results_for_participants(self, participant_ids: List[int]) -> List[ConsentFile]:
+        with self.session() as session:
+            return session.query(ConsentFile).filter(
+                ConsentFile.participant_id.in_(participant_ids)
+            ).all()

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -8,6 +8,9 @@ from rdr_service.model.participant_summary import ParticipantSummary
 
 
 class ConsentDao(BaseDao):
+    def __init__(self):
+        super(ConsentDao, self).__init__(ConsentFile)
+
     def get_participants_with_consents_in_range(self, start_date, end_date=None) -> List[ParticipantSummary]:
         with self.session() as session:
             query = session.query(ParticipantSummary).filter(ParticipantSummary.participantOrigin == 'vibrent')

--- a/rdr_service/model/consent_file.py
+++ b/rdr_service/model/consent_file.py
@@ -16,6 +16,7 @@ class ConsentType(messages.Enum):
 class ConsentSyncStatus(messages.Enum):
     NEEDS_CORRECTING = 1
     READY_FOR_SYNC = 2
+    OBSOLETE = 3
 
 
 class ConsentFile(Base):

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -20,7 +20,7 @@ class ConsentValidationController:
         self.participant_summary_dao = participant_summary_dao
         self.storage_provider = storage_provider
 
-        self.va_hpo_id = hpo_dao.get_by_name('VA').hpo_id
+        self.va_hpo_id = hpo_dao.get_by_name('VA').hpoId
 
     def check_for_corrections(self):
         """Load all of the current consent issues and see if they have been resolved yet"""

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from typing import List
+
+from rdr_service.dao.consent_dao import ConsentDao
+from rdr_service.model.participant_summary import ParticipantSummary
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ConsentFileDaoTest(BaseTestCase):
+    def test_loading_summaries_with_consent(self):
+        primary_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2020, 4, 1)
+        )
+        later_primary_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2021, 1, 1)
+        )
+        cabor_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2019, 8, 27),
+            cabor=datetime(2020, 4, 27)
+        )
+        later_cabor_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2019, 8, 27),
+            cabor=datetime(2021, 1, 27)
+        )
+        ehr_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2017, 9, 2),
+            ehr=datetime(2020, 5, 2)
+        )
+        later_ehr_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2017, 9, 2),
+            ehr=datetime(2021, 3, 2)
+        )
+        gror_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2020, 1, 4),
+            gror=datetime(2020, 6, 7)
+        )
+        later_gror_participant = self._init_summary_with_consent_dates(
+            primary=datetime(2020, 1, 4),
+            gror=datetime(2021, 3, 7)
+        )
+        self._init_summary_with_consent_dates(  # make one participant that has everything before the date window
+            primary=datetime(2019, 7, 1),
+            cabor=datetime(2019, 8, 1),
+            ehr=datetime(2019, 9, 1),
+            gror=datetime(2019, 10, 1)
+        )
+
+        consent_dao = ConsentDao(None)
+        self.assertSummariesMatch(
+            [
+                primary_participant,
+                cabor_participant,
+                ehr_participant,
+                gror_participant
+            ],
+            consent_dao.get_participants_with_consents_in_range(
+                start_date=datetime(2020, 3, 1),
+                end_date=datetime(2020, 7, 1)
+            )
+        )
+        self.assertSummariesMatch(
+            [
+                primary_participant,
+                cabor_participant,
+                ehr_participant,
+                gror_participant,
+                later_primary_participant,
+                later_cabor_participant,
+                later_ehr_participant,
+                later_gror_participant
+            ],
+            consent_dao.get_participants_with_consents_in_range(
+                start_date=datetime(2020, 3, 1)
+            )
+        )
+
+    def assertSummariesMatch(self, expected_list: List[ParticipantSummary], actual_list: List[ParticipantSummary]):
+        self.assertEqual(len(expected_list), len(actual_list))
+
+        actual_id_list = [actual.participantId for actual in actual_list]
+        for expected_summary in expected_list:
+            self.assertIn(expected_summary.participantId, actual_id_list)
+
+    def _init_summary_with_consent_dates(self, primary, cabor=None, ehr=None, gror=None):
+        return self.data_generator.create_database_participant_summary(
+            consentForStudyEnrollmentFirstYesAuthored=primary,
+            consentForCABoRAuthored=cabor,
+            consentForElectronicHealthRecordsAuthored=ehr,
+            consentForGenomicsRORAuthored=gror
+        )

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -167,5 +167,6 @@ class ConsentFileDaoTest(BaseTestCase):
             consentForStudyEnrollmentFirstYesAuthored=primary,
             consentForCABoRAuthored=cabor,
             consentForElectronicHealthRecordsAuthored=ehr,
-            consentForGenomicsRORAuthored=gror
+            consentForGenomicsRORAuthored=gror,
+            participantOrigin='vibrent'
         )

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -8,7 +8,7 @@ from tests.helpers.unittest_base import BaseTestCase
 class ConsentFileDaoTest(BaseTestCase):
     def setUp(self, *args, **kwargs) -> None:
         super(ConsentFileDaoTest, self).setUp(*args, **kwargs)
-        self.consent_dao = ConsentDao(ConsentFile)
+        self.consent_dao = ConsentDao()
 
     def test_loading_summaries_with_consent(self):
         """Check that participant summaries with any consents in the given time range are loaded"""

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -5,6 +5,7 @@ from rdr_service.model.biobank_order import BiobankMailKitOrder, BiobankOrder, B
     BiobankOrderedSample, BiobankOrderedSampleHistory, BiobankOrderIdentifier, BiobankSpecimen, BiobankSpecimenAttribute
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import Code
+from rdr_service.model.consent_file import ConsentFile
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.ehr import ParticipantEhrReceipt
 from rdr_service.model.genomics import (
@@ -308,6 +309,22 @@ class DataGenerator:
                     defaults[f'{questionnaire_field}Authored'] = datetime.now()
 
         return ParticipantSummary(**defaults)
+
+    def create_database_consent_file(self, **kwargs):
+        consent_file = self._consent_file_with_defaults(**kwargs)
+        self._commit_to_database(consent_file)
+        return consent_file
+
+    def _consent_file_with_defaults(self, **kwargs):
+        defaults = {
+            'file_exists': True
+        }
+
+        defaults.update(kwargs)
+        if defaults.get('participant_id') is None:
+            defaults['participant_id'] = self.create_database_participant().participantId
+
+        return ConsentFile(**defaults)
 
     def create_database_biobank_specimen(self, **kwargs):
         specimen = self._biobank_specimen_with_defaults(**kwargs)

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -14,6 +14,9 @@ class ConsentControllerTest(BaseTestCase):
         super(ConsentControllerTest, self).__init__(*args, **kwargs)
         self.uses_database = False
 
+    def setUp(self, *args, **kwargs) -> None:
+        super(ConsentControllerTest, self).setUp(*args, **kwargs)
+
         self.consent_dao_mock = mock.MagicMock(spec=ConsentDao)
         self.hpo_dao_mock = mock.MagicMock(spec=HPODao)
         self.participant_summary_dao_mock = mock.MagicMock(spec=ParticipantSummaryDao)

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -1,0 +1,89 @@
+import mock
+from typing import List
+
+from rdr_service.dao.consent_dao import ConsentDao
+from rdr_service.dao.hpo_dao import HPODao
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.model.consent_file import ConsentFile, ConsentType, ConsentSyncStatus
+from rdr_service.services.consent.validation import ConsentValidationController
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ConsentControllerTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(ConsentControllerTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+        self.consent_dao_mock = mock.MagicMock(spec=ConsentDao)
+        self.hpo_dao_mock = mock.MagicMock(spec=HPODao)
+        self.participant_summary_dao_mock = mock.MagicMock(spec=ParticipantSummaryDao)
+        consent_validator_patch = mock.patch('rdr_service.services.consent.validation.ConsentValidator')
+        self.consent_validator_mock = consent_validator_patch.start().return_value
+        self.addCleanup(consent_validator_patch.stop)
+        consent_factory_patch = mock.patch(
+            'rdr_service.services.consent.validation.files.ConsentFileAbstractFactory.get_file_factory'
+        )
+        consent_factory_patch.start()
+        self.addCleanup(consent_factory_patch.stop)
+
+        self.consent_controller = ConsentValidationController(
+            consent_dao=self.consent_dao_mock,
+            hpo_dao=self.hpo_dao_mock,
+            participant_summary_dao=self.participant_summary_dao_mock,
+            storage_provider=mock.MagicMock()
+        )
+
+    def test_correction_check(self):
+        """
+        The controller should load all files that need correction and update their state if they've been
+        replaced by new files.
+        """
+        self.consent_dao_mock.get_files_needing_correction.return_value = [
+            ConsentFile(type=ConsentType.GROR, file_path='/invalid_gror_1'),
+            ConsentFile(type=ConsentType.GROR, file_path='/invalid_gror_2'),
+            ConsentFile(type=ConsentType.CABOR, file_path='/invalid_cabor_1'),
+            ConsentFile(type=ConsentType.PRIMARY, file_path='/invalid_primary_1'),
+            ConsentFile(type=ConsentType.PRIMARY, file_path='/invalid_primary_2')
+        ]
+
+        self.consent_validator_mock.get_primary_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_primary_1'),
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_primary_2'),
+            ConsentFile(sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/valid_primary_1')
+        ]
+        self.consent_validator_mock.get_cabor_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_cabor_1'),
+            ConsentFile(sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/valid_cabor_1')
+        ]
+        self.consent_validator_mock.get_gror_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_gror_1'),
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_gror_2'),
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_gror_3')
+        ]
+
+        self.consent_controller.check_for_corrections()
+        self.assertConsentValidationResultsUpdated(
+            expected_updates=[
+                ConsentFile(file_path='/invalid_primary_1', sync_status=ConsentSyncStatus.OBSOLETE),
+                ConsentFile(file_path='/invalid_primary_2', sync_status=ConsentSyncStatus.OBSOLETE),
+                ConsentFile(file_path='/valid_primary_1', sync_status=ConsentSyncStatus.READY_FOR_SYNC),
+                ConsentFile(file_path='/invalid_cabor_1', sync_status=ConsentSyncStatus.OBSOLETE),
+                ConsentFile(file_path='/valid_cabor_1', sync_status=ConsentSyncStatus.READY_FOR_SYNC),
+                ConsentFile(file_path='/invalid_gror_3', sync_status=ConsentSyncStatus.NEEDS_CORRECTING)
+            ]
+        )
+
+    def assertConsentValidationResultsUpdated(self, expected_updates: List[ConsentFile]):
+        """Make sure the validation results are sent to the dao"""
+        actual_updates: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[0]
+        self.assertEqual(len(expected_updates), len(actual_updates))
+
+        for expected in expected_updates:
+            found_expected = False
+            for actual in actual_updates:
+                if expected.file_path == actual.file_path and expected.sync_status == actual.sync_status:
+                    found_expected = True
+                    break
+
+            if not found_expected:
+                self.fail('Unable to find an expected update in the updated validation results')

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import mock
 from typing import List
 
@@ -5,6 +6,8 @@ from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.consent_file import ConsentFile, ConsentType, ConsentSyncStatus
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.participant_enums import QuestionnaireStatus
 from rdr_service.services.consent.validation import ConsentValidationController
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -75,6 +78,87 @@ class ConsentControllerTest(BaseTestCase):
                 ConsentFile(file_path='/invalid_gror_3', sync_status=ConsentSyncStatus.NEEDS_CORRECTING)
             ]
         )
+
+    def test_new_consent_validation(self):
+        """The controller should find all recent participant summary consents authored and validate files for them"""
+        self.consent_validator_mock.get_primary_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_primary_1'),
+            ConsentFile(sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/valid_primary_2'),
+            ConsentFile(sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/valid_primary_3')
+        ]
+        self.consent_validator_mock.get_cabor_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/valid_cabor_1')
+        ]
+        self.consent_validator_mock.get_ehr_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_ehr_1'),
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_ehr_2')
+        ]
+        self.consent_validator_mock.get_gror_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/gror_not_checked')
+        ]
+
+        min_consent_date_checked = datetime(2020, 4, 1)
+        self.consent_dao_mock.get_participants_with_consents_in_range.return_value = [
+            ParticipantSummary(
+                consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
+                consentForStudyEnrollmentFirstYesAuthored=min_consent_date_checked + timedelta(days=5),
+                consentForElectronicHealthRecords=QuestionnaireStatus.SUBMITTED,
+                consentForElectronicHealthRecordsAuthored=min_consent_date_checked + timedelta(days=10)
+            ),
+            ParticipantSummary(
+                consentForCABoR=QuestionnaireStatus.SUBMITTED,
+                consentForCABoRAuthored=min_consent_date_checked + timedelta(days=5)
+            ),
+            ParticipantSummary(
+                consentForGenomicsROR=QuestionnaireStatus.SUBMITTED,
+                consentForGenomicsRORAuthored=min_consent_date_checked - timedelta(days=5)
+            ),
+            ParticipantSummary(
+                consentForGenomicsROR=QuestionnaireStatus.SUBMITTED_NOT_SURE,
+                consentForGenomicsRORAuthored=min_consent_date_checked + timedelta(days=20)
+            )
+        ]
+
+        self.consent_controller.validate_recent_uploads(min_consent_date=min_consent_date_checked)
+        self.assertConsentValidationResultsUpdated(
+            expected_updates=[
+                ConsentFile(file_path='/valid_primary_2', sync_status=ConsentSyncStatus.READY_FOR_SYNC),
+                ConsentFile(file_path='/invalid_ehr_2', sync_status=ConsentSyncStatus.NEEDS_CORRECTING),
+                ConsentFile(file_path='/invalid_ehr_2', sync_status=ConsentSyncStatus.NEEDS_CORRECTING),
+                ConsentFile(file_path='/valid_cabor_1', sync_status=ConsentSyncStatus.READY_FOR_SYNC),
+            ]
+        )
+
+    def test_no_duplication_in_validation(self):
+        """
+        Check to make sure the validation check for recent consents doesn't create
+        new validation records for consents that have already been checked
+        """
+        self.consent_dao_mock.get_validation_results_for_participants.return_value = [
+            ConsentFile(file_path='/previous_1'),
+            ConsentFile(file_path='/previous_2'),
+        ]
+        self.consent_validator_mock.get_primary_validation_results.return_value = [
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/previous_1'),
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/previous_2'),
+            ConsentFile(sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/new_file_1')
+        ]
+
+        min_consent_date_checked = datetime(2020, 4, 1)
+        self.consent_dao_mock.get_participants_with_consents_in_range.return_value = [
+            ParticipantSummary(
+                consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
+                consentForStudyEnrollmentFirstYesAuthored=min_consent_date_checked + timedelta(days=5)
+            )
+        ]
+
+        self.consent_controller.validate_recent_uploads(min_consent_date=min_consent_date_checked)
+        self.assertConsentValidationResultsUpdated(
+            expected_updates=[
+                ConsentFile(file_path='/new_file_1', sync_status=ConsentSyncStatus.NEEDS_CORRECTING)
+            ]
+        )
+
 
     def assertConsentValidationResultsUpdated(self, expected_updates: List[ConsentFile]):
         """Make sure the validation results are sent to the dao"""


### PR DESCRIPTION
## Resolves *[DA-2056](https://precisionmedicineinitiative.atlassian.net/browse/DA-2056)*
This wraps up DA-2056 by scheduling a pair of cron jobs. One runs daily and is responsible for checking the consents from the previous 26 hours. For each new consent that has been authored in the past 26 hours at least one record is made: either a valid file is found and will be marked as ready for sync, multiple records for each invalid file will be created to specify what was found as wrong for the files, or a special type of record will be created denoting that no consent files were found.

The other job runs roughly every 7 days and checks for any resolutions for invalid files. Any records are loaded that note invalid or missing files. Then for each participant and consent type that the records indicate, the consent files are checked again. If a new file has been uploaded and is ready to sync, then a record is created for it and each previous validation record is marked as obsolete. If no new files are ready for syncing, then any newly validated files are recorded and are all stored for the next check.

## Tests
- [x] unit tests


