### PR TITLE
Fixing consent sync recording bug

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -63,9 +63,16 @@ class ConsentDao(BaseDao):
         return query.all()
 
     @classmethod
-    def batch_update_consent_files(cls, session, consent_files: Collection[ConsentFile]):
+    def _batch_update_consent_files_with_session(cls, session, consent_files: Collection[ConsentFile]):
         for file_record in consent_files:
             session.merge(file_record)
+
+    def batch_update_consent_files(self, consent_files: Collection[ConsentFile], session=None):
+        if session is None:
+            with self.session() as dao_session:
+                return self._batch_update_consent_files_with_session(dao_session, consent_files)
+        else:
+            return self._batch_update_consent_files_with_session(session, consent_files)
 
     @classmethod
     def get_validation_results_for_participants(cls, session,

--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -192,7 +192,8 @@ class ConsentSyncController:
                 file.sync_status = ConsentSyncStatus.SYNC_COMPLETE
 
         self._zip_and_upload()
-        self.consent_dao.batch_update_consent_files(file_list)
+        with self.consent_dao.session() as session:
+            self.consent_dao.batch_update_consent_files(file_list, session)
 
     def _zip_and_upload(self):
         if not os.path.isdir(TEMP_CONSENTS_PATH):

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -70,7 +70,7 @@ class StoreResultStrategy(ValidationOutputStrategy):
             existing_results=previous_results,
             results_to_filter=self._results
         )
-        self._consent_dao.batch_update_consent_files(self._session, new_results_to_store)
+        self._consent_dao.batch_update_consent_files(new_results_to_store, self._session)
         self._session.commit()
 
 
@@ -112,7 +112,7 @@ class ReplacementStoringStrategy(ValidationOutputStrategy):
                     )
                     results_to_update.extend(new_results)
 
-        self.consent_dao.batch_update_consent_files(self.session, results_to_update)
+        self.consent_dao.batch_update_consent_files(results_to_update, self.session)
 
     @classmethod
     def _find_file_ready_for_sync(cls, results: List[ParsingResult]):
@@ -272,7 +272,7 @@ class ConsentValidationController:
                         if matching_previous_result is None:
                             validation_updates.append(new_result)
 
-        self.consent_dao.batch_update_consent_files(session, validation_updates)
+        self.consent_dao.batch_update_consent_files(validation_updates, session)
 
     def validate_recent_uploads(self, session, output_strategy: ValidationOutputStrategy, min_consent_date,
                                 max_consent_date=None):

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -105,7 +105,7 @@ class ConsentTool(ToolBase):
                     parser_func=ConsentSyncStatus,
                     callback=lambda parsed_value: setattr(file, 'sync_status', parsed_value)
                 )
-                self._consent_dao.batch_update_consent_files(session, [file])
+                self._consent_dao.batch_update_consent_files([file], session)
 
     def validate_consents(self):
         sync_controller = ConsentSyncController(
@@ -143,7 +143,7 @@ class ConsentTool(ToolBase):
                 data_to_upload.append(ConsentFile(**validation_data))
 
         with self.get_session() as session:
-            self._consent_dao.batch_update_consent_files(session, data_to_upload)
+            self._consent_dao.batch_update_consent_files(data_to_upload, session)
 
     @classmethod
     def _get_date_error_details(cls, file: ConsentFile, verbose: bool = False):

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -172,7 +172,7 @@ class ConsentFileDaoTest(BaseTestCase):
                 result.sync_status = ConsentSyncStatus.OBSOLETE
                 updates_to_send.append(result)
 
-            self.consent_dao.batch_update_consent_files(session, updates_to_send)
+            self.consent_dao.batch_update_consent_files(updates_to_send, session)
             session.commit()
             results = self.consent_dao.get_all()
             self.assertEqual(2, len(results))

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -173,7 +173,7 @@ class ConsentControllerTest(BaseTestCase):
 
     def assertConsentValidationResultsUpdated(self, expected_updates: List[ConsentFile]):
         """Make sure the validation results are sent to the dao"""
-        actual_updates: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[1]
+        actual_updates: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[0]
         self.assertEqual(len(expected_updates), len(actual_updates))
 
         for expected in expected_updates:

--- a/tests/service_tests/consent_tests/test_consent_validation.py
+++ b/tests/service_tests/consent_tests/test_consent_validation.py
@@ -319,7 +319,7 @@ class ConsentValidationTesting(BaseTestCase):
             output_strategy.add_all([new_primary_result, previous_ehr_result, new_gror_result])
 
         # Verify that both records that provide new validation information were stored
-        consent_dao_mock.batch_update_consent_files.assert_called_with(mock.ANY, [new_primary_result, new_gror_result])
+        consent_dao_mock.batch_update_consent_files.assert_called_with([new_primary_result, new_gror_result], mock.ANY)
 
     def _mock_consent(self, consent_class: Type[files.ConsentFile], **kwargs):
         consent_args = {

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -141,7 +141,7 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
                 mock.call('sync_status:    NEEDS_CORRECTING => READY_FOR_SYNC')
             ])
 
-            updated_file = self.consent_dao_mock.batch_update_consent_files.call_args_list[0].args[1][0]
+            updated_file = self.consent_dao_mock.batch_update_consent_files.call_args_list[0].args[0][0]
             self.assertEqual(file_to_update.id, updated_file.id)
             self.assertEqual(ConsentType.CABOR, updated_file.type)
             self.assertEqual(ConsentSyncStatus.READY_FOR_SYNC, updated_file.sync_status)
@@ -211,7 +211,7 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
                     'file': 'data.csv',
                 }
             )
-            uploaded_records: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[1]
+            uploaded_records: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[0]
             self.assertTrue(any([
                 (
                     record.participant_id == '4567'


### PR DESCRIPTION
## Resolves *no ticket*
The consent sync process ends with a call to save information about what consent files were synced. This was crashing because the method to save the consent file objects required a session object. This PR sets up a way for the session object to be option on that method.

## Tests
- [ ] unit tests


