### PR TITLE
[PDR Fix] Fix for removing replayed module responses

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -687,14 +687,17 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                         mod_ca['answer_id'] = consent['consent_value_id']
 
                         # Compare against the last consent response processed to filter replays/duplicates
-                        if not self.is_replay(last_consent_processed, consent, created_key='consent_module_created'):
+                        if not self.is_replay(last_consent_processed, consent,
+                                              ignore_keys=['consent_module_created', 'questionnaire_response_id']):
                             consents.append(consent)
                             consent_added = True
 
                         last_consent_processed = consent.copy()
 
                 # consent_added == True means we already know it wasn't a replayed consent
-                if consent_added or not self.is_replay(last_mod_processed, module_data, created_key='module_created'):
+                if consent_added or not self.is_replay(last_mod_processed, module_data,
+                                                       ignore_keys=['module_created', 'questionnaire_response_id']):
+
                     modules.append(module_data)
 
                     # Find module in ParticipantActivity Enum via a case-insensitive way.
@@ -1572,32 +1575,30 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
 
     @staticmethod
-    def is_replay(prev_data_dict, data_dict, created_key=None):
+    def is_replay(prev_data_dict, data_dict, ignore_keys=None):
         """
         Compares two module or consent data dictionaries to identify replayed responses
         Replayed/resent responses are usually the result of trying to resolve a data issue, and are basically
-        duplicate QuestionnaireResponse payloads except for differing creation timestamps
+        duplicate QuestionnaireResponse payloads except for differing creation timestamps and questionnaire response ids
 
         :param prev_data_dict: data dictionary to compare
         :param data_dict: data dictionary to compare
-        :param created_key:  Dict key for the created timestamp value
-        :return:  Boolean, True if the dictionaries match on everything except the created timestamp value
+        :param ignore_keys:  List of dict fields that should be excluded from matching.  E.g., created timestamp field
+        :return:  Boolean, True if the dictionaries match on everything except the excluded keys
         """
         # Confirm both data dictionaries are populated
         if not bool(prev_data_dict) or not bool(data_dict):
             return False
 
-        # Validate we're comparing "like" dictionaries, with a valid created timestamp key name
+        # Validate we're comparing "like" dictionaries
         prev_data_dict_keys = sorted(list(prev_data_dict.keys()))
         data_dict_keys = sorted(list(data_dict.keys()))
         if prev_data_dict_keys != data_dict_keys:
             return False
-        if not (created_key and created_key in data_dict_keys):
-            return False
 
-        # Content must match on everything but created timestamp value
+        # Content must match on everything except the specifically excluded field names
         for key in data_dict.keys():
-            if key == created_key:
+            if ignore_keys and key in ignore_keys:
                 continue
             if data_dict[key] != prev_data_dict[key]:
                 return False


### PR DESCRIPTION
## Resolves *no ticket*


## Description of changes/additions
Updated the `is_replay()` method that flags identical/replayed responses in the participant's module data to accept a list of fields to ignore when validating if response data matches.  

We used to only ignore the created timestamp differences, but now that the `questionnaire_response_id` is also being included in the PDR data, we need to ignore mismatches for it, too.
## Tests
No new tests


