### PR TITLE
[DA-2086] Validation for Primary Consent Update

### DIFF
--- a/rdr_service/model/consent_file.py
+++ b/rdr_service/model/consent_file.py
@@ -12,6 +12,7 @@ class ConsentType(messages.Enum):
     EHR = 3
     GROR = 4
     UNKNOWN = 5
+    PRIMARY_UPDATE = 6
 
 
 class ConsentSyncStatus(messages.Enum):
@@ -23,7 +24,6 @@ class ConsentSyncStatus(messages.Enum):
     LEGACY = 5
     DELAYING_SYNC = 6
     UNKNOWN = 7
-
 
 
 class ConsentFile(Base):

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -164,7 +164,7 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
         return (
             basename(blob_wrapper.blob.name).startswith('PrimaryConsentUpdate')
             and blob_wrapper.get_parsed_pdf().get_page_number_of_text([
-                "Do you agree to this updated consent?"
+                'Do you agree to this updated consent?'
             ]) is not None
         )
 

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -347,7 +347,7 @@ class ConsentValidationController:
 
     @classmethod
     def _has_primary_update_consent(cls, summary: ParticipantSummary, min_authored=None):
-        if min_authored is None and summary.consentForStudyEnrollmentAuthored > min_authored:
+        if min_authored is None or summary.consentForStudyEnrollmentAuthored > min_authored:
             return (
                 summary.consentCohort == 1 and
                 summary.consentForStudyEnrollmentAuthored.date() !=

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -10,7 +10,7 @@ from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.consent_file import ConsentFile as ParsingResult, ConsentSyncStatus, ConsentType
 from rdr_service.model.participant_summary import ParticipantSummary
-from rdr_service.participant_enums import QuestionnaireStatus
+from rdr_service.participant_enums import ParticipantCohort, QuestionnaireStatus
 from rdr_service.services.consent import files
 from rdr_service.storage import GoogleCloudStorageProvider
 
@@ -349,7 +349,7 @@ class ConsentValidationController:
     def _has_primary_update_consent(cls, summary: ParticipantSummary, min_authored=None):
         if min_authored is None or summary.consentForStudyEnrollmentAuthored > min_authored:
             return (
-                summary.consentCohort == 1 and
+                summary.consentCohort == ParticipantCohort.COHORT_1 and
                 summary.consentForStudyEnrollmentAuthored.date() !=
                 summary.consentForStudyEnrollmentFirstYesAuthored.date()
             )
@@ -448,19 +448,40 @@ class ConsentValidator:
         )
 
     def get_primary_update_validation_results(self) -> List[ParsingResult]:
+        def extra_primary_update_checks(consent: files.PrimaryConsentUpdateFile, result):
+            errors_detected = []
+
+            if not consent.is_agreement_selected():
+                errors_detected.append('missing consent check mark')
+
+            va_version_error_str = self._check_for_va_version_mismatch(consent)
+            if va_version_error_str:
+                errors_detected.append(va_version_error_str)
+
+            if errors_detected:
+                result.other_errors = ', '.join(errors_detected)
+                result.sync_status = ConsentSyncStatus.NEEDS_CORRECTING
+
         return self._generate_validation_results(
             consent_files=self.factory.get_primary_update_consents(),
             consent_type=ConsentType.PRIMARY_UPDATE,
+            additional_validation=extra_primary_update_checks,
             expected_sign_datetime=self.participant_summary.consentForStudyEnrollmentAuthored
         )
 
-    def _validate_is_va_file(self, consent, result: ParsingResult):
+    def _check_for_va_version_mismatch(self, consent):
         is_va_consent = consent.get_is_va_consent()
         if self.participant_summary.hpoId == self.va_hpo_id and not is_va_consent:
-            result.other_errors = 'non-veteran consent for veteran participant'
-            result.sync_status = ConsentSyncStatus.NEEDS_CORRECTING
+            return 'non-veteran consent for veteran participant'
         elif self.participant_summary.hpoId != self.va_hpo_id and is_va_consent:
