### PR TITLE
Fix CircleCI MySQL install issues.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 job_defaults: &job_defaults
   docker:
-    - image: circleci/python:3.7.11
+    - image: cimg/base:2021.05-18.04
   working_directory: ~/all-of-us/raw-data-repository
   parallelism: 1
   shell: /bin/bash --login
@@ -28,7 +28,7 @@ commands:
           name: Check Licenses
           command : |
             export PYTHONPATH=$PYTHONPATH:`pwd`
-            python ./ci/check_licenses.py --root ./venv/lib/python3.7/site-packages \
+            python3.7 ./ci/check_licenses.py --root ./venv/lib/python3.7/site-packages \
                             --licenses_file ci/license_allowed_list.txt --exceptions_file ci/license_exceptions.txt
       - run:
           name: Install MySQL Server

--- a/ci/install_mysql.sh
+++ b/ci/install_mysql.sh
@@ -7,20 +7,20 @@ export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update
 sudo apt-get -y install lsb-release
 mkdir ~/tmp_mysql && cd ~/tmp_mysql/
-curl -LO https://dev.mysql.com/get/mysql-apt-config_0.8.14-1_all.deb
+curl -LO https://dev.mysql.com/get/mysql-apt-config_0.8.18-1_all.deb
 sudo debconf-set-selections <<< 'mysql-apt-config mysql-apt-config/select-preview select '
 sudo debconf-set-selections <<< 'mysql-apt-config mysql-apt-config/select-product select Ok'
 sudo debconf-set-selections <<< 'mysql-apt-config mysql-apt-config/select-server select mysql-5.7'
 sudo debconf-set-selections <<< 'mysql-apt-config mysql-apt-config/select-tools select '
 sudo debconf-set-selections <<< 'mysql-apt-config mysql-apt-config/unsupported-platform select abort'
-dpkg -c mysql-apt-config_0.8.14-1_all.deb
-sudo -E dpkg -i mysql-apt-config_0.8.14-1_all.deb
+dpkg -c mysql-apt-config_0.8.18-1_all.deb
+sudo -E dpkg -i mysql-apt-config_0.8.18-1_all.deb
 sudo apt-get update
 sudo debconf-set-selections <<< "mysql-community-server mysql-community-server/root-pass password root"
 sudo debconf-set-selections <<< "mysql-community-server mysql-community-server/re-root-pass password root"
 sudo -E apt-get -y install mysql-community-server
-sudo chmod 660 /var/log/mysql/error.log
-sudo chmod 750 /var/log/mysql
+sudo chmod 666 /var/log/mysql/error.log
+sudo chmod 755 /var/log/mysql
 sudo chmod 775 /var/log
 sudo chmod 755 /var
 export MYSQL_ROOT_PASSWORD=root

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -3,7 +3,9 @@
 #
 # Install the python library requirements
 #
-python3 -m venv venv
+sudo apt-get update
+sudo apt-get install python3.7-venv python3-pip libpython3.7-dev libmysqlclient-dev
+python3.7 -m venv venv
 source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"


### PR DESCRIPTION
Oracle MySQL 5.7 will not install on newer Ubuntu versions than 18.04.  (See [MySQL Support Matrix](https://www.mysql.com/support/supportedplatforms/database.html) )
Select Ubuntu 18.04 for image so we can use MySQL 5.7.
Install python 3.7 virtual environment package manually and force python 3.7 usage.



