### PR TITLE
[DA-2229]  AW1F to PubSub

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -218,7 +218,6 @@
     "a3_manifest_workflow": 1,
     "aw0_manifest_workflow": 1,
     "aw1_manifest_workflow": 1,
-    "aw1f_manifest_workflow": 1,
     "aw1c_manifest_workflow": 0,
     "aw1cf_manifest_workflow": 0,
     "aw2f_manifest_workflow": 1,

--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -81,7 +81,7 @@ class IngestAW1ManifestTaskApi(BaseGenomicTaskApi):
             message = 'AW1'
 
             # Write a different manifest type and JOB ID if an AW1F
-            if "FAILURE" in file_path:
+            if "failure" in file_path.lower():
                 job = GenomicJob.AW1F_MANIFEST
                 manifest_type = GenomicManifestTypes.AW1F
                 create_fb = False

--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -78,12 +78,14 @@ class IngestAW1ManifestTaskApi(BaseGenomicTaskApi):
             job = GenomicJob.AW1_MANIFEST
             manifest_type = GenomicManifestTypes.BIOBANK_GC
             create_fb = True
+            message = 'AW1'
 
             # Write a different manifest type and JOB ID if an AW1F
             if "FAILURE" in file_path:
                 job = GenomicJob.AW1F_MANIFEST
                 manifest_type = GenomicManifestTypes.AW1F
                 create_fb = False
+                message = 'AW1F'
 
             # Set up file/JSON
             task_data = {
@@ -97,9 +99,7 @@ class IngestAW1ManifestTaskApi(BaseGenomicTaskApi):
                 }
             }
 
-            _type = 'AW1F' if job == GenomicJob.AW1F_MANIFEST else 'AW1'
-
-            logging.info(f'{_type} task data: {task_data}')
+            logging.info(f'{message} task data: {task_data}')
 
             # Call pipeline function
             genomic_pipeline.execute_genomic_manifest_file_pipeline(task_data)

--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -66,7 +66,7 @@ class LoadRawAWNManifestDataAPI(BaseGenomicTaskApi):
 
 class IngestAW1ManifestTaskApi(BaseGenomicTaskApi):
     """
-    Cloud Task endpoint: Ingest AW1 Manifest.
+    Cloud Task endpoint: Ingest AW1/AW1F Manifest.
     """
     def post(self):
         super(IngestAW1ManifestTaskApi, self).post()
@@ -97,7 +97,9 @@ class IngestAW1ManifestTaskApi(BaseGenomicTaskApi):
                 }
             }
 
-            logging.info(f'AW1 task data: {task_data}')
+            _type = 'AW1F' if job == GenomicJob.AW1F_MANIFEST else 'AW1'
+
+            logging.info(f'{_type} task data: {task_data}')
 
             # Call pipeline function
             genomic_pipeline.execute_genomic_manifest_file_pipeline(task_data)

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -75,7 +75,6 @@
     "a3_manifest_workflow": 1,
     "aw0_manifest_workflow": 1,
     "aw1_manifest_workflow": 1,
-    "aw1f_manifest_workflow": 1,
     "aw1c_manifest_workflow": 0,
     "aw1cf_manifest_workflow": 0,
     "aw2f_manifest_workflow": 1,

--- a/rdr_service/config/pub_sub_config_prod.json
+++ b/rdr_service/config/pub_sub_config_prod.json
@@ -445,6 +445,17 @@
       "event_types": [
         "OBJECT_FINALIZE"
       ],
+      "id": "42",
+      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
       "id": "49",
       "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
       "payload_format": "JSON_API_V1",
@@ -456,18 +467,7 @@
       "event_types": [
         "OBJECT_FINALIZE"
       ],
-      "id": "61",
-      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "62",
+      "id": "50",
       "object_name_prefix": "AW1F_genotyping_accessioning_results/AW1F_pre_results/",
       "payload_format": "JSON_API_V1",
       "topic_name": "genomic_manifest_upload",

