### PR TITLE
Source the venv before running pylint

### DIFF
--- a/ci/test_pre_commit.sh
+++ b/ci/test_pre_commit.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# Run tests which are fast enough to be run before very push.
+if [ "$RDR_VENV" ]; then
+  source "$RDR_VENV"/bin/activate
+fi
+
+# Run tests which are fast enough to be run before every push.
 set -e
 
 echo "Grepping for checked-in credentials..."


### PR DESCRIPTION
## Resolves *no ticket*
I was running into an issue running the pre-commit hook in a git GUI. It wasn't finding pylint because it wasn't using the RDR venv that is set up. This adds a check at the start of the pre-commit that looks for an environment variable and sources the venv if the variable is set.


## Tests
- [ ] unit tests


