### PR TITLE
[DA-1453] Resolving unknown delete issue with specimen API

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -57,7 +57,7 @@ class BiobankSpecimenApi(BiobankApiBase):
                     try:
                         self._check_required_specimen_fields(specimen_json)
 
-                        m = self.dao.from_client_json(specimen_json)
+                        m = self.dao.from_client_json(specimen_json, session=session)
                         if m.id is not None:
                             self.dao.update_with_session(session, m)
                         else:

--- a/rdr_service/model/biobank_order.py
+++ b/rdr_service/model/biobank_order.py
@@ -335,10 +335,10 @@ class SpecimenAliquotBase(object):
 class BiobankSpecimen(Base, BiobankSpecimenBase, SpecimenAliquotBase):
     __tablename__ = "biobank_specimen"
 
-    aliquots = relationship("BiobankAliquot", cascade="all, delete-orphan",
+    aliquots = relationship("BiobankAliquot", cascade="all",
                               foreign_keys="BiobankAliquot.specimen_id",
                               order_by="BiobankAliquot.rlimsId")
-    attributes = relationship("BiobankSpecimenAttribute", cascade="all, delete-orphan",
+    attributes = relationship("BiobankSpecimenAttribute", cascade="all",
                               foreign_keys="BiobankSpecimenAttribute.specimen_id",
                               order_by="BiobankSpecimenAttribute.name")
     rlimsId = Column("rlims_id", String(80), unique=True)
@@ -384,10 +384,10 @@ class BiobankAliquot(Base, BiobankSpecimenBase, BiobbankSpecimenAliquotBase, Spe
     initialTreatment = Column("initial_treatment", String(100))
     containerTypeId = Column("container_type_id", String(100))
 
-    datasets = relationship("BiobankAliquotDataset", cascade="all, delete-orphan",
+    datasets = relationship("BiobankAliquotDataset", cascade="all",
                             foreign_keys="BiobankAliquotDataset.aliquot_id",
                             order_by="BiobankAliquotDataset.rlimsId")
-    aliquots = relationship("BiobankAliquot", cascade="all, delete-orphan",
+    aliquots = relationship("BiobankAliquot", cascade="all",
                             foreign_keys="BiobankAliquot.parent_aliquot_id",
                             order_by="BiobankAliquot.rlimsId")
 


### PR DESCRIPTION
## Further work for *[DA-1453](https://precisionmedicineinitiative.atlassian.net/browse/DA-1453)*
The biobank was seeing several updates fail when trying to add new information within a nested structure. To make an example: a specimen is stored in the database with a child aliquot, and that child aliquot has another child aliquot (making a three level nesting structure, i.e. specimen -> child aliquot -> grandchild aliquot). In some cases, if a dataset with dataset items was added to the grandchild aliquot then an error would result. The error arose from sqlalchemy attempting to delete the items being added, but being unable to because they didn't have values for the primary key. It seems that somehow sqlalchemy thought they needed to be deleted because it thought one of the aliquots was an orphan.

This removes the hint for sqlalchemy that orphans should be deleted, which may still have sqlalchemy believe them to be orphans but wouldn't attempt to remove them. I believe it's ok for sqlachemy to see them as orphans anyway (for now) since the ids line up with the database and any data has been loaded and would be written back in the event an object was deleted.

Through this checking I also noticed that a session was being re-created in the migration endpoint where it should have been using the original. This updates the DAO to accept the original session object when migrating.

## Tests
- [ ] unit tests
Unable to reproduce in tests

