### PR TITLE
[DA-2122] Fix AW2F Job for genome type

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -11,6 +11,7 @@ from collections import deque, namedtuple
 from copy import deepcopy
 from dateutil.parser import parse
 import sqlalchemy
+from werkzeug.exceptions import NotFound
 
 from rdr_service import clock
 from rdr_service.dao.bq_genomics_dao import bq_genomic_set_member_update, bq_genomic_gc_validation_metrics_update, \
@@ -3105,6 +3106,10 @@ class ManifestCompiler:
             record_count = len(source_data)
             for row in source_data:
                 member = self.member_dao.get_member_from_sample_id(row.sample_id, genome_type)
+
+                if member is None:
+                    raise NotFound(f"Cannot find genomic set member with sample ID {row.sample_id}")
+
                 if self.manifest_def.job_run_field is not None:
                     results.append(
                         self.member_dao.update_member_job_run_id(

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -327,7 +327,7 @@ def create_aw2f_manifest(feedback_record):
                               bucket_name=config.BIOBANK_SAMPLES_BUCKET_NAME,
                               ) as controller:
         controller.generate_manifest(GenomicManifestTypes.AW2F,
-                                     _genome_type=config.GENOME_TYPE_ARRAY,
+                                     _genome_type=None,
                                      feedback_record=feedback_record)
 
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -1242,7 +1242,7 @@ class GenomicProcessRunner(GenomicManifestBase):
                 controller.bucket_name = server_config[config.BIOBANK_SAMPLES_BUCKET_NAME][0]
 
                 controller.generate_manifest(GenomicManifestTypes.AW2F,
-                                             _genome_type=config.GENOME_TYPE_ARRAY,
+                                             _genome_type=None,
                                              feedback_record=feedback_record)
 
             return 0


### PR DESCRIPTION
## Resolves *[DA-2122](https://precisionmedicineinitiative.atlassian.net/browse/DA-2122)*


## Description of changes/additions
This PR removes the `genome_type` filter for the AW2F manifest. The filter was incorrectly set to only lookup Array samples. Since sample_ids are unique across genome types, there is no need for the filter. This was causing the genomic set member lookups to return None for all WGS samples, which caused an exception and therefore prevented any other AW2F files from being produced. A check was added in this PR to raise an exception if the member is not found. This PR should resolve the backlog.

## Tests
- [] unit tests


