### PR TITLE
Fix ingestion tool

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1518,7 +1518,8 @@ class GenomicAW1RawDao(BaseDao):
             return session.query(
                 functions.count(GenomicAW1Raw.id)
             ).filter(
-                GenomicAW1Raw.file_path == filepath
+                GenomicAW1Raw.file_path == filepath,
+                GenomicAW1Raw.biobank_id != ""
             ).one_or_none()
 
     def get_raw_record_from_bid_genome_type(self, biobank_id, genome_type):

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -479,7 +479,7 @@ class GenomicJobController:
         path_map = {}
 
         for p in paths:
-            file_obj = self.file_processed_dao.get_max_file_processed_for_filepath(f'/{p}')
+            file_obj = self.file_processed_dao.get_max_file_processed_for_filepath(f'{p}')
 
             if not file_obj:
                 raise DataError(f"No genomic_file_processed record for {p}")

--- a/tests/tool_tests/test_genomic_utils.py
+++ b/tests/tool_tests/test_genomic_utils.py
@@ -82,7 +82,7 @@ class GenomicUtilsGeneralTest(GenomicUtilsTestBase):
         self.data_generator.create_database_genomic_file_processed(
             runId=1,
             startTime=clock.CLOCK.now(),
-            filePath=f'/{test_aw1}',
+            filePath=f'{test_aw1}',
             bucketName="test-bucket",
             fileName="test_GEN_sample_manifest.csv"
         )
@@ -91,7 +91,7 @@ class GenomicUtilsGeneralTest(GenomicUtilsTestBase):
         self.data_generator.create_database_genomic_file_processed(
             runId=2,
             startTime=clock.CLOCK.now(),
-            filePath=f'/{test_aw2}',
+            filePath=f'{test_aw2}',
             bucketName="test-bucket",
             fileName="test_GEN_data_manifest.csv"
         )


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR updates the ingestion tool to remove the leading `/` character from the `genomic_file_processed.file_path` record. This PR also updates the comparison tool to not count empty wells in the raw AW1 record. This is inferred by the empty string for `biobank_id`.

## Tests
- [x] unit tests


