### PR TITLE
[PDR 356] Update GROR Enrollment Status logic

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -740,10 +740,9 @@ class ParticipantSummaryDao(UpdatableDao):
         consent_cohort, gror_consent, consent_expire_status=ConsentExpireStatus.NOT_EXPIRED
     ):
         """
-          2021-07-Note on enrollment status calculations and GROR:
+          2021-07 Note on enrollment status calculations and GROR:
           Per NIH Analytics Data Glossary and confirmation on requirements for Core participants:
-          Cohort 3 participants need a GROR response (yes/no/not sure) to qualify for PM&B and therefore
-          Core / FULL_PARTICIPANT status.  GROR not required for CORE_MINUS_PM.
+          Cohort 3 participants need any GROR response (yes/no/not sure) to elevate to Core or Core Minus PM status
         """
         if consent:
             if (
@@ -751,6 +750,7 @@ class ParticipantSummaryDao(UpdatableDao):
                 and physical_measurements_status == PhysicalMeasurementsStatus.COMPLETED
                 and samples_to_isolate_dna == SampleStatus.RECEIVED
                 and (consent_cohort != ParticipantCohort.COHORT_3 or
+                     # All response status enum values other than UNSET or SUBMITTED_INVALID meet the GROR requirement
                      (gror_consent and gror_consent != QuestionnaireStatus.UNSET
                       and gror_consent != QuestionnaireStatus.SUBMITTED_INVALID))
             ):

--- a/rdr_service/resource/calculators/participant_enrollment_status.py
+++ b/rdr_service/resource/calculators/participant_enrollment_status.py
@@ -102,6 +102,7 @@ class EnrollmentStatusCalculator:
             if status == PDREnrollmentStatusEnum.Participant and ehr_consented:
                 status = PDREnrollmentStatusEnum.ParticipantPlusEHR
             if status == PDREnrollmentStatusEnum.ParticipantPlusEHR and biobank_samples and \
+                    (cohort != ConsentCohortEnum.COHORT_3 or gror_received) and \
                     (modules and len(modules.values) >= len(self._module_enums)):
                 status = PDREnrollmentStatusEnum.CoreParticipantMinusPM
             if status == PDREnrollmentStatusEnum.CoreParticipantMinusPM and \

--- a/rdr_service/resource/calculators/participant_enrollment_status.py
+++ b/rdr_service/resource/calculators/participant_enrollment_status.py
@@ -48,6 +48,7 @@ class EnrollmentStatusCalculator:
     _signup = None
     _consented = None
     _ehr_consented = None
+    _gror_received = None
     _gror_consented = None
     _biobank_samples = None
     _physical_measurements = None
@@ -84,7 +85,7 @@ class EnrollmentStatusCalculator:
             signed_up = self.calc_signup(events)
             consented, cohort = self.calc_consent(events)
             ehr_consented = self.calc_ehr_consent(events)
-            gror_consented = self.calc_gror_consent(events)
+            gror_received = self.calc_gror_received(events)
             biobank_samples = self.calc_biobank_samples(events)
             physical_measurements = self.calc_physical_measurements(events)
             modules = self.calc_baseline_modules(events)
@@ -101,12 +102,11 @@ class EnrollmentStatusCalculator:
             if status == PDREnrollmentStatusEnum.Participant and ehr_consented:
                 status = PDREnrollmentStatusEnum.ParticipantPlusEHR
             if status == PDREnrollmentStatusEnum.ParticipantPlusEHR and biobank_samples and \
-                    (modules and len(modules.values) >= len(self._module_enums)) and \
-                    (cohort != ConsentCohortEnum.COHORT_3 or gror_consented):
+                    (modules and len(modules.values) >= len(self._module_enums)):
                 status = PDREnrollmentStatusEnum.CoreParticipantMinusPM
             if status == PDREnrollmentStatusEnum.CoreParticipantMinusPM and \
                     physical_measurements and \
-                    (cohort != ConsentCohortEnum.COHORT_3 or gror_consented):
+                    (cohort != ConsentCohortEnum.COHORT_3 or gror_received):
                 status = PDREnrollmentStatusEnum.CoreParticipant
 
             # Set the permanent enrollment status value if needed. Enrollment status can go down
@@ -226,6 +226,25 @@ class EnrollmentStatusCalculator:
 
         return self.save_calc('_ehr_consented', info)
 
+    def calc_gror_received(self, events):
+        """
+        Determine if a participant ever submitted a valid GROR response (regardless of consent status)
+        """
+        info = EnrollmentStatusInfo()
+        for ev in events:
+            if (ev.event == ParticipantEventEnum.GROR
+                     and ev.answer in [CONSENT_GROR_NO_CODE, CONSENT_GROR_YES_CODE, CONSENT_GROR_NOT_SURE]):
+                info.calculated = True
+                info.first_ts = ev.last_ts = ev.timestamp
+                info.add_value(ev)
+                break
+
+        return self.save_calc('_gror_received', info)
+
+    # Note:  New guidance from NIH as of July 2021 says GROR affirmative consent is not a requirement for Core
+    # status, so calc_gror_recieved() will replace this function in the enrollment status calculation.   Leaving this
+    # code here for potential leverage in case of a future need to confirm a GROR 'yes' consent in a participant's
+    # activity history.
     def calc_gror_consent(self, events):
         """
         Determine if participant has consented to GROR.

--- a/tests/resource_tests/calculator_tests/test_enrollment_status_calculator.py
+++ b/tests/resource_tests/calculator_tests/test_enrollment_status_calculator.py
@@ -120,9 +120,8 @@ class EnrollmentStatusCalculatorTest(BaseTestCase):
         """ Shift activity dates so we look like a cohort 3 participant with no GROR consent. """
         activity = self._shift_timestamps(get_basic_activity(), 800)
         self.esc.run(activity)
-        # GROR is considered a pre-requisite for Cohort 3 PM&B appointments and therefore Core status, but is not
-        # needed to reach CORE_MINUS_PM (e.g., ParticipantPlusEHR + biobank sample but no GROR qualifies)
-        self.assertEqual(self.esc.status, PDREnrollmentStatusEnum.CoreParticipantMinusPM)
+        # No GROR response means they cannot elevate to Core/Core Minus PM status
+        self.assertEqual(self.esc.status, PDREnrollmentStatusEnum.ParticipantPlusEHR)
         self.assertEqual(self.esc.cohort, ConsentCohortEnum.COHORT_3)
 
     def test_cohort_3_gror_no_answer(self):


### PR DESCRIPTION
## Resolves *[PDR 356](https://precisionmedicineinitiative.atlassian.net/browse/PDR-356)*


## Description of changes/additions
NIH determined that any valid gROR response (yes, no, not sure) is required to elevate a Cohort 3 participant to either CORE_PARTICIPANT (FULL_PARTICIPANT in RDR) or CORE_MINUS_PM status.   Updating logic in both the RDR enrollment status calculations and the PDR generators/EnrollmentStatusCalculator to account for this. 

This will require both a partial data rebuild for PDR and a potential backfill in RDR to correct some participants who may have either been prevented from elevating to CORE_PARTICIPANT/FULL_PARTICIPANT, or were elevated to CORE_MINUS_PM without a gROR response on record.
## Tests
- [x] unit tests
Updated existing unit tests to match the new calculation logic and revised expected results

Did a  PDR data rebuild on sandbox to verify no unexpected spam from the new log warnings.   This logging should be helpful in detecting/resolving data quality issues between RDR and PDR, and also QC'ing the new EnrollmentStatusCalculator logic.

