### PR TITLE
[DA-2185] Add cron job to update members' state if all data files received

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -230,6 +230,7 @@
     "feedback_record_reconciliation_workflow": 1,
     "missing_files_clean_up_workflow": 1,
     "missing_files_resolve_workflow": 1,
+    "members_state_resolved_workflow": 1,
     "wgs_reconciliation_workflow": 1,
     "w1_manifest_workflow": 0,
     "w2_manifest_workflow": 0,

--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -253,7 +253,7 @@ class IngestSamplesFromRawTaskAPI(BaseGenomicTaskApi):
 class IngestDataFilesTaskApi(BaseGenomicTaskApi):
     """
     Cloud Task endpoint: Ingest data files from buckets and saves
-    records to GenomicGCValidationMetrics
+    records to GenomicGcDataFile
     """
     def post(self):
         super(IngestDataFilesTaskApi, self).post()

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -88,6 +88,7 @@
     "feedback_record_reconciliation_workflow": 1,
     "missing_files_clean_up_workflow": 1,
     "missing_files_resolve_workflow": 1,
+    "members_state_resolved_workflow": 1,
     "wgs_reconciliation_workflow": 1,
     "w1_manifest_workflow": 0,
     "w2_manifest_workflow": 0,

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -154,4 +154,9 @@ cron:
   timezone: America/New_York
   schedule: every 6 hours
   target: offline
+- description: Genomic Update Members With Missing Files Resolved
+  url: /offline/GenomicUpdateMembersStateResolved
+  timezone: America/New_York
+  schedule: every 12 hours
+  target: offline
 

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -548,6 +548,53 @@ class GenomicSetMemberDao(UpdatableDao):
                 GenomicManifestFile.filePath == filepath
             ).one_or_none()
 
+    def get_aw2_missing_with_all_files(self, genome_type):
+        with self.session() as session:
+            members_query = session.query(
+                GenomicSetMember.id
+            ).join(
+                GenomicGCValidationMetrics,
+                GenomicSetMember.id == GenomicGCValidationMetrics.genomicSetMemberId
+            ).filter(
+                GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
+                GenomicGCValidationMetrics.ignoreFlag != 1
+            )
+            if genome_type == config.GENOME_TYPE_ARRAY:
+                members_query = members_query.filter(
+                    GenomicSetMember.genomeType == config.GENOME_TYPE_ARRAY,
+                    GenomicGCValidationMetrics.idatRedReceived == 1,
+                    GenomicGCValidationMetrics.idatGreenReceived == 1,
+                    GenomicGCValidationMetrics.idatRedMd5Received == 1,
+                    GenomicGCValidationMetrics.idatGreenMd5Received == 1,
+                    GenomicGCValidationMetrics.vcfReceived == 1,
+                    GenomicGCValidationMetrics.vcfTbiReceived == 1,
+                    GenomicGCValidationMetrics.vcfMd5Received == 1,
+                    GenomicGCValidationMetrics.idatRedPath.isnot(None),
+                    GenomicGCValidationMetrics.idatGreenPath.isnot(None),
+                    GenomicGCValidationMetrics.idatRedMd5Path.isnot(None),
+                    GenomicGCValidationMetrics.idatGreenMd5Path.isnot(None),
+                    GenomicGCValidationMetrics.vcfPath.isnot(None),
+                    GenomicGCValidationMetrics.vcfTbiPath.isnot(None),
+                    GenomicGCValidationMetrics.vcfMd5Path.isnot(None),
+                )
+            if genome_type == config.GENOME_TYPE_WGS:
+                members_query = members_query.filter(
+                    GenomicSetMember.genomeType == config.GENOME_TYPE_WGS,
+                    GenomicGCValidationMetrics.hfVcfReceived == 1,
+                    GenomicGCValidationMetrics.hfVcfTbiReceived == 1,
+                    GenomicGCValidationMetrics.hfVcfMd5Received == 1,
+                    GenomicGCValidationMetrics.cramReceived == 1,
+                    GenomicGCValidationMetrics.cramMd5Received == 1,
+                    GenomicGCValidationMetrics.craiReceived == 1,
+                    GenomicGCValidationMetrics.hfVcfPath.isnot(None),
+                    GenomicGCValidationMetrics.hfVcfTbiPath.isnot(None),
+                    GenomicGCValidationMetrics.hfVcfMd5Path.isnot(None),
+                    GenomicGCValidationMetrics.cramPath.isnot(None),
+                    GenomicGCValidationMetrics.cramMd5Path.isnot(None),
+                    GenomicGCValidationMetrics.craiPath.isnot(None),
+                )
+            return members_query.all()
+
     def update_report_consent_removal_date(self, member, date):
         """
         Updates the reportConsentRemovalDate on the genomic set member
@@ -1110,7 +1157,8 @@ class GenomicGCValidationMetricsDao(UpsertableDao):
                 .outerjoin(
                     GenomicGcDataFileMissing,
                     and_(GenomicGcDataFileMissing.gc_validation_metric_id == GenomicGCValidationMetrics.id,
-                         GenomicGcDataFileMissing.resolved == 0)
+                         GenomicGcDataFileMissing.resolved == 0,
+                         GenomicGcDataFileMissing.ignore_flag == 0)
                 )
                 .filter(
                     GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
@@ -1119,8 +1167,7 @@ class GenomicGCValidationMetricsDao(UpsertableDao):
                     GenomicGCValidationMetrics.genomicFileProcessedId.isnot(None),
                     sqlalchemy.func.lower(GenomicGCValidationMetrics.processingStatus) == "pass",
                     GenomicGcDataFileMissing.id.is_(None),
-                    ((GenomicGCValidationMetrics.ignoreFlag != 1) |
-                     (GenomicGCValidationMetrics.ignoreFlag is not None)),
+                    GenomicGCValidationMetrics.ignoreFlag == 0,
                     (GenomicGCValidationMetrics.idatRedReceived == 0) |
                     (GenomicGCValidationMetrics.idatGreenReceived == 0) |
                     (GenomicGCValidationMetrics.idatRedMd5Received == 0) |
@@ -1132,7 +1179,7 @@ class GenomicGCValidationMetricsDao(UpsertableDao):
                 .all()
             )
 
-    def get_with_missing_wsg_files(self, _gc_site_id):
+    def get_with_missing_wgs_files(self, _gc_site_id):
         """
         Retrieves all gc metrics with missing sequencing files
         :param: _date: last run time
