### PR TITLE
[DA-2148] Moving Genomic job run update to cloud task

### DIFF
--- a/rdr_service/api/message_broker_cloud_tasks_api.py
+++ b/rdr_service/api/message_broker_cloud_tasks_api.py
@@ -80,6 +80,8 @@ class StoreMessageBrokerEventDataTaskApi(Resource):
                 payload['event_type'] = self.event_type
                 payload['records'] = informing_records
                 _task = GCPCloudTask()
-                _task.execute('ingest_informing_loop',
-                              payload=payload,
-                              queue='genomics')
+                _task.execute(
+                    'ingest_informing_loop_task',
+                    payload=payload,
+                    queue='genomics'
+                )

--- a/rdr_service/dao/message_broker_dao.py
+++ b/rdr_service/dao/message_broker_dao.py
@@ -1,13 +1,13 @@
 from rdr_service import clock
 from werkzeug.exceptions import BadRequest
 
+from rdr_service.config import GAE_PROJECT
+from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.dao.database_utils import parse_datetime, format_datetime
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.message_broker import MessageBrokerRecord, MessageBrokerEventData
 from rdr_service.message_broker.message_broker import MessageBrokerFactory
-from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
-from rdr_service.config import GAE_PROJECT
 
 
 class MessageBrokerDao(BaseDao):

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1854,6 +1854,7 @@ class GenomicReconciler:
 
         logging.info("Found {len(metrics)} metrics records missing data...")
 
+        member_ids = []
         for result in metrics:
             # Lookup identifier in data files table
             id_value = getattr(result, identifier)
@@ -1861,10 +1862,9 @@ class GenomicReconciler:
 
             file_types_received = set([f.file_type for f in files])
             missing_data_files = required_files_set - file_types_received
-
             metric_touched = False
 
-            # WGS query results requre GenomicGCValidationMetrics model to be specified
+            # WGS query results require GenomicGCValidationMetrics model to be specified
             if isinstance(result, GenomicGCValidationMetrics):
                 _obj = result
             else:
@@ -1881,18 +1881,25 @@ class GenomicReconciler:
                         if not getattr(_obj, file_type_config['file_received_attribute']):
                             setattr(_obj, file_type_config['file_received_attribute'], 1)  # received
                             setattr(_obj, file_type_config['file_path_attribute'], f'gs://{file.file_path}')
-
                             metric_touched = True
+                            member_ids.append(_obj.genomicSetMemberId)
 
             if metric_touched or missing_data_files:
                 logging.info(f'Updating metric record {_obj.id}')
                 self.update_reconciled_metric(_obj, missing_data_files, _gc_site_id)
 
+            if member_ids:
+                payload = {
+                    'member_ids': member_ids,
+                    'job_run_id': self.run_id,
+                    'field': 'reconcileMetricsSequencingJobRunId',
+                    'project_id': self.controller.bq_project_id
+                }
+                self.controller.execute_cloud_task(payload, 'genomic_set_member_job_run_task')
+
         return GenomicSubProcessResult.SUCCESS
 
     def update_reconciled_metric(self, _obj, missing_data_files, _gc_site_id):
-        member = self.member_dao.get(_obj.genomicSetMemberId)
-
         # Only upsert the metric if changed
         inserted_metrics_obj = self.metrics_dao.upsert(_obj)
         logging.info(f'id {_obj.id} updated with attributes')
@@ -1903,17 +1910,13 @@ class GenomicReconciler:
                                                     project_id=self.controller.bq_project_id)
             genomic_gc_validation_metrics_update(inserted_metrics_obj.id)
 
+        member = self.member_dao.get(_obj.genomicSetMemberId)
         next_state = GenomicStateHandler.get_new_state(member.genomicWorkflowState, signal=self.ready_signal)
-
-        self.member_dao.update_member_job_run_id(member, self.run_id, 'reconcileMetricsSequencingJobRunId',
-                                                 project_id=self.controller.bq_project_id)
 
         # Handle for missing data files
         if missing_data_files:
             next_state = GenomicStateHandler.get_new_state(member.genomicWorkflowState, signal='missing')
-
             incident = self.controller.incident_dao.get_by_source_file_id(_obj.genomicFileProcessedId)
