### PR TITLE
[DA-2108] Optionally disable generation of withdrawal report

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -418,8 +418,8 @@ def _query_and_write_reports(exporter, now, report_type, path_received,
                             query_params, backup=True, predicate=report_predicate)
         logging.info(f"Completed {report_path} report.")
 
-    # Now generate the withdrawal report, within the past n days.
-    _query_and_write_withdrawal_report(exporter, path_withdrawals, report_cover_range, now)
+    if config.getSetting('biobank_withdrawal_report_enabled', default=True):
+        _query_and_write_withdrawal_report(exporter, path_withdrawals, report_cover_range, now)
 
     # Generate the missing salivary report, within last n days (10 1/20)
     if report_type != "monthly" and path_salivary_missing is not None:


### PR DESCRIPTION
## Partially Resolves *[DA-2108](https://precisionmedicineinitiative.atlassian.net/browse/DA-2108)*
We're transitioning to generating the biobank withdrawal report monthly rather than nightly. For now we'll be generating the monthly report manually, but future work will be done to automate it. These changes let us disable the nightly report when we'd like, without needing to coordinate a release for it.

## Tests
- [ ] unit tests

Unit tests seemed too difficult to get around just this functionality, and this will be removed entirely in a near-future release.


