### PR TITLE
[DA-2010] Updates to Mayolink requests for v2 salivary orders

### DIFF
--- a/rdr_service/api/mayolink_api.py
+++ b/rdr_service/api/mayolink_api.py
@@ -13,17 +13,18 @@ from rdr_service.app_util import auth_required
 class MayoLinkApi:
     def __init__(self):
         self.namespace = "http://orders.mayomedicallaboratories.com"
-        self.config_bucket = config.CONFIG_BUCKET
-        self.config = config.getSetting(config.MAYOLINK_CREDS)
-        self.path = "/" + self.config_bucket + "/" + self.config
         self.endpoint = config.getSetting(config.MAYOLINK_ENDPOINT)
-        # For now I can not figure out how to use google cloud on dev_appserver, comment out the
-        # below and manually add self.username, etc.
-        with open_cloud_file(self.path) as file_path:
-            self.creds = json.load(file_path)
-        self.username = self.creds.get("username")
-        self.pw = self.creds.get("password")
-        self.account = self.creds.get("account")
+        self.username, self.pw, self.account = self._get_credentials()
+
+    @classmethod
+    def _get_credentials(cls):
+        credentials_bucket_name = config.CONFIG_BUCKET
+        credentials_file_name = config.getSetting(config.MAYOLINK_CREDS)
+
+        with open_cloud_file("/" + credentials_bucket_name + "/" + credentials_file_name) as file:
+            credentials = json.load(file)
+
+        return credentials.get('username'), credentials.get('password'), credentials.get('account')
 
     @auth_required(RDR_AND_PTC)
     def post(self, order):

--- a/rdr_service/api/mayolink_api.py
+++ b/rdr_service/api/mayolink_api.py
@@ -80,5 +80,5 @@ class MayoLinkApi:
                     for item in v:
                         self.create_xml_tree_from_dict(sub_element, item)
             return root
-        else:
+        elif dict_tree is not None:
             root.text = str(dict_tree)

--- a/rdr_service/api/mayolink_api.py
+++ b/rdr_service/api/mayolink_api.py
@@ -11,18 +11,24 @@ from rdr_service.app_util import auth_required
 
 
 class MayoLinkApi:
-    def __init__(self):
+    def __init__(self, credentials_key='default'):
         self.namespace = "http://orders.mayomedicallaboratories.com"
         self.endpoint = config.getSetting(config.MAYOLINK_ENDPOINT)
-        self.username, self.pw, self.account = self._get_credentials()
+
+        self.username, self.pw, self.account = self._get_credentials(credentials_key=credentials_key)
 
     @classmethod
-    def _get_credentials(cls):
+    def _get_credentials(cls, credentials_key):
         credentials_bucket_name = config.CONFIG_BUCKET
         credentials_file_name = config.getSetting(config.MAYOLINK_CREDS)
-
         with open_cloud_file("/" + credentials_bucket_name + "/" + credentials_file_name) as file:
-            credentials = json.load(file)
+            credentials_json = json.load(file)
+            if credentials_key in credentials_json:
+                credentials = credentials_json[credentials_key]
+            else:
+                # If the key is not found, that likely means the file is still a legacy version
+                # (where the entire file was one set of credentials)
+                credentials = credentials_json
 
         return credentials.get('username'), credentials.get('password'), credentials.get('account')
 

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -54,8 +54,8 @@ class MailKitOrderDao(UpdatableDao):
         }
 
     def send_order(self, resource, pid):
-        mayo = MayoLinkApi()
-        order = self._filter_order_fields(resource, pid)
+        order, is_version_two = self._filter_order_fields(resource, pid)
+        mayo = MayoLinkApi(credentials_key='version_two' if is_version_two else 'default')
         response = mayo.post(order)
         return self.to_client_json(response, for_update=True)
 
@@ -115,7 +115,8 @@ class MailKitOrderDao(UpdatableDao):
             }
         }
 
