### PR TITLE
[DA-2073] exclude_under_18_from_etl

### DIFF
--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -4,7 +4,6 @@
 #
 
 import logging
-import datetime
 from sqlalchemy import and_, case, insert, or_
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import func
@@ -382,7 +381,7 @@ class CurationExportClass(ToolBase):
                 ParticipantSummary.dateOfBirth.is_(None),
                 and_(
                     ParticipantSummary.dateOfBirth.isnot(None),
-                    func.year(func.from_days(func.datediff(datetime.datetime.now(),
+                    func.year(func.from_days(func.datediff(ParticipantSummary.consentForStudyEnrollmentAuthored,
                                                            ParticipantSummary.dateOfBirth))) >= 18
                 )
             )

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from rdr_service.clock import FakeClock
 from rdr_service.code_constants import CONSENT_FOR_STUDY_ENROLLMENT_MODULE, EMPLOYMENT_ZIPCODE_QUESTION_CODE, PMI_SKIP_CODE,\
     STREET_ADDRESS_QUESTION_CODE, STREET_ADDRESS2_QUESTION_CODE, ZIPCODE_QUESTION_CODE
 from rdr_service.etl.model.src_clean import SrcClean
@@ -10,6 +11,8 @@ from rdr_service.tools.tool_libs.curation import CurationExportClass
 from tests.helpers.unittest_base import BaseTestCase
 from tests.helpers.tool_test_mixin import ToolTestMixin
 
+TIME = datetime(2000, 1, 10)
+
 
 class CurationEtlTest(ToolTestMixin, BaseTestCase):
     def setUp(self):
@@ -18,6 +21,8 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
 
     def _setup_data(self):
         self.participant = self.data_generator.create_database_participant()
+        self.data_generator.create_database_participant_summary(participant=self.participant,
+                                                                dateOfBirth=datetime(1982, 1, 9))
 
         self.module_code = self.data_generator.create_database_code(value='src_clean_test')
 
@@ -380,25 +385,18 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
 
     def test_exclude_participants_age_under_18(self):
         """
-        Curation team request to exclude participants that were under 18 at the time of consent.
+        Curation team request to exclude participants that were under 18 at the time of ETL run.
         """
         self._create_consent_questionnaire()
-        dob = datetime(2000, 1, 1)
-        consent_time = datetime(2021, 1, 2)
-        self.data_generator.create_database_participant_summary(participant=self.participant,
-                                                                consentForStudyEnrollment=1,
-                                                                consentForStudyEnrollmentAuthored=consent_time,
-                                                                dateOfBirth=dob)
-        self.run_cdm_data_generation()
+        with FakeClock(TIME):
+            self.run_cdm_data_generation()
         src_clean_answers = self.session.query(SrcClean).all()
         self.assertEqual(4, len(src_clean_answers))
 
-        dob = datetime(2020, 1, 1)
-        self.data_generator.create_database_participant_summary(participant=self.participant,
-                                                                consentForStudyEnrollment=1,
-                                                                consentForStudyEnrollmentAuthored=consent_time,
-                                                                dateOfBirth=dob)
-        self.run_cdm_data_generation()
+        dob = datetime(1982, 1, 11)
+        self.data_generator.create_database_participant_summary(participant=self.participant, dateOfBirth=dob)
+        with FakeClock(TIME):
+            self.run_cdm_data_generation()
         src_clean_answers = self.session.query(SrcClean).all()
         self.assertEqual(0, len(src_clean_answers))
 

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -377,3 +377,28 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
             else:
                 self.assertEqual(expected_value, src_cln.value_string)
                 self.assertIsNone(src_cln.value_number)
+
+    def test_exclude_participants_age_under_18(self):
+        """
+        Curation team request to exclude participants that were under 18 at the time of consent.
+        """
+        self._create_consent_questionnaire()
+        dob = datetime(2000, 1, 1)
+        consent_time = datetime(2021, 1, 2)
+        self.data_generator.create_database_participant_summary(participant=self.participant,
+                                                                consentForStudyEnrollment=1,
+                                                                consentForStudyEnrollmentAuthored=consent_time,
+                                                                dateOfBirth=dob)
+        self.run_cdm_data_generation()
+        src_clean_answers = self.session.query(SrcClean).all()
+        self.assertEqual(4, len(src_clean_answers))
+
+        dob = datetime(2020, 1, 1)
+        self.data_generator.create_database_participant_summary(participant=self.participant,
+                                                                consentForStudyEnrollment=1,
+                                                                consentForStudyEnrollmentAuthored=consent_time,
+                                                                dateOfBirth=dob)
+        self.run_cdm_data_generation()
+        src_clean_answers = self.session.query(SrcClean).all()
+        self.assertEqual(0, len(src_clean_answers))
+


### PR DESCRIPTION
## Resolves *[DA-2073](https://precisionmedicineinitiative.atlassian.net/browse/DA-2073)*
Filter the curation ETL export to exclude participants that were under 18 at the time of consent. 

## Description of changes/additions
Added a filter to the ETL SQL.

## Tests
[x] test cases


