### PR TITLE
Consent changes and optimization

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List
+from typing import Collection
 
 from sqlalchemy import or_
 
@@ -13,64 +13,66 @@ class ConsentDao(BaseDao):
     def __init__(self):
         super(ConsentDao, self).__init__(ConsentFile)
 
-    def get_participants_with_consents_in_range(self, start_date, end_date=None) -> List[ParticipantSummary]:
-        with self.session() as session:
-            query = session.query(
-                ParticipantSummary
-            ).join(
-                Participant,
-                Participant.participantId == ParticipantSummary.participantId
-            ).filter(
-                ParticipantSummary.participantOrigin == 'vibrent',
-                Participant.isGhostId.isnot(True),
-                Participant.isTestParticipant.isnot(True),
+    @classmethod
+    def get_participants_with_consents_in_range(cls, session, start_date,
+                                                end_date=None) -> Collection[ParticipantSummary]:
+        query = session.query(
+            ParticipantSummary
+        ).join(
+            Participant,
+            Participant.participantId == ParticipantSummary.participantId
+        ).filter(
+            ParticipantSummary.participantOrigin == 'vibrent',
+            Participant.isGhostId.isnot(True),
+            Participant.isTestParticipant.isnot(True),
+            or_(
+                ParticipantSummary.email.is_(None),
+                ParticipantSummary.email.notlike('%@example.com')
+            )
+        )
+        if end_date is None:
+            query = query.filter(
                 or_(
-                    ParticipantSummary.email.is_(None),
-                    ParticipantSummary.email.notlike('%@example.com')
+                    ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored >= start_date,
+                    ParticipantSummary.consentForCABoRAuthored >= start_date,
+                    ParticipantSummary.consentForElectronicHealthRecordsAuthored >= start_date,
+                    ParticipantSummary.consentForGenomicsRORAuthored >= start_date
                 )
             )
-            if end_date is None:
-                query = query.filter(
-                    or_(
-                        ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored >= start_date,
-                        ParticipantSummary.consentForCABoRAuthored >= start_date,
-                        ParticipantSummary.consentForElectronicHealthRecordsAuthored >= start_date,
-                        ParticipantSummary.consentForGenomicsRORAuthored >= start_date
-                    )
+        else:
+            query = query.filter(
+                or_(
+                    ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored.between(start_date, end_date),
+                    ParticipantSummary.consentForCABoRAuthored.between(start_date, end_date),
+                    ParticipantSummary.consentForElectronicHealthRecordsAuthored.between(start_date, end_date),
+                    ParticipantSummary.consentForGenomicsRORAuthored.between(start_date, end_date)
                 )
-            else:
-                query = query.filter(
-                    or_(
-                        ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored.between(start_date, end_date),
-                        ParticipantSummary.consentForCABoRAuthored.between(start_date, end_date),
-                        ParticipantSummary.consentForElectronicHealthRecordsAuthored.between(start_date, end_date),
-                        ParticipantSummary.consentForGenomicsRORAuthored.between(start_date, end_date)
-                    )
-                )
-            summaries = query.all()
-            return summaries
-
-    def get_files_needing_correction(self, min_modified_datetime : datetime = None) -> List[ConsentFile]:
-        with self.session() as session:
-            query = session.query(ConsentFile).filter(
-                ConsentFile.sync_status == ConsentSyncStatus.NEEDS_CORRECTING
             )
-            if min_modified_datetime:
-                query = query.filter(ConsentFile.modified >= min_modified_datetime)
-            return query.all()
+        summaries = query.all()
+        return summaries
 
-    def batch_update_consent_files(self, consent_files: List[ConsentFile]):
-        with self.session() as session:
-            for file_record in consent_files:
-                session.merge(file_record)
+    @classmethod
+    def get_files_needing_correction(cls, session, min_modified_datetime: datetime = None) -> Collection[ConsentFile]:
+        query = session.query(ConsentFile).filter(
+            ConsentFile.sync_status == ConsentSyncStatus.NEEDS_CORRECTING
+        )
+        if min_modified_datetime:
+            query = query.filter(ConsentFile.modified >= min_modified_datetime)
+        return query.all()
 
-    def get_validation_results_for_participants(self, participant_ids: List[int]) -> List[ConsentFile]:
-        with self.session() as session:
-            return session.query(ConsentFile).filter(
-                ConsentFile.participant_id.in_(participant_ids)
-            ).all()
+    @classmethod
+    def batch_update_consent_files(cls, session, consent_files: Collection[ConsentFile]):
+        for file_record in consent_files:
+            session.merge(file_record)
 
-    def get_files_ready_to_sync(self) -> List[ConsentFile]:
+    @classmethod
+    def get_validation_results_for_participants(cls, session,
+                                                participant_ids: Collection[int]) -> Collection[ConsentFile]:
+        return session.query(ConsentFile).filter(
+            ConsentFile.participant_id.in_(participant_ids)
+        ).all()
+
+    def get_files_ready_to_sync(self) -> Collection[ConsentFile]:
         with self.session() as session:
             return session.query(ConsentFile).filter(
                 ConsentFile.sync_status == ConsentSyncStatus.READY_FOR_SYNC

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -39,7 +39,7 @@ from rdr_service.offline.requests_log_migrator import RequestsLogMigrator
 from rdr_service.offline.service_accounts import ServiceAccountKeyManager
 from rdr_service.offline.sync_consent_files import ConsentSyncController
 from rdr_service.offline.table_exporter import TableExporter
-from rdr_service.services.consent.validation import ConsentValidationController
+from rdr_service.services.consent.validation import ConsentValidationController, StoreResultStrategy
 from rdr_service.services.data_quality import DataQualityChecker
 from rdr_service.services.flask import OFFLINE_PREFIX, flask_start, flask_stop
 from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging,\
@@ -240,7 +240,11 @@ def check_for_consent_corrections():
 def validate_consent_files():
     min_authored_timestamp = datetime.utcnow() - timedelta(hours=26)  # Overlap just to make sure we don't miss anything
     validation_controller = _build_validation_controller()
-    validation_controller.validate_recent_uploads(min_consent_date=min_authored_timestamp)
+    with validation_controller.consent_dao.session() as session, StoreResultStrategy(
+        session=session,
+        consent_dao=validation_controller.consent_dao
+    ) as store_strategy:
+        validation_controller.validate_recent_uploads(session, store_strategy, min_consent_date=min_authored_timestamp)
     return '{"success": "true"}'
 
 

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -231,7 +231,8 @@ def _build_validation_controller():
 @app_util.auth_required_cron
 def check_for_consent_corrections():
     validation_controller = _build_validation_controller()
-    validation_controller.check_for_corrections()
+    with validation_controller.consent_dao.session() as session:
+        validation_controller.check_for_corrections(session)
     return '{"success": "true"}'
 
 

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -52,9 +52,9 @@ class ConsentSyncController:
     def sync_ready_files(self):
         """Syncs any validated consent files that are ready for syncing"""
 
-        file_list: List[ConsentFile] = self.consent_dao.get_files_ready_to_sync()
-        pairing_info_map = self._build_participant_pairing_map(file_list)
         sync_config = config.getSettingJson(config.CONSENT_SYNC_BUCKETS)
+        file_list: List[ConsentFile] = self.consent_dao.get_files_ready_to_sync(org_names=sync_config.keys())
+        pairing_info_map = self._build_participant_pairing_map(file_list)
 
         for file in file_list:
             pairing_info = pairing_info_map.get(file.participant_id, None)

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -76,19 +76,19 @@ class ConsentFileAbstractFactory(ABC):
         ]
 
     @abstractmethod
-    def _is_primary_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+    def _is_primary_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         ...
 
     @abstractmethod
-    def _is_cabor_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+    def _is_cabor_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         ...
 
     @abstractmethod
-    def _is_ehr_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+    def _is_ehr_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         ...
 
     @abstractmethod
-    def _is_gror_consent(self, blob_wrapper: _ConsentBlobWrapper) -> bool:
+    def _is_gror_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         ...
 
     @abstractmethod

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -234,21 +234,6 @@ class ConsentValidationController:
 
         self.consent_dao.batch_update_consent_files(session, validation_updates)
 
-    def generate_new_validations(self, session, participant_id, consent_type: ConsentType,
-                                 output_strategy: ValidationOutputStrategy):
-        summary = self.participant_summary_dao.get_with_session(session, participant_id)
-        validator = self._build_validator(summary)
-        results = []
-        if consent_type == ConsentType.PRIMARY:
-            results = validator.get_primary_validation_results()
-        elif consent_type == ConsentType.CABOR:
-            results = validator.get_cabor_validation_results()
-        elif consent_type == ConsentType.EHR:
-            results = validator.get_ehr_validation_results()
-        elif consent_type == ConsentType.GROR:
-            results = validator.get_gror_validation_results()
-        output_strategy.add_all(results)
-
     def validate_recent_uploads(self, session, output_strategy: ValidationOutputStrategy, min_consent_date,
                                 max_consent_date=None):
         """Find all the expected consents since the minimum date and check the files that have been uploaded"""

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -1,7 +1,9 @@
+from abc import ABC, abstractmethod
 from collections import defaultdict
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
+from io import StringIO
 import pytz
-from typing import List
+from typing import Collection, List
 
 from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.dao.hpo_dao import HPODao
@@ -11,6 +13,173 @@ from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.participant_enums import QuestionnaireStatus
 from rdr_service.services.consent import files
 from rdr_service.storage import GoogleCloudStorageProvider
+
+
+class ValidationOutputStrategy(ABC):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.process_results()
+
+    def add_all(self, result_collection: Collection[ParsingResult]):
+        for result in result_collection:
+            self.add_result(result)
+
+    @abstractmethod
+    def add_result(self, result: ParsingResult):
+        ...
+
+    @abstractmethod
+    def process_results(self):
+        ...
+
+
+class StoreResultStrategy(ValidationOutputStrategy):
+    def __init__(self, session, consent_dao: ConsentDao):
+        self._session = session
+        self._results = []
+        self._consent_dao = consent_dao
+        self._max_batch_count = 500
+
+    def add_result(self, result: ParsingResult):
+        self._results.append(result)
+        if len(self._results) > self._max_batch_count:
+            self.process_results()
+            self._results = []
+
+    def process_results(self):
+        previous_results = self._consent_dao.get_validation_results_for_participants(
+            session=self._session,
+            participant_ids={result.participant_id for result in self._results}
+        )
+        new_results_to_store = []
+        for possible_new_result in self._results:
+            if not any(
+                [possible_new_result.file_path == previous_result.file_path for previous_result in previous_results]
+            ):
+                new_results_to_store.append(possible_new_result)
+
+        self._consent_dao.batch_update_consent_files(self._session, new_results_to_store)
+        self._session.commit()
+
+
+class ReplacementStoringStrategy(ValidationOutputStrategy):
+    def __init__(self, session, consent_dao: ConsentDao):
+        self.session = session
+        self.consent_dao = consent_dao
+        self.participant_ids = set()
+
+        def new_participant_results():
+            return defaultdict(lambda: [])
+        self.results = defaultdict(new_participant_results)
+
+    def add_result(self, result: ParsingResult):
+        self.results[result.participant_id][result.type].append(result)
+        self.participant_ids.add(result.participant_id)
+
+    def process_results(self):
+        previous_results = self.consent_dao.get_validation_results_for_participants(
+            session=self.session,
+            participant_ids=self.participant_ids
+        )
+        def new_participant_results():
+            return defaultdict(lambda: [])
+        organized_previous_results = defaultdict(new_participant_results)
+        for result in previous_results:
+            organized_previous_results[result.participant_id][result.type].append(result)
+
+        results_to_update = []
+        for participant_id, consent_type_dict in self.results.items():
+            for consent_type, result_list in consent_type_dict.items():
+                ready_for_sync = self._find_file_ready_for_sync(result_list)
+                previous_type_list: Collection[ParsingResult] = organized_previous_results[participant_id][consent_type]
+                if ready_for_sync:
+                    for result in previous_type_list:
+                        if result.sync_status == ConsentSyncStatus.NEEDS_CORRECTING:
+                            result.sync_status = ConsentSyncStatus.OBSOLETE
+                            results_to_update.append(result)
+                    results_to_update.append(ready_for_sync)
+                else:
+                    for possible_new_result in result_list:
+                        if not any([possible_new_result.file_path == previous_result.file_path
+                                    for previous_result in previous_type_list]):
+                            results_to_update.append(possible_new_result)
+
+        self.consent_dao.batch_update_consent_files(self.session, results_to_update)
+
+    @classmethod
+    def _find_file_ready_for_sync(cls, results: List[ParsingResult]):
+        for result in results:
+            if result.sync_status == ConsentSyncStatus.READY_FOR_SYNC:
+                return result
+
+        return None
+
+
+class LogResultStrategy(ValidationOutputStrategy):
+    def __init__(self, logger, verbose, storage_provider: GoogleCloudStorageProvider):
+        self.logger = logger
+        self.verbose = verbose
+        self.storage_provider = storage_provider
+
+        def new_participant_results():
+            return defaultdict(lambda: [])
+        self.results = defaultdict(new_participant_results)
+
+    def add_result(self, result: ParsingResult):
+        self.results[result.participant_id][result.type].append(result)
+
+    def process_results(self):
+        report_lines = []
+        for validation_categories in self.results.values():
+            if self.verbose:
+                report_lines.append('')
+            for result_list in validation_categories.values():
+                for result in result_list:
+                    report_lines.append(self._line_output_for_validation(result, verbose=self.verbose))
+
+        self.logger.info('\n'.join(report_lines))
+
+    def _line_output_for_validation(self, file: ParsingResult, verbose: bool):
+        output_line = StringIO()
+        if verbose:
+            output_line.write(f'{file.id} - ')  # TODO: ljust the id
+        output_line.write(f'P{file.participant_id} - {str(file.type).ljust(10)} ')
+
+        if not file.file_exists:
+            output_line.write('missing file')
+        else:
+            errors_with_file = []
+            if not file.is_signature_valid:
+                errors_with_file.append('invalid signature')
+            if not file.is_signing_date_valid:
+                errors_with_file.append(self._get_date_error_details(file, verbose))
+            if file.other_errors is not None:
+                errors_with_file.append(file.other_errors)
+
+            output_line.write(', '.join(errors_with_file))
+            if verbose:
+                output_line.write(f'\n{self._get_link(file)}')
+
+        return output_line.getvalue()
+
+    @classmethod
+    def _get_date_error_details(cls, file: ParsingResult, verbose: bool = False):
+        extra_info = ''
+        if verbose and file.signing_date and file.expected_sign_date:
+            time_difference = file.signing_date - file.expected_sign_date
+            extra_info = f', diff of {time_difference.days} days'
+        return f'invalid signing date (expected {file.expected_sign_date} '\
+               f'but file has {file.signing_date}{extra_info})'
+
+    def _get_link(self, file: ParsingResult):
+        bucket_name, *name_parts = file.file_path.split('/')
+        blob = self.storage_provider.get_blob(
+            bucket_name=bucket_name,
+            blob_name='/'.join(name_parts)
+        )
+        return blob.generate_signed_url(datetime.utcnow() + timedelta(hours=2))
 
 
 class ConsentValidationController:
@@ -67,15 +236,29 @@ class ConsentValidationController:
 
         self.consent_dao.batch_update_consent_files(validation_updates)
 
-    def validate_recent_uploads(self, min_consent_date, max_consent_date=None):
+    def generate_new_validations(self, session, participant_id, consent_type: ConsentType,
+                                 output_strategy: ValidationOutputStrategy):
+        summary = self.participant_summary_dao.get_with_session(session, participant_id)
+        validator = self._build_validator(summary)
+        results = []
+        if consent_type == ConsentType.PRIMARY:
+            results = validator.get_primary_validation_results()
+        elif consent_type == ConsentType.CABOR:
+            results = validator.get_cabor_validation_results()
+        elif consent_type == ConsentType.EHR:
+            results = validator.get_ehr_validation_results()
+        elif consent_type == ConsentType.GROR:
+            results = validator.get_gror_validation_results()
+        output_strategy.add_all(results)
+
+    def validate_recent_uploads(self, session, output_strategy: ValidationOutputStrategy, min_consent_date,
+                                max_consent_date=None):
         """Find all the expected consents since the minimum date and check the files that have been uploaded"""
-        validation_results = []
-        validated_participant_ids = []
         for summary in self.consent_dao.get_participants_with_consents_in_range(
+            session,
             start_date=min_consent_date,
             end_date=max_consent_date
         ):
-            validated_participant_ids.append(summary.participantId)
             validator = self._build_validator(summary)
 
             if self._has_new_consent(
@@ -83,37 +266,25 @@ class ConsentValidationController:
                 authored=summary.consentForStudyEnrollmentFirstYesAuthored,
                 min_authored=min_consent_date
             ):
-                validation_results.extend(self._process_validation_results(validator.get_primary_validation_results()))
+                output_strategy.add_all(self._process_validation_results(validator.get_primary_validation_results()))
             if self._has_new_consent(
                 consent_status=summary.consentForCABoR,
                 authored=summary.consentForCABoRAuthored,
                 min_authored=min_consent_date
             ):
-                validation_results.extend(self._process_validation_results(validator.get_cabor_validation_results()))
+                output_strategy.add_all(self._process_validation_results(validator.get_cabor_validation_results()))
             if self._has_new_consent(
                 consent_status=summary.consentForElectronicHealthRecords,
                 authored=summary.consentForElectronicHealthRecordsAuthored,
                 min_authored=min_consent_date
             ):
-                validation_results.extend(self._process_validation_results(validator.get_ehr_validation_results()))
+                output_strategy.add_all(self._process_validation_results(validator.get_ehr_validation_results()))
             if self._has_new_consent(
                 consent_status=summary.consentForGenomicsROR,
                 authored=summary.consentForGenomicsRORAuthored,
                 min_authored=min_consent_date
             ):
-                validation_results.extend(self._process_validation_results(validator.get_gror_validation_results()))
-
-        results_to_store = []
-        previous_results = self.consent_dao.get_validation_results_for_participants(
-            participant_ids=validated_participant_ids
-        )
-        for possible_new_result in validation_results:
-            if not any(
-                [possible_new_result.file_path == previous_result.file_path for previous_result in previous_results]
-            ):
-                results_to_store.append(possible_new_result)
-
-        self.consent_dao.batch_update_consent_files(results_to_store)
+                output_strategy.add_all(self._process_validation_results(validator.get_gror_validation_results()))
 
     @classmethod
     def _process_validation_results(cls, results: List[ParsingResult]):
@@ -125,7 +296,7 @@ class ConsentValidationController:
 
     @classmethod
     def _has_new_consent(cls, consent_status, authored, min_authored):
-        return consent_status == QuestionnaireStatus.SUBMITTED and authored > min_authored
+        return consent_status == QuestionnaireStatus.SUBMITTED and (not min_authored or authored > min_authored)
 
     def _build_validator(self, participant_summary: ParticipantSummary) -> 'ConsentValidator':
         consent_factory = files.ConsentFileAbstractFactory.get_file_factory(

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -96,7 +96,6 @@ class ConsentTool(ToolBase):
         )
         sync_controller.sync_ready_files()
 
-
         min_date = parse(self.args.min_date)
         max_date = parse(self.args.max_date) if self.args.max_date else None
 

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -2,13 +2,12 @@ import argparse
 import csv
 from datetime import datetime, timedelta
 from dateutil.parser import parse
-from io import StringIO
 
 from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
-from rdr_service.services.consent.validation import ConsentValidationController
+from rdr_service.services.consent.validation import ConsentValidationController, LogResultStrategy
 from rdr_service.storage import GoogleCloudStorageProvider
 from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
 
@@ -36,26 +35,21 @@ class ConsentTool(ToolBase):
 
     def report_files_for_correction(self):
         min_validation_date = parse(self.args.since) if self.args.since else None
-        with self.get_session() as session:
-            results_to_report = self._consent_dao.get_files_needing_correction(
+        with self.get_session() as session, LogResultStrategy(
+            logger=logger,
+            verbose=self.args.verbose,
+            storage_provider=self._storage_provider
+        ) as strategy:
+            strategy.add_all(self._consent_dao.get_files_needing_correction(
                 session=session,
                 min_modified_datetime=min_validation_date
-            )
+            ))
 
-        report_lines = []
-        previous_participant_id = None
-        for result in results_to_report:
-            if previous_participant_id and previous_participant_id != result.participant_id and self.args.verbose:
-                report_lines.append('')
-            previous_participant_id = result.participant_id
-            report_lines.append(self._line_output_for_validation(result, verbose=self.args.verbose))
-
-        logger.info('\n'.join(report_lines))
         input('Press Enter to exit...')  # The Google SA key will need to stay active for links to docs to work
 
     def modify_file_results(self):
         with self.get_session() as session:
-            file = self._consent_dao.get(session, self.args.id)
+            file = self._consent_dao.get_with_session(session, self.args.id)
             if file is None:
                 logger.error('Unable to find validation record')
 
@@ -101,7 +95,8 @@ class ConsentTool(ToolBase):
             hpo_dao=HPODao(),
             storage_provider=GoogleCloudStorageProvider()
         )
-        controller.validate_recent_uploads(min_consent_date=min_date, max_consent_date=max_date)
+        with self.get_session() as session:
+            controller.validate_recent_uploads(session, min_consent_date=min_date, max_consent_date=max_date)
 
     def upload_records(self):
         data_to_upload = []
@@ -111,29 +106,6 @@ class ConsentTool(ToolBase):
                 data_to_upload.append(ConsentFile(**validation_data))
 
         self._consent_dao.batch_update_consent_files(data_to_upload)
-
-    def _line_output_for_validation(self, file: ConsentFile, verbose: bool):
-        output_line = StringIO()
-        if verbose:
-            output_line.write(f'{str(file.id).ljust(8)} - ')
-        output_line.write(f'P{file.participant_id} - {str(file.type).ljust(10)} ')
-
-        if not file.file_exists:
-            output_line.write('missing file')
-        else:
-            errors_with_file = []
-            if not file.is_signature_valid:
-                errors_with_file.append('invalid signature')
-            if not file.is_signing_date_valid:
-                errors_with_file.append(self._get_date_error_details(file, verbose))
-            if file.other_errors is not None:
-                errors_with_file.append(file.other_errors)
-
-            output_line.write(', '.join(errors_with_file))
-            if verbose:
-                output_line.write(f' - {self._get_link(file)}')
-
-        return output_line.getvalue()
 
     @classmethod
     def _get_date_error_details(cls, file: ConsentFile, verbose: bool = False):

--- a/tests/cron_job_tests/test_consent_sync_controller.py
+++ b/tests/cron_job_tests/test_consent_sync_controller.py
@@ -148,6 +148,18 @@ class ConsentSyncControllerTest(BaseTestCase):
         # If no participants are paired, then nothing should sync
         self.storage_provider_mock.copy_blob.assert_not_called()
 
+    def test_only_loading_consents_that_will_sync(self):
+        """
+        Currently there are only a few organizations in the config to sync.
+        For performance, we just load the files that will be copied.
+        """
+        self.sync_controller.sync_ready_files()
+
+        # Check that the config was used to filter the consent files loaded
+        org_name_keys = self.consent_dao_mock.get_files_ready_to_sync.call_args.kwargs['org_names']
+        for expected_key in [self.bob_org_name, self.foo_org_name]:
+            self.assertIn(expected_key, org_name_keys)
+
     @classmethod
     def _build_expected_dest_path(cls, bucket_name, org_id, site_group, participant_id, file_name):
         return f'{bucket_name}/Participant/{org_id}/{site_group}/P{participant_id}/{file_name}'

--- a/tests/helpers/tool_test_mixin.py
+++ b/tests/helpers/tool_test_mixin.py
@@ -23,6 +23,7 @@ class ToolTestMixin:
         tool_args = ToolTestMixin._build_args(tool_args)
 
         with mock.patch.object(ToolBase, 'initialize_process_context') as mock_init_env,\
+             mock.patch.object(ToolBase, 'get_session'),\
              mock.patch('rdr_service.services.config_client.ConfigClient.get_server_config') as mock_server_config:
 
             mock_init_env.return_value.__enter__.return_value = gcp_env

--- a/tests/helpers/tool_test_mixin.py
+++ b/tests/helpers/tool_test_mixin.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 import mock
 from typing import Type
 
@@ -16,15 +17,17 @@ class ToolTestMixin:
         return args_obj
 
     @classmethod
-    def run_tool(cls, tool_class: Type[ToolBase], tool_args: dict = None, server_config: dict = None):
+    def run_tool(cls, tool_class: Type[ToolBase], tool_args: dict = None, server_config: dict = None,
+                 mock_session=False):
         gcp_env = mock.MagicMock()
         gcp_env.project = 'localhost'
 
         tool_args = ToolTestMixin._build_args(tool_args)
 
+        session_patch = mock.patch.object(ToolBase, 'get_session') if mock_session else nullcontext()
         with mock.patch.object(ToolBase, 'initialize_process_context') as mock_init_env,\
-             mock.patch.object(ToolBase, 'get_session'),\
-             mock.patch('rdr_service.services.config_client.ConfigClient.get_server_config') as mock_server_config:
+             mock.patch('rdr_service.services.config_client.ConfigClient.get_server_config') as mock_server_config,\
+             session_patch:
 
             mock_init_env.return_value.__enter__.return_value = gcp_env
             mock_server_config.return_value = server_config or {}

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -2,6 +2,7 @@ from datetime import date, datetime
 import mock
 from typing import List
 
+from rdr_service import config
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
 from rdr_service.tools.tool_libs.consents import ConsentTool
 from tests.helpers.tool_test_mixin import ToolTestMixin
@@ -29,24 +30,24 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
 
         self.consent_dao_mock.get_files_needing_correction.return_value = [
             ConsentFile(
-                participant_id=123123123, type=ConsentType.PRIMARY, file_exists=False
+                id=1, participant_id=123123123, type=ConsentType.PRIMARY, file_exists=False
             ),
             ConsentFile(
-                participant_id=222333444, type=ConsentType.CABOR, file_exists=False
+                id=2, participant_id=222333444, type=ConsentType.CABOR, file_exists=False
             ),
             ConsentFile(
-                participant_id=222333444, type=ConsentType.GROR, file_exists=True,
+                id=3, participant_id=222333444, type=ConsentType.GROR, file_exists=True,
                 is_signature_valid=False, is_signing_date_valid=True, other_errors='missing checkmark',
                 file_path='test_bucket/P222/GROR_no_checkmark_or_signature.pdf'
             ),
             ConsentFile(
-                participant_id=654321123, type=ConsentType.CABOR, file_exists=True,
+                id=4, participant_id=654321123, type=ConsentType.CABOR, file_exists=True,
                 is_signature_valid=True, is_signing_date_valid=False,
                 signing_date=date(2021, 12, 1), expected_sign_date=date(2020, 12, 1),
                 file_path='test_bucket/P654/Cabor_bad_date.pdf'
             ),
             ConsentFile(
-                participant_id=901987345, type=ConsentType.EHR, file_exists=True,
+                id=5, participant_id=901987345, type=ConsentType.EHR, file_exists=True,
                 is_signature_valid=False, is_signing_date_valid=True,
                 file_path='test_bucket/P901/EHR_no_signature.pdf'
             )
@@ -72,34 +73,38 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
 
     def test_report_to_send_to_ptsc(self, logger_mock):
         """Check the basic report format, the one that would be sent to Vibrent or CE for correcting"""
-        self._run_consents_tool(command='report-errors')
-        logger_mock.info.assert_called_once_with('\n'.join([
-            'P123123123 - PRIMARY    missing file',
-            'P222333444 - CABOR      missing file',
-            'P222333444 - GROR       invalid signature, missing checkmark',
-            'P654321123 - CABOR      invalid signing date (expected 2020-12-01 but file has 2021-12-01)',
-            'P901987345 - EHR        invalid signature',
-        ]))
+        with mock.patch('rdr_service.tools.tool_libs.consents.input'):
+            self._run_consents_tool(command='report-errors')
+            logger_mock.info.assert_called_once_with('\n'.join([
+                'P123123123 - PRIMARY    missing file',
+                'P222333444 - CABOR      missing file',
+                'P222333444 - GROR       invalid signature, missing checkmark',
+                'P654321123 - CABOR      invalid signing date (expected 2020-12-01 but file has 2021-12-01)',
+                'P901987345 - EHR        invalid signature',
+            ]))
 
     def test_report_to_audit(self, logger_mock):
         """
         Check additional information and formatting helpful for looking into whether
         the files might have been mistakenly marked as incorrect
         """
-        self._run_consents_tool(command='report-errors', verbose=True)
-        logger_mock.info.assert_called_once_with('\n'.join([
-            'P123123123 - PRIMARY    missing file',
-            '',
-            'P222333444 - CABOR      missing file',
-            'P222333444 - GROR       invalid signature, missing checkmark - '
-            'https://example.com/test_bucket/P222/GROR_no_checkmark_or_signature.pdf',
-            '',
-            'P654321123 - CABOR      '
-            'invalid signing date (expected 2020-12-01 but file has 2021-12-01, diff of 365 days) - '
-            'https://example.com/test_bucket/P654/Cabor_bad_date.pdf',
-            '',
-            'P901987345 - EHR        invalid signature - https://example.com/test_bucket/P901/EHR_no_signature.pdf',
-        ]))
+        with mock.patch('rdr_service.tools.tool_libs.consents.input'):
+            self._run_consents_tool(command='report-errors', verbose=True)
+            logger_mock.info.assert_called_once_with('\n'.join([
+                '',
+                '1        - P123123123 - PRIMARY    missing file',
+                '',
+                '2        - P222333444 - CABOR      missing file',
+                '3        - P222333444 - GROR       invalid signature, missing checkmark',
+                'https://example.com/test_bucket/P222/GROR_no_checkmark_or_signature.pdf',
+                '',
+                '4        - P654321123 - CABOR      '
+                'invalid signing date (expected 2020-12-01 but file has 2021-12-01, diff of 365 days)',
+                'https://example.com/test_bucket/P654/Cabor_bad_date.pdf',
+                '',
+                '5        - P901987345 - EHR        invalid signature',
+                'https://example.com/test_bucket/P901/EHR_no_signature.pdf',
+            ]))
 
     def test_changing_existing_record(self, logger_mock):
         with mock.patch('rdr_service.tools.tool_libs.consents.input') as input_mock:
@@ -110,7 +115,7 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
                 type=ConsentType.PRIMARY,
                 sync_status=ConsentSyncStatus.NEEDS_CORRECTING
             )
-            self.consent_dao_mock.get.return_value = file_to_update
+            self.consent_dao_mock.get_with_session.return_value = file_to_update
 
             input_mock.return_value = 'y'
             self._run_consents_tool(
@@ -127,14 +132,19 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
                 mock.call('sync_status:    NEEDS_CORRECTING => READY_FOR_SYNC')
             ])
 
-            updated_file = self.consent_dao_mock.batch_update_consent_files.call_args_list[0].args[0][0]
+            updated_file = self.consent_dao_mock.batch_update_consent_files.call_args_list[0].args[1][0]
             self.assertEqual(file_to_update.id, updated_file.id)
             self.assertEqual(ConsentType.CABOR, updated_file.type)
             self.assertEqual(ConsentSyncStatus.READY_FOR_SYNC, updated_file.sync_status)
 
     def test_validation_time_range(self, _):
-        with mock.patch('rdr_service.tools.tool_libs.consents.ConsentValidationController') as controller_class_mock:
+        with mock.patch('rdr_service.tools.tool_libs.consents.ConsentValidationController') as controller_class_mock,\
+                mock.patch('rdr_service.tools.tool_libs.consents.ParticipantDao'):
             controller_mock = controller_class_mock.return_value
+            self.temporarily_override_config_setting(
+                key=config.CONSENT_SYNC_BUCKETS,
+                value={}
+            )
 
             # Check without max_date
             self._run_consents_tool(
@@ -145,6 +155,8 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
                 }
             )
             controller_mock.validate_recent_uploads.assert_called_with(
+                mock.ANY,
+                mock.ANY,
                 min_consent_date=datetime(2021, 4, 1),
                 max_consent_date=None
             )
