### PR TITLE
[DA-2245] Implement delete raw from filepath for failed validations

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2048,6 +2048,12 @@ class GenomicAW1RawDao(BaseDao):
             with self.session() as session:
                 session.execute("DELETE FROM genomic_aw1_raw WHERE TRUE")
 
+    def delete_from_filepath(self, filepath):
+        with self.session() as session:
+            session.query(GenomicAW1Raw).filter(
+                GenomicAW1Raw.file_path == filepath
+            ).delete()
+
 
 class GenomicAW2RawDao(BaseDao):
     def __init__(self):
@@ -2104,6 +2110,17 @@ class GenomicAW2RawDao(BaseDao):
                 GenomicAW2Raw.biobank_id != "",
                 GenomicAW2Raw.sample_id != "",
             ).order_by(GenomicAW2Raw.id).all()
+
+    def delete_from_filepath(self, filepath):
+        with self.session() as session:
+            session.query(GenomicAW2Raw).filter(
+                GenomicAW2Raw.file_path == filepath
+            ).delete()
+
+    def truncate(self):
+        if GAE_PROJECT == 'localhost':
+            with self.session() as session:
+                session.execute("DELETE FROM genomic_aw2_raw WHERE TRUE")
 
 class GenomicIncidentDao(UpdatableDao):
     validate_version_match = False

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -259,6 +259,15 @@ class GenomicFileIngester:
             )
 
             if validation_result != GenomicSubProcessResult.SUCCESS:
+                # delete raw records
+                if self.job_id == GenomicJob.AW1_MANIFEST:
+                    raw_dao = GenomicAW1RawDao()
+                    raw_dao.delete_from_filepath(file_obj.filePath)
+
+                if self.job_id == GenomicJob.METRICS_INGESTION:
+                    raw_dao = GenomicAW2RawDao()
+                    raw_dao.delete_from_filepath(file_obj.filePath)
+
                 return validation_result
 
             ingestion_config = {


### PR DESCRIPTION
## Resolves *[DA-2245](https://precisionmedicineinitiative.atlassian.net/browse/DA-2245)*


## Description of changes/additions
This PR updates the ingestion validation process to delete records from the raw AW1 and AW2 tables if the files failed validation.

## Tests
- [x] unit tests