@@ -1151,7 +1198,8 @@ class GenomicGCValidationMetricsDao(UpsertableDao):
                 .outerjoin(
                     GenomicGcDataFileMissing,
                     and_(GenomicGcDataFileMissing.gc_validation_metric_id == GenomicGCValidationMetrics.id,
-                         GenomicGcDataFileMissing.resolved == 0)
+                         GenomicGcDataFileMissing.resolved == 0,
+                         GenomicGcDataFileMissing.ignore_flag == 0)
                 )
                 .filter(
                     GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
@@ -2117,6 +2165,7 @@ class GenomicGcDataFileMissingDao(UpdatableDao):
                 GenomicGcDataFileMissing
             ).filter(
                 GenomicGcDataFileMissing.resolved == 1,
+                GenomicGcDataFileMissing.ignore_flag == 0,
                 GenomicGcDataFileMissing.resolved_date.isnot(None),
                 GenomicGcDataFileMissing.resolved_date < delete_date
             ).delete()
@@ -2146,6 +2195,7 @@ class GenomicGcDataFileMissingDao(UpdatableDao):
                 GenomicSetMember.id == GenomicGCValidationMetrics.genomicSetMemberId
             ).filter(
                 GenomicGcDataFileMissing.resolved == 0,
+                GenomicGcDataFileMissing.ignore_flag == 0,
                 GenomicGcDataFileMissing.resolved_date.is_(None)
             )
 

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -556,7 +556,7 @@ class GenomicSetMemberDao(UpdatableDao):
                 GenomicGCValidationMetrics,
                 GenomicSetMember.id == GenomicGCValidationMetrics.genomicSetMemberId
             ).filter(
-                GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
+                GenomicSetMember.genomicWorkflowState == GenomicWorkflowState.AW2_MISSING,
                 GenomicGCValidationMetrics.ignoreFlag != 1
             )
             if genome_type == config.GENOME_TYPE_ARRAY:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1838,7 +1838,7 @@ class GenomicReconciler:
     def reconcile_metrics_to_data_files(self, genome_type, _gc_site_id):
         if genome_type == "wgs":
             logging.info("Running WGS reconciliation to Data Files...")
