### PR TITLE
Replacing dictalchemy with dictalchemy3

### DIFF
--- a/ci/setup_python_env.sh
+++ b/ci/setup_python_env.sh
@@ -10,6 +10,5 @@ source venv/bin/activate
 export PYTHONPATH=`pwd`
 echo "PYTHONPATH=${PYTHONPATH}"
 pip install --upgrade pip
-pip install setuptools==47.1.0
 pip install safety
 pip install -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -50,7 +50,7 @@ sqlalchemy
 alembic
 fhirclient
 protorpc
-dictalchemy
+dictalchemy3
 sqlparse
 
 # JSON schema management

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -20,7 +20,7 @@ configargparse==1.2.3     # via locust
 coverage==6.0b1             # via -r requirements.in
 cryptography==3.3.2       # via oauthlib, pyopenssl, requests
 defusedxml==0.6.0         # via jira
-dictalchemy==0.1.2.7      # via -r requirements.in
+dictalchemy3==1.0.0       # via -r requirements.in
 dnspython==1.16.0         # via -r requirements.in
 docutils==0.16            # via sphinx
 faker==4.1.0              # via -r requirements.in


### PR DESCRIPTION
## Resolves *no ticket*
Recently dictalchemy was throwing errors in CircleCI because python's `use2to3` wasn't available any more. PR #2608 had CircleCI install a specific version of setuptools to continue to have `use2to3` available for dictalchemy. However it doesn't appear that dictalchemy is going to receive any further updates that would let us use later versions of setuptools. And the ReadTheDocs builds started failing on the same issue a well.

## Description of changes/additions
This resolves the original problem in a new way. This replaces dictalchemy with dictalchemy3, a more frequently maintained version of the library that doesn't require `use2to3`.

## Tests
- [ ] unit tests

Existing tests should cover RDR functionality that depends on this.

