### PR TITLE
Validating barcode length when ingesting mail-kit order updates

### DIFF
--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -274,6 +274,10 @@ class MailKitOrderDao(UpdatableDao):
                     if barcode and not barcode.isalnum():
                         barcode = re.sub(r'\W+', '', barcode)
 
+                    if len(barcode) > 20:
+                        # MayoLINK system expects barcodes to be 20 characters or less
+                        raise BadRequest('Given barcode exceeds maximum character length')
+
                     order.barcode = barcode
 
             with self.session() as session:


### PR DESCRIPTION
## Resolves *no ticket*
We've occasionally seen that some mail-kit orders come through with invalid barcodes. In some cases the SupplyRequest update will give a barcode that is more than 20 characters, causing the MayoLINK call (triggered by subsequent SupplyDelivery requests) to fail because MayoLINK rejects any barcodes that are longer than 20 characters.

This updates the SupplyRequest code to immediately flag any issues with the barcode when it is received. This will help avoid needing to track down barcode issues that only come up indirectly when MayoLINK calls are made.

## Tests
- [x] unit tests