-
             for file_type in missing_data_files:
                 missing_file_object = GenomicGcDataFileMissing(
                     gc_site_id=_gc_site_id,
@@ -1935,10 +1938,12 @@ class GenomicReconciler:
         member = self.member_dao.get(metric.genomicSetMemberId)
         description = f"{self.job_id.name}: The following AW2 manifests are missing data files."
         description += f"\nGenomic Job Run ID: {self.run_id}"
-        description += self._compile_missing_data_alert(
-            file_name=file.fileName,
-            missing_files=missing_data_files
-        )
+
+        file_list = '\n'.join([mf for mf in missing_data_files])
+        description = f"\nManifest File: {file.fileName}"
+        description += "\nMissing Data File(s):"
+        description += f"\n{file_list}"
+
         self.controller.create_incident(
             source_job_run_id=self.run_id,
             source_file_processed_id=file.id,
@@ -1950,20 +1955,6 @@ class GenomicReconciler:
             collection_tube_id=member.collectionTubeId if member.collectionTubeId else "",
             slack=True
         )
-
-    @staticmethod
-    def _compile_missing_data_alert(file_name, missing_files):
-        """
-        Compiles the description to include in a GenomicAlert
-        :param file_name:
-        :param missing_data: list of files
-        :return: summary, description
-        """
-        file_list = '\n'.join([mf for mf in missing_files])
-        description = f"\nManifest File: {file_name}"
-        description += "\nMissing Data File(s):"
-        description += f"\n{file_list}"
-        return description
 
     def generate_cvl_reconciliation_report(self):
         """
@@ -1978,16 +1969,14 @@ class GenomicReconciler:
             self.cvl_file_name = f"{cvl_subfolder}/cvl_report_{self.run_id}.csv"
             self._write_cvl_report_to_file(members)
 
-            results = []
-            for member in members:
-                results.append(self.member_dao.update_member_job_run_id(
-                    member, job_run_id=self.run_id,
-                    field='reconcileCvlJobRunId')
-                )
+            payload = {
+                'member_ids': [m.id for m in members],
+                'job_run_id': self.run_id,
+                'field': 'reconcileCvlJobRunId',
+            }
+            self.controller.execute_cloud_task(payload, 'genomic_set_member_job_run_task')
 
-            return GenomicSubProcessResult.SUCCESS \
-                if GenomicSubProcessResult.ERROR not in results \
-                else GenomicSubProcessResult.ERROR
+            return GenomicSubProcessResult.SUCCESS
 
         return GenomicSubProcessResult.NO_FILES
 
@@ -3014,13 +3003,15 @@ class ManifestCompiler:
     This component compiles Genomic manifests
     based on definitions provided by ManifestDefinitionProvider
     """
-    def __init__(self, run_id, bucket_name=None, max_num=None):
+    def __init__(self, run_id, bucket_name=None, max_num=None, controller=None):
         self.run_id = run_id
         self.bucket_name = bucket_name
         self.max_num = max_num
+        self.controller = controller
         self.output_file_name = None
         self.manifest_def = None
         self.def_provider = None
+
         # Dao components
         self.member_dao = GenomicSetMemberDao()
         self.metrics_dao = GenomicGCValidationMetricsDao()
@@ -3090,22 +3081,16 @@ class ManifestCompiler:
                 )
                 self._write_and_upload_manifest(source_data)
 
-            results = []
+            member_ids = []
             record_count = len(source_data)
             for row in source_data:
                 member = self.member_dao.get_member_from_sample_id(row.sample_id, genome_type)
-
                 if member is None:
                     raise NotFound(f"Cannot find genomic set member with sample ID {row.sample_id}")
 
                 if self.manifest_def.job_run_field is not None:
