### PR TITLE
[DA-2093] Add participant pairing history table to BQ and resource generator.

### DIFF
--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -63,6 +63,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantBiobankOrderView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantBiobankSampleView'),
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDREhrReceiptView'),
+    ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRPairingHistoryView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRConsentPIIView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRTheBasicsView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRLifestyleView'),

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -205,7 +205,7 @@ class BQEhrReceiptSchema(BQSchema):
                                          BQFieldModeEnum.NULLABLE)
 
 
-class BQParticipantPairingHistorySchema(BQSchema):
+class BQPairingHistorySchema(BQSchema):
     """
     Participant pairing history
     """
@@ -352,7 +352,7 @@ class BQParticipantSummarySchema(BQSchema):
                                                 BQFieldModeEnum.NULLABLE)
     enrl_core_participant_time = BQField('enrl_core_participant_time', BQFieldTypeEnum.DATETIME,
                                          BQFieldModeEnum.NULLABLE)
-    pairing_history = BQRecordField('pairing_history', schema=BQParticipantPairingHistorySchema)
+    pairing_history = BQRecordField('pairing_history', schema=BQPairingHistorySchema)
 
 
 class BQParticipantSummary(BQTable):

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -205,6 +205,19 @@ class BQEhrReceiptSchema(BQSchema):
                                          BQFieldModeEnum.NULLABLE)
 
 
