### PR TITLE
Fix to PDR BQ sync process for missing COPE minute surveys

### DIFF
--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -7,6 +7,12 @@ from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao
 from rdr_service.model.bq_base import BQTable, BQSchema, BQView, BQFieldModeEnum, BQFieldTypeEnum
 from rdr_service.code_constants import PPI_SYSTEM
 
+#   NOTE:  IF NEW MODULE CLASSES ARE ADDED TO THIS FILE, TO ENSURE THEY ARE PROPAGATED TO BIGQUERY, INCLUDING
+#   DURING PDR DATA REBUILDS, THE MODULE LISTS IN THE FOLLOWING FILES MUST ALSO BE UPDATED:
+#   rdr_service/resource/tasks.py
+#   rdr_service/tools/tool_libs/resource_tool.py
+#   rdr_service/model/__init__.py
+#
 class _BQModuleSchema(BQSchema):
     """
     Helper for dynamically generating a BQSchema for a specific questionnaire

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -6,13 +6,12 @@
 import logging
 from datetime import datetime
 
+
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao
 from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGenerator, rebuild_bq_participant
 from rdr_service.dao.bq_pdr_participant_summary_dao import BQPDRParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
-from rdr_service.model.bq_questionnaires import BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth, \
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb, BQPDRFamilyHistory, \
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRStopParticipating, BQPDRWithdrawalIntro
+from rdr_service.model import bq_questionnaires as bq_modules
 from rdr_service.resource import generators
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
 
@@ -64,21 +63,23 @@ def batch_rebuild_participants_task(payload, project_id=None):
         if build_modules:
             # Generate participant questionnaire module response data
             modules = (
-                BQPDRConsentPII,
-                BQPDRTheBasics,
-                BQPDRLifestyle,
-                BQPDROverallHealth,
-                BQPDREHRConsentPII,
-                BQPDRDVEHRSharing,
-                BQPDRCOPEMay,
-                BQPDRCOPENov,
-                BQPDRCOPEDec,
-                BQPDRCOPEFeb,
-                BQPDRFamilyHistory,
-                BQPDRPersonalMedicalHistory,
-                BQPDRHealthcareAccess,
-                BQPDRStopParticipating,
-                BQPDRWithdrawalIntro
+                bq_modules.BQPDRConsentPII,
+                bq_modules.BQPDRTheBasics,
+                bq_modules.BQPDRLifestyle,
+                bq_modules.BQPDROverallHealth,
+                bq_modules.BQPDREHRConsentPII,
+                bq_modules.BQPDRDVEHRSharing,
+                bq_modules.BQPDRCOPEMay,
+                bq_modules.BQPDRCOPENov,
+                bq_modules.BQPDRCOPEDec,
+                bq_modules.BQPDRCOPEFeb,
+                bq_modules.BQPDRCopeVaccine1,
+                bq_modules.BQPDRCOPEVaccine2,
+                bq_modules.BQPDRFamilyHistory,
+                bq_modules.BQPDRPersonalMedicalHistory,
+                bq_modules.BQPDRHealthcareAccess,
+                bq_modules.BQPDRStopParticipating,
+                bq_modules.BQPDRWithdrawalIntro
             )
             for module in modules:
                 mod = module()

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -28,12 +28,7 @@ from rdr_service.dao.bq_hpo_dao import bq_hpo_update, bq_hpo_update_by_id
 from rdr_service.dao.bq_organization_dao import bq_organization_update, bq_organization_update_by_id
 from rdr_service.dao.bq_site_dao import bq_site_update, bq_site_update_by_id
 from rdr_service.dao.resource_dao import ResourceDataDao
-from rdr_service.model.bq_questionnaires import (
-    BQPDRConsentPII, BQPDRTheBasics, BQPDRLifestyle, BQPDROverallHealth,
-    BQPDREHRConsentPII, BQPDRDVEHRSharing, BQPDRCOPEMay, BQPDRCOPENov, BQPDRCOPEDec, BQPDRCOPEFeb, BQPDRFamilyHistory,
-    BQPDRHealthcareAccess, BQPDRPersonalMedicalHistory, BQPDRWithdrawalIntro, BQPDRStopParticipating,
-    BQPDRCOPEVaccine1
-)
+from rdr_service.model import bq_questionnaires as bq_modules
 from rdr_service.model.participant import Participant
 from rdr_service.model.retention_eligible_metrics import RetentionEligibleMetrics
 from rdr_service.offline.bigquery_sync import batch_rebuild_participants_task
@@ -89,22 +84,23 @@ class ParticipantResourceClass(object):
                 # Generate participant questionnaire module response data
 
                 modules = (
-                    BQPDRConsentPII,
-                    BQPDRTheBasics,
-                    BQPDRLifestyle,
-                    BQPDROverallHealth,
-                    BQPDREHRConsentPII,
-                    BQPDRDVEHRSharing,
-                    BQPDRCOPEMay,
-                    BQPDRCOPENov,
-                    BQPDRCOPEDec,
-                    BQPDRCOPEFeb,
-                    BQPDRCOPEVaccine1,
-                    BQPDRFamilyHistory,
-                    BQPDRPersonalMedicalHistory,
-                    BQPDRHealthcareAccess,
-                    BQPDRStopParticipating,
-                    BQPDRWithdrawalIntro
+                    bq_modules.BQPDRConsentPII,
+                    bq_modules.BQPDRTheBasics,
+                    bq_modules.BQPDRLifestyle,
+                    bq_modules.BQPDROverallHealth,
+                    bq_modules.BQPDREHRConsentPII,
+                    bq_modules.BQPDRDVEHRSharing,
+                    bq_modules.BQPDRCOPEMay,
+                    bq_modules.BQPDRCOPENov,
+                    bq_modules.BQPDRCOPEDec,
+                    bq_modules.BQPDRCOPEFeb,
+                    bq_modules.BQPDRCOPEVaccine1,
+                    bq_modules.BQPDRCOPEVaccine2,
+                    bq_modules.BQPDRFamilyHistory,
+                    bq_modules.BQPDRPersonalMedicalHistory,
+                    bq_modules.BQPDRHealthcareAccess,
+                    bq_modules.BQPDRStopParticipating,
+                    bq_modules.BQPDRWithdrawalIntro
                 )
 
                 for module in modules:


### PR DESCRIPTION
## Resolves *no ticket*


## Description of changes/additions
COPE minute surveys were left off the resource task/resource tool module lists and were not getting rebuilt during manually initiated PDR data rebuild.  

Changed the import statements since the list of module classes being imported was getting pretty long and unwieldy.

## Tests
- [x] unit tests


