### PR TITLE
Script for data-dictionary update

### DIFF
--- a/rdr_service/tools/tool_libs/data-dictionary.py
+++ b/rdr_service/tools/tool_libs/data-dictionary.py
@@ -1,0 +1,30 @@
+import argparse
+
+from rdr_service.config import DATA_DICTIONARY_DOCUMENT_ID
+from rdr_service.services.data_dictionary_updater import DataDictionaryUpdater
+from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
+
+
+tool_cmd = 'data-dictionary'
+tool_desc = "Supplemental tool for managing RDR's data-dictionary (for when the deploy fails to update it)."
+
+
+class DataDictionaryScript(ToolBase):
+    def run_process(self):
+        with self.initialize_process_context() as gcp_env:
+            self.gcp_env = gcp_env
+            server_config = self.get_server_config()
+
+        updater = DataDictionaryUpdater(server_config[DATA_DICTIONARY_DOCUMENT_ID], self.args.rdr_version)
+        updater.run_update_in_tool(self, logger)
+
+
+def add_additional_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        '--rdr-version',
+        help='Version number of the RDR release to label the changes with in the data dictionary.'
+    )
+
+
+def run():
+    cli_run(tool_cmd, tool_desc, DataDictionaryScript, add_additional_arguments)

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -14,7 +14,7 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         super(DataDictionaryUpdaterTest, self).setUp(**kwargs)
 
         self.mock_rdr_version = '1.97.1'
-        self.updater = DataDictionaryUpdater('', '', self.mock_rdr_version, self.session)
+        self.updater = DataDictionaryUpdater('', self.mock_rdr_version, self.session)
 
     @classmethod
     def _default_tab_names(cls):


### PR DESCRIPTION
## Resolves *no ticket*
Deploying the app has a step for automatically updating the data-dictionary. But unfortunately the google API doesn't always respond well and errors out when trying to update the data-dictionary during the deploy process. This PR adds a script for separately running the update in case it fails during the deploy.

## Description of changes/additions
The logic for the interactive process of updating the data-dictionary is moved into a reusable function in the updater class. This requires context switching (between different accounts for different access), so requires access to the tool running it. The tool passes itself as a parameter to the updater so that context switching can happen.

## Tests
- [x] unit tests

Dictionary updating should be covered by existing tests.


