### PR TITLE
[DA-2071] Script for backfilling consent validation

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -67,11 +67,14 @@ class ConsentValidationController:
 
             self.consent_dao.batch_update_consent_files(validation_updates)
 
-    def validate_recent_uploads(self, min_consent_date):
+    def validate_recent_uploads(self, min_consent_date, max_consent_date=None):
         """Find all the expected consents since the minimum date and check the files that have been uploaded"""
         validation_results = []
         validated_participant_ids = []
-        for summary in self.consent_dao.get_participants_with_consents_in_range(start_date=min_consent_date):
+        for summary in self.consent_dao.get_participants_with_consents_in_range(
+            start_date=min_consent_date,
+            end_date=max_consent_date
+        ):
             validated_participant_ids.append(summary.participantId)
             validator = self._build_validator(summary)
 

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -1,4 +1,5 @@
 import argparse
+import csv
 from datetime import datetime, timedelta
 from dateutil.parser import parse
 from io import StringIO
@@ -30,6 +31,8 @@ class ConsentTool(ToolBase):
             self.modify_file_results()
         elif self.args.command == 'validate':
             self.validate_consents()
+        elif self.args.command == 'upload':
+            self.upload_records()
 
     def report_files_for_correction(self):
         min_validation_date = parse(self.args.since) if self.args.since else None
@@ -93,6 +96,15 @@ class ConsentTool(ToolBase):
             storage_provider=GoogleCloudStorageProvider()
         )
         controller.validate_recent_uploads(min_consent_date=min_date, max_consent_date=max_date)
+
+    def upload_records(self):
+        data_to_upload = []
+        with open(self.args.file) as input_file:
+            input_csv = csv.DictReader(input_file)
+            for validation_data in input_csv:
+                data_to_upload.append(ConsentFile(**validation_data))
+
+        self._consent_dao.batch_update_consent_files(data_to_upload)
 
     def _line_output_for_validation(self, file: ConsentFile, verbose: bool):
         output_line = StringIO()
@@ -182,6 +194,13 @@ def add_additional_arguments(parser: argparse.ArgumentParser):
     modify_parser = subparsers.add_parser('validate')
     modify_parser.add_argument('--min_date', help='Earliest date of the expected consents to validate', required=True)
     modify_parser.add_argument('--max_date', help='Latest date of the expected consents to validate')
+
+    modify_parser = subparsers.add_parser('upload')
+    modify_parser.add_argument(
+        '--file',
+        help='CSV file defining validation record data that should be added to the database',
+        required=True
+    )
 
 
 def run():

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -4,7 +4,10 @@ from dateutil.parser import parse
 from io import StringIO
 
 from rdr_service.dao.consent_dao import ConsentDao
+from rdr_service.dao.hpo_dao import HPODao
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
+from rdr_service.services.consent.validation import ConsentValidationController
 from rdr_service.storage import GoogleCloudStorageProvider
 from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
 
@@ -25,6 +28,8 @@ class ConsentTool(ToolBase):
             self.report_files_for_correction()
         elif self.args.command == 'modify':
             self.modify_file_results()
+        elif self.args.command == 'validate':
+            self.validate_consents()
 
     def report_files_for_correction(self):
         min_validation_date = parse(self.args.since) if self.args.since else None
@@ -76,6 +81,18 @@ class ConsentTool(ToolBase):
                 callback=lambda parsed_value: setattr(file, 'sync_status', parsed_value)
             )
             self._consent_dao.batch_update_consent_files([file])
+
+    def validate_consents(self):
+        min_date = parse(self.args.min_date)
+        max_date = parse(self.args.max_date) if self.args.max_date else None
+
+        controller = ConsentValidationController(
+            consent_dao=ConsentDao(),
+            participant_summary_dao=ParticipantSummaryDao(),
+            hpo_dao=HPODao(),
+            storage_provider=GoogleCloudStorageProvider()
+        )
+        controller.validate_recent_uploads(min_consent_date=min_date, max_consent_date=max_date)
 
     def _line_output_for_validation(self, file: ConsentFile, verbose: bool):
         output_line = StringIO()
@@ -161,6 +178,10 @@ def add_additional_arguments(parser: argparse.ArgumentParser):
     modify_parser.add_argument(
         '--sync-status', help='New sync status to set (format: string or int value of the new status'
     )
+
+    modify_parser = subparsers.add_parser('validate')
+    modify_parser.add_argument('--min_date', help='Earliest date of the expected consents to validate', required=True)
+    modify_parser.add_argument('--max_date', help='Latest date of the expected consents to validate')
 
 
 def run():


### PR DESCRIPTION
## Resolves *[DA-2071](https://precisionmedicineinitiative.atlassian.net/browse/DA-2071)*
These changes are to help with 'backfill' work for the consents. There are two parts needed: to manually run validation for the month (for all the files that needed validation before the daily validation check was released to Prod), and to be able to create validation records for the files that haven't been synced previously (either because they were missed by the monthly sync, or because they hadn't been uploaded yet to our bucket).

## Tests
- [x] unit tests


