### PR TITLE
[DA-2049] Create report file for genomic reports longer than 25 lines

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -159,6 +159,8 @@ RDR_SLACK_WEBHOOKS = "rdr_slack_webhooks"
 
 DECEASED_REPORT_FILTER_EXCEPTIONS = "deceased_report_filter_exceptions"
 
+GENOMIC_REPORT_PATH = "/aou-rdr-sandbox-mock-data/genomic_reports_test/"
+
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}
 

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -159,7 +159,7 @@ RDR_SLACK_WEBHOOKS = "rdr_slack_webhooks"
 
 DECEASED_REPORT_FILTER_EXCEPTIONS = "deceased_report_filter_exceptions"
 
-GENOMIC_REPORT_PATH = "/aou-rdr-sandbox-mock-data/genomic_reports_test/"
+GENOMIC_REPORT_PATH = "/aou-rdr-sandbox-mock-data/genomic_reports_prod/"
 
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}

--- a/rdr_service/genomic/genomic_data_quality_components.py
+++ b/rdr_service/genomic/genomic_data_quality_components.py
@@ -2,8 +2,10 @@ import abc
 from datetime import timedelta
 
 from rdr_service import clock
+from rdr_service.api_util import open_cloud_file
 from rdr_service.dao.genomics_dao import GenomicJobRunDao
 from rdr_service.genomic.genomic_data import GenomicQueryClass
+from rdr_service.config import GENOMIC_REPORT_PATH
 
 
 class GenomicDataQualityComponentBase:
@@ -171,3 +173,14 @@ class ReportingComponent(GenomicDataQualityComponentBase):
             report_string = self.report_def.empty_report_string
 
         return report_string
+
+    def create_report_csv(self, report_string, display_name):
+        now_str = clock.CLOCK.now().replace(microsecond=0).isoformat(sep="_", )
+        report_file_name = f"{display_name.replace(' ', '_')}_{now_str}.txt"
+
+        path = GENOMIC_REPORT_PATH + report_file_name
+
+        with open_cloud_file(path, mode='wt') as cloud_file:
+            cloud_file.write(report_string)
+
+        return path

--- a/rdr_service/genomic/genomic_data_quality_components.py
+++ b/rdr_service/genomic/genomic_data_quality_components.py
@@ -174,7 +174,7 @@ class ReportingComponent(GenomicDataQualityComponentBase):
 
         return report_string
 
-    def create_report_csv(self, report_string, display_name):
+    def create_report_file(self, report_string, display_name):
         now_str = clock.CLOCK.now().replace(microsecond=0).isoformat(sep="_", )
         report_file_name = f"{display_name.replace(' ', '_')}_{now_str}.txt"
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1178,7 +1178,8 @@ class DataQualityJobController:
             file_path = rc.create_report_csv(report_string, report_params['display_name'])
 
             message = report_params['display_name'] + " too long for output.\n"
-            message += f"Report file generated here: https://storage.cloud.google.com{file_path}"
+            message += f"Report too long for Slack Output, download the report here:" \
+                       f" https://storage.cloud.google.com{file_path}"
 
             message_data = {'text': message}
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1175,7 +1175,7 @@ class DataQualityJobController:
 
         # Compile long reports to cloud file and post link
         if len(report_string.split("\n")) > 25:
-            file_path = rc.create_report_csv(report_string, report_params['display_name'])
+            file_path = rc.create_report_file(report_string, report_params['display_name'])
 
             message = report_params['display_name'] + " too long for output.\n"
             message += f"Report too long for Slack Output, download the report here:" \


### PR DESCRIPTION
## Resolves *[DA-2049](https://precisionmedicineinitiative.atlassian.net/browse/DA-2049)*


## Description of changes/additions
This PR updates the genomic report logic to output a file to Google Cloud Storage if the report is longer than 25 lines.  Since the reports are internal to the RDR and do not contain participant data, the destination for the reports was set to a temporary location on the sandbox project. This may be updated in a future PR if necessary.

## Tests
- [x] unit tests


