### PR TITLE
[PDR Fix] Make sure withdrawal module data is rebuilt in batch mode…

### DIFF
--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -12,7 +12,7 @@ from rdr_service.dao.bq_pdr_participant_summary_dao import BQPDRParticipantSumma
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
     BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb, BQPDRFamilyHistory, \
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory
+    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRStopParticipating, BQPDRWithdrawalIntro
 from rdr_service.resource.generators import ParticipantSummaryGenerator
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
 
@@ -76,7 +76,9 @@ def batch_rebuild_participants_task(payload, project_id=None):
                 BQPDRCOPEFeb,
                 BQPDRFamilyHistory,
                 BQPDRPersonalMedicalHistory,
-                BQPDRHealthcareAccess
+                BQPDRHealthcareAccess,
+                BQPDRStopParticipating,
+                BQPDRWithdrawalIntro
             )
             for module in modules:
                 mod = module()


### PR DESCRIPTION
## Resolves *no ticket*


## Description of changes/additions
When rebuilding participant data locally with the `resource participant --batch`  tool, the batch resource task was missing the withdrawal modules from its list of module data to rebuild.

Since most rebuild activity happens at the time of an API request automatically vs. through the resource tool, this likely hasn't been impacting regular PDR data builds.   The problem also was not affecting non-batch mode runs of the resource tool

## Tests
- [x] unit tests


