### PR TITLE
Adding placeholder enum values

### DIFF
--- a/rdr_service/model/consent_file.py
+++ b/rdr_service/model/consent_file.py
@@ -11,6 +11,7 @@ class ConsentType(messages.Enum):
     CABOR = 2
     EHR = 3
     GROR = 4
+    UNKNOWN = 5
 
 
 class ConsentSyncStatus(messages.Enum):
@@ -18,6 +19,11 @@ class ConsentSyncStatus(messages.Enum):
     READY_FOR_SYNC = 2
     OBSOLETE = 3
     SYNC_COMPLETE = 4
+
+    LEGACY = 5
+    DELAYING_SYNC = 6
+    UNKNOWN = 7
+
 
 
 class ConsentFile(Base):


### PR DESCRIPTION
## Resolves *no ticket*
There's a need to run validation against a large number of files to get their data. But a large number of them were already copied to the sites' buckets. This adds some extra fields to give a little flexibility for setting a file outside of the sync pipeline for a time.

## Tests
- [x] unit tests


