### PR TITLE
[DA-2058] Consent issue reporting script

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 
 from sqlalchemy import or_
@@ -49,11 +50,14 @@ class ConsentDao(BaseDao):
             summaries = query.all()
             return summaries
 
-    def get_files_needing_correction(self) -> List[ConsentFile]:
+    def get_files_needing_correction(self, min_modified_datetime : datetime = None) -> List[ConsentFile]:
         with self.session() as session:
-            return session.query(ConsentFile).filter(
+            query = session.query(ConsentFile).filter(
                 ConsentFile.sync_status == ConsentSyncStatus.NEEDS_CORRECTING
-            ).all()
+            )
+            if min_modified_datetime:
+                query = query.filter(ConsentFile.modified >= min_modified_datetime)
+            return query.all()
 
     def batch_update_consent_files(self, consent_files: List[ConsentFile]):
         with self.session() as session:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -12,6 +12,18 @@ from pdfminer.layout import LTChar, LTCurve, LTFigure, LTImage, LTTextBox
 from rdr_service.storage import GoogleCloudStorageProvider
 
 
+class _ConsentBlobWrapper:
+    def __init__(self, blob: Blob):
+        self.blob = blob
+        self._parsed_pdf = None
+
+    def get_parsed_pdf(self) -> 'Pdf':
+        if self._parsed_pdf is None:
+            self._parsed_pdf = Pdf.from_google_storage_blob(self.blob)
+
+        return self._parsed_pdf
+
+
 class ConsentFileAbstractFactory(ABC):
     @classmethod
     def get_file_factory(cls, participant_id: int, participant_origin: str,
@@ -28,22 +40,81 @@ class ConsentFileAbstractFactory(ABC):
             bucket_name=factory_consent_bucket,
             prefix=f'Participant/P{participant_id}'
         )
-        self.pdf_blobs = [blob for blob in file_blobs if blob.name.endswith('.pdf')]
+        self.consent_blobs = [_ConsentBlobWrapper(blob) for blob in file_blobs if blob.name.endswith('.pdf')]
+        self._storage_provider = storage_provider
 
-    @abstractmethod
+    def get_consent_for_path(self, file_path) -> 'ConsentFile':
+        bucket_name, blob_name_parts = file_path.split('/')
+        blob = self._storage_provider.get_blob(bucket_name=bucket_name, blob_name='/'.join(blob_name_parts))
+        blob_wrapper = _ConsentBlobWrapper(blob)
+
+        if self._is_primary_consent(blob_wrapper):
+            return self._build_primary_consent(blob_wrapper)
+        elif self._is_cabor_consent(blob_wrapper):
+            return self._build_cabor_consent(blob_wrapper)
+        elif self._is_ehr_consent(blob_wrapper):
+            return self._build_ehr_consent(blob_wrapper)
+        elif self._is_gror_consent(blob_wrapper):
+            return self._build_gror_consent(blob_wrapper)
+
     def get_primary_consents(self) -> List['PrimaryConsentFile']:
-        ...
+        return [
+            self._build_primary_consent(blob_wrapper)
+            for blob_wrapper in self.consent_blobs
+            if self._is_primary_consent(blob_wrapper)
+        ]
 
-    @abstractmethod
     def get_cabor_consents(self) -> List['CaborConsentFile']:
-        ...
+        return [
+            self._build_cabor_consent(blob_wrapper)
+            for blob_wrapper in self.consent_blobs
+            if self._is_cabor_consent(blob_wrapper)
+        ]
 
-    @abstractmethod
     def get_ehr_consents(self) -> List['EhrConsentFile']:
+        return [
+            self._build_ehr_consent(blob_wrapper)
+            for blob_wrapper in self.consent_blobs
+            if self._is_ehr_consent(blob_wrapper)
+        ]
+
+    def get_gror_consents(self) -> List['GrorConsentFile']:
+        return [
+            self._build_gror_consent(blob_wrapper)
+            for blob_wrapper in self.consent_blobs
+            if self._is_gror_consent(blob_wrapper)
+        ]
+
+    @abstractmethod
+    def _is_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
         ...
 
     @abstractmethod
