### PR TITLE
[DA-2130] Adding New York and sex at birth flags to received report

### DIFF
--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -519,6 +519,78 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
                 'example'  # Participant origin
             )])
 
+    def test_demographic_flags_in_received_report(self):
+        self._init_report_codes()
+        self.temporarily_override_config_setting('enable_biobank_manifest_received_flags', 1)
+
+        # Generate data for a New York sample to be in the report
+        participant = self.data_generator.create_database_participant()
+        collection_site = self.data_generator.create_database_site(state='NY')
+        order = self.data_generator.create_database_biobank_order(
+            participantId=participant.participantId,
+            collectedSiteId=collection_site.siteId
+        )
+
+        # Setup order identifiers that CE would send for Quest order
+        self.data_generator.create_database_biobank_order_identifier(
+            biobankOrderId=order.biobankOrderId,
+            value='aoeu-1234',  # CE CareTask system doesn't use the KIT numbers for identifiers
+            system=biobank_samples_pipeline._CE_QUEST_SYSTEM
+        )
+        kit_order_identifier = self.data_generator.create_database_biobank_order_identifier(
+            biobankOrderId=order.biobankOrderId,
+            value='KIT-001',
+            system=biobank_samples_pipeline._KIT_ID_SYSTEM
+        )
+
+        ordered_sample = self.data_generator.create_database_biobank_ordered_sample(
+            biobankOrderId=order.biobankOrderId,
+            collected=datetime(2020, 6, 5),
+            processed=datetime(2020, 6, 6),
+            finalized=datetime(2020, 6, 7)
+        )
+        stored_sample = self.data_generator.create_database_biobank_stored_sample(
+            test=ordered_sample.test,
+            biobankId=participant.biobankId,
+            biobankOrderIdentifier=kit_order_identifier.value,
+            confirmed=self._datetime_days_ago(7)
+        )
+
+        # Mocking the file writer to catch what gets exported and mocking the upload method because
+        # that isn't what this test is meant to cover
+        with mock.patch('rdr_service.offline.sql_exporter.csv.writer') as mock_writer_class,\
+                mock.patch('rdr_service.offline.sql_exporter.SqlExporter.upload_export_file'):
+            biobank_samples_pipeline.write_reconciliation_report(datetime.now())
+
+            mock_write_rows = mock_writer_class.return_value.writerows
+            mock_write_rows.assert_called_once_with([(
+                f'Z{participant.biobankId}',
+                ordered_sample.test,
+                Decimal('1'),  # sent count
+                kit_order_identifier.value,
+                self._format_datetime(ordered_sample.collected),
+                self._format_datetime(ordered_sample.processed),
+                self._format_datetime(ordered_sample.finalized),
+                None, None, None, 'UNKNOWN',  # site info: name, client_number, hpo, hpo_type
+                None, None, None, 'UNKNOWN',  # finalized site info: name, client_number, hpo, hpo_type
+                None,  # finalized username
+                ordered_sample.test,
+                1,  # received count
+                str(stored_sample.biobankStoredSampleId),
+                self._format_datetime(stored_sample.confirmed),  # received time
+                None,  # created family date
+                None,  # elapsed hours
+                'KIT-001',  # kit identifier
+                None,  # fedex tracking number
+                'N',  # is Native American
+                None, None, None,  # notes info: collected, processed, finalized
+                None, None, None, None, None,  # cancelled_restored info: status_flag, name, name, time, reason
+                None,  # order origin
+                'example',  # Participant origin,
+                'Y',  # NY flag
+                'NA'  # sex at birth flag
+            )])
+
     def _get_questionnaire(self):
         if self.withdrawal_questionnaire is None:
             race_question = self.data_generator.create_database_questionnaire_question(


### PR DESCRIPTION
## Resolves *[DA-2130](https://precisionmedicineinitiative.atlassian.net/browse/DA-2130)*
The Biobank has been needing to reference AIAN, New York, and sex-at-birth data for incoming samples but they haven't all been appearing on the AW0 reports. This adds New York and sex-at-birth data to the nightly received reports (excluding AIAN since it's already on the report) so that they will have it for each incoming sample regardless of whether it would be on the AW0.

## Description of changes/additions
I want to make sure Biobank is ready for the changes before we switch to having the new columns, so this wraps the changes with a config switch that will only enable the new columns when we're all ready.

I'd really like to be able to switch over to using sqlalchemy for these queries, but didn't have the time to make those changes. So this breaks the reconciliation query up a bit so that additional columns can optionally be selected. The report query happens in a couple of steps and two separate queries are UNIONed together. Both of those will always have the data. But each report wraps that UNION in an outer select. The received report will optionally add the additional columns to that outer select.

The logic for these new fields is based on the way that the data is processed in the genomics. It seems like we may be leaving out inter-sex and other non-binary answers, but I believe this is based on passed genomics requirements.

## Tests
- [x] unit tests


