### PR TITLE
Update CI steps to run "Safety Check" early in the process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ commands:
           name: Code static analysis checks
           command: ci/full_static_analysis.sh
       - run:
+          name: Safety Check
+          command: source venv/bin/activate && safety check
+      - run:
           name: Check Licenses
           command : |
             export PYTHONPATH=$PYTHONPATH:`pwd`
@@ -43,9 +46,6 @@ commands:
       - run:
           name: Upload Coverage Report
           command: ./ci/run_upload_coverage_report.sh
-      - run:
-          name: Safety Check
-          command: source venv/bin/activate && safety check
 
   deploy-app-steps:
     parameters:


### PR DESCRIPTION
## Description of changes/additions
Reordered CI job step "Safety Check" so it runs early so we fail fast instead making us wait 20 minutes.

## Tests
- [] unit tests


