### PR TITLE
Passing number field as required by ML

### DIFF
--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -118,7 +118,6 @@ class MailKitOrderDao(UpdatableDao):
 
         is_version_two = barcode and len(barcode) > 14
         if is_version_two:
-            order["order"]["number"] = None
             client_fields = {"client_passthrough_fields": {
                 "field1": barcode,
                 "field2": None,

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -145,7 +145,6 @@ class MailKitOrderDaoTestBase(BaseTestCase):
             ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests','comments'],
             list(mayo_order_payload.keys())
         )
-        self.assertIsNone(mayo_order_payload['number'])  # An empty number field should be given for version two
 
         # Make sure the correct account is used for version two
         self.mock_mayolinkapi.assert_called_once_with(credentials_key='version_two')


### PR DESCRIPTION
## More work for *DA-2010*
During testing with the MayoLink API we found that the number field is required, and needs to have data for the order to go through to the Biobank. Adding the barcode back in to the number field for v2 salivary orders.


## Tests
- [x] unit tests


