### PR TITLE
Ks/roc 1130

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -9,6 +9,7 @@ from google.cloud.storage.blob import Blob
 from pdfminer.high_level import extract_pages
 from pdfminer.layout import LTChar, LTCurve, LTFigure, LTImage, LTTextBox
 
+from rdr_service import config
 from rdr_service.storage import GoogleCloudStorageProvider
 
 
@@ -157,7 +158,7 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
         return VibrentGrorConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
 
     def _get_source_bucket(self) -> str:
-        return 'ptc-uploads-all-of-us-rdr-prod'
+        return config.getSettingJson(config.CONSENT_PDF_BUCKET)['vibrent']
 
     def _get_source_prefix(self) -> str:
         return 'Participant'
@@ -189,7 +190,7 @@ class CeConsentFactory(ConsentFileAbstractFactory):
         pass
 
     def _get_source_bucket(self) -> str:
-        return 'ce-uploads-all-of-us-rdr-prod'
+        return config.getSettingJson(config.CONSENT_PDF_BUCKET)['careevolution']
 
     def _get_source_prefix(self) -> str:
         return 'Participants'

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -30,6 +30,10 @@ class ConsentTool(ToolBase):
     def run(self):
         super(ConsentTool, self).run()
 
+        # Overwrite the local config consent buckets with what is available from the target environment
+        server_config = self.get_server_config()
+        config.override_setting(config.CONSENT_PDF_BUCKET, server_config[config.CONSENT_PDF_BUCKET])
+
         if self.args.command == 'report-errors':
             self.report_files_for_correction()
         elif self.args.command == 'modify':

--- a/tests/service_tests/consent_tests/test_consent_factories.py
+++ b/tests/service_tests/consent_tests/test_consent_factories.py
@@ -1,5 +1,6 @@
 import mock
 
+from rdr_service import config
 from rdr_service.services.consent import files
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -12,6 +13,11 @@ class ConsentFactoryTest(BaseTestCase):
     def setUp(self, *args, **kwargs) -> None:
         super(ConsentFactoryTest, self).setUp(*args, **kwargs)
         self.storage_provider_mock = mock.MagicMock()
+
+        # Provide a config value that gives bucket names for the factories to read
+        self.temporarily_override_config_setting(config.CONSENT_PDF_BUCKET, {
+            'vibrent': 'test-bucket-name'
+        })
 
         # Patch the PDF wrapper class to simply return the blob object that was meant to be parsed
         pdf_patcher = mock.patch('rdr_service.services.consent.files.Pdf.from_google_storage_blob')

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -69,7 +69,16 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
             if additional_args:
                 tool_args.update(additional_args)
 
-            self.run_tool(ConsentTool, tool_args, mock_session=True)
+            self.run_tool(
+                ConsentTool,
+                tool_args,
+                mock_session=True,
+                server_config={
+                    config.CONSENT_PDF_BUCKET: {
+                        'vibrent': 'test-bucket-name'
+                    }
+                }
+            )
 
     def test_report_to_send_to_ptsc(self, logger_mock):
         """Check the basic report format, the one that would be sent to Vibrent or CE for correcting"""


### PR DESCRIPTION
## Resolves *[ROC-1130](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1130)*
The testing environments are seeing errors because of prod bucket names being hardcoded into the code. This updates the code to use the config for finding the bucket names.

## Description of changes/additions
When running the code on the server, the config will have the correct data. But running it through a tool would have local data loaded into the config. The tool script retrieves the config data from the target project and then sets that locally so that the validation code can use the same mechanism for getting the bucket names.

## Tests
- [x] unit tests


