### PR TITLE
Consent validation updates

### DIFF
--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -58,7 +58,8 @@ class ConsentSyncController:
         for file in file_list:
             pairing_info = pairing_info_map.get(file.participant_id, None)
 
-            if pairing_info:  # Ignore participants that aren't paired to an organization
+            # Ignore participants that aren't paired to a configured organization
+            if pairing_info and pairing_info.org_name in sync_config:
                 org_consent_config = sync_config[pairing_info.org_name]
 
                 if org_consent_config['zip_consents']:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -213,14 +213,29 @@ class VibrentEhrConsentFile(EhrConsentFile):
 
 
 class VibrentGrorConsentFile(GrorConsentFile):
+    _SIGNATURE_PAGE = 9
+
     def _get_signature_elements(self):
-        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=150, right=400, bottom=155, top=160), page=9)
+        return self.pdf.get_elements_intersecting_box(
+            Rect.from_edges(left=150, right=400, bottom=155, top=160),
+            page=self._SIGNATURE_PAGE
+        )
 
     def _get_date_elements(self):
-        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=130, right=400, bottom=110, top=115), page=9)
+        return self.pdf.get_elements_intersecting_box(
+            Rect.from_edges(left=130, right=400, bottom=110, top=115),
+            page=self._SIGNATURE_PAGE
+        )
 
     def _get_confirmation_check_elements(self):
-        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=70,  right=73, bottom=475, top=478), page=9)
+        spanish_signature_text = '¿Desea conocer alguno de sus resultados de ADN?'
+        if self.pdf.get_page_number_of_text([spanish_signature_text]) is not None:
+            # Spanish versions of the the GROR have the checkmark a bit more to the left
+            search_box = Rect.from_edges(left=33, right=36, bottom=480, top=485)
+        else:
+            search_box = Rect.from_edges(left=70, right=73, bottom=475, top=478)
+
+        return self.pdf.get_elements_intersecting_box(search_box, page=self._SIGNATURE_PAGE)
 
 
 class Pdf:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from dateutil import parser
 from io import BytesIO
 from os.path import basename
-from typing import List
+from typing import List, Union
 
 from geometry import Rect
 from google.cloud.storage.blob import Blob
@@ -52,7 +52,10 @@ class ConsentFileAbstractFactory(ABC):
 
 
 class VibrentConsentFactory(ConsentFileAbstractFactory):
-    CABOR_TEXT = 'California Experimental Subject’s Bill of Rights'
+    CABOR_TEXT = (
+        'California Experimental Subject’s Bill of Rights',
+        'Declaración de Derechos del Sujeto de Investigación Experimental'
+    )
 
     def get_primary_consents(self) -> List['PrimaryConsentFile']:
         primary_consents = []
@@ -267,7 +270,7 @@ class Pdf:
 
         return elements
 
-    def get_page_number_of_text(self, search_str_list: List[str]):
+    def get_page_number_of_text(self, search_str_list: List[Union[str, tuple]]):
         for page_number, page in enumerate(self.pages):
             all_strings_found_in_page = True
             for search_str in search_str_list:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -146,7 +146,8 @@ class CaborConsentFile(ConsentFile, ABC):
 
 
 class EhrConsentFile(ConsentFile, ABC):
-    ...
+    def get_is_va_consent(self):
+        return self.pdf.get_page_number_of_text(['We may ask you to go to a local clinic to be measured']) is not None
 
 
 class GrorConsentFile(ConsentFile, ABC):

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -285,7 +285,8 @@ class ConsentValidator:
         if not signing_date or not expected_date:
             return False
         else:
-            return signing_date == expected_date
+            days_off = (signing_date - expected_date).days
+            return abs(days_off) < 10
 
     def _get_date_from_datetime(self, timestamp: datetime):
         return timestamp.replace(tzinfo=pytz.utc).astimezone(self._central_time).date()

