### PR TITLE
Bump sqlparse for safety check

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -112,7 +112,7 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlalchemy==1.3.17        # via -r requirements.in, alembic, dictalchemy
-sqlparse==0.3.1           # via -r requirements.in
+sqlparse==0.4.2           # via -r requirements.in
 supervisor==4.2.0         # via -r requirements.in
 text-unidecode==1.3       # via faker
 toml==0.10.1              # via pylint


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
CicleCI is failing on safety check for deprecated sqlparse version, bump sqlparse to latest release 0.4.2

## Tests
- [] unit tests
** All current tests should pass with new version bump

