### PR TITLE
[DA-2220] Data quality checks for questionnaire responses

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -913,6 +913,11 @@ class QuestionnaireResponseDao(BaseDao):
         authored = None
         if fhir_qr.authored and fhir_qr.authored.date:
             authored = fhir_qr.authored.date
+        else:
+            logging.error(
+                f'Response by P{participant_id} to questionnaire {questionnaire.questionnaireId} '
+                f'has missing or invalid authored date'
+            )
 
         language = None
         non_participant_author = None

--- a/rdr_service/services/data_quality.py
+++ b/rdr_service/services/data_quality.py
@@ -6,7 +6,6 @@ from typing import List, Type
 
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.participant import Participant
-from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.patient_status import PatientStatus
 from rdr_service.model.questionnaire import Questionnaire, QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
@@ -119,13 +118,12 @@ class ResponseQualityChecker(_ModelQualityChecker):
                 QuestionnaireResponse.created,
                 QuestionnaireResponse.authored,
                 Participant.signUpTime,
-                ParticipantSummary.suspensionTime,
-                ParticipantSummary.withdrawalAuthored,
+                Participant.suspensionTime,
+                Participant.withdrawalAuthored,
                 func.count(QuestionnaireResponseAnswer.questionnaireResponseAnswerId)
             )
             .select_from(QuestionnaireResponse)
             .join(Participant)
-            .outerjoin(ParticipantSummary)
             .outerjoin(QuestionnaireResponseAnswer)
             .group_by(QuestionnaireResponse.questionnaireResponseId)
         )

--- a/tests/service_tests/test_data_quality_checker.py
+++ b/tests/service_tests/test_data_quality_checker.py
@@ -70,9 +70,8 @@ class DataQualityCheckerTest(BaseTestCase):
         )
 
     def test_response_after_suspension(self, mock_logging):
-        suspended_participant = self.data_generator.create_database_participant(signUpTime=datetime(2020, 4, 10))
-        self.data_generator.create_database_participant_summary(
-            participant=suspended_participant,
+        suspended_participant = self.data_generator.create_database_participant(
+            signUpTime=datetime(2020, 4, 10),
             suspensionTime=datetime(2020, 8, 4)
         )
         now = datetime.now().replace(microsecond=0)
@@ -89,9 +88,8 @@ class DataQualityCheckerTest(BaseTestCase):
         )
 
     def test_response_after_withdrawal(self, mock_logging):
-        withdrawn_participant = self.data_generator.create_database_participant(signUpTime=datetime(2020, 4, 10))
-        self.data_generator.create_database_participant_summary(
-            participant=withdrawn_participant,
+        withdrawn_participant = self.data_generator.create_database_participant(
+            signUpTime=datetime(2020, 4, 10),
             withdrawalAuthored=datetime(2020, 8, 4)
         )
         now = datetime.now().replace(microsecond=0)


### PR DESCRIPTION
## Resolves *[DA-2220](https://precisionmedicineinitiative.atlassian.net/browse/DA-2220)*
This PR adds additional checks for questionnaire responses to make sure we're receiving valid data from PTSC. The following four checks are made, and if they fail validation we will get a log message printed out:
- authored date after participant's suspension or withdrawal time
- missing or malformed authored date
- authored date before the survey launch date (approximated by using the questionnaire's created date)
- authored date any date in the future (checked using the datetime that the RDR receives the response payload)


## Tests
- [x] unit tests


