### PR TITLE
Bumping Py CircleCI image to 3.7.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 job_defaults: &job_defaults
   docker:
-    - image: circleci/python:3.7.5
+    - image: circleci/python:3.7.11
   working_directory: ~/all-of-us/raw-data-repository
   parallelism: 1
   shell: /bin/bash --login


### PR DESCRIPTION
## Resolves *[ticket N/A]


## Description of changes/additions
Need to bump the Circle CI version python version

## Tests
- [] unit tests


