### PR TITLE
Consent validation hotfix changes

### DIFF
--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -232,6 +232,7 @@ def _build_validation_controller():
 def check_for_consent_corrections():
     validation_controller = _build_validation_controller()
     validation_controller.check_for_corrections()
+    return '{"success": "true"}'
 
 
 @app_util.auth_required_cron
@@ -239,6 +240,7 @@ def validate_consent_files():
     min_authored_timestamp = datetime.utcnow() - timedelta(hours=26)  # Overlap just to make sure we don't miss anything
     validation_controller = _build_validation_controller()
     validation_controller.validate_recent_uploads(min_consent_date=min_authored_timestamp)
+    return '{"success": "true"}'
 
 
 @app_util.auth_required_cron

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -47,6 +47,7 @@ class ConsentSyncController:
         self.consent_dao = consent_dao
         self.participant_dao = participant_dao
         self.storage_provider = storage_provider
+        self._destination_folder = config.getSettingJson('consent_destination_prefix', default='Participant')
 
     def sync_ready_files(self):
         """Syncs any validated consent files that are ready for syncing"""
@@ -112,7 +113,7 @@ class ConsentSyncController:
         file_name = os.path.basename(zip_file_path)
         self.storage_provider.upload_from_file(
             source_file=zip_file_path,
-            path=f'{bucket_name}/Participant/{org_name}/{file_name}'
+            path=f'{bucket_name}/{self._destination_folder}/{org_name}/{file_name}'
         )
 
     def _download_file_for_zip(self, file: ConsentFile, bucket_name, org_name, site_name):
@@ -145,9 +146,8 @@ class ConsentSyncController:
             )
         )
 
-    @classmethod
-    def _build_cloud_destination_path(cls, bucket_name, org_name, site_name, participant_id, file_name):
-        return f'{bucket_name}/Participant/{org_name}/{site_name}/P{participant_id}/{file_name}'
+    def _build_cloud_destination_path(self, bucket_name, org_name, site_name, participant_id, file_name):
+        return f'{bucket_name}/{self._destination_folder}/{org_name}/{site_name}/P{participant_id}/{file_name}'
 
     def _build_participant_pairing_map(self, files: List[ConsentFile]) -> Dict[int, ParticipantPairingInfo]:
         """

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -167,8 +167,8 @@ class GrorConsentFile(ConsentFile, ABC):
 class VibrentPrimaryConsentFile(PrimaryConsentFile):
     def _get_signature_page(self):
         return self.pdf.get_page_number_of_text([
-            'I freely and willingly choose',
-            'sign your full name'
+            ('I freely and willingly choose', 'Decido participar libremente y por voluntad propia'),
+            ('sign your full name', 'Firme con su nombre completo')
         ])
 
     def _get_signature_elements(self):

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -65,7 +65,7 @@ class ConsentValidationController:
                         if matching_previous_result is None:
                             validation_updates.append(new_result)
 
-            self.consent_dao.batch_update_consent_files(validation_updates)
+        self.consent_dao.batch_update_consent_files(validation_updates)
 
     def validate_recent_uploads(self, min_consent_date):
         """Find all the expected consents since the minimum date and check the files that have been uploaded"""

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -190,6 +190,7 @@ class ConsentValidator:
         return self._generate_validation_results(
             consent_files=self.factory.get_ehr_consents(),
             consent_type=ConsentType.EHR,
+            additional_validation=self._validate_is_va_file,
             expected_sign_datetime=self.participant_summary.consentForElectronicHealthRecordsAuthored
         )
 

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -203,6 +203,41 @@ class ConsentFileParsingTest(BaseTestCase):
             )
         )
 
+        # Build Spanish version of the Primary file
+        pdf = self._build_pdf(pages=[
+            [
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(
+                            cls=LTTextLineHorizontal,
+                            text='Decido participar libremente y por voluntad propia'
+                        )
+                    ]
+                ),
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(
+                            cls=LTTextLineHorizontal,
+                            children=[
+                                self._build_pdf_element(LTTextLineHorizontal, text='Firme con su nombre completo:')
+                            ]
+                        )
+                    ]
+                ),
+                self._build_form_element(text='Spanish Participant', bbox=(116, 147, 517, 169)),
+                self._build_form_element(text='Mar 3, 2021', bbox=(116, 97, 266, 119))
+            ]
+        ])
+        test_data.append(
+            PrimaryConsentTestData(
+                file=files.VibrentPrimaryConsentFile(pdf=pdf, blob=mock.MagicMock()),
+                expected_signature='Spanish Participant',
+                expected_sign_date=date(2021, 3, 3)
+            )
+        )
+
         return test_data
 
     def _get_vibrent_cabor_test_data(self) -> List['ConsentTestData']:


### PR DESCRIPTION
## Resolves *no ticket*
Various changes to consent sync to help with validation efforts

## Description of changes/additions
Adding expected return message for cron jobs so the logs don't keep showing errors.

Adding a way to configure where in an organization's bucket the consent files are copied to, that we have the possibility of manually running a sync that won't overwrite files that have been sent monthly.

Adding Spanish translations for the Primary consent.

Fixing an error with how the script that checks for corrections saves the updates (it was saving everything gathered so far each time a new participant was checked.

## Tests
- [x] unit tests
