### PR TITLE
[DA-1453] Specimen API debugging - logging dataset items that are being deleted

### DIFF
--- a/rdr_service/model/biobank_order.py
+++ b/rdr_service/model/biobank_order.py
@@ -4,6 +4,7 @@ from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, UnicodeText
 from sqlalchemy.dialects.mysql import JSON
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
+
 from rdr_service.model.field_types import BlobUTF8
 from rdr_service.model.base import Base, model_insert_listener, model_update_listener
 from rdr_service.model.biobank_mail_kit_order import BiobankMailKitOrder

--- a/rdr_service/model/biobank_order.py
+++ b/rdr_service/model/biobank_order.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, UnicodeText, event
 from sqlalchemy.dialects.mysql import JSON
 from sqlalchemy.ext.declarative import declared_attr
@@ -417,6 +419,16 @@ class BiobankAliquotDatasetItem(Base, BiobankSpecimenBase):
     paramId = Column("param_id", String(80))
     displayValue = Column("display_value", String(80))
     displayUnits = Column("display_units", String(80))
+
+
+def before_item_delete(_, __, dataset_item: BiobankAliquotDatasetItem):
+    logging.info(
+        f'deleting dataset item with id "{dataset_item.id}", paramId "{dataset_item.paramId}" '
+        f'and dataset rlims id "{dataset_item.dataset_rlims_id}"'
+    )
+
+
+event.listen(BiobankAliquotDatasetItem, 'before_delete', before_item_delete)
 
 
 for model_class in [MayolinkCreateOrderHistory, BiobankSpecimen, BiobankSpecimenAttribute,


### PR DESCRIPTION
## Description of changes/additions
it looks like `session.delete` in the API code only iterates objects that have been explicitly deleted using the session. For reasons I still can't track down there are dataset items and aliquots that are being deleted (likely because of how the relationships to their parents are handled). I'm adding this log statement to find out which dataset item is being deleted to try to better understand what's causing the error.

## Tests
- [ ] unit tests


