### PR TITLE
[DA-2213] Allowing for codes longer than 50 chars in curation ETL

### DIFF
--- a/rdr_service/model/code.py
+++ b/rdr_service/model/code.py
@@ -49,9 +49,12 @@ class _CodeBase(object):
     @rdr_dictionary_show_unique_values
     """
     value = Column("value", String(80), nullable=False)
-    # OMOP codes are supposed to be at most 50 characters long; for legacy codes that exceeded this
-    # limit, we populate a shortened version for use in OMOP here. Otherwise, shortValue is identical
-    # to value.
+    # OMOP codes can be any length according to OHDSI:
+    # https://ohdsi.github.io/CommonDataModel/dataModelConventions.html#general
+    # "Precision is provided only for VARCHAR. It reflects the minimal required string length
+    # and can be expanded within a CDM instantiation."
+    #
+    # Leaving shortValue field and functionality in for any downstream users, but no longer using it in curation ETL.
     shortValue = Column("short_value", String(50))
     display = Column("display", UnicodeText)
     topic = Column("topic", UnicodeText)

--- a/rdr_service/services/data_dictionary_updater.py
+++ b/rdr_service/services/data_dictionary_updater.py
@@ -334,7 +334,6 @@ class DataDictionaryUpdater:
             QuestionnaireConcept.questionnaireId,
             Code.display,
             Code.value,
-            Code.shortValue,
             QuestionnaireResponse.questionnaireResponseId.isnot(None)
         ).join(
             Code,
@@ -348,14 +347,14 @@ class DataDictionaryUpdater:
         ).order_by(QuestionnaireConcept.questionnaireId).distinct().all()
         self._sheet.set_current_tab(questionnaire_key_tab_id)
         for row_number, (questionnaire_id, code_display, code_value,
-                         code_short_value, has_responses) in enumerate(questionnaire_data_list):
+                         has_responses) in enumerate(questionnaire_data_list):
             has_responses_yn_indicator = 'Y' if has_responses else 'N'
 
             is_ppi_survey = 'Scheduling' not in code_value and 'SNAP' not in code_value
             is_ppi_survey_yn_indicator = 'Y' if is_ppi_survey else 'N'
 
             update_helper.update_with_values(row_number, [
-                questionnaire_id, code_display, code_short_value, has_responses_yn_indicator, is_ppi_survey_yn_indicator
+                questionnaire_id, code_display, code_value, has_responses_yn_indicator, is_ppi_survey_yn_indicator
             ])
 
         self._sheet.truncate_tab_at_row(len(questionnaire_data_list))

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -282,9 +282,9 @@ class CurationExportClass(ToolBase):
             SrcClean.external_id: Participant.externalId,
             SrcClean.survey_name: module_code.value,
             SrcClean.date_of_survey: coalesce(QuestionnaireResponse.authored, QuestionnaireResponse.created),
-            SrcClean.question_ppi_code: question_code.shortValue,
+            SrcClean.question_ppi_code: question_code.value,
             SrcClean.question_code_id: QuestionnaireQuestion.codeId,
-            SrcClean.value_ppi_code: answer_code.shortValue,
+            SrcClean.value_ppi_code: answer_code.value,
             SrcClean.topic_value: answer_code.topic,
             SrcClean.value_code_id: QuestionnaireResponseAnswer.valueCodeId,
             SrcClean.value_number: case([(

--- a/tests/service_tests/test_data_dictionary_updater.py
+++ b/tests/service_tests/test_data_dictionary_updater.py
@@ -180,11 +180,10 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
     def test_questionnaire_key_tab(self):
         # Create two questionnaires for the test, one without any responses and another that has one
         # Also make one a scheduling survey to check the PPI survey indicator
-        code = self.data_generator.create_database_code(display='Test Questionnaire', shortValue='test_questionnaire')
+        code = self.data_generator.create_database_code(display='Test Questionnaire', value='test_questionnaire')
         scheduling_code = self.data_generator.create_database_code(
             display='Scheduling Survey',
-            value='Scheduling',
-            shortValue='Scheduling'
+            value='Scheduling'
         )
         no_response_questionnaire = self.data_generator.create_database_questionnaire_history()
         self.data_generator.create_database_questionnaire_concept(
@@ -209,12 +208,12 @@ class DataDictionaryUpdaterTest(GoogleSheetsTestBase):
         self.updater.run_update()
         questionnaire_values = self._get_tab_rows(questionnaire_key_tab_id)
         self.assertIn(
-            [str(no_response_questionnaire.questionnaireId), code.display, code.shortValue, 'N', 'Y'],
+            [str(no_response_questionnaire.questionnaireId), code.display, code.value, 'N', 'Y'],
             questionnaire_values
         )
         self.assertIn(
             [str(response_questionnaire.questionnaireId),
-             scheduling_code.display, scheduling_code.shortValue, 'Y', 'N'],
+             scheduling_code.display, scheduling_code.value, 'Y', 'N'],
             questionnaire_values
         )
 


### PR DESCRIPTION
## Resolves *[DA-2213](https://precisionmedicineinitiative.atlassian.net/browse/DA-2213)*
When exporting to curation, RDR has been truncating code values to 50 characters. But according to OHDSI, `VARCHAR(50)` in their documentation means that the minimum number of characters that should be in a code is 50 and that they can be longer than 50 characters.

## Description of changes/additions
This PR uses the full code value in the curation ETL, rather than the truncated version of the string. The truncating logic has been left in place, in case other downstream systems use it.

This also updates the data-dictionary to use the full code value.

## Tests
- [x] unit tests

Existing unit tests have been modified to no longer use the short code value.