-            result.other_errors = 'veteran consent for non-veteran participant'
+            return 'veteran consent for non-veteran participant'
+
+        return None
+
+    def _validate_is_va_file(self, consent, result: ParsingResult):
+        mismatch_error_str = self._check_for_va_version_mismatch(consent)
+        if mismatch_error_str:
+            result.other_errors = mismatch_error_str
             result.sync_status = ConsentSyncStatus.NEEDS_CORRECTING
 
     def _generate_validation_results(self, consent_files: List[files.ConsentFile], consent_type: ConsentType,

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -102,20 +102,24 @@ class ConsentControllerTest(BaseTestCase):
         self.consent_dao_mock.get_participants_with_consents_in_range.return_value = [
             ParticipantSummary(
                 consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
+                consentForStudyEnrollmentAuthored=min_consent_date_checked,  # Needs to be set for PrimaryUpdate check
                 consentForStudyEnrollmentFirstYesAuthored=min_consent_date_checked + timedelta(days=5),
                 consentForElectronicHealthRecords=QuestionnaireStatus.SUBMITTED,
                 consentForElectronicHealthRecordsAuthored=min_consent_date_checked + timedelta(days=10)
             ),
             ParticipantSummary(
                 consentForCABoR=QuestionnaireStatus.SUBMITTED,
+                consentForStudyEnrollmentAuthored=min_consent_date_checked,  # Needs to be set for PrimaryUpdate check
                 consentForCABoRAuthored=min_consent_date_checked + timedelta(days=5)
             ),
             ParticipantSummary(
                 consentForGenomicsROR=QuestionnaireStatus.SUBMITTED,
+                consentForStudyEnrollmentAuthored=min_consent_date_checked,  # Needs to be set for PrimaryUpdate check
                 consentForGenomicsRORAuthored=min_consent_date_checked - timedelta(days=5)
             ),
             ParticipantSummary(
                 consentForGenomicsROR=QuestionnaireStatus.SUBMITTED_NOT_SURE,
+                consentForStudyEnrollmentAuthored=min_consent_date_checked,  # Needs to be set for PrimaryUpdate check
                 consentForGenomicsRORAuthored=min_consent_date_checked + timedelta(days=20)
             )
         ]
@@ -154,6 +158,7 @@ class ConsentControllerTest(BaseTestCase):
         self.consent_dao_mock.get_participants_with_consents_in_range.return_value = [
             ParticipantSummary(
                 consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
+                consentForStudyEnrollmentAuthored=datetime(2020, 5, 1),  # Needs to be set for PrimaryUpdate check
                 consentForStudyEnrollmentFirstYesAuthored=min_consent_date_checked + timedelta(days=5)
             )
         ]

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -175,7 +175,6 @@ class ConsentControllerTest(BaseTestCase):
             ]
         )
 
-
     def assertConsentValidationResultsUpdated(self, expected_updates: List[ConsentFile]):
         """Make sure the validation results are sent to the dao"""
         actual_updates: List[ConsentFile] = self.consent_dao_mock.batch_update_consent_files.call_args.args[1]

--- a/tests/service_tests/consent_tests/test_consent_factories.py
+++ b/tests/service_tests/consent_tests/test_consent_factories.py
@@ -40,6 +40,10 @@ class ConsentFactoryTest(BaseTestCase):
         self.another_ehr = self._mock_pdf(name='EHRConsentPII_2.pdf')
         self.signature_image = self._mock_pdf(name='EHRConsentPII.png')
         self.gror_file = self._mock_pdf(name='GROR_234.pdf')
+        self.primary_update_file = self._mock_pdf(
+            name='PrimaryConsentUpdate_7890.pdf',
+            text_in_file='Do you agree to this updated consent?'
+        )
 
         self.storage_provider_mock.list.return_value = [
             self.primary_file,
@@ -49,7 +53,8 @@ class ConsentFactoryTest(BaseTestCase):
             self.ehr_file,
             self.another_ehr,
             self.signature_image,
-            self.gror_file
+            self.gror_file,
+            self.primary_update_file
         ]
 
         self.vibrent_factory = files.ConsentFileAbstractFactory.get_file_factory(
@@ -103,6 +108,13 @@ class ConsentFactoryTest(BaseTestCase):
             actual_files=self.vibrent_factory.get_gror_consents()
         )
 
+    def test_vibrent_primary_update_consent(self):
+        self.assertConsentListEquals(
+            expected_class=files.VibrentPrimaryConsentUpdateFile,
+            expected_files=[self.primary_update_file],
+            actual_files=self.vibrent_factory.get_primary_update_consents()
+        )
+
     def assertConsentListEquals(self, expected_class, expected_files, actual_files):
         for file_object in actual_files:
             self.assertIsInstance(file_object, expected_class)
