### PR TITLE
[DA-2117] retention_cronjob_for_stable

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -154,3 +154,8 @@ cron:
   timezone: America/New_York
   schedule: every sunday 3:00
   target: offline
+- description: Calculate retention metrics
+  url: /offline/UpdateRetentionEligibleMetrics
+  timezone: America/New_York
+  schedule: every day 1:15
+  target: offline

--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -1,4 +1,5 @@
 cron:
+- description: Calculate retention metrics
 - description: Validate the previous day's consent files
   url: /offline/ValidateConsentFiles
   schedule: every day 02:00

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -32,6 +32,7 @@ from rdr_service.offline.import_hpo_lite_pairing import HpoLitePairingImporter
 from rdr_service.offline.enrollment_check import check_enrollment
 from rdr_service.offline.exclude_ghost_participants import mark_ghost_participants
 from rdr_service.offline.participant_counts_over_time import calculate_participant_metrics
+from rdr_service.offline.retention_eligible_import import calculate_retention_eligible_metrics
 from rdr_service.offline.participant_maint import skew_duplicate_last_modified
 from rdr_service.offline.patient_status_backfill import backfill_patient_status
 from rdr_service.offline.public_metrics_export import LIVE_METRIC_SET_ID, PublicMetricsExport
@@ -195,6 +196,14 @@ def delete_old_keys():
 @_alert_on_exceptions
 def participant_counts_over_time():
     calculate_participant_metrics()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
+@_alert_on_exceptions
+def update_retention_eligible_metrics():
+    # This for for lower env only
+    calculate_retention_eligible_metrics()
     return '{"success": "true"}'
 
 
@@ -667,6 +676,13 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "ParticipantCountsOverTime",
         endpoint="participant_counts_over_time",
         view_func=participant_counts_over_time,
+        methods=["GET"],
+    )
+
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "UpdateRetentionEligibleMetrics",
+        endpoint="update_retention_eligible_metrics",
+        view_func=update_retention_eligible_metrics,
         methods=["GET"],
     )
 

--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -1,6 +1,8 @@
 import logging
+import datetime
 
 from dateutil.parser import parse
+from rdr_service.clock import CLOCK
 from rdr_service.storage import GoogleCloudStorageCSVReader
 from rdr_service.dao.retention_eligible_metrics_dao import RetentionEligibleMetricsDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
@@ -72,6 +74,7 @@ _BATCH_SIZE = 1000
 #     ParticipantSummaryDao().bulk_update_retention_eligible_flags(upload_date)
 #     logging.info(f"Import and update completed for gs://{csv_file_cloud_path}")
 