-        if barcode and len(barcode) > 14:
+        is_version_two = barcode and len(barcode) > 14
+        if is_version_two:
             order["order"]["number"] = None
             client_fields = {"client_passthrough_fields": {
                 "field1": barcode
@@ -123,7 +124,7 @@ class MailKitOrderDao(UpdatableDao):
             order['order']['tests'][0]['test'].update(client_fields)
 
         order['order']['comments'] = "Salivary Kit Order, direct from participant"
-        return order
+        return order, is_version_two
 
     def to_client_json(self, model, for_update=False):
         if for_update:

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -116,11 +116,11 @@ class MailKitOrderDao(UpdatableDao):
         }
 
         if barcode and len(barcode) > 14:
-            del order["order"]["number"]
+            order["order"]["number"] = None
             client_fields = {"client_passthrough_fields": {
                 "field1": barcode
             }}
-            order['order'].update(client_fields)
+            order['order']['tests'][0]['test'].update(client_fields)
 
         order['order']['comments'] = "Salivary Kit Order, direct from participant"
         return order

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -62,3 +62,21 @@ class MayolinkClientTest(BaseTestCase):
         self.assertEqual('legacy_user', mayolink_client.username)
         self.assertEqual('9283', mayolink_client.pw)
         self.assertEqual(7676, mayolink_client.account)
+
+    def test_empty_field_in_xml(self):
+        """Making sure an empty field gets sent in the xml"""
+        client = MayoLinkApi()
+        xml_output = client.__dict_to_mayo_xml__({
+            'order': {
+                'blank': None
+            }
+        })
+        self.assertEqual(
+            b'<orders xmlns="http://orders.mayomedicallaboratories.com">'
+            b'<order>'
+            b'<blank />'
+            b'<account>1122</account>'
+            b'</order>'
+            b'</orders>',
+            xml_output
+        )

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -1,0 +1,64 @@
+import mock
+
+from rdr_service.api.mayolink_api import MayoLinkApi
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class MayolinkClientTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(MayolinkClientTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs) -> None:
+        super(MayolinkClientTest, self).setUp(*args, **kwargs)
+
+        open_cloud_file_patch = mock.patch('rdr_service.api.mayolink_api.open_cloud_file')
+        self.open_cloud_file_mock = open_cloud_file_patch.start()
+        self.addCleanup(open_cloud_file_patch.stop)
+
+        self.open_cloud_file_mock.return_value.__enter__.return_value.read.return_value = """
+            {
+                "default": {
+                    "username": "test_user",
+                    "password": "1234",
+                    "account": 1122
+                },
+                "version_two": {
+                    "username": "v2_user",
+                    "password": "9876",
+                    "account": 8765
+                }
+            }
+        """
+
+    def test_default_credentials(self):
+        """Test that the client uses the default account by default"""
+        mayolink_client = MayoLinkApi()
+        self.assertEqual('test_user', mayolink_client.username)
+        self.assertEqual('1234', mayolink_client.pw)
+        self.assertEqual(1122, mayolink_client.account)
+
+    def test_specific_account_credentials(self):
+        """Test that the client switches to the new credentials when specified"""
+        mayolink_client = MayoLinkApi(credentials_key='version_two')
+        self.assertEqual('v2_user', mayolink_client.username)
+        self.assertEqual('9876', mayolink_client.pw)
+        self.assertEqual(8765, mayolink_client.account)
+
+    def test_new_code_with_old_file(self):
+        """
+        Test that the new code can work with the previous file structure.
+        This way the code can deploy, and we can take our time updating the file structure.
+        """
+        self.open_cloud_file_mock.return_value.__enter__.return_value.read.return_value = """
+            {
+                "username": "legacy_user",
+                "password": "9283",
+                "account": 7676
+            }
+        """
+
+        mayolink_client = MayoLinkApi()
+        self.assertEqual('legacy_user', mayolink_client.username)
+        self.assertEqual('9283', mayolink_client.pw)
+        self.assertEqual(7676, mayolink_client.account)

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -135,10 +135,14 @@ class MailKitOrderDaoTestBase(BaseTestCase):
 
         mayo_order_payload = self.mock_mayolinkapi.return_value.post.call_args.args[0]
         mayo_order_payload = mayo_order_payload['order']
-        mayo_payload_fields = ['collected', 'account', 'patient', 'physician', 'report_notes', 'tests', 'client_passthrough_fields','comments']
 
-        self.assertEqual(mayo_order_payload['client_passthrough_fields']['field1'], version_two_barcode)
-        self.assertTrue(all(key in mayo_order_payload.keys() for key in mayo_payload_fields))
+        mayo_request_test_data = mayo_order_payload['tests'][0]['test']
+        self.assertEqual(mayo_request_test_data['client_passthrough_fields']['field1'], version_two_barcode)
+        self.assertEqual(
+            ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests','comments'],
+            list(mayo_order_payload.keys())
+        )
+        self.assertIsNone(mayo_order_payload['number'])
 
     def test_biobank_order_finalized_and_identifier_created(self):
         self.send_post(

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -142,7 +142,10 @@ class MailKitOrderDaoTestBase(BaseTestCase):
             ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests','comments'],
             list(mayo_order_payload.keys())
         )
-        self.assertIsNone(mayo_order_payload['number'])
+        self.assertIsNone(mayo_order_payload['number'])  # An empty number field should be given for version two
+
+        # Make sure the correct account is used for version two
+        self.mock_mayolinkapi.assert_called_once_with(credentials_key='version_two')
 
     def test_biobank_order_finalized_and_identifier_created(self):
         self.send_post(


### PR DESCRIPTION
## Updates for *[DA-2010](https://precisionmedicineinitiative.atlassian.net/browse/DA-2010)*
When testing the v2 changes for salivary kit orders we found a couple of changes that needed to be made:
- the client passthrough fields needs to be within the `test` structure
- another account number (and likely a different set of mayolink credentials) will need to be used for v2 orders
- we won't be sending data for the `number` field, but we still need to send the element (it just needs to be empty)

## Description of changes/additions
Updates for the first one were simple enough. Rather than set the client passthrough fields at the level of `order`, it's set on the `test` dictionary for the first (and only) object in the `tests` list.

The MayolinkAPI client code was set up to read one set of credentials from a file. This updates the code to allow for a specific key to be passed in (one for default orders, and another if it's a v2 salivary order). If the file only has one set of credentials, then those will be used regardless of what was passed in as a key.

The last change needed an update to the xml generation code in the Mayolink code. If the value of an element is `None` then the text for that node is left as `None`. Otherwise it will set the string value the same way it was before.

## Tests
- [x] unit tests


