### PR TITLE
Fix typo in weekly report

### DIFF
--- a/rdr_service/tools/tool_libs/consent_validation_report.py
+++ b/rdr_service/tools/tool_libs/consent_validation_report.py
@@ -62,7 +62,7 @@ CONSENT_ERROR_COUNT_COLUMNS = [
     ('Invalid DOB', 12),
     ('Age at Primary Consent < 18', 13),
     ('Checkbox Unchecked', 14),
-    ('Non-VA Consent for VA Particip[ant', 15),
+    ('Non-VA Consent for VA Participant', 15),
     ('VA Consent for Non-VA Participant', 16)
 
 ]


### PR DESCRIPTION
## Resolves *No ticket*


## Description of changes/additions
A rogue character in a report column header made it into the last commit/merge of the consent report tool.  Fixing

## Tests
Manual report generation