-                    results.append(
-                        self.member_dao.update_member_job_run_id(
-                            member,
-                            job_run_id=self.run_id,
-                            field=self.manifest_def.job_run_field
-                        )
-                    )
+                    member_ids.append(member.id)
+
                 # Handle Genomic States for manifests
                 if self.manifest_def.signal != "bypass":
                     new_state = GenomicStateHandler.get_new_state(member.genomicWorkflowState,
@@ -3114,18 +3099,22 @@ class ManifestCompiler:
                     if new_state is not None or new_state != member.genomicWorkflowState:
                         self.member_dao.update_member_state(member, new_state)
 
-            # Assemble result dict
-            result_code = GenomicSubProcessResult.SUCCESS \
-                if GenomicSubProcessResult.ERROR not in results \
-                else GenomicSubProcessResult.ERROR
+            if member_ids:
+                payload = {
+                    'member_ids': member_ids,
+                    'job_run_id': self.run_id,
+                    'field': self.manifest_def.job_run_field,
+                }
+                self.controller.execute_cloud_task(payload, 'genomic_set_member_job_run_task')
 
             result = {
-                "code": result_code,
+                "code": GenomicSubProcessResult.SUCCESS,
                 "record_count": record_count,
             }
             return result
 
         logging.info(f'No records found for manifest type: {manifest_type}.')
+
         return {
             "code": GenomicSubProcessResult.NO_FILES,
             "record_count": 0,

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -10,13 +10,16 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from rdr_service import clock, config
 from rdr_service.api_util import list_blobs
-
+from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.config import (
+    GAE_PROJECT,
     GENOMIC_GC_METRICS_BUCKET_NAME,
     getSetting,
     getSettingList,
     GENOME_TYPE_ARRAY,
-    MissingConfigException, RDR_SLACK_WEBHOOKS)
+    MissingConfigException,
+    RDR_SLACK_WEBHOOKS
+)
 from rdr_service.dao.bq_genomics_dao import bq_genomic_job_run_update, bq_genomic_file_processed_update, \
     bq_genomic_manifest_file_update, bq_genomic_manifest_feedback_update, \
     bq_genomic_gc_validation_metrics_batch_update, bq_genomic_set_member_batch_update, \
@@ -888,9 +891,13 @@ class GenomicJobController:
         """
         Creates Genomic manifest using ManifestCompiler component
         """
-        self.manifest_compiler = ManifestCompiler(run_id=self.job_run.id,
-                                                  bucket_name=self.bucket_name,
-                                                  max_num=self.max_num)
+        self.manifest_compiler = ManifestCompiler(
+            run_id=self.job_run.id,
+            bucket_name=self.bucket_name,
+            max_num=self.max_num,
+            controller=self
+        )
+
         try:
             logging.info(f'Running Manifest Compiler for {manifest_type.name}.')
 
@@ -1081,6 +1088,16 @@ class GenomicJobController:
 
         logging.warning(message)
 
+    @staticmethod
+    def execute_cloud_task(payload, endpoint):
+        if GAE_PROJECT != 'localhost':
+            _task = GCPCloudTask()
+            _task.execute(
+                endpoint,
+                payload=payload,
+                queue='genomics'
+            )
+
     def _end_run(self):
         """Updates the genomic_job_run table with end result"""
         self.job_run_dao.update_run_record(
@@ -1179,13 +1196,7 @@ class GenomicJobController:
         :return: sendgrid response
         """
         sg = sendgrid.SendGridAPIClient(api_key=config.getSetting(config.SENDGRID_KEY))
-
         response = sg.client.mail.send.post(request_body=_email)
-
-        # print(response.status_code)
-        # print(response.body)
-        # print(response.headers)
-
         return response
 
 

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -114,10 +114,15 @@ def _build_resource_app():
                       TASK_PREFIX + "CalculateContaminationCategoryApi",
                       endpoint="calculate_contamination_category_task", methods=["POST"])
 
-    # Calculate Contamination Category
+    # Ingest Informing Loop
     _api.add_resource(genomic_cloud_tasks_api.IngestInformingLoopTaskApi,
                       TASK_PREFIX + "IngestInformingLoopTaskApi",
                       endpoint="ingest_informing_loop", methods=["POST"])
+
+    # Update Genomic Set Member Job Run
+    _api.add_resource(genomic_cloud_tasks_api.GenomicSetMemberJobRunApi,
+                      TASK_PREFIX + "GenomicSetMemberJobRunApi",
+                      endpoint="genomic_set_member_job_run_task", methods=["POST"])
 
     #
     # End Genomic Cloud Task API endpoints

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -117,7 +117,7 @@ def _build_resource_app():
     # Ingest Informing Loop
     _api.add_resource(genomic_cloud_tasks_api.IngestInformingLoopTaskApi,
                       TASK_PREFIX + "IngestInformingLoopTaskApi",
-                      endpoint="ingest_informing_loop", methods=["POST"])
+                      endpoint="ingest_informing_loop_task", methods=["POST"])
 
     # Update Genomic Set Member Job Run
     _api.add_resource(genomic_cloud_tasks_api.GenomicSetMemberJobRunApi,

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -785,3 +785,33 @@ class GenomicCloudTasksApiTest(BaseTestCase):
         self.assertEqual(len(inserted_files), len(test_file_paths))
         self.assertTrue(all([file for file in inserted_files if file.bucket_name == test_bucket_baylor]))
         self.assertTrue(all([file for file in inserted_files if file.file_path in test_file_paths]))
+
+    @mock.patch('rdr_service.dao.genomics_dao.GenomicSetMemberDao.update_member_job_run_id')
+    def test_set_member_job_run_api(self, update_mock):
+
+        data = {
+            'member_ids': [],
+        }
+
+        from rdr_service.resource import main as resource_main
+
+        update_member = self.send_post(
+            local_path='GenomicSetMemberJobRunApi',
+            request_data=data,
+            prefix="/resource/task/",
+            test_client=resource_main.app.test_client(),
+        )
+
+        self.assertFalse(update_member['success'])
+
+        data['member_ids'] = [1, 2, 3]
+
+        update_member = self.send_post(
+            local_path='GenomicSetMemberJobRunApi',
+            request_data=data,
+            prefix="/resource/task/",
+            test_client=resource_main.app.test_client(),
+        )
+
+        self.assertTrue(update_mock.called)
+        self.assertTrue(update_member['success'])

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1023,7 +1023,8 @@ class GenomicPipelineTest(BaseTestCase):
         self.assertEqual(GenomicSubProcessResult.SUCCESS, self.job_run_dao.get(1).runResult)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, self.job_run_dao.get(2).runResult)
 
-    def test_gc_metrics_reconciliation_vs_array_data(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_gc_metrics_reconciliation_vs_array_data(self, cloud_task):
 
         # Create the fake ingested data
         self._create_fake_datasets_for_gc_tests(3, arr_override=True, array_participants=[1, 2, 3],
@@ -1094,6 +1095,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 2
 
+        self.assertTrue(cloud_task.called)
+
         gc_record = self.metrics_dao.get(1)
 
         # Test the gc_metrics were updated with reconciliation data
@@ -1125,12 +1128,10 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test member updated with job ID
         member = self.member_dao.get(1)
-        self.assertEqual(2, member.reconcileMetricsSequencingJobRunId)
         self.assertEqual(GenomicWorkflowState.AW2_MISSING, member.genomicWorkflowState)
 
         # Test member updated with job ID
         member = self.member_dao.get(2)
-        self.assertEqual(2, member.reconcileMetricsSequencingJobRunId)
         self.assertEqual(GenomicWorkflowState.GEM_READY, member.genomicWorkflowState)
 
         missing_file = self.missing_file_dao.get(1)
@@ -1151,7 +1152,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    def test_aw2_wgs_reconciliation_vs_wgs_data(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_aw2_wgs_reconciliation_vs_wgs_data(self, cloud_task):
 
         # Create the fake ingested data
         self._create_fake_datasets_for_gc_tests(3, genome_center='rdr', genomic_workflow_state=GenomicWorkflowState.AW1)
@@ -1203,6 +1205,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_wgs_data()  # run_id = 2
 
+        self.assertTrue(cloud_task.called)
+
         gc_record = self.metrics_dao.get(1)
 
         # Test the gc_metrics were updated with reconciliation data
@@ -1224,7 +1228,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test member updated with job ID and state
         member = self.member_dao.get(2)
-        self.assertEqual(2, member.reconcileMetricsSequencingJobRunId)
         self.assertEqual(GenomicWorkflowState.AW2_MISSING, member.genomicWorkflowState)
 
         missing_file = self.missing_file_dao.get(1)
@@ -2311,7 +2314,8 @@ class GenomicPipelineTest(BaseTestCase):
         self.assertEqual(GenomicJob.AW1F_ALERTS, job_run.jobId)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, job_run.runResult)
 
-    def test_gem_a1_manifest_end_to_end(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_gem_a1_manifest_end_to_end(self, cloud_task):
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
                                               startTime=clock.CLOCK.now(),
@@ -2398,6 +2402,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 3
 
+        self.assertTrue(cloud_task.called)
+
         # finally run the manifest workflow
         bucket_name = config.getSetting(config.GENOMIC_GEM_BUCKET_NAME)
         a1_time = datetime.datetime(2020, 4, 1, 0, 0, 0, 0)
@@ -2424,7 +2430,6 @@ class GenomicPipelineTest(BaseTestCase):
                 GenomicSetMember.id == 1
             ).one()
 
-        self.assertEqual(4, test_member_1.gemA1ManifestJobRunId)
         self.assertEqual(GenomicWorkflowState.A1, test_member_1.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -2561,7 +2566,8 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(2)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    def test_gem_a3_manifest_workflow(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_gem_a3_manifest_workflow(self, cloud_task):
         # Create A1 manifest job run: id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.GEM_A1_MANIFEST,
                                               startTime=clock.CLOCK.now(),
@@ -2595,15 +2601,15 @@ class GenomicPipelineTest(BaseTestCase):
         with clock.FakeClock(fake_now):
             genomic_pipeline.gem_a3_manifest_workflow()  # run_id 2
 
+        self.assertTrue(cloud_task.called)
+
         # Test the members' job run ID
         # Picked up by job
         test_member_3 = self.member_dao.get(3)
-        self.assertEqual(2, test_member_3.gemA3ManifestJobRunId)
         self.assertEqual(GenomicWorkflowState.GEM_RPT_DELETED, test_member_3.genomicWorkflowState)
 
         # picked up by job
         test_member_2 = self.member_dao.get(2)
-        self.assertEqual(2, test_member_2.gemA3ManifestJobRunId)
         self.assertEqual(GenomicWorkflowState.GEM_RPT_DELETED, test_member_2.genomicWorkflowState)
 
         members = self.member_dao.get_all()
@@ -2651,7 +2657,8 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(2)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    def test_cvl_w1_manifest(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_cvl_w1_manifest(self, cloud_task):
 
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
@@ -2714,6 +2721,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_wgs_data()  # run_id = 3
 
+        self.assertTrue(cloud_task.called)
+
         # Run the W1 manifest workflow
         fake_dt = datetime.datetime(2020, 4, 3, 0, 0, 0, 0)
 
@@ -2724,7 +2733,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test member was updated
         member = self.member_dao.get(2)
-        self.assertEqual(4, member.cvlW1ManifestJobRunId)
         self.assertEqual(GenomicWorkflowState.W1, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -2819,7 +2827,8 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(2)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    def test_cvl_w3_manifest_generation(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_cvl_w3_manifest_generation(self, cloud_task):
         # Create W1 manifest job run: id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.CREATE_CVL_W1_MANIFESTS,
                                               startTime=clock.CLOCK.now(),
@@ -2841,9 +2850,10 @@ class GenomicPipelineTest(BaseTestCase):
         with clock.FakeClock(fake_now):
             genomic_pipeline.create_cvl_w3_manifest()  # run_id 2
 
+        self.assertTrue(cloud_task.called)
+
         # Test member was updated
         member = self.member_dao.get(1)
-        self.assertEqual(2, member.cvlW3ManifestJobRunID)
         self.assertEqual(GenomicWorkflowState.W3, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -2887,7 +2897,8 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(2)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    def test_aw3_array_manifest_generation(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_aw3_array_manifest_generation(self, cloud_task):
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
                                               startTime=clock.CLOCK.now(),
@@ -2957,6 +2968,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 3
 
+        self.assertTrue(cloud_task.called)
+
         # finally run the AW3 manifest workflow
         fake_dt = datetime.datetime(2020, 8, 3, 0, 0, 0, 0)
 
@@ -2967,8 +2980,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test member was updated
         member = self.member_dao.get(2)
-
-        self.assertEqual(4, member.aw3ManifestJobRunID)
         self.assertEqual(GenomicWorkflowState.GEM_READY, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -3030,7 +3041,8 @@ class GenomicPipelineTest(BaseTestCase):
 
             self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    def test_aw3_array_manifest_with_max_num(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_aw3_array_manifest_with_max_num(self, cloud_task):
         stored_samples = [
             (1, 1001),
             (2, 1002),
@@ -3108,11 +3120,12 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 3
 
+        self.assertTrue(cloud_task.called)
+
         with clock.FakeClock(fake_dt):
             genomic_pipeline.aw3_array_manifest_workflow(max_num=3)  # run_id = 4
 
         member = self.member_dao.get(2)
-        self.assertEqual(4, member.aw3ManifestJobRunID)
         self.assertEqual(GenomicWorkflowState.GEM_READY, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -3155,7 +3168,8 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(4)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    def test_aw3_wgs_manifest_generation(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_aw3_wgs_manifest_generation(self, cloud_task):
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
                                               startTime=clock.CLOCK.now(),
@@ -3228,6 +3242,8 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_wgs_data()  # run_id = 3
 
+        self.assertTrue(cloud_task.called)
+
         # finally run the AW3 manifest workflow
         fake_dt = datetime.datetime(2020, 8, 3, 0, 0, 0, 0)
 
@@ -3238,8 +3254,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test member was updated
         member = self.member_dao.get(2)
-
-        self.assertEqual(4, member.aw3ManifestJobRunID)
         self.assertEqual(GenomicWorkflowState.CVL_READY, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -3405,7 +3419,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Test member was updated
         member = self.member_dao.get(2)
-        self.assertEqual(4, member.aw3ManifestJobRunID)
         self.assertEqual(GenomicWorkflowState.CVL_READY, member.genomicWorkflowState)
 
         # Test the manifest file contents
@@ -3847,7 +3860,8 @@ class GenomicPipelineTest(BaseTestCase):
         # manifest_feedback
         self.assertEqual(1, feedback_record.inputManifestFileId)
 
-    def test_aw2f_manifest_generation_e2e(self):
+    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
+    def test_aw2f_manifest_generation_e2e(self, cloud_task):
         # Create test genomic members
         self._create_fake_datasets_for_gc_tests(3, arr_override=True,
                                                 array_participants=range(1, 4),
@@ -3927,18 +3941,14 @@ class GenomicPipelineTest(BaseTestCase):
         with clock.FakeClock(fake_dt):
             genomic_pipeline.scan_and_complete_feedback_records()  # run_id = 4 & 5
 
+        self.assertTrue(cloud_task.called)
+
         # Test manifest feedback record was updated
         manifest_feedback_record = self.manifest_feedback_dao.get(1)
 
         self.assertEqual(1, manifest_feedback_record.inputManifestFileId)  # id = 1 is the AW1
         self.assertEqual(2, manifest_feedback_record.feedbackManifestFileId)  # id = 2 is the AW2F
 
-        # check aw2f_job_run_id
-        members = self.member_dao.get_all()
-
-        for member in members:
-            if member.id in (1, 2):
-                self.assertEqual(7, member.aw2fManifestJobRunID)
 
         # Test the manifest file contents
         expected_aw2f_columns = (

--- a/tests/dao_tests/test_genomic_dao.py
+++ b/tests/dao_tests/test_genomic_dao.py
@@ -1,0 +1,57 @@
+from rdr_service import clock
+from rdr_service.dao.genomics_dao import GenomicSetMemberDao
+from rdr_service.genomic_enums import GenomicJob, GenomicSubProcessResult
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class GenomicDaoTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.member_dao = GenomicSetMemberDao()
+
+    def test_update_member_job_run_id(self):
+        bad_field_passed = self.member_dao.update_member_job_run_id([], 1, 'badFieldName')
+        self.assertEqual(bad_field_passed, GenomicSubProcessResult.ERROR)
+
+        gen_set = self.data_generator.create_database_genomic_set(
+            genomicSetName=".",
+            genomicSetCriteria=".",
+            genomicSetVersion=1
+        )
+
+        gen_job_run = self.data_generator.create_database_genomic_job_run(
+            jobId=GenomicJob.AW1_MANIFEST,
+            startTime=clock.CLOCK.now(),
+            runResult=GenomicSubProcessResult.SUCCESS
+        )
+
+        for num in range(6):
+            self.data_generator.create_database_genomic_set_member(
+                genomicSetId=gen_set.id,
+                biobankId="11111111",
+                sampleId="222222222222",
+                genomeType="aou_wgs",
+            )
+
+        members = self.member_dao.get_all()
+        member_ids = [m.id for m in members]
+
+        mid = len(member_ids) // 2
+        first = member_ids[:mid]
+        second = member_ids[mid:]
+
+        first_set = self.member_dao.update_member_job_run_id(first, gen_job_run.id, 'gemA1ManifestJobRunId')
+
+        self.assertEqual(first_set, GenomicSubProcessResult.SUCCESS)
+
+        for num in first:
+            member = self.member_dao.get(num)
+            self.assertEqual(member.gemA1ManifestJobRunId, gen_job_run.id)
+
+        second_set = self.member_dao.update_member_job_run_id(second, gen_job_run.id, 'aw3ManifestJobRunID')
+
+        self.assertEqual(second_set, GenomicSubProcessResult.SUCCESS)
+
+        for num in second:
+            member = self.member_dao.get(num)
+            self.assertEqual(member.aw3ManifestJobRunID, gen_job_run.id)


### PR DESCRIPTION
## Resolves *[ticket DA-2148]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2148

## Description of changes/additions
Moving GenomicSetMember job run an update to cloud task for mitigating memory usage in-app as well as sending ids instead of objects for more peformance.

## Tests
- [x] unit tests


