### PR TITLE
[DA-2090] Re-syncing consent files for repaired participants

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Collection
 
 from sqlalchemy import or_
+from sqlalchemy.orm import Session
 
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus
@@ -73,14 +74,33 @@ class ConsentDao(BaseDao):
             ConsentFile.participant_id.in_(participant_ids)
         ).all()
 
-    def get_files_ready_to_sync(self, org_names=None) -> Collection[ConsentFile]:
-        with self.session() as session:
-            query = (
-                session.query(ConsentFile)
-                .join(Participant)
-                .join(Organization)
-                .filter(ConsentFile.sync_status == ConsentSyncStatus.READY_FOR_SYNC)
-            )
-            if org_names is not None:
-                query = query.filter(Organization.externalId.in_(org_names))
-            return query.all()
+    @classmethod
+    def _get_ready_to_sync_with_session(cls, session: Session, org_names=None):
+        query = (
+            session.query(ConsentFile)
+            .join(Participant)
+            .join(Organization)
+            .filter(ConsentFile.sync_status == ConsentSyncStatus.READY_FOR_SYNC)
+        )
+        if org_names is not None:
+            query = query.filter(Organization.externalId.in_(org_names))
+        return query.all()
+
+    def get_files_ready_to_sync(self, org_names=None, session: Session = None) -> Collection[ConsentFile]:
+        if session is None:
+            with self.session() as dao_session:
+                return self._get_ready_to_sync_with_session(session=dao_session, org_names=org_names)
+        else:
+            return self._get_ready_to_sync_with_session(session=session, org_names=org_names)
+
+    @classmethod
+    def set_previously_synced_files_as_ready(cls, session: Session, participant_id: int):
+        session.query(
+            ConsentFile
+        ).filter(
+            ConsentFile.sync_status == ConsentSyncStatus.SYNC_COMPLETE,
+            ConsentFile.participant_id == participant_id
+        ).update({
+            ConsentFile.sync_status: ConsentSyncStatus.READY_FOR_SYNC,
+            ConsentFile.sync_time: None
+        })

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -44,7 +44,6 @@ from rdr_service.participant_enums import (
     WithdrawalStatus,
     make_primary_provider_link_for_id,
 )
-from rdr_service.services.consent.validation import ConsentValidationController, ReplacementStoringStrategy
 
 
 class ParticipantHistoryDao(BaseDao):
@@ -275,8 +274,9 @@ class ParticipantDao(UpdatableDao):
                 # Get valid files ready for sync when a participant is paired to an organization
                 ConsentDao.set_previously_synced_files_as_ready(session, obj.participantId)
 
-                controller = ConsentValidationController.build_controller()
-                with ReplacementStoringStrategy(
+                import rdr_service.services.consent.validation as validation
+                controller = validation.ConsentValidationController.build_controller()
+                with validation.ReplacementStoringStrategy(
                     session=session,
                     consent_dao=controller.consent_dao
                 ) as store_strategy:

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -44,6 +44,7 @@ from rdr_service.participant_enums import (
     WithdrawalStatus,
     make_primary_provider_link_for_id,
 )
+from rdr_service.services.consent.validation import ConsentValidationController, ReplacementStoringStrategy
 
 
 class ParticipantHistoryDao(BaseDao):
@@ -254,9 +255,19 @@ class ParticipantDao(UpdatableDao):
                     need_new_summary = True
 
         if update_pairing:
-            if obj.organizationId != existing_obj.organizationId:
+            if obj.organizationId != existing_obj.organizationId and existing_obj.participantSummary is not None:
                 # Get valid files ready for sync when a participant is paired to an organization
                 ConsentDao.set_previously_synced_files_as_ready(session, obj.participantId)
+
+                controller = ConsentValidationController.build_controller()
+                with ReplacementStoringStrategy(
+                    session=session,
+                    consent_dao=controller.consent_dao
+                ) as store_strategy:
+                    controller.validate_all_for_participant(
+                        participant_id=obj.participantId,
+                        output_strategy=store_strategy
+                    )
         else:
             # No pairing updates sent, keep existing values.
             obj.siteId = existing_obj.siteId

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -24,6 +24,7 @@ from rdr_service.api_util import (
 from rdr_service.app_util import get_oauth_id, lookup_user_info, get_account_origin_id, is_care_evo_and_not_prod
 from rdr_service.code_constants import UNSET, ORIGINATING_SOURCES
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
+from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.organization_dao import OrganizationDao
 from rdr_service.dao.site_dao import SiteDao
@@ -252,8 +253,12 @@ class ParticipantDao(UpdatableDao):
                     obj.organizationId = None
                     need_new_summary = True
 
-        # No pairing updates sent, keep existing values.
-        if update_pairing == False:
+        if update_pairing:
+            if obj.organizationId != existing_obj.organizationId:
+                # Get valid files ready for sync when a participant is paired to an organization
+                ConsentDao.set_previously_synced_files_as_ready(session, obj.participantId)
+        else:
+            # No pairing updates sent, keep existing values.
             obj.siteId = existing_obj.siteId
             obj.organizationId = existing_obj.organizationId
             obj.hpoId = existing_obj.hpoId

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1,6 +1,7 @@
 import datetime
 import faker
 import http.client
+import mock
 import threading
 import unittest
 
@@ -168,6 +169,13 @@ class ParticipantSummaryMySqlApiTest(BaseTestCase):
             "identifier": [{"system": "http://any-columbia-mrn-system", "value": "MRN456"}],
         }
 
+        # Patching to prevent consent validation checks from running
+        build_validator_patch = mock.patch(
+            'rdr_service.services.consent.validation.ConsentValidationController.build_controller'
+        )
+        build_validator_patch.start()
+        self.addCleanup(build_validator_patch.stop)
+
     def testUpdate_raceCondition(self):
         self.create_questionnaire("questionnaire3.json")
         participant = self.send_post("Participant", {})
@@ -221,6 +229,13 @@ class ParticipantSummaryApiTest(BaseTestCase):
         )
         self.ps_dao = ParticipantSummaryDao()
         self.faker = faker.Faker()