@@ -124,10 +136,10 @@ class ConsentFactoryTest(BaseTestCase):
             # The code uses strings when there aren't translations, and tuples when there are
             for search_item in search_list:
                 if isinstance(search_item, str) and search_item not in text_in_file:
-                    return False
+                    return None
                 elif not any([search_str in text_in_file for search_str in search_item]):
-                    return False
-            return True
+                    return None
+            return 1
         pdf_mock.get_page_number_of_text.side_effect = page_number_for_text
 
         return pdf_mock

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -361,41 +361,6 @@ class ConsentFileParsingTest(BaseTestCase):
 
         return [basic_gror_case, no_confirmation_case, spanish_gror_case]
 
-    def _get_vibrent_ehr_test_data(self) -> List['EhrConsentTestData']:
-        six_empty_pages = [[], [], [], [], [], []]  # The EHR signature is expected to be on the 7th page
-        basic_ehr_pdf = self._build_pdf(pages=[
-            *six_empty_pages,
-            [
-                self._build_form_element(text='Test ehr', bbox=(125, 150, 450, 180)),
-                self._build_form_element(text='Dec 21, 2019', bbox=(125, 100, 450, 130))
-            ]
-        ])
-        basic_ehr_case = EhrConsentTestData(
-            file=files.VibrentEhrConsentFile(pdf=basic_ehr_pdf, blob=mock.MagicMock()),
-            expected_signature='Test ehr',
-            expected_sign_date=date(2019, 12, 21)
-        )
-
-        va_ehr_pdf = self._build_pdf(pages=[
-            *six_empty_pages,
-            [
-                self._build_pdf_element(
-                    cls=LTTextLineHorizontal,
-                    text='We may ask you to go to a local clinic to be measured'
-                ),
-                self._build_form_element(text='Test va ehr', bbox=(125, 150, 450, 180)),
-                self._build_form_element(text='Oct 10, 2020', bbox=(125, 100, 450, 130))
-            ]
-        ])
-        va_ehr_case = EhrConsentTestData(
-            file=files.VibrentEhrConsentFile(pdf=va_ehr_pdf, blob=mock.MagicMock()),
-            expected_signature='Test va ehr',
-            expected_sign_date=date(2020, 10, 10),
-            expected_to_be_va_file=True
-        )
-
-        return [basic_ehr_case, va_ehr_case]
-
     def _get_vibrent_primary_update_test_data(self) -> List['PrimaryUpdateConsentTestData']:
         # The GROR signature is expected to be on the 10th page
         thirteen_empty_pages = [

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -40,6 +40,14 @@ class ConsentFileParsingTest(BaseTestCase):
             self.assertEqual(consent_example.expected_sign_date, consent_file.get_date_signed())
             self.assertEqual(consent_example.has_yes_selected, consent_file.is_confirmation_selected())
 
+    def test_vibrent_primary_update_consent(self):
+        for consent_example in self._get_vibrent_primary_update_test_data():
+            consent_file = consent_example.file
+            self.assertEqual(consent_example.expected_signature, consent_file.get_signature_on_file())
+            self.assertEqual(consent_example.expected_sign_date, consent_file.get_date_signed())
+            self.assertEqual(consent_example.has_yes_selected, consent_file.is_agreement_selected())
+            self.assertEqual(consent_example.expected_to_be_va_file, consent_file.get_is_va_consent())
+
     def _get_vibrent_primary_test_data(self) -> List['PrimaryConsentTestData']:
         """
         Builds a list of PDFs that represent the different layouts of Vibrent's primary consent
@@ -353,6 +361,100 @@ class ConsentFileParsingTest(BaseTestCase):
 
         return [basic_gror_case, no_confirmation_case, spanish_gror_case]
 
+    def _get_vibrent_ehr_test_data(self) -> List['EhrConsentTestData']:
+        six_empty_pages = [[], [], [], [], [], []]  # The EHR signature is expected to be on the 7th page
+        basic_ehr_pdf = self._build_pdf(pages=[
+            *six_empty_pages,
+            [
+                self._build_form_element(text='Test ehr', bbox=(125, 150, 450, 180)),
+                self._build_form_element(text='Dec 21, 2019', bbox=(125, 100, 450, 130))
+            ]
+        ])
+        basic_ehr_case = EhrConsentTestData(
+            file=files.VibrentEhrConsentFile(pdf=basic_ehr_pdf, blob=mock.MagicMock()),
+            expected_signature='Test ehr',
+            expected_sign_date=date(2019, 12, 21)
+        )
+
+        va_ehr_pdf = self._build_pdf(pages=[
+            *six_empty_pages,
+            [
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='We may ask you to go to a local clinic to be measured'
+                ),
+                self._build_form_element(text='Test va ehr', bbox=(125, 150, 450, 180)),
+                self._build_form_element(text='Oct 10, 2020', bbox=(125, 100, 450, 130))
+            ]
+        ])
+        va_ehr_case = EhrConsentTestData(
+            file=files.VibrentEhrConsentFile(pdf=va_ehr_pdf, blob=mock.MagicMock()),
+            expected_signature='Test va ehr',
+            expected_sign_date=date(2020, 10, 10),
+            expected_to_be_va_file=True
+        )
+
+        return [basic_ehr_case, va_ehr_case]
+
+    def _get_vibrent_primary_update_test_data(self) -> List['PrimaryUpdateConsentTestData']:
+        # The GROR signature is expected to be on the 10th page
+        thirteen_empty_pages = [
+            [], [], [], [], [], [], [], [], [], [], [], [], []
+        ]
+        basic_update_pdf = self._build_pdf(pages=[
+            *thirteen_empty_pages,
+            [
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(cls=LTTextLineHorizontal, text='Do you agree to this updated consent?')
+                    ]
+                ),
+                self._build_form_element(
+                    children=[self._build_pdf_element(LTChar, text='4')],
+                    bbox=(34, 669, 45, 683)
+                ),
+                self._build_form_element(text='Test update', bbox=(116, 146, 521, 170)),
+                self._build_form_element(text='Jan 1st, 2021', bbox=(116, 96, 521, 120))
+            ]
+        ])
+        basic_update_case = PrimaryUpdateConsentTestData(
+            file=files.VibrentPrimaryConsentUpdateFile(pdf=basic_update_pdf, blob=mock.MagicMock()),
+            expected_signature='Test update',
+            expected_sign_date=date(2021, 1, 1),
+            has_yes_selected=True,
+            expected_to_be_va_file=False
+        )
+
+        va_update_pdf = self._build_pdf(pages=[
+            *thirteen_empty_pages,
+            [
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(cls=LTTextLineHorizontal, text='Do you agree to this updated consent?')
+                    ]
+                ),
+                self._build_pdf_element(
+                    cls=LTTextBoxHorizontal,
+                    children=[
+                        self._build_pdf_element(cls=LTTextLineHorizontal, text='you will get care at a VA facility')
+                    ]
+                ),
+                self._build_form_element(text='Test update', bbox=(116, 146, 521, 170)),
+                self._build_form_element(text='Jan 1st, 2021', bbox=(116, 96, 521, 120))
+            ]
+        ])
+        va_update_case = PrimaryUpdateConsentTestData(
+            file=files.VibrentPrimaryConsentUpdateFile(pdf=va_update_pdf, blob=mock.MagicMock()),
+            expected_signature='Test update',
+            expected_sign_date=date(2021, 1, 1),
+            has_yes_selected=False,
+            expected_to_be_va_file=True
+        )
+
+        return [basic_update_case, va_update_case]
+
     @classmethod
     def _build_pdf(cls, pages) -> files.Pdf:
         """
@@ -449,3 +551,10 @@ class EhrConsentTestData(ConsentTestData):
 class GrorConsentTestData(ConsentTestData):
     file: files.GrorConsentFile
     has_yes_selected: bool = False
+
+
+@dataclass
+class PrimaryUpdateConsentTestData(ConsentTestData):
+    file: files.PrimaryConsentUpdateFile
+    has_yes_selected: bool = False
+    expected_to_be_va_file: bool = False


### PR DESCRIPTION
## Resolves *[DA-2086](https://precisionmedicineinitiative.atlassian.net/browse/DA-2086)*
This adds code to validate the Primary Consent Update file for cohort 1 participants that should have received it. 

## Description of changes/additions
This adds loading, parsing, and validation code to the layers of the consents code for checking the primary consent update files. The primary update files need to have a 'Yes' option checked (similarly to the GROR files) and there is a specific version for VA and general consent update (depending on whether the participant is associated with the VA). It also looks like we have received normal consent files (basic primary consent files that are just like consenting initially) in place of a file that has specific wording around the update, so there's a check to make sure that any files validated are the correct file.

## Tests
- [x] unit tests


