### PR TITLE
[PDR-368]  Update PDR schemas to add cope_vaccine2 survey

### DIFF
--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -9,7 +9,7 @@ from rdr_service.model.bq_questionnaires import (
     BQPDRTheBasics, BQPDRConsentPII, BQPDRLifestyle,
     BQPDROverallHealth, BQPDRDVEHRSharing, BQPDREHRConsentPII, BQPDRFamilyHistory,
     BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb,
-    BQPDRStopParticipating, BQPDRWithdrawalIntro, BQPDRCOPEVaccine1
+    BQPDRStopParticipating, BQPDRWithdrawalIntro, BQPDRCOPEVaccine1, BQPDRCOPEVaccine2
 )
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.participant_enums import QuestionnaireResponseStatus, TEST_HPO_NAME
@@ -113,6 +113,7 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
             'cope_dec': BQPDRCOPEDec,
             'cope_feb': BQPDRCOPEFeb,
             'cope_vaccine1': BQPDRCOPEVaccine1,
+            'cope_vaccine2': BQPDRCOPEVaccine2,
             # There are two different module id codes in use for the withdrawal survey
             'withdrawal_intro': BQPDRWithdrawalIntro,
             'StopParticipating': BQPDRStopParticipating

--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -22,6 +22,7 @@ BQ_TABLES = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEDec'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEFeb'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEVaccine1'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEVaccine2'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRWithdrawalIntro'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRStopParticipating'),
 
@@ -77,6 +78,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEDecView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEFebView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEVaccine1View'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRCOPEVaccine2View'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRWithdrawalView'),
 
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherView'),

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -653,6 +653,24 @@ class BQPDRCOPEVaccine1View(BQView):
     __pk_id__ = ['participant_id', 'questionnaire_response_id']
     _show_created = True
 
+class BQPDRCOPEVaccine2Schema(_BQModuleSchema):
+    """ COPE Vaccine Survey 2 (Fall 2021) """
+    _module = 'cope_vaccine2'
+    _excluded_fields = ()
+
+class BQPDRCOPEVaccine2(BQTable):
+    """ COPE Vaccine 2 BigQuery Table """
+    __tablename__ = 'pdr_mod_cope_vaccine2'
+    __schema__ = BQPDRCOPEVaccine2Schema
+
+class BQPDRCOPEVaccine2View(BQView):
+    """ PDR COPE Vaccine2 BigQuery View """
+    __viewname__ = 'v_pdr_mod_cope_vaccine2'
+    __viewdescr__ = 'PDR COPE Vaccine2 Module View'
+    __table__ = BQPDRCOPEVaccine2
+    __pk_id__ = ['participant_id', 'questionnaire_response_id']
+    _show_created = True
+
 # Note:  the StopParticipating and withdrawal_intro module codes are used for similar surveys that contain the
 # same survey questions.
 class BQPDRWithdrawalIntroSchema(_BQModuleSchema):

--- a/rdr_service/resource/constants.py
+++ b/rdr_service/resource/constants.py
@@ -124,6 +124,7 @@ class ParticipantEventEnum(IntEnum):
     cope_feb = 52,
     GeneticAncestry = 53
     cope_vaccine1 = 54
+    cope_vaccine2 = 55
 
     # Genomics: 70 - 99
 


### PR DESCRIPTION
## Resolves *[PDR-368](https://precisionmedicineinitiative.atlassian.net/browse/PDR-368)*


## Description of changes/additions
Adds the upcoming `cope_vaccine2 ` fall minute survey module to the PDR schemas.  Codebook imports were already completed in stable and prod RDR

## Tests
No changes at this time; if RDR unittests are updated when RDR work is done for processing the fall minute survey, the tests may include the PDRGeneratorTextMixin so the PDR generator output is also validated.