+class BQParticipantPairingHistorySchema(BQSchema):
+    """
+    Participant pairing history
+    """
+    last_modified = BQField('last_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    hpo = BQField('hpo', BQFieldTypeEnum.STRING, BQFieldModeEnum.REQUIRED)
+    hpo_id = BQField('hpo_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    organization = BQField('organization', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    organization_id = BQField('organization_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    site = BQField('site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    site_id = BQField('site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+
+
 class BQParticipantSummarySchema(BQSchema):
     """
     Note: Do not use camelCase for property names. Property names must exactly match BQ
@@ -339,6 +352,7 @@ class BQParticipantSummarySchema(BQSchema):
                                                 BQFieldModeEnum.NULLABLE)
     enrl_core_participant_time = BQField('enrl_core_participant_time', BQFieldTypeEnum.DATETIME,
                                          BQFieldModeEnum.NULLABLE)
+    pairing_history = BQRecordField('pairing_history', schema=BQParticipantPairingHistorySchema)
 
 
 class BQParticipantSummary(BQTable):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -11,7 +11,7 @@ from rdr_service.model.bq_participant_summary import (
     BQConsentSchema,
     BQPatientStatusSchema,
     BQBiobankOrderSchema,
-    BQParticipantPairingHistorySchema
+    BQPairingHistorySchema
 )
 
 
@@ -194,7 +194,7 @@ class BQPDRParticipantSummarySchema(BQSchema):
                                                 BQFieldModeEnum.NULLABLE)
     enrl_core_participant_time = BQField('enrl_core_participant_time', BQFieldTypeEnum.DATETIME,
                                          BQFieldModeEnum.NULLABLE)
-    pairing_history = BQRecordField('pairing_history', schema=BQParticipantPairingHistorySchema)
+    pairing_history = BQRecordField('pairing_history', schema=BQPairingHistorySchema)
 
 
 class BQPDRParticipantSummary(BQTable):

--- a/rdr_service/resource/__init__.py
+++ b/rdr_service/resource/__init__.py
@@ -29,10 +29,10 @@ class SchemaMeta(object):
         """
         if 'resource_uri' not in kwargs or 'schema_id' not in kwargs:
             raise ValueError('Missing schema type information')
-        if not isinstance(kwargs['schema_id'], SchemaID):
-            raise ValueError('Schema ID value must be a SchemaID Enum object.')
         if not isinstance(kwargs['resource_uri'], str):
             raise ValueError('Schema resource URI must be a string')
+        if not isinstance(kwargs['schema_id'], SchemaID):
+            raise ValueError(f'Schema ID has not been set on Schema object {kwargs["resource_uri"]}.')
         # if not isinstance(kwargs['resource_pk_field'], str):
         #     raise ValueError('Schema resource PK field must be a string')
 

--- a/rdr_service/resource/constants.py
+++ b/rdr_service/resource/constants.py
@@ -28,6 +28,7 @@ class SchemaID(IntEnum):
     participant_consents = 2060
     participant_modules = 2070
     participant_address = 2080
+    participant_pairing_history = 2085
     patient_statuses = 2090
     ehr_recept = 2100
     pdr_participant = 2110

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -395,9 +395,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         query = ro_session.query(ParticipantHistory.lastModified, ParticipantHistory.hpoId, HPO.name.label('hpo'),
                                    ParticipantHistory.organizationId, Organization.externalId.label('organization'),
                                    ParticipantHistory.siteId, Site.googleGroup.label('site')). \
-                join(HPO, HPO.hpoId == ParticipantHistory.hpoId).\
-                join(Organization, Organization.organizationId == ParticipantHistory.organizationId).\
-                join(Site, Site.siteId == ParticipantHistory.siteId).\
+                outerjoin(HPO, HPO.hpoId == ParticipantHistory.hpoId).\
+                outerjoin(Organization, Organization.organizationId == ParticipantHistory.organizationId).\
+                outerjoin(Site, Site.siteId == ParticipantHistory.siteId).\
                 filter(ParticipantHistory.participantId == p_id).order_by(ParticipantHistory.lastModified)
         # sql = self.ro_dao.query_to_text(query)
         pairing = query.all()

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -243,7 +243,7 @@ class EhrReceiptSchema(Schema):
         pii_filter = {}  # dict(field: lambda function).
 
 
-class ParticipantParingHistorySchema(Schema):
+class PairingHistorySchema(Schema):
     """
     Participant pairing history
     """
@@ -348,7 +348,7 @@ class ParticipantSchema(Schema):
     sexual_orientation = fields.String(validate=validate.Length(max=80))
     sexual_orientation_id = fields.Int32()
 
-    pairing_history = fields.Nested(ParticipantParingHistorySchema, many=True)
+    pairing_history = fields.Nested(PairingHistorySchema, many=True)
     pm = fields.Nested(PhysicalMeasurementsSchema, many=True)
 
     races = fields.Nested(RaceSchema, many=True)

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -243,6 +243,27 @@ class EhrReceiptSchema(Schema):
         pii_filter = {}  # dict(field: lambda function).
 
 
+class ParticipantParingHistorySchema(Schema):
+    """
+    Participant pairing history
+    """
+    last_modified = fields.DateTime(
+        description='Last time the participant pairing was updated.')
+    hpo = fields.String(validate=validate.Length(max=20))
+    hpo_id = fields.Int32()
+    organization = fields.String(validate=validate.Length(max=255))
+    organization_id = fields.Int32()
+    site = fields.String(validate=validate.Length(max=255))
+    site_id = fields.Int32()
+
+    class Meta:
+        schema_id = SchemaID.participant_pairing_history
+        resource_uri = 'Participant/{participant_id}/PairingHistory'
+        # Exclude fields and/or functions to strip PII information from fields.
+        pii_fields = ()  # List fields that contain PII data.
+        pii_filter = {}  # dict(field: lambda function).
+
+
 class ParticipantSchema(Schema):
     """ Participant Activity Summary Schema """
     last_modified = fields.DateTime(
@@ -327,6 +348,7 @@ class ParticipantSchema(Schema):
     sexual_orientation = fields.String(validate=validate.Length(max=80))
     sexual_orientation_id = fields.Int32()
 
+    pairing_history = fields.Nested(ParticipantParingHistorySchema, many=True)
     pm = fields.Nested(PhysicalMeasurementsSchema, many=True)
 
     races = fields.Nested(RaceSchema, many=True)

--- a/tests/resource_tests/schema_tests/test_resource_schemas.py
+++ b/tests/resource_tests/schema_tests/test_resource_schemas.py
@@ -177,6 +177,11 @@ class ResourceSchemaTest(BaseTestCase):
                                      rschemas.participant.RaceSchema(),
                                      bq_participant_summary.BQRaceSchema())
 
+    def test_pairing_history_resource_schema(self):
+        self._verify_resource_schema('ParingHistorySchema',
+                                     rschemas.participant.PairingHistorySchema(),
+                                     bq_participant_summary.BQPairingHistorySchema())
+
     def test_site_resource_schema(self):
         self._verify_resource_schema('SiteSchema',
                                      rschemas.SiteSchema(),


### PR DESCRIPTION
## Resolves *[DA-2093](https://precisionmedicineinitiative.atlassian.net/browse/DA-2093)*


## Description of changes/additions
* Add participant pairing history table to BQ and Resource data.

## Tests
- [X] unit tests


