### PR TITLE
[DA-2010] Sending other client-passthrough fields to MayoLINK

### DIFF
--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -119,7 +119,11 @@ class MailKitOrderDao(UpdatableDao):
         if is_version_two:
             order["order"]["number"] = None
             client_fields = {"client_passthrough_fields": {
-                "field1": barcode
+                "field1": barcode,
+                "field2": None,
+                "field3": None,
+                "field4": None,
+                "field5": None,
             }}
             order['order']['tests'][0]['test'].update(client_fields)
 

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -122,8 +122,7 @@ class MailKitOrderDao(UpdatableDao):
                 "field1": barcode,
                 "field2": None,
                 "field3": None,
-                "field4": None,
-                "field5": None,
+                "field4": None
             }}
             order['order']['tests'][0]['test'].update(client_fields)
 

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -138,6 +138,10 @@ class MailKitOrderDaoTestBase(BaseTestCase):
 
         mayo_request_test_data = mayo_order_payload['tests'][0]['test']
         self.assertEqual(mayo_request_test_data['client_passthrough_fields']['field1'], version_two_barcode)
+        self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field2'])
+        self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field3'])
+        self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field4'])
+        self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field5'])
         self.assertEqual(
             ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests','comments'],
             list(mayo_order_payload.keys())

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -141,7 +141,6 @@ class MailKitOrderDaoTestBase(BaseTestCase):
         self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field2'])
         self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field3'])
         self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field4'])
-        self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field5'])
         self.assertEqual(
             ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests','comments'],
             list(mayo_order_payload.keys())


### PR DESCRIPTION
## Additional changes for *[DA-2010](https://precisionmedicineinitiative.atlassian.net/browse/DA-2010)*
After another round of testing I was reminded that the MayoLINK expects all 4 client-passthrough fields if any one of them is sent. This adds the others when we are also sending the first one.

## Tests
- [x] unit tests


