### PR TITLE
[PDR-441] Investigate why PDR enrollment status calculations are off from RDR

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -608,12 +608,16 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         modules = list()
         consents = list()
         data = dict()
+        min_valid_authored = datetime.datetime(2017, 1, 1, 0, 0, 0)
 
         if results:
             # Track the last module/consent data dictionaries generated, so we can detect and omit replayed responses
             last_mod_processed = {}
             last_consent_processed = {}
             for row in results:
+                # ROC-692 Exclude CE replayed ConsentPII responses that contain an invalid minimum authored date.
+                if row.authored and row.authored < min_valid_authored:
+                    continue
                 consent_added = False
                 module_name = self._lookup_code_value(row.codeId, ro_session)
                 # Start with a default submittal status.  May be updated if this is a consent module with a specific

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -832,7 +832,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'created': row.created,
                 'created_site': self._lookup_site_name(row.createdSiteId, ro_session),
                 'created_site_id': row.createdSiteId,
-                'final': row.final,
+                'final': 1 if row.final else 0,
                 'finalized': row.finalized,
                 'finalized_site': self._lookup_site_name(row.finalizedSiteId, ro_session),
                 'finalized_site_id': row.finalizedSiteId,

--- a/rdr_service/tools/tool_libs/bq_participant_fix.py
+++ b/rdr_service/tools/tool_libs/bq_participant_fix.py
@@ -1,0 +1,116 @@
+#! /bin/env python
+#
+# Template for RDR tool python program.
+#
+
+import argparse
+
+# pylint: disable=superfluous-parens
+# pylint: disable=broad-except
+import datetime
+import json
+import logging
+import sys
+
+from rdr_service.services.system_utils import setup_logging, setup_i18n, print_progress_bar
+from rdr_service.tools.tool_libs import GCPProcessContext, GCPEnvConfigObject
+
+_logger = logging.getLogger("rdr_logger")
+
+# Tool_cmd and tool_desc name are required.
+# Remember to add/update bash completion in 'tool_lib/tools.bash'
+tool_cmd = "bq-participant-fix"
+tool_desc = "Temporary tool to fix bad pm values"
+
+
+class ProgramTemplateClass(object):
+    def __init__(self, args, gcp_env: GCPEnvConfigObject):
+        """
+        :param args: command line arguments.
+        :param gcp_env: gcp environment information, see: gcp_initialize().
+        """
+        self.args = args
+        self.gcp_env = gcp_env
+
+    def run(self):
+        """
+        Main program process
+        :return: Exit code value
+        """
+        self.gcp_env.activate_sql_proxy()
+        db_conn = self.gcp_env.make_mysqldb_connection()
+
+        project_suffix = self.gcp_env.project.split("-")[-1]
+        pdr_project_id = f'aou-pdr-data-{project_suffix}'
+
+        if pdr_project_id not in ('aou-pdr-data-stable', 'aou-pdr-data-prod'):
+            _logger.error(f'Project {pdr_project_id} is not supported, aborting.')
+            return -1
+
+        # Force resource 'pm_final' value to string and see if it is 'true' or 'false', this excludes fixed records.
+        sql = f"""
+            select id from bigquery_sync
+            where project_id = '{pdr_project_id}' and dataset_id = 'rdr_ops_data_view' and table_id = 'pdr_participant'
+                and resource ->> '$.pm[0].pm_final' in ('true', 'false')
+            order by modified;
+        """
+
+        cursor = db_conn.cursor()
+        cursor.execute(sql)
+        results = cursor.fetchall()
+        ids = [r[0] for r in results]
+        pos = 0
+        total_ids = len(ids)
+
+        print(f'Processing {len(ids)} records...')
+
+        sql = "select resource from bigquery_sync where id = %s"
+        ins_sql = "update bigquery_sync set resource = %s, modified = %s where id = %s"
+
+        for id_ in ids:
+            args = [id_]
+            cursor.execute(sql, args)
+            resource = json.loads(cursor.fetchone()[0])
+
+            for pm in resource['pm']:
+                pm['pm_final'] = 1 if pm['pm_final'] else 0
+
+            ins_args = [json.dumps(resource), datetime.datetime.utcnow(), id_]
+            cursor.execute(ins_sql, ins_args)
+            db_conn.commit()
+
+            pos += 1
+            print_progress_bar(
+                pos, total_ids, prefix="{0}/{1}:".format(pos, total_ids), suffix="complete"
+            )
+
+        cursor.close()
+
+        return 0
+
+
+def run():
+    # Set global debug value and setup application logging.
+    setup_logging(
+        _logger, tool_cmd, "--debug" in sys.argv, "{0}.log".format(tool_cmd) if "--log-file" in sys.argv else None
+    )
+    setup_i18n()
+
+    # Setup program arguments.
+    parser = argparse.ArgumentParser(prog=tool_cmd, description=tool_desc)
+    parser.add_argument("--debug", help="enable debug output", default=False, action="store_true")  # noqa
+    parser.add_argument("--log-file", help="write output to a log file", default=False, action="store_true")  # noqa
+    parser.add_argument("--project", help="gcp project name", default="localhost")  # noqa
+    parser.add_argument("--account", help="pmi-ops account", default=None)  # noqa
+    parser.add_argument("--service-account", help="gcp iam service account", default=None)  # noqa
+    args = parser.parse_args()
+
+    with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
+        process = ProgramTemplateClass(args, gcp_env)
+        exit_code = process.run()
+        return exit_code
+
+
+# --- Main Program Call ---
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
## Resolves *[PDR-441](https://precisionmedicineinitiative.atlassian.net/browse/PDR-441)*


## Description of changes/additions
A boolean json value was used for a newly added field to PDR, BigQuery does not accept boolean values from JSON data. 
Because of the weekend rebuild of all PDR data, there were 305k records that could not be sent to BigQuery.
This PR fixes that issue and another issue that was allowing questionnaire responses with authored timestamps from before the program started with the new enrollment status calculation code.

There is a new tool that is used to convert the boolean value in the participant records in the 'bigquery_sync' table to 0 or 1, which allows the records to be sent to BigQuery.

## Tests
- [x] unit tests


