### PR TITLE
[DA-2215] Validation script changes

### DIFF
--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 from datetime import datetime, timedelta
 from dateutil.parser import parse
+from itertools import islice
 
 import requests
 
@@ -14,7 +15,7 @@ from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.services.gcp_utils import gcp_make_auth_header
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
 from rdr_service.offline.sync_consent_files import ConsentSyncGuesser
-from rdr_service.services.consent.validation import ConsentValidationController, LogResultStrategy, StoreResultStrategy
+from rdr_service.services.consent.validation import ConsentValidationController, ReplacementStoringStrategy
 from rdr_service.storage import GoogleCloudStorageProvider
 from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
 
@@ -148,8 +149,10 @@ class ConsentTool(ToolBase):
                 self._consent_dao.batch_update_consent_files([file], session)
 
     def validate_consents(self):
-        min_date = parse(self.args.min_date)
-        max_date = parse(self.args.max_date) if self.args.max_date else None
+        summary_dao = ParticipantSummaryDao()
+        consent_type = None
+        if self.args.type:
+            consent_type = ConsentType(self.args.type)
 
         controller = ConsentValidationController(
             consent_dao=ConsentDao(),
@@ -157,16 +160,23 @@ class ConsentTool(ToolBase):
             hpo_dao=HPODao(),
             storage_provider=GoogleCloudStorageProvider()
         )
-        with self.get_session() as session, StoreResultStrategy(
-            session=session,
-            consent_dao=controller.consent_dao
-        ) as store_strategy:
-            controller.validate_recent_uploads(
-                session,
-                store_strategy,
-                min_consent_date=min_date,
-                max_consent_date=max_date
-            )
+        with open(self.args.pid_file) as pid_file,\
+                self.get_session() as session,\
+                ReplacementStoringStrategy(
+                    session=session,
+                    consent_dao=controller.consent_dao
+                ) as store_strategy:
+            # Get participant ids from the file in batches
+            # (retrieving all their summaries at once, processing them before the next batch)
+            participant_lookup_batch_size = 500
+            for participant_ids in islice(pid_file, __stop=participant_lookup_batch_size):
+                summaries = summary_dao.get_by_ids_with_session(session=session, obj_ids=participant_ids)
+                for participant_summary in summaries:
+                    controller.validate_participant_consents(
+                        summary=participant_summary,
+                        output_strategy=store_strategy,
+                        types_to_validate=consent_type
+                    )
 
     def upload_records(self):
         data_to_upload = []
@@ -243,8 +253,9 @@ def add_additional_arguments(parser: argparse.ArgumentParser):
     )
 
     modify_parser = subparsers.add_parser('validate')
-    modify_parser.add_argument('--min_date', help='Earliest date of the expected consents to validate', required=True)
-    modify_parser.add_argument('--max_date', help='Latest date of the expected consents to validate')
+    modify_parser.add_argument('--pid-file', help='File listing the participant ids to validate', required=True)
+    modify_parser.add_argument('--type', help='Consent type to validate, defaults to validating all consents.')
+
 
     modify_parser = subparsers.add_parser('upload')
     modify_parser.add_argument(

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -15,7 +15,8 @@ from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.services.gcp_utils import gcp_make_auth_header
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
 from rdr_service.offline.sync_consent_files import ConsentSyncGuesser
-from rdr_service.services.consent.validation import ConsentValidationController, ReplacementStoringStrategy
+from rdr_service.services.consent.validation import ConsentValidationController, ReplacementStoringStrategy,\
+    LogResultStrategy
 from rdr_service.storage import GoogleCloudStorageProvider
 from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
 


### PR DESCRIPTION
## Assists with *[DA-2215](https://precisionmedicineinitiative.atlassian.net/browse/DA-2215)*
This addresses a few issues and makes some improvements to make for an easier workflow. We're validating large numbers of participants, and we're only needing to check their GROR file. So this makes the following changes to help with that:
- Adds a method to the validation controller that allows for specifying a specific consent type to validate for a given participant
- Changes the `validate` command of the consents script to provide a list of participant ids (in a file) and optionally a type of consent that should be checked
- Storing validation results for the participants will be processed in batches of 500 for the participants being processed
- Checks for previously valid versions of a consent for that participant and doesn't store the new one if it's a copy of the file
- Uses a newer storage strategy that will mark older, invalid files as obsolete.


## Tests
- [x] unit tests