--- a/tests/cron_job_tests/test_consent_sync_controller.py
+++ b/tests/cron_job_tests/test_consent_sync_controller.py
@@ -136,6 +136,18 @@ class ConsentSyncControllerTest(BaseTestCase):
         # If no participants are paired, then nothing should sync
         self.storage_provider_mock.copy_blob.assert_not_called()
 
+    def test_ignore_unrecognized_orgs(self):
+        """Test that the sync ignores participants paired to an organization that isn't specified in the config"""
+        # Return empty list, indicating that the participants are not paired to organizations
+        self.participant_dao_mock.get_org_and_site_for_ids.return_value = [
+            (self.bob_participant_id, 'not_in_config', None),
+        ]
+
+        self.sync_controller.sync_ready_files()
+
+        # If no participants are paired, then nothing should sync
+        self.storage_provider_mock.copy_blob.assert_not_called()
+
     @classmethod
     def _build_expected_dest_path(cls, bucket_name, org_id, site_group, participant_id, file_name):
         return f'{bucket_name}/Participant/{org_id}/{site_group}/P{participant_id}/{file_name}'

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -275,7 +275,29 @@ class ConsentFileParsingTest(BaseTestCase):
             has_yes_selected=False
         )
 
-        return [basic_gror_case, no_confirmation_case]
+        spanish_gror_pdf = self._build_pdf(pages=[
+            *nine_empty_pages,
+            [
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='¿Desea conocer alguno de sus resultados de ADN?'
+                ),
+                self._build_form_element(
+                    children=[self._build_pdf_element(LTCurve)],
+                    bbox=(30, 478, 40, 488)
+                ),
+                self._build_form_element(text='spanish gror', bbox=(140, 150, 450, 180)),
+                self._build_form_element(text='May 1st, 2018', bbox=(125, 100, 450, 130))
+            ]
+        ])
+        spanish_gror_case = GrorConsentTestData(
+            file=files.VibrentGrorConsentFile(pdf=spanish_gror_pdf, blob=mock.MagicMock()),
+            expected_signature='spanish gror',
+            expected_sign_date=date(2018, 5, 1),
+            has_yes_selected=True
+        )
+
+        return [basic_gror_case, no_confirmation_case, spanish_gror_case]
 
     @classmethod
     def _build_pdf(cls, pages) -> files.Pdf:

--- a/tests/service_tests/consent_tests/test_consent_validation.py
+++ b/tests/service_tests/consent_tests/test_consent_validation.py
@@ -89,6 +89,28 @@ class ConsentValidationTesting(BaseTestCase):
             self.validator.get_primary_validation_results()
         )
 
+    def test_primary_with_slightly_off_date(self):
+        shifted_date_on_file = self._default_signing_date - timedelta(days=3)
+        self.consent_factory_mock.get_primary_consents.return_value = [
+            self._mock_consent(
+                consent_class=files.PrimaryConsentFile,
+                get_signature_on_file='signed with slightly off date',
+                get_date_signed=shifted_date_on_file
+            )
+        ]
+        self.assertMatchesExpectedResults(
+            [
+                {
+                    'type': ConsentType.PRIMARY,
+                    'signature_str': 'signed with slightly off date',
+                    'is_signing_date_valid': True,
+                    'signing_date': shifted_date_on_file,
+                    'sync_status': ConsentSyncStatus.READY_FOR_SYNC
+                }
+            ],
+            self.validator.get_primary_validation_results()
+        )
+
     def test_primary_with_signature_image(self):
         self.consent_factory_mock.get_primary_consents.return_value = [
             self._mock_consent(


### PR DESCRIPTION
## Resolves *no ticket*
This makes various changes and updates to the consent validation code:
- Fixes a bug in the sync code for when participants are paired to organizations that aren't set up for syncing
- Adds a check for VA worded EHR files
- Adds translations for Spanish Cabor, EHR, and GROR files (because nobody expects the Spanish GROR)
- The authored date we receive on the API is when they started the consent, and the date on the file is when they actually signed (and completed it). So I'm adding some wiggle room in the date check so that it won't count as invalid unless it's more than 10 days off.

## Tests
- [x] unit tests