@@ -158,6 +170,8 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
                 }
             )
             controller_mock.validate_recent_uploads.assert_called_with(
+                mock.ANY,
+                mock.ANY,
                 min_consent_date=datetime(2021, 5, 1),
                 max_consent_date=datetime(2021, 6, 17)
             )
@@ -188,7 +202,7 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
                     'file': 'data.csv',
                 }
             )
-            uploaded_records: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[0]
+            uploaded_records: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[1]
             self.assertTrue(any([
                 (
                     record.participant_id == '4567'

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -69,7 +69,7 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
             if additional_args:
                 tool_args.update(additional_args)
 
-            self.run_tool(ConsentTool, tool_args)
+            self.run_tool(ConsentTool, tool_args, mock_session=True)
 
     def test_report_to_send_to_ptsc(self, logger_mock):
         """Check the basic report format, the one that would be sent to Vibrent or CE for correcting"""


### PR DESCRIPTION
## Resolves *no ticket*
This addresses some local issues with the consent scripts and also handles a few memory issues that have been seen in the server.

## Description of changes/additions
- When creating a session locally, the default is to connect to the local database and there doesn't seem to be a way to globally change that. So this passes a session through the consent code to make sure it's working against the server.
- This adds ValidationOutputStrategies to make code for finding validation results and then what to do with that data more 'plug-and-play'.
- Some more refactoring was done in the consent file module to help make it easier for when we implement CE's validation.
- There was a memory issue when syncing files, so this loads only the ones that we know will sync (there are many more that won't be synced).

## Tests
- [x] unit tests


