### PR TITLE
Update Pub/Sub Config and tool

### DIFF
--- a/rdr_service/config/pub_sub_config_prod.json
+++ b/rdr_service/config/pub_sub_config_prod.json
@@ -219,6 +219,72 @@
       "event_types": [
         "OBJECT_FINALIZE"
       ]
+    },
+    {
+      "bucket": "prod-genomics-baylor",
+      "id": "45",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod",
+      "payload_format": "JSON_API_V1",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ]
+    },
+    {
+      "bucket": "prod-genomics-baylor",
+      "id": "46",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod",
+      "payload_format": "JSON_API_V1",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ]
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "id": "40",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod",
+      "payload_format": "JSON_API_V1",
+      "object_name_prefix": "wgs_sample_raw_data/",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ]
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "id": "41",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod",
+      "payload_format": "JSON_API_V1",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ]
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "id": "55",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod",
+      "payload_format": "JSON_API_V1",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ]
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "id": "56",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod",
+      "payload_format": "JSON_API_V1",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ]
     }
   ]
 }

--- a/rdr_service/tools/tool_libs/pubsub_notification_manager.py
+++ b/rdr_service/tools/tool_libs/pubsub_notification_manager.py
@@ -80,7 +80,7 @@ class PubSubNotificationManager(ToolBase):
 
                 notifications_dict['notifications'].append(output_dict)
 
-        print(json.dumps(notifications_dict))
+        pprint(notifications_dict)
 
         return 0
 
@@ -150,7 +150,7 @@ class PubSubNotificationManager(ToolBase):
         _logger.info(f"Notification id {self.args.id} has been deleted.")
 
         _logger.info("Removing notification from config...")
-        self.delete_notification_from_config(self.args.id)
+        self.delete_notification_from_config()
 
         return 0
 


### PR DESCRIPTION
## Resolves *No Ticket*

## Description of changes/additions
This PR updates the production pub/sub config file with the new notifications for the genomic data file accessioning processes. Some minor changes were made to the pub/sub manager tool

## Tests
No tests