-    def get_gror_consents(self) -> List['GrorConsentFile']:
+    def _is_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+        ...
+
+    @abstractmethod
+    def _is_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+        ...
+
+    @abstractmethod
+    def _is_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+        ...
+
+    @abstractmethod
+    def _build_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'PrimaryConsentFile':
+        ...
+
+    @abstractmethod
+    def _build_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'CaborConsentFile':
+        ...
+
+    @abstractmethod
+    def _build_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'EhrConsentFile':
+        ...
+
+    @abstractmethod
+    def _build_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'GrorConsentFile':
         ...
 
     @abstractmethod
@@ -52,49 +123,39 @@ class ConsentFileAbstractFactory(ABC):
 
 
 class VibrentConsentFactory(ConsentFileAbstractFactory):
+
     CABOR_TEXT = 'California Experimental Subject’s Bill of Rights'
 
-    def get_primary_consents(self) -> List['PrimaryConsentFile']:
-        primary_consents = []
-        for blob in self._get_consent_pii_blobs():
-            pdf_data = Pdf.from_google_storage_blob(blob)
-            if pdf_data.get_page_number_of_text([self.CABOR_TEXT]) is None:
-                primary_consents.append(VibrentPrimaryConsentFile(pdf=pdf_data, blob=blob))
+    def _is_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+        pdf = blob_wrapper.get_parsed_pdf()
+        name = blob_wrapper.blob.name
+        return basename(name).startswith('ConsentPII') and pdf.get_page_number_of_text([self.CABOR_TEXT]) is None
 
-        return primary_consents
+    def _is_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+        pdf = blob_wrapper.get_parsed_pdf()
+        name = blob_wrapper.blob.name
+        return basename(name).startswith('ConsentPII') and pdf.get_page_number_of_text([self.CABOR_TEXT]) is not None
 
-    def get_cabor_consents(self) -> List['CaborConsentFile']:
-        cabor_consents = []
-        for blob in self._get_consent_pii_blobs():
-            pdf_data = Pdf.from_google_storage_blob(blob)
-            if pdf_data.get_page_number_of_text([self.CABOR_TEXT]) is not None:
-                cabor_consents.append(VibrentCaborConsentFile(pdf=pdf_data, blob=blob))
+    def _is_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+        return basename(blob_wrapper.blob.name).startswith('EHRConsentPII')
 
-        return cabor_consents
+    def _is_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+        return basename(blob_wrapper.blob.name).startswith('GROR')
 
-    def get_ehr_consents(self) -> List['EhrConsentFile']:
-        ehr_consents = []
-        for blob in self.pdf_blobs:
-            if basename(blob.name).startswith('EHRConsentPII'):
-                ehr_consents.append(VibrentEhrConsentFile(pdf=Pdf.from_google_storage_blob(blob), blob=blob))
+    def _build_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'PrimaryConsentFile':
+        return VibrentPrimaryConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
 
-        return ehr_consents
+    def _build_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'CaborConsentFile':
+        return VibrentCaborConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
 
-    def get_gror_consents(self) -> List['GrorConsentFile']:
-        gror_consents = []
-        for blob in self.pdf_blobs:
-            if basename(blob.name).startswith('GROR'):
-                gror_consents.append(VibrentGrorConsentFile(pdf=Pdf.from_google_storage_blob(blob), blob=blob))
+    def _build_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'EhrConsentFile':
+        return VibrentEhrConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
 
-        return gror_consents
+    def _build_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'GrorConsentFile':
+        return VibrentGrorConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
 
     def _get_source_bucket(self) -> str:
         return 'ptc-uploads-all-of-us-rdr-prod'
