### PR TITLE
Filter CE participants from HPro consents

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -118,6 +118,7 @@ HPO_LITE_REDCAP_PROJECT_TOKEN = 'hpo_lite_pairing_import_key'
 HPO_LITE_ORG_NAME_MAPPING = 'hpo_lite_org_name_mapping'
 DATA_BUCKET_SUBFOLDERS_PROD = 'data_bucket_subfolders_prod'
 HEALTHPRO_CONSENT_BUCKET = 'hpro_consent_bucket'
+HEALTHPRO_CONSENTS_TRANSFER_LIMIT = 'hpro_consents_transfer_limit'
 
 # Buckets to listen for Pub/Sub notifications
 PUBSUB_NOTIFICATION_BUCKETS_PROD = [

--- a/rdr_service/dao/hpro_consent_dao.py
+++ b/rdr_service/dao/hpro_consent_dao.py
@@ -25,6 +25,7 @@ class HealthProConsentDao(UpdatableDao):
                     ConsentSyncStatus.READY_FOR_SYNC,
                     ConsentSyncStatus.SYNC_COMPLETE
                 ]),
+                ConsentFile.file_path.notlike('%ce-uploads%'),
                 HealthProConsentFile.id.is_(None)
             )
 

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -407,7 +407,7 @@ def migrate_requests_logs(target_db):
 @app_util.auth_required_cron
 def transfer_hpro_consents():
     hpro_consents = HealthProConsentFile()
-    hpro_consents.transfer_limit = 1000
+    hpro_consents.transfer_limit = config.getSetting(config.HEALTHPRO_CONSENTS_TRANSFER_LIMIT, default=1000)
     hpro_consents.initialize_consent_transfer()
     return '{ "success": "true" }'
 

--- a/tests/dao_tests/test_hpro_consent_file_dao.py
+++ b/tests/dao_tests/test_hpro_consent_file_dao.py
@@ -112,3 +112,23 @@ class HealthProConsentDaoTest(BaseTestCase):
         records = self.dao.batch_get_by_participant(pids_inserted)
         self.assertEqual(len(records), num_pid_records * no_path_num)
 
+    def test_get_needed_consents_only_vibrent(self):
+        exclude = 'ce-uploads-all-of-us-rdr-prod/'
+        include = 'test-file-path/'
+
+        for num in range(self.num_consents):
+            if num % 2 == 0:
+                file_path = include
+            else:
+                file_path = exclude
+
+            self.data_generator.create_database_consent_file(
+                file_path=f'{file_path}{num}',
+                sync_status=self.sync_statuses[0]
+            )
+
+        needed_transfer_consents = self.dao.get_needed_consents_for_transfer()
+
+        self.assertTrue(all(obj for obj in needed_transfer_consents if exclude not in obj.file_path))
+        self.assertTrue(all(obj for obj in needed_transfer_consents if include in obj.file_path))
+

--- a/tests/dao_tests/test_hpro_consent_file_dao.py
+++ b/tests/dao_tests/test_hpro_consent_file_dao.py
@@ -129,6 +129,7 @@ class HealthProConsentDaoTest(BaseTestCase):
 
         needed_transfer_consents = self.dao.get_needed_consents_for_transfer()
 
-        self.assertTrue(all(obj for obj in needed_transfer_consents if exclude not in obj.file_path))
-        self.assertTrue(all(obj for obj in needed_transfer_consents if include in obj.file_path))
+        self.assertTrue(all(exclude not in obj.file_path for obj in needed_transfer_consents))
+        self.assertTrue(all(include in obj.file_path for obj in needed_transfer_consents))
+
 

--- a/tests/service_tests/test_hpro_consent_file.py
+++ b/tests/service_tests/test_hpro_consent_file.py
@@ -145,3 +145,27 @@ class HealthProConsentFileTest(BaseTestCase):
             self.assertIsNotNone(paths[i]['dest'])
             self.assertEqual(paths[i]['src'], val[0][0])
             self.assertEqual(paths[i]['dest'], val[0][1])
+
+    def test_hpro_transfer_limit_from_config(self):
+        limit = [2]
+
+        for num in range(self.num_consents):
+            self.data_generator.create_database_consent_file(
+                file_path=f'test_file_path/{num}',
+                file_exists=1,
+                sync_status=self.sync_statuses[0]
+            )
+
+        self.hpro_consents.get_consents_for_transfer()
+        self.assertEqual(len(self.hpro_consents.consents_for_transfer), self.num_consents)
+
+        self.hpro_consents.transfer_limit = config.getSetting(config.HEALTHPRO_CONSENTS_TRANSFER_LIMIT, default=1)
+        self.hpro_consents.get_consents_for_transfer()
+        self.assertEqual(len(self.hpro_consents.consents_for_transfer), 1)
+
+        config.override_setting(config.HEALTHPRO_CONSENTS_TRANSFER_LIMIT, limit)
+        self.hpro_consents.transfer_limit = config.getSetting(config.HEALTHPRO_CONSENTS_TRANSFER_LIMIT)
+        self.hpro_consents.get_consents_for_transfer()
+        self.assertEqual(len(self.hpro_consents.consents_for_transfer), limit[0])
+
+


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Need to filter CE participants from sending consents to Healthpro in lieu of validation process for CE participants is not active. Filtering is done based on file path in consent files model.

## Tests
- [x] unit tests