--- a/rdr_service/config/pub_sub_config_prod.json
+++ b/rdr_service/config/pub_sub_config_prod.json
@@ -2,289 +2,476 @@
   "notifications": [
     {
       "bucket": "prod-genomics-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
       "id": "43",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
       "object_name_prefix": "AW1_genotyping_sample_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
     },
     {
       "bucket": "prod-genomics-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
       "id": "44",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
       "object_name_prefix": "AW1_wgs_sample_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "id": "38",
+      "payload_format": "JSON_API_V1",
       "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW1_genotyping_sample_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "id": "39",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW1_wgs_sample_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "id": "53",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW1_genotyping_sample_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "id": "54",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW1_wgs_sample_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "id": "32",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW2_genotyping_data_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "id": "33",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW2_wgs_data_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "id": "35",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "id": "37",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW2_genotyping_data_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "id": "38",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "aw2_wgs_data_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "id": "40",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "wgs_sample_raw_data/ss_vcf_research/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "id": "37",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW2_genotyping_data_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "id": "38",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW2_wgs_data_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "id": "40",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "id": "9",
-      "topic_name": "prod-drc-broad",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW3_genotyping_data_manifests/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "id": "14",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW4_array_manifest/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "id": "15",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW4_wgs_manifest/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "id": "16",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW5_array_manifest/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "id": "17",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "AW5_wgs_manifest/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
+      "topic_project": "all-of-us-rdr-prod"
     },
     {
       "bucket": "prod-genomics-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
       "id": "45",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
       "object_name_prefix": "Wgs_sample_raw_data/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
     },
     {
       "bucket": "prod-genomics-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
       "id": "46",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
       "object_name_prefix": "Genotyping_sample_raw_data/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
     },
     {
-      "bucket": "prod-genomics-broad",
-      "id": "40",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "wgs_sample_raw_data/",
+      "bucket": "prod-genomics-baylor",
       "event_types": [
         "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "id": "41",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ]
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "id": "55",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
+      ],
+      "id": "47",
       "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-baylor",
       "event_types": [
         "OBJECT_FINALIZE"
-      ]
+      ],
+      "id": "48",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "38",
+      "object_name_prefix": "AW1_genotyping_sample_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "39",
+      "object_name_prefix": "AW1_wgs_sample_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "40",
+      "object_name_prefix": "wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "41",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "42",
+      "object_name_prefix": "wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "43",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
     },
     {
       "bucket": "prod-genomics-northwest",
-      "id": "56",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod",
-      "payload_format": "JSON_API_V1",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
       "event_types": [
         "OBJECT_FINALIZE"
-      ]
+      ],
+      "id": "53",
+      "object_name_prefix": "AW1_genotyping_sample_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "54",
+      "object_name_prefix": "AW1_wgs_sample_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "55",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "56",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "57",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "58",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "59",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "60",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "32",
+      "object_name_prefix": "AW2_genotyping_data_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "33",
+      "object_name_prefix": "AW2_wgs_data_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "39",
+      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "40",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "41",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "37",
+      "object_name_prefix": "AW2_genotyping_data_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "38",
+      "object_name_prefix": "aw2_wgs_data_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "46",
+      "object_name_prefix": "wgs_sample_raw_data/ss_vcf_research/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "47",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "48",
+      "object_name_prefix": "wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "37",
+      "object_name_prefix": "AW2_genotyping_data_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "38",
+      "object_name_prefix": "AW2_wgs_data_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "44",
+      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "45",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-data-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "48",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-drc-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "9",
+      "object_name_prefix": "AW3_genotyping_data_manifests/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "prod-drc-broad",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-drc-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "14",
+      "object_name_prefix": "AW4_array_manifest/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-drc-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "15",
+      "object_name_prefix": "AW4_wgs_manifest/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-drc-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "16",
+      "object_name_prefix": "AW5_array_manifest/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-drc-broad",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "17",
+      "object_name_prefix": "AW5_wgs_manifest/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-baylor",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "49",
+      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "61",
+      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
+    },
+    {
+      "bucket": "prod-genomics-northwest",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "62",
+      "object_name_prefix": "AW1F_genotyping_accessioning_results/AW1F_pre_results/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-prod"
     }
   ]
 }

