### PR TITLE
Remove cloud task in reconcile data files workflow

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1862,7 +1862,7 @@ class GenomicReconciler:
 
         required_files_set = set([f['file_type'] for f in file_types if f['required']])
 
-        logging.info("Found {len(metrics)} metrics records missing data...")
+        logging.info(f"Found {len(metrics)} metrics records missing data...")
 
         for result in metrics:
             # Lookup identifier in data files table
@@ -1891,19 +1891,10 @@ class GenomicReconciler:
                             setattr(_obj, file_type_config['file_received_attribute'], 1)  # received
                             setattr(_obj, file_type_config['file_path_attribute'], f'gs://{file.file_path}')
                             metric_touched = True
-                            self.controller.member_ids_for_update.append(_obj.genomicSetMemberId)
 
             if metric_touched or missing_data_files:
                 logging.info(f'Updating metric record {_obj.id}')
                 self.update_reconciled_metric(_obj, missing_data_files, _gc_site_id)
-
-            if self.controller.member_ids_for_update:
-                self.controller.execute_cloud_task({
-                    'member_ids': self.controller.member_ids_for_update,
-                    'field': 'reconcileMetricsSequencingJobRunId',
-                    'value': self.run_id,
-                    'is_job_run': True,
-                }, 'genomic_set_member_update_task')
 
         return GenomicSubProcessResult.SUCCESS
 
