### PR TITLE
[PDR-348] Convert and rename dv_order field in to enum for collection method.

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -158,7 +158,6 @@ class BQBiobankOrderSchema(BQSchema):
     bbo_created = BQField('bbo_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     bbo_status = BQField('bbo_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     bbo_status_id = BQField('bbo_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-    bbo_dv_order = BQField('bbo_dv_order', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     bbo_collected_site = BQField('bbo_collected_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     bbo_collected_site_id = BQField('bbo_collected_site_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     bbo_processed_site = BQField('bbo_processed_site', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
@@ -174,6 +173,8 @@ class BQBiobankOrderSchema(BQSchema):
     bbo_finalized_status = BQField('bbo_finalized_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     bbo_finalized_status_id = BQField('bbo_finalized_status_id',
                                       BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    bbo_collection_method = BQField('bbo_collection_method', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    bbo_collection_method_id = BQField('bbo_collection_method_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQPatientStatusSchema(BQSchema):

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -9,7 +9,7 @@ from marshmallow import validate
 from rdr_service.participant_enums import QuestionnaireStatus, ParticipantCohort, Race, GenderIdentity, \
     PhysicalMeasurementsStatus, OrderStatus, EnrollmentStatusV2, EhrStatus, WithdrawalStatus, WithdrawalReason, \
     SuspensionStatus, QuestionnaireResponseStatus, DeceasedStatus, ParticipantCohortPilotFlag, \
-    WithdrawalAIANCeremonyStatus, BiobankOrderStatus
+    WithdrawalAIANCeremonyStatus, BiobankOrderStatus, SampleCollectionMethod
 from rdr_service.resource import Schema, fields
 from rdr_service.resource.constants import SchemaID
 
@@ -174,7 +174,10 @@ class BiobankOrderSchema(Schema):
     created = fields.DateTime()
     status = fields.EnumString(enum=BiobankOrderStatus)
     status_id = fields.EnumInteger(enum=BiobankOrderStatus)
-    dv_order = fields.Boolean()
+    collection_method = fields.EnumString(enum=SampleCollectionMethod,
+        description='Collection method name used for biobank order.')
+    collection_method_id = fields.EnumInteger(enum=SampleCollectionMethod,
+        description='Collection method id value used for biobank order.')
     collected_site = fields.String(validate=validate.Length(max=255))
     collected_site_id = fields.Int32()
     processed_site = fields.String(validate=validate.Length(max=255))

--- a/tests/resource_tests/schema_tests/test_resource_schemas.py
+++ b/tests/resource_tests/schema_tests/test_resource_schemas.py
@@ -178,7 +178,7 @@ class ResourceSchemaTest(BaseTestCase):
                                      bq_participant_summary.BQRaceSchema())
 
     def test_pairing_history_resource_schema(self):
-        self._verify_resource_schema('ParingHistorySchema',
+        self._verify_resource_schema('PairingHistorySchema',
                                      rschemas.participant.PairingHistorySchema(),
                                      bq_participant_summary.BQPairingHistorySchema())
 


### PR DESCRIPTION
## Resolves *[PDR-348](https://precisionmedicineinitiative.atlassian.net/browse/PDR-348)* and *[PDR-180](https://precisionmedicineinitiative.atlassian.net/browse/PDR-180)*


## Description of changes/additions
* Removed the 'dv_order' field from BQ and Resource biobank order models.
* Added 'collection_method' and 'collection_method_id' fields to models.
* Updated SQL in participant generator to set correct enum value for collection method.

## Tests
- [x] unit tests