+
+        # Patching to prevent consent validation checks from running
+        build_validator_patch = mock.patch(
+            'rdr_service.services.consent.validation.ConsentValidationController.build_controller'
+        )
+        build_validator_patch.start()
+        self.addCleanup(build_validator_patch.stop)
 
     def overwrite_test_user_awardee(self, awardee, roles):
         new_user_info = deepcopy(config.getSettingJson(config.USER_INFO))

--- a/tests/cron_job_tests/test_hpo_lite_pairing_importer.py
+++ b/tests/cron_job_tests/test_hpo_lite_pairing_importer.py
@@ -22,6 +22,13 @@ class HpoLitePairingImporterTest(BaseTestCase):
                                     '1': 'ORG_TEST'
                                 })
 
+        # Patching to prevent consent validation checks from running
+        build_validator_patch = mock.patch(
+            'rdr_service.services.consent.validation.ConsentValidationController.build_controller'
+        )
+        build_validator_patch.start()
+        self.addCleanup(build_validator_patch.stop)
+
     @staticmethod
     def _redcap_hpo_lite_pairing_record(participant_id, paired_date, hpo_name, user_email, hpo_lite_pairing_complete):
         """Build out a record that matches the codes we're expecting from redcap"""

--- a/tests/dao_tests/test_biobank_order_dao.py
+++ b/tests/dao_tests/test_biobank_order_dao.py
@@ -1,4 +1,5 @@
 import datetime
+import mock
 
 from werkzeug.exceptions import BadRequest, Conflict, Forbidden
 
@@ -27,6 +28,13 @@ class BiobankOrderDaoTest(BaseTestCase):
         self.participant = Participant(participantId=123, biobankId=555)
         ParticipantDao().insert(self.participant)
         self.dao = BiobankOrderDao()
+
+        # Patching to prevent consent validation checks from running
+        build_validator_patch = mock.patch(
+            'rdr_service.services.consent.validation.ConsentValidationController.build_controller'
+        )
+        build_validator_patch.start()
+        self.addCleanup(build_validator_patch.stop)
 
     def _make_biobank_order(self, **kwargs):
         """Makes a new BiobankOrder (same values every time) with valid/complete defaults.

--- a/tests/dao_tests/test_physical_measurements_dao.py
+++ b/tests/dao_tests/test_physical_measurements_dao.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import mock
 
 from werkzeug.exceptions import BadRequest, Forbidden
 
@@ -67,6 +68,13 @@ class PhysicalMeasurementsDaoTest(BaseTestCase):
         self.participant_summary_dao = ParticipantSummaryDao()
         self.measurement_json = json.dumps(load_measurement_json(self.participant.participantId, TIME_1.isoformat()))
         self.biobank = BiobankOrderDao()
+
+        # Patching to prevent consent validation checks from running
+        build_validator_patch = mock.patch(
+            'rdr_service.services.consent.validation.ConsentValidationController.build_controller'
+        )
+        build_validator_patch.start()
+        self.addCleanup(build_validator_patch.stop)
 
     def test_from_client_json(self):
         measurement = self.dao.from_client_json(json.loads(self.measurement_json))


### PR DESCRIPTION
## Resolves *[DA-2090](https://precisionmedicineinitiative.atlassian.net/browse/DA-2090)*
For any participants that have been paired to any organization and then get re-paired, we need to make sure their consent files get sent to the new organization's bucket.

Additionally, this will retrospectively validate any participants that have not yet had all their consent files validated. That functionality will be removed when all previously received consents have been validated for existing participants.

## Tests
- [x] unit tests


