### PR TITLE
Updating validation code for older version Cabor files

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -361,10 +361,18 @@ class VibrentPrimaryConsentFile(PrimaryConsentFile):
 
 class VibrentCaborConsentFile(CaborConsentFile):
     def _get_signature_elements(self):
-        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=200, right=400, bottom=110, top=115))
+        elements = self.pdf.get_elements_intersecting_box(Rect.from_edges(left=200, right=400, bottom=110, top=115))
+        if not elements:  # old style cabor have signature higher up on the page
+            elements = self.pdf.get_elements_intersecting_box(Rect.from_edges(left=200, right=400, bottom=165, top=170))
+
+        return elements
 
     def _get_date_elements(self):
-        return self.pdf.get_elements_intersecting_box(Rect.from_edges(left=520, right=570, bottom=110, top=115))
+        elements = self.pdf.get_elements_intersecting_box(Rect.from_edges(left=520, right=570, bottom=110, top=115))
+        if not elements:  # old style cabor have signature higher up on the page
+            elements = self.pdf.get_elements_intersecting_box(Rect.from_edges(left=520, right=570, bottom=165, top=170))
+
+        return elements
 
 
 class VibrentEhrConsentFile(EhrConsentFile):

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -263,7 +263,19 @@ class ConsentFileParsingTest(BaseTestCase):
             expected_sign_date=date(2020, 4, 27)
         )
 
-        return [basic_cabor_case]
+        older_cabor_pdf = self._build_pdf(pages=[
+            [
+                self._build_form_element(text='2017 Cabor', bbox=(150, 150, 350, 188)),
+                self._build_form_element(text='Sep 8, 2017', bbox=(434, 153, 527, 182))
+            ]
+        ])
+        older_cabor_case = ConsentTestData(
+            file=files.VibrentCaborConsentFile(pdf=older_cabor_pdf, blob=mock.MagicMock()),
+            expected_signature='2017 Cabor',
+            expected_sign_date=date(2017, 9, 8)
+        )
+
+        return [basic_cabor_case, older_cabor_case]
 
     def _get_vibrent_ehr_test_data(self) -> List['EhrConsentTestData']:
         six_empty_pages = [[], [], [], [], [], []]  # The EHR signature is expected to be on the 7th page


### PR DESCRIPTION
## Resolves *no ticket*
An older versions of the Cabor consent file is failing validation. A version used in 2017/2018 has the signature line higher up on the page. This adds a fallback to check for the elements higher up on the page.

## Tests
- [x] unit tests


