### PR TITLE
[DA-2058] Script for modifying consent validation records

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -12,9 +12,9 @@ class ConsentDao(BaseDao):
     def __init__(self):
         super(ConsentDao, self).__init__(ConsentFile)
 
-    def get(self, obj_id):
+    def get(self, obj_id) -> ConsentFile:
         with self.session() as session:
-            return session.query(ConsentFile).filter(ConsentFile.id == obj_id).one()
+            return session.query(ConsentFile).filter(ConsentFile.id == obj_id).one_or_none()
 
     def get_participants_with_consents_in_range(self, start_date, end_date=None) -> List[ParticipantSummary]:
         with self.session() as session:

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -12,6 +12,10 @@ class ConsentDao(BaseDao):
     def __init__(self):
         super(ConsentDao, self).__init__(ConsentFile)
 
+    def get(self, obj_id):
+        with self.session() as session:
+            return session.query(ConsentFile).filter(ConsentFile.id == obj_id).one()
+
     def get_participants_with_consents_in_range(self, start_date, end_date=None) -> List[ParticipantSummary]:
         with self.session() as session:
             query = session.query(

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -13,10 +13,6 @@ class ConsentDao(BaseDao):
     def __init__(self):
         super(ConsentDao, self).__init__(ConsentFile)
 
-    def get(self, obj_id) -> ConsentFile:
-        with self.session() as session:
-            return session.query(ConsentFile).filter(ConsentFile.id == obj_id).one_or_none()
-
     def get_participants_with_consents_in_range(self, start_date, end_date=None) -> List[ParticipantSummary]:
         with self.session() as session:
             query = session.query(

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -46,26 +46,34 @@ class ConsentTool(ToolBase):
             logger.error('Unable to find validation record')
 
         logger.info('File info:'.ljust(16) + f'P{file.participant_id}, {file.file_path}')
-        self._respond_if_different(
-            self.args.type, file.type, ConsentType,
-            new_value_callback=lambda new_value: self._log_property_change('type', file.type, new_value)
+        self._check_for_update(
+            new_value=self.args.type,
+            stored_value=file.type,
+            parser_func=ConsentType,
+            callback=lambda parsed_value: self._log_property_change('type', file.type, parsed_value)
         )
-        self._respond_if_different(
-            self.args.sync_status, file.sync_status, ConsentSyncStatus,
-            new_value_callback=lambda new_value: self._log_property_change('sync_status', file.sync_status, new_value)
+        self._check_for_update(
+            new_value=self.args.sync_status,
+            stored_value=file.sync_status,
+            parser_func=ConsentSyncStatus,
+            callback=lambda parsed_value: self._log_property_change('sync_status', file.sync_status, parsed_value)
         )
-        confirm = input('\nMake the changes above (Y/n)? : ')
-        if confirm and confirm.lower().strip() != 'y':
+        confirmation_answer = input('\nMake the changes above (Y/n)? : ')
+        if confirmation_answer and confirmation_answer.lower().strip() != 'y':
             logger.info('Aborting update')
         else:
             logger.info('Updating file record')
-            self._respond_if_different(
-                self.args.type, file.type, ConsentType,
-                new_value_callback=lambda new_value: setattr(file, 'type', new_value)
+            self._check_for_update(
+                new_value=self.args.type,
+                stored_value=file.type,
+                parser_func=ConsentType,
+                callback=lambda parsed_value: setattr(file, 'type', parsed_value)
             )
-            self._respond_if_different(
-                self.args.sync_status, file.sync_status, ConsentSyncStatus,
-                new_value_callback=lambda new_value: setattr(file, 'sync_status', new_value)
+            self._check_for_update(
+                new_value=self.args.sync_status,
+                stored_value=file.sync_status,
+                parser_func=ConsentSyncStatus,
+                callback=lambda parsed_value: setattr(file, 'sync_status', parsed_value)
             )
             self._consent_dao.batch_update_consent_files([file])
 
@@ -121,11 +129,11 @@ class ConsentTool(ToolBase):
             return entered_value
 
     @classmethod
-    def _respond_if_different(cls, new_value, stored_value, parser_func=None, new_value_callback=None):
+    def _check_for_update(cls, new_value, stored_value, parser_func=None, callback=None):
         if new_value is not None:
             parsed_value = cls._new_value(entered_value=new_value, parser_func=parser_func)
             if parsed_value != stored_value:
-                new_value_callback(parsed_value)
+                callback(parsed_value)
 
 
 def add_additional_arguments(parser: argparse.ArgumentParser):

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -1,0 +1,113 @@
+import argparse
+from datetime import datetime, timedelta
+from dateutil.parser import parse
+from io import StringIO
+
+from rdr_service.dao.consent_dao import ConsentDao
+from rdr_service.model.consent_file import ConsentFile
+from rdr_service.storage import GoogleCloudStorageProvider
+from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
+
+tool_cmd = 'consents'
+tool_desc = 'Get reports of consent issues and modify validation records'
+
+
+class ConsentTool(ToolBase):
+    def __init__(self, *args, **kwargs):
+        super(ConsentTool, self).__init__(*args, **kwargs)
+        self._consent_dao = ConsentDao()
+        self._storage_provider = GoogleCloudStorageProvider()
+
+    def run(self):
+        super(ConsentTool, self).run()
+
+        if self.args.command == 'report-errors':
+            self.report_files_for_correction()
+        elif self.args.command == 'modify':
+            self.modify_file_results()
+
+    def report_files_for_correction(self):
+        min_validation_date = parse(self.args.since) if self.args.since else None
+        results_to_report = self._consent_dao.get_files_needing_correction(min_modified_datetime=min_validation_date)
+
+        report_lines = []
+        previous_participant_id = None
+        for result in results_to_report:
+            if previous_participant_id and previous_participant_id != result.participant_id and self.args.verbose:
+                report_lines.append('')
+            previous_participant_id = result.participant_id
+            report_lines.append(self._line_output_for_validation(result, verbose=self.args.verbose))
+
+        logger.info('\n'.join(report_lines))
+
+    def modify_file_results(self):
+        # TODO:
+        #  make changes to the record specified by the id
+        #  print the changes being made (NEEDS_CORRECTIONS => READY_TO_SYNC) and ask for confirmation
+        ...
+
+    # todo: methods for
+    #  re-evaluating sync validations in time range, and/or by type of consent
+    #  triggering validation for consents
+    #  batch-adding records (for CE participants)
+
+    def _line_output_for_validation(self, file: ConsentFile, verbose: bool):
+        output_line = StringIO()
+        output_line.write(f'P{file.participant_id} - {str(file.type).ljust(10)} ')
+
+        if not file.file_exists:
+            output_line.write('missing file')
+        else:
+            errors_with_file = []
+            if not file.is_signature_valid:
+                errors_with_file.append('invalid signature')
+            if not file.is_signing_date_valid:
+                errors_with_file.append(self._get_date_error_details(file, verbose))
+            if file.other_errors is not None:
+                errors_with_file.append(file.other_errors)
+
+            output_line.write(', '.join(errors_with_file))
+            if verbose:
+                output_line.write(f' - {self._get_link(file)}')
+
+        return output_line.getvalue()
+
+    @classmethod
+    def _get_date_error_details(cls, file: ConsentFile, verbose: bool = False):
+        extra_info = ''
+        if verbose:
+            time_difference = file.signing_date - file.expected_sign_date
+            extra_info = f', diff of {time_difference.days} days'
+        return f'invalid signing date (expected {file.expected_sign_date} '\
+               f'but file has {file.signing_date}{extra_info})'
+
+    def _get_link(self, file: ConsentFile):
+        bucket_name, *name_parts = file.file_path.split('/')
+        blob = self._storage_provider.get_blob(
+            bucket_name=bucket_name,
+            blob_name='/'.join(name_parts)
+        )
+        return blob.generate_signed_url(datetime.now() + timedelta(hours=2))
+
+
+def add_additional_arguments(parser: argparse.ArgumentParser):
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    report_parser = subparsers.add_parser('report-errors')
+    report_parser.add_argument(
+        '--since',
+        help='date or timestamp, if provided the report will only contain more recent validation information'
+    )
+    report_parser.add_argument(
+        '--verbose',
+        help='Enable verbose output, useful when auditing flagged files',
+        default=False,
+        action="store_true"
+    )
+
+    modify_parser = subparsers.add_parser('modify')
+    modify_parser.add_argument('--id', help='Database id of the record to modify', required=True)
+
+
+def run():
+    cli_run(tool_cmd, tool_desc, ConsentTool, add_additional_arguments)

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -1,0 +1,126 @@
+from datetime import date
+import mock
+
+from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
+from rdr_service.tools.tool_libs.consents import ConsentTool
+from tests.helpers.tool_test_mixin import ToolTestMixin
+from tests.helpers.unittest_base import BaseTestCase
+
+
+@mock.patch('rdr_service.tools.tool_libs.consents.logger')
+class ConsentsTest(ToolTestMixin, BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(ConsentsTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs) -> None:
+        super(ConsentsTest, self).setUp(*args, **kwargs)
+
+        consent_dao_patcher = mock.patch('rdr_service.tools.tool_libs.consents.ConsentDao')
+        self.consent_dao_mock = consent_dao_patcher.start().return_value
+        self.addCleanup(consent_dao_patcher.stop)
+
+        self.consent_dao_mock.get_files_needing_correction.return_value = [
+            ConsentFile(
+                participant_id=123123123, type=ConsentType.PRIMARY, file_exists=False
+            ),
+            ConsentFile(
+                participant_id=222333444, type=ConsentType.CABOR, file_exists=False
+            ),
+            ConsentFile(
+                participant_id=222333444, type=ConsentType.GROR, file_exists=True,
+                is_signature_valid=False, is_signing_date_valid=True, other_errors='missing checkmark',
+                file_path='test_bucket/P222/GROR_no_checkmark_or_signature.pdf'
+            ),
+            ConsentFile(
+                participant_id=654321123, type=ConsentType.CABOR, file_exists=True,
+                is_signature_valid=True, is_signing_date_valid=False,
+                signing_date=date(2021, 12, 1), expected_sign_date=date(2020, 12, 1),
+                file_path='test_bucket/P654/Cabor_bad_date.pdf'
+            ),
+            ConsentFile(
+                participant_id=901987345, type=ConsentType.EHR, file_exists=True,
+                is_signature_valid=False, is_signing_date_valid=True,
+                file_path='test_bucket/P901/EHR_no_signature.pdf'
+            )
+        ]
+
+    def _run_consents_tool(self, command, verbose=False, additional_args=None):
+        with mock.patch('rdr_service.tools.tool_libs.consents.GoogleCloudStorageProvider') as storage_provider_mock:
+            def blob_that_gives_url(bucket_name, blob_name):
+                blob_mock = mock.MagicMock()
+                blob_mock.generate_signed_url.return_value = f'https://example.com/{bucket_name}/{blob_name}'
+                return blob_mock
+            storage_provider_mock.return_value.get_blob.side_effect = blob_that_gives_url
+
+            tool_args = {
+                'command': command,
+                'since': None,
+                'verbose': verbose
+            }
+            if additional_args:
+                tool_args.update(additional_args)
+
+            self.run_tool(ConsentTool, tool_args)
+
+    def test_report_to_send_to_ptsc(self, logger_mock):
+        """Check the basic report format, the one that would be sent to Vibrent or CE for correcting"""
+        self._run_consents_tool(command='report-errors')
+        logger_mock.info.assert_called_once_with('\n'.join([
+            'P123123123 - PRIMARY    missing file',
+            'P222333444 - CABOR      missing file',
+            'P222333444 - GROR       invalid signature, missing checkmark',
+            'P654321123 - CABOR      invalid signing date (expected 2020-12-01 but file has 2021-12-01)',
+            'P901987345 - EHR        invalid signature',
+        ]))
+
+    def test_report_to_audit(self, logger_mock):
+        """
+        Check additional information and formatting helpful for looking into whether
+        the files might have been mistakenly marked as incorrect
+        """
+        self._run_consents_tool(command='report-errors', verbose=True)
+        logger_mock.info.assert_called_once_with('\n'.join([
+            'P123123123 - PRIMARY    missing file',
+            '',
+            'P222333444 - CABOR      missing file',
+            'P222333444 - GROR       invalid signature, missing checkmark - '
+            'https://example.com/test_bucket/P222/GROR_no_checkmark_or_signature.pdf',
+            '',
+            'P654321123 - CABOR      '
+            'invalid signing date (expected 2020-12-01 but file has 2021-12-01, diff of 365 days) - '
+            'https://example.com/test_bucket/P654/Cabor_bad_date.pdf',
+            '',
+            'P901987345 - EHR        invalid signature - https://example.com/test_bucket/P901/EHR_no_signature.pdf',
+        ]))
+
+    def test_changing_existing_record(self, logger_mock):
+        with mock.patch('rdr_service.tools.tool_libs.consents.input') as input_mock:
+            file_to_update = ConsentFile(
+                id=24,
+                participant_id=1234,
+                file_path='test_bucket/file.pdf',
+                type=ConsentType.PRIMARY,
+                sync_status=ConsentSyncStatus.NEEDS_CORRECTING
+            )
+            self.consent_dao_mock.get.return_value = file_to_update
+
+            input_mock.return_value = 'y'
+            self._run_consents_tool(
+                command='modify',
+                additional_args={
+                    'type': 'CABOR',
+                    'sync_status': 'READY_FOR_SYNC'
+                }
+            )
+
+            logger_mock.info.assert_has_calls([
+                mock.call('File info:      P1234, test_bucket/file.pdf'),
+                mock.call('type:           PRIMARY => CABOR'),
+                mock.call('sync_status:    NEEDS_CORRECTING => READY_FOR_SYNC')
+            ])
+
+            updated_file = self.consent_dao_mock.batch_update_consent_files.call_args_list[0].args[0][0]
+            self.assertEqual(file_to_update.id, updated_file.id)
+            self.assertEqual(ConsentType.CABOR, updated_file.type)
+            self.assertEqual(ConsentSyncStatus.READY_FOR_SYNC, updated_file.sync_status)


### PR DESCRIPTION
## Resolves *[DA-2058](https://precisionmedicineinitiative.atlassian.net/browse/DA-2058)*
This updates the consent tool to allow for modifying consent validation records. It will take the id of the record and optional values to set (I've only added the ones I imagine we'll need for now). Then it'll list out what the update will be (to make sure it's the correct record and the changes are correct) before applying them.

## Tests
- [x] unit tests