-            metrics = self.metrics_dao.get_with_missing_wsg_files(_gc_site_id)
+            metrics = self.metrics_dao.get_with_missing_wgs_files(_gc_site_id)
             identifier = 'sampleId'
             lookup_method = self.data_file_dao.get_with_sample_id
             file_types = genomic_mappings.wgs_file_types_attributes

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -547,6 +547,27 @@ class GenomicJobController:
         else:
             logging.info('No missing gc data files to resolve')
 
+    def update_member_aw2_missing_states_if_resolved(self):
+        # get array member_ids that are resolved but still in AW2_MISSING
+        logging.info("Updating Array AW2_MISSING members")
+        array_member_ids = self.member_dao.get_aw2_missing_with_all_files(config.GENOME_TYPE_ARRAY)
+        self.member_dao.batch_update_member_field(member_ids=array_member_ids,
+                                                  field='genomicWorkflowState',
+                                                  value=GenomicWorkflowState.GEM_READY,
+                                                  project_id=self.bq_project_id)
+        logging.info(f"Updated {len(array_member_ids)} Array members.")
+
+        logging.info("Updating WGS AW2_MISSING members")
+        # get wgs member_ids that are resolved but still in AW2_MISSING
+        wgs_member_ids = self.member_dao.get_aw2_missing_with_all_files(config.GENOME_TYPE_WGS)
+        self.member_dao.batch_update_member_field(member_ids=wgs_member_ids,
+                                                  field='genomicWorkflowState',
+                                                  value=GenomicWorkflowState.CVL_READY,
+                                                  project_id=self.bq_project_id)
+        logging.info(f"Updated {len(wgs_member_ids)} WGS members.")
+
+        self.job_result = GenomicSubProcessResult.SUCCESS
+
     @staticmethod
     def set_aw1_attributes_from_raw(rec: tuple):
         """

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -96,6 +96,7 @@ class GenomicJob(messages.Enum):
     RESOLVE_MISSING_FILES = 42
     MISSING_FILES_CLEANUP = 43
     GENERATE_AW2F_REMAINDER = 44
+    UPDATE_MEMBERS_STATE_RESOLVED_DATA_FILES = 45
 
     # Data Quality Pipeline Jobs
     # Naming matters for reports (timeframe_level_report_target)

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -322,6 +322,11 @@ def genomic_missing_files_resolve():
         controller.resolve_missing_gc_files()
 
 
+def update_members_state_resolved_data_files():
+    with GenomicJobController(GenomicJob.UPDATE_MEMBERS_STATE_RESOLVED_DATA_FILES) as controller:
+        controller.update_member_aw2_missing_states_if_resolved()
+
+
 def create_aw2f_manifest(feedback_record):
     with GenomicJobController(GenomicJob.AW2F_MANIFEST,
                               bucket_name=config.BIOBANK_SAMPLES_BUCKET_NAME,

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -592,6 +592,13 @@ def genomic_missing_files_resolve():
 
 
 @app_util.auth_required_cron
+@run_genomic_cron_job('members_state_resolved_workflow')
+def genomic_members_state_resolved():
+    genomic_pipeline.update_members_state_resolved_data_files()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
 @run_genomic_cron_job('daily_ingestion_summary')
 def genomic_data_quality_daily_ingestion_summary():
     genomic_data_quality_pipeline.data_quality_workflow(GenomicJob.DAILY_SUMMARY_REPORT_INGESTIONS)
@@ -866,6 +873,12 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicMissingFilesResolve",
         endpoint="genomic_missing_files_resolve",
         view_func=genomic_missing_files_resolve,
+        methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicUpdateMembersStateResolved",
+        endpoint="genomic_members_state_resolved",
+        view_func=genomic_members_state_resolved,
         methods=["GET"]
     )
 


### PR DESCRIPTION
## Resolves *[DA-2185](https://precisionmedicineinitiative.atlassian.net/browse/DA-2185)*


## Description of changes/additions
This PR adds a new cron job to update `genomic_set_member` records' `genomic_workflow_state` if all GC data files have been received. Previously, if a file had been missing, the record was put into the `AW2_MISSING` state. There was no method to move records out of this state if a missing file was later uploaded. This cron job resolve that.
Additionally, a typo in a method name was fixed, and some of the queries were cleaned up by adding a condition for the `genomic_gc_data_files_missing.ignore_flag`.

## Tests
- [x] unit tests


