### PR TITLE
Pulling sendgrid code out into an interface

### DIFF
--- a/rdr_service/services/email.py
+++ b/rdr_service/services/email.py
@@ -38,7 +38,7 @@ class EmailService:
         return {
             'personalizations': [
                 {
-                    'to': [{'email': r} for r in email.recipients],
+                    'to': [{'email': recipient} for recipient in email.recipients],
                     'subject': email.subject
                 }
             ],

--- a/rdr_service/services/email.py
+++ b/rdr_service/services/email.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from sendgrid import sendgrid
+
+from rdr_service import config
+
+
+class Email:
+    """Object for encapsulating the data for an email"""
+    def __init__(self, subject: str = '', recipients: List[str] = None, from_email: str = None,
+                 plain_text_content: str = ''):
+        self.subject = subject
+        self.plain_text_content = plain_text_content
+
+        if from_email is None:
+            from_email = config.SENDGRID_FROM_EMAIL
+        self.from_email = from_email
+
+        if recipients is None:
+            recipients = []
+        self.recipients = recipients
+
+
+class EmailService:
+    """
+    Class for acting as an interface for sending an email.
+    Will build the data structure as required by an external API (such as SendGrid).
+    """
+    @classmethod
+    def send_email(cls, email: Email):
+        sendgrid_client = sendgrid.SendGridAPIClient(api_key=config.getSetting(config.SENDGRID_KEY))
+
+        sendgrid_email_dict = cls._sendgrid_dict_from_email(email)
+        return sendgrid_client.client.mail.send.post(request_body=sendgrid_email_dict)
+
+    @classmethod
+    def _sendgrid_dict_from_email(cls, email: Email) -> dict:
+        return {
+            'personalizations': [
+                {
+                    'to': [{'email': r} for r in email.recipients],
+                    'subject': email.subject
+                }
+            ],
+            'from': {
+                'email': email.from_email
+            },
+            'content': [
+                {
+                    'type': 'text/plain',
+                    'value': email.plain_text_content
+                }
+            ]
+        }

--- a/tests/service_tests/test_email_service.py
+++ b/tests/service_tests/test_email_service.py
@@ -1,0 +1,58 @@
+import mock
+
+from rdr_service import config
+from rdr_service.services.email import Email, EmailService
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class EmailServiceTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(EmailServiceTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs) -> None:
+        super(EmailServiceTest, self).setUp(*args, **kwargs)
+        self.temporarily_override_config_setting(config.SENDGRID_KEY, ['test_key'])
+
+    def test_from_email_default(self):
+        """Test that an email without a from-email provided will default to the no-reply email"""
+        email = Email()
+        self.assertEqual(config.SENDGRID_FROM_EMAIL, email.from_email)
+
+    @mock.patch('rdr_service.services.email.sendgrid')
+    def test_sendgrid_email_data_structure(self, sendgrid_mock):
+        """Make sure the email data structure is formed correctly when sending an email to SendGrid"""
+        email = Email(
+            from_email='unit@test.me',
+            recipients=[
+                'first@test.com',
+                'another@foo.baz'
+            ],
+            subject='Testing email data structure for SendGrid',
+            plain_text_content='This is the content\n\tof the test email'
+        )
+        EmailService.send_email(email)
+
+        sendgrid_post_mock = sendgrid_mock.SendGridAPIClient.return_value.client.mail.send.post
+        sent_email_dict = sendgrid_post_mock.call_args.kwargs['request_body']
+        self.assertEqual({
+            'personalizations': [
+                {
+                    'to': [
+                        {'email': 'first@test.com'},
+                        {'email': 'another@foo.baz'}
+                    ],
+                    'subject': 'Testing email data structure for SendGrid',
+                }
+            ],
+            'from': {
+                'email': 'unit@test.me'
+            },
+            'content': [
+                {
+                    'type': 'text/plain',
+                    'value': 'This is the content\n\tof the test email'
+                }
+            ]
+        }, sent_email_dict)
+


### PR DESCRIPTION
## Resolves *no ticket*
This PR pulls the SendGrid API interaction code out into an interface that can be called from other code where we'd want to send an email.

## Description of changes/additions
Adds an `Email` class that acts as a wrapper for all the email data. And an `EmailService` class that has a method for sending that email (using SendGrid). These two classes can act as a buffer between us and SendGrid (just in case we ever want to switch to something else).

This also modifies the Genomics code so it doesn't use SendGrid directly.

## Tests
- [x] unit tests


