### PR TITLE
[DA-2201] Fix Missing Files Resolve query

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2123,7 +2123,7 @@ class GenomicGcDataFileMissingDao(UpdatableDao):
 
     def get_files_to_resolve(self, limit=None):
         with self.session() as session:
-            results = session.query(
+            subquery = session.query(
                 GenomicGcDataFileMissing.id,
                 GenomicGcDataFileMissing.gc_validation_metric_id,
                 GenomicGcDataFileMissing.file_type,
@@ -2147,6 +2147,15 @@ class GenomicGcDataFileMissingDao(UpdatableDao):
             ).filter(
                 GenomicGcDataFileMissing.resolved == 0,
                 GenomicGcDataFileMissing.resolved_date.is_(None)
+            ).subquery()
+
+            results = session.query(
+                GenomicGcDataFile
+            ).join(
+                subquery,
+                and_(GenomicGcDataFile.identifier_type == subquery.c.identifier_type,
+                     GenomicGcDataFile.identifier_value == subquery.c.identifier_value,
+                     GenomicGcDataFile.file_type == subquery.c.file_type,)
             )
 
             if limit:

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -5120,6 +5120,17 @@ class GenomicPipelineTest(BaseTestCase):
             if file.resolved == 1 and file.resolved_date is not None
         ))
 
+        # Test file not in GC Data File not returned by get_files_to_resolve()
+        self.data_generator.create_database_gc_data_missing_file(
+            gc_validation_metric_id=1,
+            run_id=gen_job_run.id,
+            gc_site_id='rdr',
+            file_type='vcf.gz.tbi',
+        )
+        need_resolve_files = self.missing_file_dao.get_files_to_resolve()
+
+        self.assertEqual(len(need_resolve_files), 0)
+
     def test_missing_files_resolved_clean_up(self):
 
         gen_set = self.data_generator.create_database_genomic_set(


### PR DESCRIPTION
## Resolves *[DA-2201](https://precisionmedicineinitiative.atlassian.net/browse/DA-2201)*


## Description of changes/additions
The `get_files_to_resolve` query did not take existing files into account. The query needed to be updated to include a join to the `genomic_gc_data_file` table. This PR adds a join to `genomic_gc_data_file` in the `get_files_to_resolve` query to fix this issue.

## Tests
- [x] unit tests