--- a/rdr_service/config/pub_sub_config_sandbox.json
+++ b/rdr_service/config/pub_sub_config_sandbox.json
@@ -61,6 +61,50 @@
       "event_types": [
         "OBJECT_FINALIZE"
       ]
+    },
+    {
+      "bucket": "aou-rdr-sandbox-mock-data",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "86",
+      "object_name_prefix": "Genotyping_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-sandbox"
+    },
+    {
+      "bucket": "aou-rdr-sandbox-mock-data",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "87",
+      "object_name_prefix": "Wgs_sample_raw_data/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_data_files_upload",
+      "topic_project": "all-of-us-rdr-sandbox"
+    },
+    {
+      "bucket": "aou-rdr-sandbox-mock-data",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "88",
+      "object_name_prefix": "AW4_wgs_manifest/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-sandbox"
+    },
+    {
+      "bucket": "aou-rdr-sandbox-mock-data",
+      "event_types": [
+        "OBJECT_FINALIZE"
+      ],
+      "id": "89",
+      "object_name_prefix": "AW1F_genotyping_accessioning_results/AW1F_pre_results/",
+      "payload_format": "JSON_API_V1",
+      "topic_name": "genomic_manifest_upload",
+      "topic_project": "all-of-us-rdr-sandbox"
     }
   ]
 }

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -79,11 +79,6 @@ cron:
   timezone: America/New_York
   schedule: every day 06:30
   target: offline
-- description: Genomic AW1 Failures Workflow
-  url: /offline/GenomicFailuresWorkflow
-  timezone: America/New_York
-  schedule: every day 06:00
-  target: offline
 - description: Genomic AW1C (CVL) Workflow (Manual)
   url: /offline/GenomicAW1CManifestWorkflow
   timezone: America/New_York

--- a/rdr_service/gcloud_functions/genomic_ingest_manifest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_ingest_manifest_function/main.py
@@ -37,6 +37,7 @@ class GenomicIngestManifestFunction(FunctionPubSubHandler):
 
         self.task_mappings = {
             "aw1": "IngestAW1ManifestTaskApi",
+            "aw1f": "IngestAW1ManifestTaskApi",
             "aw2": "IngestAW2ManifestTaskApi",
             "aw4": "IngestAW4ManifestTaskApi",
             "aw5": "IngestAW5ManifestTaskApi"
@@ -53,7 +54,6 @@ class GenomicIngestManifestFunction(FunctionPubSubHandler):
         _logger.info(f"File found: {self.event.attributes.objectId}")
 
         object_id = self.event.attributes.objectId.lower()
-        task_key = None
 
         # AW1 files have "_sample_manifests" in file name
         if '_sample_manifests' in object_id:

--- a/rdr_service/gcloud_functions/genomic_ingest_manifest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_ingest_manifest_function/main.py
@@ -58,6 +58,10 @@ class GenomicIngestManifestFunction(FunctionPubSubHandler):
         if '_sample_manifests' in object_id:
             task_key = "aw1"
 
+        # AW1F files have "aw1f_pre_results" in file name
+        elif 'aw1f_pre_results' in object_id:
+            task_key = "aw1"
+
         # AW2 files have "_data_manifests" in their file name
         elif '_data_manifests' in object_id:
             task_key = "aw2"

--- a/rdr_service/gcloud_functions/genomic_ingest_manifest_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_ingest_manifest_function/main.py
@@ -37,7 +37,6 @@ class GenomicIngestManifestFunction(FunctionPubSubHandler):
 
         self.task_mappings = {
             "aw1": "IngestAW1ManifestTaskApi",
-            "aw1f": "IngestAW1ManifestTaskApi",
             "aw2": "IngestAW2ManifestTaskApi",
             "aw4": "IngestAW4ManifestTaskApi",
             "aw5": "IngestAW5ManifestTaskApi"

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -280,6 +280,7 @@ class GenomicJobController:
                                                 _controller=self)
 
             self.job_result = self.ingester.generate_file_queue_and_do_ingestion()
+
         except RuntimeError:
             self.job_result = GenomicSubProcessResult.ERROR
 
@@ -895,27 +896,6 @@ class GenomicJobController:
                                                 _controller=self)
 
             self.job_result = self.ingester.generate_file_queue_and_do_ingestion()
