### PR TITLE
[DA-2087] Script for sending batches of ids to server for validation

### DIFF
--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -3,11 +3,15 @@ import csv
 from datetime import datetime, timedelta
 from dateutil.parser import parse
 
+import requests
+
 from rdr_service import config
+from rdr_service.app_util import BatchManager
 from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_dao import ParticipantHistoryDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.services.gcp_utils import gcp_make_auth_header
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
 from rdr_service.offline.sync_consent_files import ConsentSyncGuesser
 from rdr_service.services.consent.validation import ConsentValidationController, LogResultStrategy, StoreResultStrategy
@@ -26,13 +30,26 @@ class ConsentTool(ToolBase):
         super(ConsentTool, self).__init__(*args, **kwargs)
         self._consent_dao = ConsentDao()
         self._storage_provider = GoogleCloudStorageProvider()
+        self._sever_config = None
+
+    def run_process(self):
+        # start a gcp environment without the service account to retrieve the config without permission issues
+        with self.initialize_process_context(
+            self.tool_cmd,
+            self.args.project,
+            self.args.account,
+            service_account=''
+        ) as gcp_env:
+            self.gcp_env = gcp_env
+            self._sever_config = self.get_server_config()
+
+        super(ConsentTool, self).run_process()
 
     def run(self):
         super(ConsentTool, self).run()
 
         # Overwrite the local config consent buckets with what is available from the target environment
-        server_config = self.get_server_config()
-        config.override_setting(config.CONSENT_PDF_BUCKET, server_config[config.CONSENT_PDF_BUCKET])
+        config.override_setting(config.CONSENT_PDF_BUCKET, self._sever_config[config.CONSENT_PDF_BUCKET])
 
         if self.args.command == 'report-errors':
             self.report_files_for_correction()
@@ -44,6 +61,31 @@ class ConsentTool(ToolBase):
             self.upload_records()
         elif self.args.command == 'check-retro-sync':
             self.check_retro_sync()
+        elif self.args.command == 'retro-validation':
+            self.retro_validate()
+
+    def _call_server_for_retro_validation(self, participant_ids):
+        if len(participant_ids) > 0:
+            print(f'Processing batch that starts with {participant_ids[0]}')
+
+        response = requests.post(
+            'https://offline-dot-all-of-us-rdr-prod.appspot.com/offline/ManuallyValidateFiles',
+            headers=gcp_make_auth_header(),
+            json={
+                'ids': participant_ids
+            }
+        )
+
+        if response.status_code != 200:
+            exit(1)  # Exiting program to prevent further calls with a bad key
+
+    def retro_validate(self):
+        with self.get_session() as session:
+            participant_summaries = ConsentDao.get_participants_needing_validation(session=session)
+
+        with BatchManager(batch_size=10, callback=self._call_server_for_retro_validation) as batch_manager:
+            for summary in participant_summaries:
+                batch_manager.add(summary.participantId)
 
     def check_retro_sync(self):
         with self.get_session() as session:
@@ -221,6 +263,7 @@ def add_additional_arguments(parser: argparse.ArgumentParser):
     )
 
     subparsers.add_parser('check-retro-sync')
+    subparsers.add_parser('retro-validation')
 
 
 def run():


### PR DESCRIPTION
## Partially Resolves *[DA-2087](https://precisionmedicineinitiative.atlassian.net/browse/DA-2087)*
This adds functionality to the consents script to be able to send batches of participant ids to the offline server for validating their consent files. Each request to the server will contain 10 participants (each batch completes within 50 seconds), and each run of the script to perform this process will validate the files for 5000 participants that don't have any files validated (each run completes in about 2 hours).

This also adds a `BatchManager` class to help encapsulate some of the pattern that we're developing in processing batches of objects (collecting them in a list and comparing them to a specific threshold, and making sure to process any remaining items that didn't make a full batch at the end).

Running the script with a SA also causes an error (because the SA doesn't have permission to the config). So this retrieves the config before activating an environment with the SA.

## Tests
- [x] unit tests


