### PR TITLE
Removing organization change validation code

### DIFF
--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -24,6 +24,7 @@ from rdr_service.api_util import (
 from rdr_service.app_util import get_oauth_id, lookup_user_info, get_account_origin_id, is_care_evo_and_not_prod
 from rdr_service.code_constants import UNSET, ORIGINATING_SOURCES
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
+from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.organization_dao import OrganizationDao
 from rdr_service.dao.site_dao import SiteDao
@@ -268,7 +269,11 @@ class ParticipantDao(UpdatableDao):
                     obj.organizationId = None
                     need_new_summary = True
 
-        if not update_pairing:
+        if update_pairing:
+            if obj.organizationId != existing_obj.organizationId and existing_obj.participantSummary is not None:
+                # Get valid files ready for sync when a participant is paired to an organization
+                ConsentDao.set_previously_synced_files_as_ready(session, obj.participantId)
+        else:
             # No pairing updates sent, keep existing values.
             obj.siteId = existing_obj.siteId
             obj.organizationId = existing_obj.organizationId


### PR DESCRIPTION
## Resolves *no ticket*
This removes the consent file validation for when a participant is paired to an organization. This was set up for when participants changed organizations (or were paired for the first time) and didn't yet have all their files validated. All participant consent files will be validated by the time this makes it to prod. So we won't need to have the code for validating any unvalidated files.


## Tests
- [ ] unit tests


