### PR TITLE
[PDR-426] Update PM calulations and fields in particpant gen.

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -129,6 +129,10 @@ class BQPhysicalMeasurements(BQSchema):
     pm_finalized = BQField('pm_finalized', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     pm_physical_measurements_id = BQField('pm_physical_measurements_id', BQFieldTypeEnum.INTEGER,
                                          BQFieldModeEnum.NULLABLE)
+    pm_amended_measurements_id = BQField('pm_amended_measurements_id', BQFieldTypeEnum.INTEGER,
+                                         BQFieldModeEnum.NULLABLE)
+    pm_final = BQField('pm_final', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    pm_restored = BQField('pm_restored', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQBiobankSampleSchema(BQSchema):

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -130,9 +130,12 @@ class PhysicalMeasurementsSchema(Schema):
     created = fields.DateTime()
     created_site = fields.String(validate=validate.Length(max=255))
     created_site_id = fields.Int32()
+    final = fields.Boolean()
     finalized_site = fields.String(validate=validate.Length(max=255))
     finalized_site_id = fields.Int32()
     finalized = fields.DateTime()
+    amended_measurements_id = fields.Int32()
+    restored = fields.Boolean()
 
     class Meta:
         schema_id = SchemaID.participant_physical_measurements


### PR DESCRIPTION
## Resolves *[PDR-426](https://precisionmedicineinitiative.atlassian.net/browse/PDR-426)*


## Description of changes/additions
Changed PM generator code to emulate closer to the 'participant_summary' table PM logic.
Added additional fields to resource model.

## Tests
- [x] unit tests


