### PR TITLE
[DA-2203] Remove consent status for draft participants

### DIFF
--- a/rdr_service/tools/tool_libs/unconsent.py
+++ b/rdr_service/tools/tool_libs/unconsent.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from rdr_service.model.code import Code
 from rdr_service.model.utils import from_client_participant_id
+from rdr_service.model.consent_file import ConsentFile
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.questionnaire import QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer,\
@@ -99,6 +100,11 @@ class UnconsentTool(ToolBase):
             ).delete()
             session.query(QuestionnaireResponse).filter(
                 QuestionnaireResponse.questionnaireResponseId.in_(questionnaire_response_ids)
+            ).delete()
+
+            # Remove any consent file expectations
+            session.query(ConsentFile).filter(
+                ConsentFile.participant_id == participant_id
             ).delete()
 
         # Commit to finalize the changes for this participant and release the locks

--- a/rdr_service/tools/tool_libs/unconsent.py
+++ b/rdr_service/tools/tool_libs/unconsent.py
@@ -1,0 +1,114 @@
+import argparse
+
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+
+from rdr_service.model.code import Code
+from rdr_service.model.utils import from_client_participant_id
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.questionnaire import QuestionnaireQuestion
+from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer,\
+    QuestionnaireResponseExtension
+from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
+
+
+tool_cmd = 'unconsent'
+tool_desc = 'Remove participants that we have received ConsentPII payloads for, but have not actually consented'
+
+
+class UnconsentTool(ToolBase):
+
+    def run(self):
+        super(UnconsentTool, self).run()
+
+        with self.get_session() as session:
+            for participant_id in self._load_participant_ids():
+                if not self._participant_has_signed_consent(session, participant_id):
+                    self._delete_participant_consent(session, participant_id)
+                else:
+                    logger.info(f'P{participant_id} has signed consent')
+
+    def _load_participant_ids(self) -> set:
+        participant_ids = set()
+        with open(self.args.pid_file) as file:
+            for participant_id_str in file:
+                participant_id = from_client_participant_id(participant_id_str)
+                participant_ids.add(participant_id)
+
+        return participant_ids
+
+    @classmethod
+    def _participant_has_signed_consent(cls, session: Session, participant_id: int):
+        """
+        If the participant has a module where they've actually signed the consent, then don't unconsent them.
+        This is to make sure we don't remove participants that have consented since verifying the list.
+        """
+        signed_response_query = (
+            session.query(QuestionnaireResponseAnswer.questionnaireResponseAnswerId)
+            .join(
+                QuestionnaireResponse,
+                and_(
+                    QuestionnaireResponse.participantId == participant_id,
+                    QuestionnaireResponse.questionnaireResponseId == QuestionnaireResponseAnswer.questionnaireResponseId
+                )
+            ).join(
+                QuestionnaireQuestion,
+                QuestionnaireQuestion.questionnaireQuestionId == QuestionnaireResponseAnswer.questionId
+            ).join(
+                Code,
+                and_(
+                    Code.value == 'ExtraConsent_Signature',
+                    Code.codeId == QuestionnaireQuestion.codeId
+                )
+            )
+        )
+
+        return signed_response_query.count() > 0
+
+    def _delete_participant_consent(self, session: Session, participant_id: int):
+        """Remove the participant's consent status and responses from the RDR"""
+
+        # Retrieve the participant summary
+        summary_query = session.query(ParticipantSummary.participantId).filter(
+            ParticipantSummary.participantId == participant_id
+        )
+        if not self.args.dry_run:
+            # Obtain a lock on the participant summary to prevent possible race conditions with incoming responses
+            summary_query = summary_query.with_for_update()
+        participant_summary = summary_query.one_or_none()
+
+        if participant_summary is None:
+            logger.info(f'No participant summary found for P{participant_id}')
+        elif self.args.dry_run:
+            logger.info(f'would remove consent for P{participant_id}')
+        else:
+            # Delete the participant summary
+            session.query(ParticipantSummary).filter(
+                ParticipantSummary.participantId == participant_id
+            ).delete()
+
+            # Delete the QuestionnaireResponses and associated objects
+            questionnaire_response_ids = session.query(QuestionnaireResponse.questionnaireResponseId).filter(
+                QuestionnaireResponse.participantId == participant_id
+            ).all()
+            session.query(QuestionnaireResponseAnswer).filter(
+                QuestionnaireResponseAnswer.questionnaireResponseId.in_(questionnaire_response_ids)
+            ).delete()
+            session.query(QuestionnaireResponseExtension).filter(
+                QuestionnaireResponseExtension.questionnaireResponseId.in_(questionnaire_response_ids)
+            ).delete()
+            session.query(QuestionnaireResponse).filter(
+                QuestionnaireResponse.questionnaireResponseId.in_(questionnaire_response_ids)
+            ).delete()
+
+        # Commit to finalize the changes for this participant and release the locks
+        session.commit()
+
+
+def add_additional_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument('--pid-file', required=True)
+    parser.add_argument('--dry-run', default=False, action="store_true")
+
+
+def run():
+    cli_run(tool_cmd, tool_desc, UnconsentTool, add_additional_arguments)


### PR DESCRIPTION
## Resolves *[DA-2203](https://precisionmedicineinitiative.atlassian.net/browse/DA-2203)*
This adds a script that will remove participant summaries, consent file records, and questionnaire responses for participants that have been identified by Vibrent as only having a draft version of the primary consent on file (and not having actually signed it). This will reset the participants back to an unconsented state.

The script uses a file listing the participant ids. I've attached the file provided by Vibrent to DA-2203 and will use those participant ids. The code also checks that the participants haven't yet sent a consent in case they consented fully after our checks and before running this script. The code also makes sure no incoming data would be deleted if they consent while the script is running.


## Tests
- [ ] unit tests
No unit tests were added, as this code will be removed once the participants are unconsented.


