### PR TITLE
[DA-2214] Primary Update consent validation

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -422,7 +422,6 @@ class VibrentGrorConsentFile(GrorConsentFile):
 
 class VibrentPrimaryConsentUpdateFile(PrimaryConsentUpdateFile):
     FIRST_VERSION_END_DATE = datetime(2020, 11, 1)
-    _SIGNATURE_PAGE = 13
 
     def __init__(self, *args, consent_date: datetime, **kwargs):
         super(VibrentPrimaryConsentUpdateFile, self).__init__(*args, **kwargs)
@@ -434,13 +433,18 @@ class VibrentPrimaryConsentUpdateFile(PrimaryConsentUpdateFile):
         if consent_date < self.FIRST_VERSION_END_DATE and not PrimaryConsentUpdateFile.pdf_has_update_text(self.pdf):
             self.wrapped_consent_file = VibrentPrimaryConsentFile(*args, **kwargs)
 
+    def _get_signature_page(self):
+        return self.pdf.get_page_number_of_text([
+            ('Do you agree to this updated consent?', '¿Está de acuerdo con este consentimiento actualizado?')
+        ])
+
     def _get_signature_elements(self):
         if self.wrapped_consent_file:
             return self.wrapped_consent_file._get_signature_elements()
         else:
             return self.pdf.get_elements_intersecting_box(
                 Rect.from_edges(left=150, right=400, bottom=155, top=160),
-                page=self._SIGNATURE_PAGE
+                page=self._get_signature_page()
             )
 
     def _get_date_elements(self):
@@ -449,7 +453,7 @@ class VibrentPrimaryConsentUpdateFile(PrimaryConsentUpdateFile):
         else:
             return self.pdf.get_elements_intersecting_box(
                 Rect.from_edges(left=130, right=400, bottom=110, top=115),
-                page=self._SIGNATURE_PAGE
+                page=self._get_signature_page()
             )
 
     def is_agreement_selected(self):
@@ -458,7 +462,7 @@ class VibrentPrimaryConsentUpdateFile(PrimaryConsentUpdateFile):
         else:
             agreement_elements = self.pdf.get_elements_intersecting_box(
                 Rect.from_edges(left=38, right=40, bottom=676, top=678),
-                page=self._SIGNATURE_PAGE
+                page=self._get_signature_page()
             )
 
             for element in agreement_elements:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from dateutil import parser
 from io import BytesIO
 from os.path import basename
@@ -76,11 +77,11 @@ class ConsentFileAbstractFactory(ABC):
             if self._is_gror_consent(blob_wrapper)
         ]
 
-    def get_primary_update_consents(self) -> List['PrimaryConsentUpdateFile']:
+    def get_primary_update_consents(self, consent_date: datetime) -> List['PrimaryConsentUpdateFile']:
         return [
-            self._build_primary_update_consent(blob_wrapper)
+            self._build_primary_update_consent(blob_wrapper, consent_date)
             for blob_wrapper in self.consent_blobs
-            if self._is_primary_update_consent(blob_wrapper)
+            if self._is_primary_update_consent(blob_wrapper, consent_date)
         ]
 
     @abstractmethod
@@ -100,7 +101,7 @@ class ConsentFileAbstractFactory(ABC):
         ...
 
     @abstractmethod
-    def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
+    def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date: datetime) -> bool:
         ...
 
     @abstractmethod
@@ -120,7 +121,8 @@ class ConsentFileAbstractFactory(ABC):
         ...
 
     @abstractmethod
-    def _build_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'PrimaryConsentUpdateFile':
+    def _build_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date: datetime) \
+            -> 'PrimaryConsentUpdateFile':
         ...
 
     @abstractmethod
@@ -160,15 +162,13 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
     def _is_gror_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         return basename(blob_wrapper.blob.name).startswith('GROR')
 
-    def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
+    def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date) -> bool:
         return (
             basename(blob_wrapper.blob.name).startswith('PrimaryConsentUpdate')
-            and blob_wrapper.get_parsed_pdf().get_page_number_of_text([
-                (
-                    'Do you agree to this updated consent?',
-                    '¿Está de acuerdo con este consentimiento actualizado?'
-                )
-            ]) is not None
+            and (
+                PrimaryConsentUpdateFile.pdf_has_update_text(blob_wrapper.get_parsed_pdf())
+                or consent_date < VibrentPrimaryConsentUpdateFile.FIRST_VERSION_END_DATE
+            )
         )
 
     def _build_primary_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'PrimaryConsentFile':
@@ -183,8 +183,13 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
     def _build_gror_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'GrorConsentFile':
         return VibrentGrorConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
 
-    def _build_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'PrimaryConsentUpdateFile':
-        return VibrentPrimaryConsentUpdateFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
+    def _build_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date: datetime) \
+            -> 'PrimaryConsentUpdateFile':
+        return VibrentPrimaryConsentUpdateFile(
+            pdf=blob_wrapper.get_parsed_pdf(),
+            blob=blob_wrapper.blob,
+            consent_date=consent_date
+        )
 
     def _get_source_bucket(self) -> str:
         return config.getSettingJson(config.CONSENT_PDF_BUCKET)['vibrent']