-        except RuntimeError:
-            self.job_result = GenomicSubProcessResult.ERROR
-
-    def run_aw1f_manifest_workflow(self):
-        """
-        Ingests the BB to GC failure manifest (AW1F)
-        from post-accessioning subfolder.
-        """
-        try:
-            for gc_bucket_name in self.bucket_name_list:
-                for folder in self.sub_folder_tuple:
-                    self.sub_folder_name = config.getSetting(folder)
-                    self.ingester = GenomicFileIngester(job_id=self.job_id,
-                                                        job_run_id=self.job_run.id,
-                                                        bucket=gc_bucket_name,
-                                                        sub_folder=self.sub_folder_name,
-                                                        _controller=self)
-                    self.subprocess_results.add(
-                        self.ingester.generate_file_queue_and_do_ingestion()
-                    )
-            self.job_result = self._aggregate_run_results()
         except RuntimeError:
             self.job_result = GenomicSubProcessResult.ERROR
 

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -57,19 +57,6 @@ def genomic_centers_manifest_workflow():
         controller.run_genomic_centers_manifest_workflow()
 
 
-def genomic_centers_aw1f_manifest_workflow():
-    """
-        Entrypoint for Ingestion:
-            Failure Manifest (AW1F)
-        """
-    with GenomicJobController(GenomicJob.AW1F_MANIFEST,
-                              bucket_name=None,
-                              bucket_name_list=config.GENOMIC_CENTER_BUCKET_NAME,
-                              sub_folder_tuple=config.GENOMIC_AW1F_SUBFOLDERS
-                              ) as controller:
-        controller.run_aw1f_manifest_workflow()
-
-
 def ingest_aw1c_manifest():
     """
     Entrypoint for CVL AW1C Manifest Ingestion workflow
@@ -102,19 +89,6 @@ def aw1cf_alerts_workflow():
                               bucket_name=None,
                               bucket_name_list=config.GENOMIC_CENTER_BUCKET_NAME,
                               sub_folder_tuple=config.GENOMIC_CVL_AW1CF_MANIFEST_SUBFOLDER
-                              ) as controller:
-        controller.process_failure_manifests_for_alerts()
-
-
-def genomic_centers_accessioning_failures_workflow():
-    """
-        Entrypoint for Accessioning Alerts:
-            Failure Manifest (AW1F)
-        """
-    with GenomicJobController(GenomicJob.AW1F_ALERTS,
-                              bucket_name=None,
-                              bucket_name_list=config.GENOMIC_CENTER_BUCKET_NAME,
-                              sub_folder_tuple=config.GENOMIC_AW1F_SUBFOLDERS
                               ) as controller:
         controller.process_failure_manifests_for_alerts()
 
@@ -368,8 +342,10 @@ def execute_genomic_manifest_file_pipeline(_task_data: dict, project_id=None):
                               task_data=task_data,
                               bq_project_id=project_id) as controller:
         manifest_file = controller.insert_genomic_manifest_file_record()
+
         if task_data.file_data.create_feedback_record:
             controller.insert_genomic_manifest_feedback_record(manifest_file)
+
         controller.job_result = GenomicSubProcessResult.SUCCESS
 
     if task_data.job:
@@ -396,7 +372,6 @@ def dispatch_genomic_job_from_task(_task_data: JSONObject, project_id=None):
         GenomicJob.AW5_ARRAY_MANIFEST,
         GenomicJob.AW5_WGS_MANIFEST
     ):
-
         # Ingestion Job
         with GenomicJobController(_task_data.job,
                                   task_data=_task_data,

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -438,14 +438,6 @@ def genomic_gc_manifest_workflow():
 
 
 @app_util.auth_required_cron
-@run_genomic_cron_job('aw1f_manifest_workflow')
-def genomic_aw1f_failures_workflow():
-    genomic_pipeline.genomic_centers_aw1f_manifest_workflow()
-    genomic_pipeline.genomic_centers_accessioning_failures_workflow()
-    return '{"success": "true"}'
-
-
-@app_util.auth_required_cron
 @run_genomic_cron_job('aw1c_manifest_workflow')
 def aw1c_manifest_workflow():
     """Temporarily running this manually for E2E Testing"""
@@ -789,12 +781,6 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicGCManifestWorkflow",
         endpoint="genomic_gc_manifest_workflow",
         view_func=genomic_gc_manifest_workflow,
-        methods=["GET"]
-    )
-    offline_app.add_url_rule(
-        OFFLINE_PREFIX + "GenomicFailuresWorkflow",
-        endpoint="genomic_aw1f_failures_workflow",
-        view_func=genomic_aw1f_failures_workflow,
         methods=["GET"]
     )
     offline_app.add_url_rule(

--- a/tests/cron_job_tests/test_genomic_pipeline.py
+++ b/tests/cron_job_tests/test_genomic_pipeline.py
@@ -2231,52 +2231,6 @@ class GenomicPipelineTest(BaseTestCase):
         # Test the end-to-end result code
         self.assertEqual(GenomicSubProcessResult.SUCCESS, self.job_run_dao.get(2).runResult)
 
-    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController._send_email_with_sendgrid')
-    def test_aw1f_alerting_emails(self, send_email_mock):
-        gc_manifest_filename = "RDR_AoU_SEQ_PKG-1908-218051_FAILURE.csv"
-
-        self._write_cloud_csv(
-            gc_manifest_filename,
-            ".",
-            bucket=_FAKE_GENOMIC_CENTER_BUCKET_A,
-            folder=_FAKE_FAILURE_FOLDER,
-        )
-
-        genomic_pipeline.genomic_centers_accessioning_failures_workflow()
-
-        # Todo: change to expected response code
-        # send_email_mock.return_value = "SUCCESS"
-
-        # Set up expected SendGrid request
-        email_message = "New AW1 Failure manifests have been found:\n"
-        email_message += f"\t{_FAKE_GENOMIC_CENTER_BUCKET_A}:\n"
-        email_message += f"\t\t{_FAKE_FAILURE_FOLDER}/{gc_manifest_filename}\n"
-
-        expected_email_req = {
-            "personalizations": [
-                {
-                    "to": [{"email": "test-genomic@vumc.org"}],
-                    "subject": "All of Us GC Manifest Failure Alert"
-                }
-            ],
-            "from": {
-                "email": "no-reply@pmi-ops.org"
-            },
-            "content": [
-                {
-                    "type": "text/plain",
-                    "value": email_message
-                }
-            ]
-        }
-
-        send_email_mock.assert_called_with(expected_email_req)
-
-        # Test the end-to-end result code
-        job_run = self.job_run_dao.get(1)
-        self.assertEqual(GenomicJob.AW1F_ALERTS, job_run.jobId)
-        self.assertEqual(GenomicSubProcessResult.SUCCESS, job_run.runResult)
-
     def test_gem_a1_manifest_end_to_end(self):
         # Need GC Manifest for source query : run_id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,


### PR DESCRIPTION
## Resolves *[ticket DA-2229]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2229

## Description of changes/additions
Moving AW1F workflow from cron to pub sub

## Tests
- [] unit tests
** Removed some existing tests that were no longer need. Tested Pub sub trigger on sandbox.
** Local pub-sub configs were a little out of date, sandbox and prod config notifications now match with corresponding env notifications 

<img width="1287" alt="Screen Shot 2021-10-11 at 1 04 57 PM" src="https://user-images.githubusercontent.com/5114837/136828786-447235c8-307f-4004-b310-61878567e707.png">

