### PR TITLE
[DA-2066] Catch null key values in lower enviornments.

### DIFF
--- a/rdr_service/model/bq_base.py
+++ b/rdr_service/model/bq_base.py
@@ -8,6 +8,7 @@ import importlib
 import inspect
 import itertools
 import json
+import logging
 import operator
 import re
 from enum import Enum, EnumMeta
@@ -567,6 +568,9 @@ class BQRecord(object):
             :return: dict
             """
             for key, val in src.items():
+                if not isinstance(key, str):
+                    logging.warning('Dict key is not a string.')
+                    continue
                 # validate key against schema if needed
                 if schema and not getattr(schema, key, None):
                     # raise KeyError('{0} key not in schema'.format(key))

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -325,7 +325,8 @@ class BQPDRModuleView(BQView):
            nt.mod_module, nt.mod_baseline_module,
            CAST(nt.mod_authored AS DATETIME) as mod_authored, CAST(nt.mod_created AS DATETIME) as mod_created,
            nt.mod_language, nt.mod_status, nt.mod_status_id, nt.mod_response_status, nt.mod_response_status_id,
-           nt.mod_external_id
+           nt.mod_external_id, nt.mod_questionnaire_response_id, nt.mod_consent, nt.mod_consent_value,
+           nt.mod_consent_value_id, nt.mod_consent_expired, nt.mod_non_participant_answer
       FROM (
         SELECT *,
             ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY modified desc, test_participant desc) AS rn


### PR DESCRIPTION
Update v_pdr_participant_module view.

## Resolves *[DA-2066](https://precisionmedicineinitiative.atlassian.net/browse/DA-2066)*

Minor fixes for issues discovered from testing  in Stable.
* Check for BQ schema data dict has null key values (lower environment problem)
* Add new fields to BQ 'v_pdr_participant_module' view.