-
-    def _get_consent_pii_blobs(self):
-        def is_consent_pii_blob(blob):
-            return basename(blob.name).startswith('ConsentPII') and blob.name.endswith('.pdf')
-        return [blob for blob in self.pdf_blobs if is_consent_pii_blob(blob)]
 
 
 class ConsentFile(ABC):

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -12,18 +12,6 @@ from pdfminer.layout import LTChar, LTCurve, LTFigure, LTImage, LTTextBox
 from rdr_service.storage import GoogleCloudStorageProvider
 
 
-class _ConsentBlobWrapper:
-    def __init__(self, blob: Blob):
-        self.blob = blob
-        self._parsed_pdf = None
-
-    def get_parsed_pdf(self) -> 'Pdf':
-        if self._parsed_pdf is None:
-            self._parsed_pdf = Pdf.from_google_storage_blob(self.blob)
-
-        return self._parsed_pdf
-
-
 class ConsentFileAbstractFactory(ABC):
     @classmethod
     def get_file_factory(cls, participant_id: int, participant_origin: str,
@@ -40,81 +28,22 @@ class ConsentFileAbstractFactory(ABC):
             bucket_name=factory_consent_bucket,
             prefix=f'Participant/P{participant_id}'
         )
-        self.consent_blobs = [_ConsentBlobWrapper(blob) for blob in file_blobs if blob.name.endswith('.pdf')]
-        self._storage_provider = storage_provider
+        self.pdf_blobs = [blob for blob in file_blobs if blob.name.endswith('.pdf')]
 
-    def get_consent_for_path(self, file_path) -> 'ConsentFile':
-        bucket_name, blob_name_parts = file_path.split('/')
-        blob = self._storage_provider.get_blob(bucket_name=bucket_name, blob_name='/'.join(blob_name_parts))
-        blob_wrapper = _ConsentBlobWrapper(blob)
-
-        if self._is_primary_consent(blob_wrapper):
-            return self._build_primary_consent(blob_wrapper)
-        elif self._is_cabor_consent(blob_wrapper):
-            return self._build_cabor_consent(blob_wrapper)
-        elif self._is_ehr_consent(blob_wrapper):
-            return self._build_ehr_consent(blob_wrapper)
-        elif self._is_gror_consent(blob_wrapper):
-            return self._build_gror_consent(blob_wrapper)
-
+    @abstractmethod
     def get_primary_consents(self) -> List['PrimaryConsentFile']:
-        return [
-            self._build_primary_consent(blob_wrapper)
-            for blob_wrapper in self.consent_blobs
-            if self._is_primary_consent(blob_wrapper)
-        ]
+        ...
 
+    @abstractmethod
     def get_cabor_consents(self) -> List['CaborConsentFile']:
-        return [
-            self._build_cabor_consent(blob_wrapper)
-            for blob_wrapper in self.consent_blobs
-            if self._is_cabor_consent(blob_wrapper)
-        ]
+        ...
 
+    @abstractmethod
     def get_ehr_consents(self) -> List['EhrConsentFile']:
-        return [
-            self._build_ehr_consent(blob_wrapper)
-            for blob_wrapper in self.consent_blobs
-            if self._is_ehr_consent(blob_wrapper)
-        ]
+        ...
 
+    @abstractmethod
     def get_gror_consents(self) -> List['GrorConsentFile']:
-        return [
-            self._build_gror_consent(blob_wrapper)
-            for blob_wrapper in self.consent_blobs
-            if self._is_gror_consent(blob_wrapper)
-        ]
-
-    @abstractmethod
-    def _is_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        ...
-
-    @abstractmethod
-    def _is_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        ...
-
-    @abstractmethod
-    def _is_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        ...
-
-    @abstractmethod
-    def _is_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        ...
-
-    @abstractmethod
-    def _build_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'PrimaryConsentFile':
-        ...
-
-    @abstractmethod
-    def _build_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'CaborConsentFile':
-        ...
-
-    @abstractmethod
-    def _build_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'EhrConsentFile':
-        ...
-
-    @abstractmethod
-    def _build_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'GrorConsentFile':
         ...
 
     @abstractmethod
