### PR TITLE
[PDR-386] Add covid_19_serology_results module consent.

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -61,7 +61,7 @@ from rdr_service.resource.schemas.participant import StreetAddressTypeEnum
 
 
 _consent_module_question_map = {
-    # module: question code string
+    # { module: question code string }
     'ConsentPII': None,
     'DVEHRSharing': 'DVEHRSharing_AreYouInterested',
     'EHRConsentPII': 'EHRConsentPII_ConsentPermission',
@@ -72,25 +72,17 @@ _consent_module_question_map = {
     'cope_nov': 'section_participation',
     'cope_dec': 'section_participation',
     'cope_feb': 'section_participation',
-    'GeneticAncestry': 'GeneticAncestry_ConsentAncestryTraits'
+    'GeneticAncestry': 'GeneticAncestry_ConsentAncestryTraits',
+    'covid_19_serology_results': 'covid_19_serology_results_decision'
 }
 
-# _consent_expired_question_map must contain every module ID from _consent_module_question_map.
+# _consent_expired_question_map, for expired consents. { module: question code string }
 _consent_expired_question_map = {
-    'ConsentPII': None,
-    'DVEHRSharing': None,
-    'EHRConsentPII': 'EHRConsentPII_ConsentExpired',
-    'GROR': None,
-    'PrimaryConsentUpdate': None,
-    'ProgramUpdate': None,
-    'COPE': None,
-    'cope_nov': None,
-    'cope_dec': None,
-    'cope_feb': None,
-    'GeneticAncestry': None
+    'EHRConsentPII': 'EHRConsentPII_ConsentExpired'
 }
 
-# Possible answer codes for the consent module questions and what submittal status the answers correspond to
+# Possible answer codes for the consent module questions and what submittal status the answers correspond to.
+# { answer code string: BQModuleStatusEnum value }
 _consent_answer_status_map = {
     'ConsentPermission_Yes': BQModuleStatusEnum.SUBMITTED,
     'ConsentPermission_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
@@ -112,6 +104,9 @@ _consent_answer_status_map = {
     'ConsentAncestryTraits_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'ConsentAncestryTraits_NotSure': BQModuleStatusEnum.SUBMITTED_NOT_SURE,
     'PMI_Skip': BQModuleStatusEnum.UNSET,
+    # covid_19_serology_results_decision
+    'Decision_Yes': BQModuleStatusEnum.SUBMITTED,
+    'Decision_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
 }
 
 # PDR-252:  When RDR starts accepting QuestionnaireResponse payloads for withdrawal screens, AIAN participants
@@ -682,8 +677,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                             consent['consent_value'] = module_data['consent_value'] = consent_value
                             consent['consent_value_id'] = module_data['consent_value_id'] = \
                                 self._lookup_code_id(consent_value, ro_session)
-                            consent['consent_expired'] = module_data['consent_expired'] = \
-                                qnan.get(_consent_expired_question_map[module_name] or 'None', None)
+                            if module_name in _consent_expired_question_map:
+                                consent['consent_expired'] = module_data['consent_expired'] = \
+                                    qnan.get(_consent_expired_question_map[module_name] or 'None', None)
                             # TODO: Should we have also have a 'consent_expired_id', if so what would the integer
                             #  value be (there is only a question code_id in the code table, no answer code_id)?
 

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -892,6 +892,7 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             if mod['module'] == 'covid_19_serology_results':
                 decision_found = True
                 self.assertEqual(mod['consent_value'], 'Decision_No')
+                self.assertEqual(mod['status'], 'SUBMITTED_NO_CONSENT')
                 break
         self.assertEqual(decision_found, True)
 

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -4,7 +4,6 @@ import mock
 from sqlalchemy.exc import IntegrityError
 from werkzeug.exceptions import BadRequest, Forbidden
 
-from concepts import Concept
 from rdr_service import config
 from rdr_service.api_util import open_cloud_file
 from rdr_service.clock import FakeClock
@@ -22,6 +21,7 @@ from rdr_service.code_constants import (
     THE_BASICS_PPI_MODULE
 )
 from rdr_service.dao.code_dao import CodeDao
+from rdr_service.concepts import Concept
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.questionnaire_dao import QuestionnaireDao
@@ -870,7 +870,7 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
         self.assertEqual(num_completed_ppi_after_setup + 1, participant_summary.numCompletedPPIModules)
 
     def test_covid_19_serology_results(self):
-        """Make sure the dao fills in the summary data for the first COPE minute survey"""
+        """ Test the covid 19 serology results survey"""
         self.insert_codes()
         participant_id = self.create_participant()
         self.send_consent(participant_id)

--- a/tests/test-data/questionnaire_covid_19_serology_results.json
+++ b/tests/test-data/questionnaire_covid_19_serology_results.json
@@ -1,0 +1,84 @@
+{
+  "resourceType": "Questionnaire",
+  "identifier": [
+    {
+      "value": "Vibrent_FORM_ID_1489"
+    }
+  ],
+  "version": "V2021V2021.04.29",
+  "status": "published",
+  "date": "2021-07-29T09:47:16+00:00",
+  "group": {
+    "linkId": "root_group",
+    "title": "COVID-19 Research: Your Antibody Result",
+    "concept": [
+      {
+        "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+        "code": "covid_19_serology_results"
+      }
+    ],
+    "required": true,
+    "repeats": false,
+    "question": [
+      {
+        "linkId": "covid_19_serology_results_decision",
+        "concept": [
+          {
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "code": "covid_19_serology_results_decision"
+          }
+        ],
+        "text": "QUESTION LABEL WAS NOT DEFINED, PLEASE CONTACT ADMINISTRATOR",
+        "type": "choice",
+        "repeats": false,
+        "option": [
+          {
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "code": "Decision_Yes",
+            "display": "Yes, I want to see my COVID-19 antibody study result.",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "S\u00ed, quiero ver el resultado del estudio de mis anticuerpos contra el COVID-19."
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "system": "http://terminology.pmi-ops.org/CodeSystem/ppi",
+            "code": "Decision_No",
+            "display": "No, I do not want to see my COVID-19 antibody study result.",
+            "_display": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "es"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "No, no quiero ver el resultado del estudio de mis anticuerpos contra el COVID-19."
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "id": "669"
+}


### PR DESCRIPTION
## Resolves *[PDR-386](https://precisionmedicineinitiative.atlassian.net/browse/PDR-386)*


## Description of changes/additions
* PDR user requested COVID serology consent answers.  Add answers to participant module data.

## Tests
- [x] unit tests


