### PR TITLE
Pin setup tools version for CI

### DIFF
--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -10,6 +10,6 @@ source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
 pip install --upgrade pip
-pip install setuptools==58.0.2
+pip install setuptools==47.1.0
 pip install safety
 pip install -r requirements.txt

--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -10,5 +10,6 @@ source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
 pip install --upgrade pip
+pip install setuptools==58.0.2
 pip install safety
 pip install -r requirements.txt


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Having to pin `setup_tools` version to `47.1.0` which matches local dev version since `58.0.2` is now having conflicts with `dictalchemy` package

<img width="741" alt="Screen Shot 2021-09-08 at 11 46 50 AM" src="https://user-images.githubusercontent.com/5114837/132541969-be4d8a8b-4f4a-4bab-a492-8596a53dc0b0.png">

<img width="877" alt="Screen Shot 2021-09-08 at 11 48 56 AM" src="https://user-images.githubusercontent.com/5114837/132542284-bcb70131-7f62-4c11-bf10-c0a5ce9bcf45.png">

## Tests
- [] unit tests