@@ -123,39 +52,49 @@ class ConsentFileAbstractFactory(ABC):
 
 
 class VibrentConsentFactory(ConsentFileAbstractFactory):
-
     CABOR_TEXT = 'California Experimental Subject’s Bill of Rights'
 
-    def _is_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        pdf = blob_wrapper.get_parsed_pdf()
-        name = blob_wrapper.blob.name
-        return basename(name).startswith('ConsentPII') and pdf.get_page_number_of_text([self.CABOR_TEXT]) is None
+    def get_primary_consents(self) -> List['PrimaryConsentFile']:
+        primary_consents = []
+        for blob in self._get_consent_pii_blobs():
+            pdf_data = Pdf.from_google_storage_blob(blob)
+            if pdf_data.get_page_number_of_text([self.CABOR_TEXT]) is None:
+                primary_consents.append(VibrentPrimaryConsentFile(pdf=pdf_data, blob=blob))
 
-    def _is_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        pdf = blob_wrapper.get_parsed_pdf()
-        name = blob_wrapper.blob.name
-        return basename(name).startswith('ConsentPII') and pdf.get_page_number_of_text([self.CABOR_TEXT]) is not None
+        return primary_consents
 
-    def _is_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        return basename(blob_wrapper.blob.name).startswith('EHRConsentPII')
+    def get_cabor_consents(self) -> List['CaborConsentFile']:
+        cabor_consents = []
+        for blob in self._get_consent_pii_blobs():
+            pdf_data = Pdf.from_google_storage_blob(blob)
+            if pdf_data.get_page_number_of_text([self.CABOR_TEXT]) is not None:
+                cabor_consents.append(VibrentCaborConsentFile(pdf=pdf_data, blob=blob))
 
-    def _is_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
-        return basename(blob_wrapper.blob.name).startswith('GROR')
+        return cabor_consents
 
-    def _build_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'PrimaryConsentFile':
-        return VibrentPrimaryConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
+    def get_ehr_consents(self) -> List['EhrConsentFile']:
+        ehr_consents = []
+        for blob in self.pdf_blobs:
+            if basename(blob.name).startswith('EHRConsentPII'):
+                ehr_consents.append(VibrentEhrConsentFile(pdf=Pdf.from_google_storage_blob(blob), blob=blob))
 
-    def _build_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'CaborConsentFile':
-        return VibrentCaborConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
+        return ehr_consents
 
-    def _build_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'EhrConsentFile':
-        return VibrentEhrConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
+    def get_gror_consents(self) -> List['GrorConsentFile']:
+        gror_consents = []
+        for blob in self.pdf_blobs:
+            if basename(blob.name).startswith('GROR'):
+                gror_consents.append(VibrentGrorConsentFile(pdf=Pdf.from_google_storage_blob(blob), blob=blob))
 
-    def _build_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> 'GrorConsentFile':
-        return VibrentGrorConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
+        return gror_consents
 
     def _get_source_bucket(self) -> str:
         return 'ptc-uploads-all-of-us-rdr-prod'
+
+    def _get_consent_pii_blobs(self):
+        def is_consent_pii_blob(blob):
+            return basename(blob.name).startswith('ConsentPII') and blob.name.endswith('.pdf')
+        return [blob for blob in self.pdf_blobs if is_consent_pii_blob(blob)]
 
 
 class ConsentFile(ABC):

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -21,6 +21,10 @@ class ConsentTool(ToolBase):
     def run(self):
         super(ConsentTool, self).run()
 
+        if self.args.command == 'report-errors':
+            self.report_files_for_correction()
+
+    def report_files_for_correction(self):
         min_validation_date = parse(self.args.since) if self.args.since else None
         results_to_report = self._consent_dao.get_files_needing_correction(min_modified_datetime=min_validation_date)
 

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -21,10 +21,6 @@ class ConsentTool(ToolBase):
     def run(self):
         super(ConsentTool, self).run()
 