@@ -3065,7 +3056,7 @@ class ManifestCompiler:
 
         if self.controller.member_ids_for_update:
             self.controller.execute_cloud_task({
-                'member_ids': self.controller.member_ids_for_update,
+                'member_ids': list(set(self.controller.member_ids_for_update)),
                 'field': self.manifest_def.job_run_field,
                 'value': self.run_id,
                 'is_job_run': True

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -1025,8 +1025,7 @@ class GenomicPipelineTest(BaseTestCase):
         self.assertEqual(GenomicSubProcessResult.SUCCESS, self.job_run_dao.get(1).runResult)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, self.job_run_dao.get(2).runResult)
 
-    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
-    def test_gc_metrics_reconciliation_vs_array_data(self, cloud_task):
+    def test_gc_metrics_reconciliation_vs_array_data(self):
 
         # Create the fake ingested data
         self._create_fake_datasets_for_gc_tests(3, arr_override=True, array_participants=[1, 2, 3],
@@ -1097,11 +1096,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 2
 
-        self.assertTrue(cloud_task.called)
-        cloud_task_args = cloud_task.call_args.args[0]
-        req_keys = ['member_ids', 'field', 'value', 'is_job_run']
-        self.assertTrue(list(cloud_task_args.keys()) == req_keys)
-
         gc_record = self.metrics_dao.get(1)
 
         # Test the gc_metrics were updated with reconciliation data
@@ -1157,8 +1151,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
-    def test_aw2_wgs_reconciliation_vs_wgs_data(self, cloud_task):
+    def test_aw2_wgs_reconciliation_vs_wgs_data(self):
 
         # Create the fake ingested data
         self._create_fake_datasets_for_gc_tests(3, genome_center='rdr', genomic_workflow_state=GenomicWorkflowState.AW1)
@@ -1209,11 +1202,6 @@ class GenomicPipelineTest(BaseTestCase):
                 self.data_generator.create_database_gc_data_file_record(**test_file_dict)
 
         genomic_pipeline.reconcile_metrics_vs_wgs_data()  # run_id = 2
-
-        self.assertTrue(cloud_task.called)
-        cloud_task_args = cloud_task.call_args.args[0]
-        req_keys = ['member_ids', 'is_job_run', 'field', 'value']
-        self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
 
         gc_record = self.metrics_dao.get(1)
 
@@ -2321,8 +2309,7 @@ class GenomicPipelineTest(BaseTestCase):
         self.assertEqual(GenomicJob.AW1F_ALERTS, job_run.jobId)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, job_run.runResult)
 
-    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
-    def test_gem_a1_manifest_end_to_end(self, cloud_task):
+    def test_gem_a1_manifest_end_to_end(self):
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
                                               startTime=clock.CLOCK.now(),
@@ -2408,11 +2395,6 @@ class GenomicPipelineTest(BaseTestCase):
                 self.data_generator.create_database_gc_data_file_record(**test_file_dict)
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 3
-
-        self.assertTrue(cloud_task.called)
-        cloud_task_args = cloud_task.call_args.args[0]
-        req_keys = ['member_ids', 'is_job_run', 'field', 'value']
-        self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
 
         # finally run the manifest workflow
         bucket_name = config.getSetting(config.GENOMIC_GEM_BUCKET_NAME)
@@ -2616,6 +2598,10 @@ class GenomicPipelineTest(BaseTestCase):
         req_keys = ['member_ids', 'is_job_run', 'field', 'value']
         self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
 
+        member_ids = cloud_task_args['member_ids']
+        self.assertIsNotNone(member_ids)
+        self.assertTrue(len(set(member_ids)) == len(member_ids))
+
         # Test the members' job run ID
         # Picked up by job
         test_member_3 = self.member_dao.get(3)
@@ -2670,8 +2656,7 @@ class GenomicPipelineTest(BaseTestCase):
         run_obj = self.job_run_dao.get(2)
         self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
-    def test_cvl_w1_manifest(self, cloud_task):
+    def test_cvl_w1_manifest(self):
 
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
@@ -2733,11 +2718,6 @@ class GenomicPipelineTest(BaseTestCase):
                 self.data_generator.create_database_gc_data_file_record(**test_file_dict)
 
         genomic_pipeline.reconcile_metrics_vs_wgs_data()  # run_id = 3
-
-        self.assertTrue(cloud_task.called)
-        cloud_task_args = cloud_task.call_args.args[0]
-        req_keys = ['member_ids', 'is_job_run', 'field', 'value']
-        self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
 
         # Run the W1 manifest workflow
         fake_dt = datetime.datetime(2020, 4, 3, 0, 0, 0, 0)
@@ -2871,6 +2851,10 @@ class GenomicPipelineTest(BaseTestCase):
         req_keys = ['member_ids', 'is_job_run', 'field', 'value']
         self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
 
+        member_ids = cloud_task_args['member_ids']
+        self.assertIsNotNone(member_ids)
+        self.assertTrue(len(set(member_ids)) == len(member_ids))
+
         # Test member was updated
         member = self.member_dao.get(1)
         self.assertEqual(GenomicWorkflowState.W3, member.genomicWorkflowState)
@@ -2987,11 +2971,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 3
 
-        self.assertTrue(cloud_task.called)
-        cloud_task_args = cloud_task.call_args.args[0]
-        req_keys = ['member_ids', 'is_job_run', 'field', 'value']
-        self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
-
         # finally run the AW3 manifest workflow
         fake_dt = datetime.datetime(2020, 8, 3, 0, 0, 0, 0)
 
@@ -3007,6 +2986,10 @@ class GenomicPipelineTest(BaseTestCase):
         self.assertTrue(cloud_task.called)
         cloud_task_args = cloud_task.call_args.args[0]
         self.assertEqual(cloud_task_args['field'], 'aw3ManifestFileId')
+
+        member_ids = cloud_task_args['member_ids']
+        self.assertIsNotNone(member_ids)
+        self.assertTrue(len(set(member_ids)) == len(member_ids))
 
         aw3_dtf = fake_dt.strftime("%Y-%m-%d-%H-%M-%S")
 
@@ -3073,8 +3056,7 @@ class GenomicPipelineTest(BaseTestCase):
 
             self.assertEqual(GenomicSubProcessResult.SUCCESS, run_obj.runResult)
 
-    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
-    def test_aw3_array_manifest_with_max_num(self, cloud_task):
+    def test_aw3_array_manifest_with_max_num(self):
         stored_samples = [
             (1, 1001),
             (2, 1002),
@@ -3151,11 +3133,6 @@ class GenomicPipelineTest(BaseTestCase):
                 self.data_generator.create_database_gc_data_file_record(**test_file_dict)
 
         genomic_pipeline.reconcile_metrics_vs_array_data()  # run_id = 3
-
-        self.assertTrue(cloud_task.called)
-        cloud_task_args = cloud_task.call_args.args[0]
-        req_keys = ['member_ids', 'is_job_run', 'field', 'value']
-        self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
 
         with clock.FakeClock(fake_dt):
             genomic_pipeline.aw3_array_manifest_workflow(max_num=3)  # run_id = 4
@@ -3480,11 +3457,6 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_metrics_vs_wgs_data()  # run_id = 3
 
-        self.assertTrue(cloud_task.called)
-        cloud_task_args = cloud_task.call_args.args[0]
-        req_keys = ['member_ids', 'is_job_run', 'field', 'value']
-        self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
-
         # finally run the AW3 manifest workflow
         fake_dt = datetime.datetime(2020, 8, 3, 0, 0, 0, 0)
 
@@ -3500,6 +3472,10 @@ class GenomicPipelineTest(BaseTestCase):
         self.assertTrue(cloud_task.called)
         cloud_task_args = cloud_task.call_args.args[0]
         self.assertEqual(cloud_task_args['field'], 'aw3ManifestFileId')
+
+        member_ids = cloud_task_args['member_ids']
+        self.assertIsNotNone(member_ids)
+        self.assertTrue(len(set(member_ids)) == len(member_ids))
 
         aw3_dtf = fake_dt.strftime("%Y-%m-%d-%H-%M-%S")
 
@@ -4411,6 +4387,10 @@ class GenomicPipelineTest(BaseTestCase):
         cloud_task_args = cloud_task.call_args.args[0]
         req_keys = ['member_ids', 'is_job_run', 'field', 'value']
         self.assertTrue(set(cloud_task_args.keys()) == set(req_keys))
+
+        member_ids = cloud_task_args['member_ids']
+        self.assertIsNotNone(member_ids)
+        self.assertTrue(len(set(member_ids)) == len(member_ids))
 
         # Test manifest feedback record was updated
         manifest_feedback_record = self.manifest_feedback_dao.get(1)


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Current bug on prod where cloud task is one-tab off and getting caught in nested reconcile data file loop resulting in large sets of non-distinct member ids getting processed.

**Removing cloud task from reconciling workflow as it's not really needed and making sure member ids sent to other cloud tasks in the genomic pipeline are distinct.

## Tests
- [x] unit tests


