### PR TITLE
Make AW3 query distinct

### DIFF
--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -1,4 +1,5 @@
 import sqlalchemy
+from sqlalchemy import distinct
 from sqlalchemy.orm import aliased
 
 from rdr_service.config import GENOME_TYPE_ARRAY, GENOME_TYPE_WGS
@@ -33,7 +34,7 @@ class GenomicQueryClass:
         self.genomic_data_config = {
             GenomicManifestTypes.AW3_ARRAY: (sqlalchemy.select(
                 [
-                    GenomicGCValidationMetrics.chipwellbarcode,
+                    distinct(GenomicGCValidationMetrics.chipwellbarcode),
                     sqlalchemy.func.concat(get_biobank_id_prefix(), GenomicSetMember.biobankId),
                     GenomicSetMember.sampleId,
                     GenomicSetMember.sexAtBirth,
@@ -80,7 +81,7 @@ class GenomicQueryClass:
             )),
             GenomicManifestTypes.AW3_WGS: (sqlalchemy.select(
                 [
-                    sqlalchemy.func.concat(get_biobank_id_prefix(), GenomicSetMember.biobankId),
+                    distinct(sqlalchemy.func.concat(get_biobank_id_prefix(), GenomicSetMember.biobankId)),
                     GenomicSetMember.sampleId,
                     sqlalchemy.func.concat(get_biobank_id_prefix(),
                                            GenomicSetMember.biobankId, '_',


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
In rare cases, there are duplicate `genomic_gc_validation_metrics` records that are causing the AW3 manifest to contain duplicate rows. This PR adds a `distinct` clause to the AW3 queries to prevent this.

## Tests
- [x] unit tests