-        if self.args.command == 'report-errors':
-            self.report_files_for_correction()
-
-    def report_files_for_correction(self):
         min_validation_date = parse(self.args.since) if self.args.since else None
         results_to_report = self._consent_dao.get_files_needing_correction(min_modified_datetime=min_validation_date)
 

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -1,0 +1,74 @@
+import argparse
+from dateutil.parser import parse
+
+from rdr_service.dao.consent_dao import ConsentDao
+from rdr_service.model.consent_file import ConsentFile
+from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
+
+tool_cmd = 'consents'
+tool_desc = 'Get reports of consent issues and modify validation records'
+
+
+class ConsentTool(ToolBase):
+    def __init__(self, *args, **kwargs):
+        super(ConsentTool, self).__init__(*args, **kwargs)
+        self._consent_dao = ConsentDao()
+
+    def run(self):
+        super(ConsentTool, self).run()
+
+        min_validation_date = parse(self.args.since) if self.args.since else None
+        results_to_report = self._consent_dao.get_files_needing_correction(min_modified_datetime=min_validation_date)
+
+        report_lines = []
+        previous_participant_id = None
+        for result in results_to_report:
+            if previous_participant_id and previous_participant_id != result.participant_id and self.args.verbose:
+                report_lines.append('')
+            previous_participant_id = result.participant_id
+
+            report_lines.append(self._line_output_for_validation(result, verbose=self.args.verbose))
+
+        logger.info('\n'.join(report_lines))
+
+    @classmethod
+    def _line_output_for_validation(cls, result: ConsentFile, verbose: bool):
+        if not result.file_exists:
+            error_message = 'missing file'
+        else:
+            errors_with_file = []
+            if not result.is_signature_valid:
+                errors_with_file.append('invalid signature')
+            if not result.is_signing_date_valid:
+                extra_info = ''
+                if verbose:
+                    time_difference = result.signing_date - result.expected_sign_date
+                    extra_info = f', diff of {time_difference.days} days'
+                errors_with_file.append(
+                    f'invalid signing date (expected {result.expected_sign_date} '
+                    f'but file has {result.signing_date}{extra_info})'
+                )
+            if result.other_errors is not None:
+                errors_with_file.append(result.other_errors)
+            error_message = ', '.join(errors_with_file)
+        return f'P{result.participant_id} - {str(result.type).ljust(10)} {error_message}'
+
+
+def add_additional_arguments(parser: argparse.ArgumentParser):
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    report_parser = subparsers.add_parser('report-errors')
+    report_parser.add_argument(
+        '--since',
+        help='date or timestamp, if provided the report will only contain more recent validation information'
+    )
+    report_parser.add_argument(
+        '--verbose',
+        help='Enable verbose output, useful when auditing flagged files',
+        default=False,
+        action="store_true"
+    )
+
+
+def run():
+    cli_run(tool_cmd, tool_desc, ConsentTool, add_additional_arguments)

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -1,0 +1,69 @@
+from datetime import date
+import mock
+
+from rdr_service.model.consent_file import ConsentFile, ConsentType
+from rdr_service.tools.tool_libs.consents import ConsentTool
+from tests.helpers.tool_test_mixin import ToolTestMixin
+from tests.helpers.unittest_base import BaseTestCase
+
+
+@mock.patch('rdr_service.tools.tool_libs.consents.logger')
+class ConsentsTest(ToolTestMixin, BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(ConsentsTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs) -> None:
+        super(ConsentsTest, self).setUp(*args, **kwargs)
+
+        self.invalid_files = [
+            ConsentFile(participant_id=123123123, type=ConsentType.PRIMARY, file_exists=False),
+            ConsentFile(participant_id=222333444, type=ConsentType.CABOR, file_exists=False),
+            ConsentFile(participant_id=222333444, type=ConsentType.GROR, file_exists=True,
+                        is_signature_valid=False, is_signing_date_valid=True,
+                        other_errors='missing checkmark'),
+            ConsentFile(participant_id=654321123, type=ConsentType.CABOR, file_exists=True,
+                        is_signature_valid=True, is_signing_date_valid=False,
+                        signing_date=date(2021, 12, 1), expected_sign_date=date(2020, 12, 1)),
+            ConsentFile(participant_id=901987345, type=ConsentType.EHR, file_exists=True,
+                        is_signature_valid=False, is_signing_date_valid=True)
+        ]
+
+    def _run_error_report(self, verbose=False):
+        with mock.patch('rdr_service.tools.tool_libs.consents.ConsentDao') as consent_dao_class_mock:
+            consent_dao_instance_mock = consent_dao_class_mock.return_value
+            consent_dao_instance_mock.get_files_needing_correction.return_value = self.invalid_files
+            self.run_tool(ConsentTool, tool_args={
+                'since': None,
+                'verbose': verbose
+            })
+
+    def test_report_to_send_to_ptsc(self, logger_mock):
+        """Check the basic report format, the one that would be sent to Vibrent or CE for correcting"""
+        self._run_error_report()
+        logger_mock.info.assert_called_once_with('\n'.join([
+            'P123123123 - PRIMARY    missing file',
+            'P222333444 - CABOR      missing file',
+            'P222333444 - GROR       invalid signature, missing checkmark',
+            'P654321123 - CABOR      invalid signing date (expected 2020-12-01 but file has 2021-12-01)',
+            'P901987345 - EHR        invalid signature',
+        ]))
+
+    def test_report_to_audit(self, logger_mock):
+        """
+        Check additional information and formatting helpful for looking into whether
+        the files might have been mistakenly marked as incorrect
+        """
+        self._run_error_report(verbose=True)
+        logger_mock.info.assert_called_once_with('\n'.join([
+            'P123123123 - PRIMARY    missing file',
+            '',
+            'P222333444 - CABOR      missing file',
+            'P222333444 - GROR       invalid signature, missing checkmark',
+            '',
+            'P654321123 - CABOR      '
+            'invalid signing date (expected 2020-12-01 but file has 2021-12-01, diff of 365 days)',
+            '',
+            'P901987345 - EHR        invalid signature',
+        ]))
+

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -41,7 +41,7 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
             )
         ]
 
