### PR TITLE
[DA-2010] removing race data from salivary v2 ML calls

### DIFF
--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -126,6 +126,10 @@ class MailKitOrderDao(UpdatableDao):
             }}
             order['order']['tests'][0]['test'].update(client_fields)
 
+            # The system that the biobank uses to process orders can't take race strings greater than 20 characters
+            # and the race data isn't needed here
+            order['order']['patient']['race'] = None
+
         order['order']['comments'] = "Salivary Kit Order, direct from participant"
         return order, is_version_two
 

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -142,9 +142,10 @@ class MailKitOrderDaoTestBase(BaseTestCase):
         self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field3'])
         self.assertIsNone(mayo_request_test_data['client_passthrough_fields']['field4'])
         self.assertEqual(
-            ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests','comments'],
+            ['collected', 'account', 'number', 'patient', 'physician', 'report_notes', 'tests', 'comments'],
             list(mayo_order_payload.keys())
         )
+        self.assertIsNone(mayo_order_payload['patient']['race'])
 
         # Make sure the correct account is used for version two
         self.mock_mayolinkapi.assert_called_once_with(credentials_key='version_two')


### PR DESCRIPTION
## Additional work for  *[DA-2010](https://precisionmedicineinitiative.atlassian.net/browse/DA-2010)*
For salivary orders the RDR sends the participant's race string as part of the data. For some reason, sending this same data for the v2 salivary orders causes errors in the Biobank system because the strings are too long. After an email chain with Lary and Jordan, we're deciding to remove the race data from the v2 salivary orders.

## Tests
- [x] unit tests