@@ -206,7 +211,7 @@ class CeConsentFactory(ConsentFileAbstractFactory):
     def _is_gror_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         pass
 
-    def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
+    def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date: datetime) -> bool:
         pass
 
     def _build_primary_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'PrimaryConsentFile':
@@ -221,7 +226,8 @@ class CeConsentFactory(ConsentFileAbstractFactory):
     def _build_gror_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'GrorConsentFile':
         pass
 
-    def _build_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'PrimaryConsentUpdateFile':
+    def _build_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date: datetime) \
+            -> 'PrimaryConsentUpdateFile':
         pass
 
     def _get_source_bucket(self) -> str:
@@ -313,17 +319,19 @@ class PrimaryConsentUpdateFile(PrimaryConsentFile, ABC):
     needed to agree to (or decline) new wording for DNA data
     """
 
-    def is_agreement_selected(self):
-        for element in self._get_agreement_check_elements():
-            for child in element:
-                if isinstance(child, LTChar) and child.get_text() == '4':
-                    return True
-
-        return False
-
     @abstractmethod
-    def _get_agreement_check_elements(self):
+    def is_agreement_selected(self):
         ...
+
+    @classmethod
+    def pdf_has_update_text(cls, pdf: 'Pdf'):
+        update_agreement_page_number = pdf.get_page_number_of_text([
+            (
+                'Do you agree to this updated consent?',
+                '¿Está de acuerdo con este consentimiento actualizado?'
+            )
+        ])
+        return update_agreement_page_number is not None
 
 
 class VibrentPrimaryConsentFile(PrimaryConsentFile):
@@ -413,25 +421,52 @@ class VibrentGrorConsentFile(GrorConsentFile):
 
 
 class VibrentPrimaryConsentUpdateFile(PrimaryConsentUpdateFile):
+    FIRST_VERSION_END_DATE = datetime(2020, 11, 1)
     _SIGNATURE_PAGE = 13
 
+    def __init__(self, *args, consent_date: datetime, **kwargs):
+        super(VibrentPrimaryConsentUpdateFile, self).__init__(*args, **kwargs)
+
+        # In Sep 2020, the content of the update consent changed. Versions prior ot that were essentially just
+        # copies of the Primary consent file. If the given file is close enough to the switch-over date then
+        # treat it as a normal consent.
+        self.wrapped_consent_file = None
+        if consent_date < self.FIRST_VERSION_END_DATE and not PrimaryConsentUpdateFile.pdf_has_update_text(self.pdf):
+            self.wrapped_consent_file = VibrentPrimaryConsentFile(*args, **kwargs)
+
     def _get_signature_elements(self):
-        return self.pdf.get_elements_intersecting_box(
-            Rect.from_edges(left=150, right=400, bottom=155, top=160),
-            page=self._SIGNATURE_PAGE
-        )
+        if self.wrapped_consent_file:
+            return self.wrapped_consent_file._get_signature_elements()
+        else:
+            return self.pdf.get_elements_intersecting_box(
+                Rect.from_edges(left=150, right=400, bottom=155, top=160),
+                page=self._SIGNATURE_PAGE
+            )
 
     def _get_date_elements(self):
-        return self.pdf.get_elements_intersecting_box(
-            Rect.from_edges(left=130, right=400, bottom=110, top=115),
-            page=self._SIGNATURE_PAGE
-        )
+        if self.wrapped_consent_file:
+            return self.wrapped_consent_file._get_date_elements()
+        else:
+            return self.pdf.get_elements_intersecting_box(
+                Rect.from_edges(left=130, right=400, bottom=110, top=115),
+                page=self._SIGNATURE_PAGE
+            )
 
-    def _get_agreement_check_elements(self):
-        return self.pdf.get_elements_intersecting_box(
-            Rect.from_edges(left=38, right=40, bottom=676, top=678),
-            page=self._SIGNATURE_PAGE
-        )
+    def is_agreement_selected(self):
+        if self.wrapped_consent_file:
+            return True  # TODO: implement and use checkbox validation of Primary consent
+        else:
+            agreement_elements = self.pdf.get_elements_intersecting_box(
+                Rect.from_edges(left=38, right=40, bottom=676, top=678),
+                page=self._SIGNATURE_PAGE
+            )
+
+            for element in agreement_elements:
+                for child in element:
+                    if isinstance(child, LTChar) and child.get_text() == '4':
+                        return True
+
+            return False
 
 
 class Pdf:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -164,7 +164,10 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
         return (
             basename(blob_wrapper.blob.name).startswith('PrimaryConsentUpdate')
             and blob_wrapper.get_parsed_pdf().get_page_number_of_text([
-                'Do you agree to this updated consent?'
+                (
+                    'Do you agree to this updated consent?',
+                    '¿Está de acuerdo con este consentimiento actualizado?'
+                )
             ]) is not None
         )
 

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -325,6 +325,9 @@ class PrimaryConsentUpdateFile(PrimaryConsentFile, ABC):
 
     @classmethod
     def pdf_has_update_text(cls, pdf: 'Pdf'):
+        # Text being checked is based on the F1.20a.C1U.0915.Eng/Esp and later versions of the Cohort 1 Update consent
+        # file. Found at https://joinallofus.atlassian.net/wiki/spaces/PROT/pages/2678587466/
+        # Primary+Consent#Primary-Consent-Form-(Appendix-F1)
         update_agreement_page_number = pdf.get_page_number_of_text([
             (
                 'Do you agree to this updated consent?',

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -491,7 +491,9 @@ class ConsentValidator:
                 result.sync_status = ConsentSyncStatus.NEEDS_CORRECTING
 
         return self._generate_validation_results(
-            consent_files=self.factory.get_primary_update_consents(),
+            consent_files=self.factory.get_primary_update_consents(
+                self.participant_summary.consentForStudyEnrollmentAuthored
+            ),
             consent_type=ConsentType.PRIMARY_UPDATE,
             additional_validation=extra_primary_update_checks,
             expected_sign_datetime=self.participant_summary.consentForStudyEnrollmentAuthored

--- a/tests/service_tests/consent_tests/test_consent_factories.py
+++ b/tests/service_tests/consent_tests/test_consent_factories.py
@@ -48,6 +48,7 @@ class ConsentFactoryTest(BaseTestCase):
             name='PrimaryConsentUpdate_es21.pdf',
             text_in_file='¿Está de acuerdo con este consentimiento actualizado?'
         )
+        self.older_update_file = self._mock_pdf(name='PrimaryConsentUpdate_v1.pdf')
 
         self.storage_provider_mock.list.return_value = [
             self.primary_file,

--- a/tests/service_tests/consent_tests/test_consent_factories.py
+++ b/tests/service_tests/consent_tests/test_consent_factories.py
@@ -44,6 +44,10 @@ class ConsentFactoryTest(BaseTestCase):
             name='PrimaryConsentUpdate_7890.pdf',
             text_in_file='Do you agree to this updated consent?'
         )
+        self.spanish_primary_update_file = self._mock_pdf(
+            name='PrimaryConsentUpdate_es21.pdf',
+            text_in_file='¿Está de acuerdo con este consentimiento actualizado?'
+        )
 
         self.storage_provider_mock.list.return_value = [
             self.primary_file,
@@ -54,7 +58,8 @@ class ConsentFactoryTest(BaseTestCase):
             self.another_ehr,
             self.signature_image,
             self.gror_file,
-            self.primary_update_file
+            self.primary_update_file,
+            self.spanish_primary_update_file
         ]
 
         self.vibrent_factory = files.ConsentFileAbstractFactory.get_file_factory(
@@ -111,7 +116,7 @@ class ConsentFactoryTest(BaseTestCase):
     def test_vibrent_primary_update_consent(self):
         self.assertConsentListEquals(
             expected_class=files.VibrentPrimaryConsentUpdateFile,
-            expected_files=[self.primary_update_file],
+            expected_files=[self.primary_update_file, self.spanish_primary_update_file],
             actual_files=self.vibrent_factory.get_primary_update_consents()
         )
 

--- a/tests/service_tests/consent_tests/test_consent_factories.py
+++ b/tests/service_tests/consent_tests/test_consent_factories.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import mock
 
 from rdr_service import config
@@ -118,7 +119,7 @@ class ConsentFactoryTest(BaseTestCase):
         self.assertConsentListEquals(
             expected_class=files.VibrentPrimaryConsentUpdateFile,
             expected_files=[self.primary_update_file, self.spanish_primary_update_file],
-            actual_files=self.vibrent_factory.get_primary_update_consents()
+            actual_files=self.vibrent_factory.get_primary_update_consents(consent_date=datetime.now())
         )
 
     def assertConsentListEquals(self, expected_class, expected_files, actual_files):

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -377,12 +377,7 @@ class ConsentFileParsingTest(BaseTestCase):
         return [basic_gror_case, no_confirmation_case, spanish_gror_case]
 
     def _get_vibrent_primary_update_test_data(self) -> List['PrimaryUpdateConsentTestData']:
-        # The GROR signature is expected to be on the 10th page
-        thirteen_empty_pages = [
-            [], [], [], [], [], [], [], [], [], [], [], [], []
-        ]
         basic_update_pdf = self._build_pdf(pages=[
-            *thirteen_empty_pages,
             [
                 self._build_pdf_element(
                     cls=LTTextBoxHorizontal,
@@ -411,7 +406,6 @@ class ConsentFileParsingTest(BaseTestCase):
         )
 
         va_update_pdf = self._build_pdf(pages=[
-            *thirteen_empty_pages,
             [
                 self._build_pdf_element(
                     cls=LTTextBoxHorizontal,


### PR DESCRIPTION
## Resolves *[DA-2214](https://precisionmedicineinitiative.atlassian.net/browse/DA-2214)*
This finishes up the code for validating the PrimaryUpdate consent. It allows for a variable page number for where the signature is, and falls back to validating the file as a Primary consent for when the participant had received that rather than the current version of the file.

## Description of changes/additions


## Tests
- [x] unit tests