-    def _run_error_report(self, verbose=False):
+    def _run_consents_tool(self, command, verbose=False):
         with mock.patch('rdr_service.tools.tool_libs.consents.ConsentDao') as consent_dao_class_mock,\
                 mock.patch('rdr_service.tools.tool_libs.consents.GoogleCloudStorageProvider') as storage_provider_mock:
             consent_dao_instance_mock = consent_dao_class_mock.return_value
@@ -54,13 +54,14 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
             storage_provider_mock.return_value.get_blob.side_effect = blob_that_gives_url
 
             self.run_tool(ConsentTool, tool_args={
+                'command': command,
                 'since': None,
                 'verbose': verbose
             })
 
     def test_report_to_send_to_ptsc(self, logger_mock):
         """Check the basic report format, the one that would be sent to Vibrent or CE for correcting"""
-        self._run_error_report()
+        self._run_consents_tool(command='report-errors')
         logger_mock.info.assert_called_once_with('\n'.join([
             'P123123123 - PRIMARY    missing file',
             'P222333444 - CABOR      missing file',
@@ -74,7 +75,7 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
         Check additional information and formatting helpful for looking into whether
         the files might have been mistakenly marked as incorrect
         """
-        self._run_error_report(verbose=True)
+        self._run_consents_tool(command='report-errors', verbose=True)
         logger_mock.info.assert_called_once_with('\n'.join([
             'P123123123 - PRIMARY    missing file',
             '',


### PR DESCRIPTION
## Partially resolves *[DA-2058](https://precisionmedicineinitiative.atlassian.net/browse/DA-2058)*
This adds a way to report out the consent sync issues. There are essentially two modes for it: one lists the issues out in a way that we would be able to send directly to PTSC, and the other helps with auditing the consent file validation (giving additional information to help find if the files really are ok and if something needs to be fixed in the code). 

## Tests
- [x] unit tests