+
 def import_retention_eligible_metrics_file(task_data):
     """
     Import PTSC retention eligible metric file from bucket.
@@ -106,6 +109,152 @@ def import_retention_eligible_metrics_file(task_data):
     logging.info(f"Updating participant summary retention eligible flags for {upsert_count} participants...")
     ParticipantSummaryDao().bulk_update_retention_eligible_flags(upload_date)
     logging.info(f"Import and update completed for gs://{csv_file_cloud_path}")
+
+
+def calculate_retention_eligible_metrics():
+    # Calculate retention eligible metrics
+    # This method is for lower env only, Prod env will import from file use above method
+    retention_window = datetime.timedelta(days=547)
+    eighteen_month_ago = CLOCK.now() - retention_window
+    eighteen_month_ago_str = eighteen_month_ago.strftime('%Y-%m-%d %H:%M:%S')
+    update_sql = """
+        UPDATE participant_summary
+        SET retention_eligible_status =
+        CASE WHEN
+            consent_for_study_enrollment = 1
+            AND (consent_for_electronic_health_records = 1 OR consent_for_dv_electronic_health_records_sharing = 1)
+            AND questionnaire_on_the_basics = 1
+            AND questionnaire_on_overall_health = 1
+            AND questionnaire_on_lifestyle = 1
+            AND withdrawal_status = 1
+            AND suspension_status = 1
+            AND samples_to_isolate_dna = 1
+            THEN 2 ELSE 1
+        END,
+        retention_eligible_time =
+        CASE WHEN
+            consent_for_study_enrollment = 1
+            AND (consent_for_electronic_health_records = 1 OR consent_for_dv_electronic_health_records_sharing = 1)
+            AND questionnaire_on_the_basics = 1
+            AND questionnaire_on_overall_health = 1
+            AND questionnaire_on_lifestyle = 1
+            AND withdrawal_status = 1
+            AND suspension_status = 1
+            AND samples_to_isolate_dna = 1
+            AND
+              COALESCE(sample_status_1ed10_time, sample_status_2ed10_time, sample_status_1ed04_time,
+                     sample_status_1sal_time, sample_status_1sal2_time, 0) != 0
+            THEN GREATEST(
+                GREATEST (consent_for_study_enrollment_authored,
+                 questionnaire_on_the_basics_authored,
+                 questionnaire_on_overall_health_authored,
+                 questionnaire_on_lifestyle_authored,
+                 COALESCE(consent_for_electronic_health_records_authored, consent_for_study_enrollment_authored),
+                 COALESCE(consent_for_dv_electronic_health_records_sharing_authored, consent_for_study_enrollment_authored)
+                ),
+                LEAST(COALESCE(sample_status_1ed10_time, '9999-01-01'),
+                    COALESCE(sample_status_2ed10_time, '9999-01-01'),
+                    COALESCE(sample_status_1ed04_time, '9999-01-01'),
+                    COALESCE(sample_status_1sal_time, '9999-01-01'),
+                    COALESCE(sample_status_1sal2_time, '9999-01-01')
+                )
+            )
+            ELSE NULL
+        END,
+        retention_type =
+        CASE WHEN
+            consent_for_study_enrollment = 1
+            AND (consent_for_electronic_health_records = 1 OR consent_for_dv_electronic_health_records_sharing = 1)
+            AND questionnaire_on_the_basics = 1
+            AND questionnaire_on_overall_health = 1
+            AND questionnaire_on_lifestyle = 1
+            AND withdrawal_status = 1
+            AND suspension_status = 1
+            AND samples_to_isolate_dna = 1
+            AND (
+                    (questionnaire_on_healthcare_access_authored is not null and
+                     questionnaire_on_healthcare_access_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_family_health_authored is not null and
+                     questionnaire_on_family_health_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_medical_history_authored is not null and
+                     questionnaire_on_medical_history_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_nov_authored is not null
+                        and questionnaire_on_cope_nov_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_july_authored is not null
+                        and questionnaire_on_cope_july_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_june_authored is not null
+                        and questionnaire_on_cope_june_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_dec_authored is not null
+                        and questionnaire_on_cope_dec_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_may_authored is not null
+                        and questionnaire_on_cope_may_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_feb_authored is not null
+                        and questionnaire_on_cope_feb_authored > '{eighteen_month_ago}') or
+                    (consent_cohort = 1 and consent_for_study_enrollment_authored !=
+                                            participant_summary.consent_for_study_enrollment_first_yes_authored and
+                     consent_for_study_enrollment_authored > '{eighteen_month_ago}') or
+                    (consent_cohort = 1 and consent_for_genomics_ror_authored is not null and
+                     consent_for_genomics_ror_authored > '{eighteen_month_ago}') or
+                    (consent_cohort = 2 and consent_for_genomics_ror_authored is not null and
+                     consent_for_genomics_ror_authored > '{eighteen_month_ago}')
+                )
+            AND ehr_update_time is not null and ehr_update_time>'{eighteen_month_ago}'
+            THEN 3
+            WHEN
+            consent_for_study_enrollment = 1
+            AND (consent_for_electronic_health_records = 1 OR consent_for_dv_electronic_health_records_sharing = 1)
+            AND questionnaire_on_the_basics = 1
+            AND questionnaire_on_overall_health = 1
+            AND questionnaire_on_lifestyle = 1
+            AND withdrawal_status = 1
+            AND suspension_status = 1
+            AND samples_to_isolate_dna = 1
+            AND (
+                    (questionnaire_on_healthcare_access_authored is not null and
+                     questionnaire_on_healthcare_access_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_family_health_authored is not null and
+                     questionnaire_on_family_health_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_medical_history_authored is not null and
+                     questionnaire_on_medical_history_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_nov_authored is not null
+                        and questionnaire_on_cope_nov_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_july_authored is not null
+                        and questionnaire_on_cope_july_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_june_authored is not null
+                        and questionnaire_on_cope_june_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_dec_authored is not null
+                        and questionnaire_on_cope_dec_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_may_authored is not null
+                        and questionnaire_on_cope_may_authored > '{eighteen_month_ago}') or
+                    (questionnaire_on_cope_feb_authored is not null
+                        and questionnaire_on_cope_feb_authored > '{eighteen_month_ago}') or
+                    (consent_cohort = 1 and consent_for_study_enrollment_authored !=
+                                            participant_summary.consent_for_study_enrollment_first_yes_authored and
+                     consent_for_study_enrollment_authored > '{eighteen_month_ago}') or
+                    (consent_cohort = 1 and consent_for_genomics_ror_authored is not null and
+                     consent_for_genomics_ror_authored > '{eighteen_month_ago}') or
+                    (consent_cohort = 2 and consent_for_genomics_ror_authored is not null and
+                     consent_for_genomics_ror_authored > '{eighteen_month_ago}')
+                )
+            THEN 1
+            WHEN
+            consent_for_study_enrollment = 1
+            AND (consent_for_electronic_health_records = 1 OR consent_for_dv_electronic_health_records_sharing = 1)
+            AND questionnaire_on_the_basics = 1
+            AND questionnaire_on_overall_health = 1
+            AND questionnaire_on_lifestyle = 1
+            AND withdrawal_status = 1
+            AND suspension_status = 1
+            AND samples_to_isolate_dna = 1
+            THEN 2
+            ELSE 0
+        END
+        WHERE 1=1
+    """.format(eighteen_month_ago=eighteen_month_ago_str)
+
+    dao = ParticipantSummaryDao()
+    with dao.session() as session:
+        session.execute(update_sql)
 
 
 def _parse_field(parser_func, field_str):

--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -3,6 +3,7 @@ import datetime
 
 from dateutil.parser import parse
 from rdr_service.clock import CLOCK
+from rdr_service.app_util import nonprod
 from rdr_service.storage import GoogleCloudStorageCSVReader
 from rdr_service.dao.retention_eligible_metrics_dao import RetentionEligibleMetricsDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
@@ -111,6 +112,7 @@ def import_retention_eligible_metrics_file(task_data):
     logging.info(f"Import and update completed for gs://{csv_file_cloud_path}")
 
 
+@nonprod
 def calculate_retention_eligible_metrics():
     # Calculate retention eligible metrics
     # This method is for lower env only, Prod env will import from file use above method


### PR DESCRIPTION
## Resolves *[DA-2117](https://precisionmedicineinitiative.atlassian.net/browse/DA-2117)*
Create a cronjob to calculate retention metrics for lower envs only

## Description of changes/additions
Instead of import from bucket file, use SQL to calculate retention metrics for lower envs for test purpose.

## Tests
- [x] unit tests


