### PR TITLE
Change storage provider for HPro consents transfer

### DIFF
--- a/rdr_service/services/hpro_consent.py
+++ b/rdr_service/services/hpro_consent.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from rdr_service import config
 from rdr_service.dao.hpro_consent_dao import HealthProConsentDao
-from rdr_service.services.gcp_utils import gcp_cp
+from rdr_service.storage import GoogleCloudStorageProvider
 
 
 class HealthProConsentFile:
@@ -18,6 +18,7 @@ class HealthProConsentFile:
         store_failures=False
     ):
         self.dao = HealthProConsentDao()
+        self.storage_provider = GoogleCloudStorageProvider()
         self.consents_for_transfer = None
         self.hpro_bucket = config.getSetting(config.HEALTHPRO_CONSENT_BUCKET)
         self.transfer_limit = None
@@ -42,40 +43,36 @@ class HealthProConsentFile:
         self.logger.info(f'Ready to transfer {len(self.consents_for_transfer)} consent(s) to {self.hpro_bucket} bucket')
 
         for consent in self.consents_for_transfer:
-            src = f'gs://{consent.file_path}'
-            dest = self.create_path_destination(consent.file_path)
+            src = consent.file_path
+            dest = self.create_path_destination(src)
             obj = self.make_object(consent, dest)
 
             try:
-                transfer = gcp_cp(src, dest)
-                if not transfer:
-                    if self.store_failures:
-                        self.transfer_failures.append({
-                            'original': consent.file_path,
-                            'destination': dest.split('gs://')[1],
-                        })
-                    self.logger.warning(f'Healthpro consent {src} failed to transfer to {dest}')
-                    continue
-
+                self.storage_provider.copy_blob(src, dest)
                 self.transfer_count += 1
                 self.dao.insert(obj)
 
             # pylint: disable=broad-except
-            except Exception as e:
-                self.logger.warning(f'Healthpro consent transfer process error occurred: {e}')
+            except Exception:
+                if self.store_failures:
+                    self.transfer_failures.append({
+                        'original': consent.file_path,
+                        'destination': dest,
+                    })
+                self.logger.warning(f'Healthpro consent {src} failed to transfer to {dest}', exc_info=True)
 
         self.logger.info(f'Healthpro consent(s) {self.transfer_count} transferred to {self.hpro_bucket} bucket')
 
     def create_path_destination(self, file_path):
         dest_base = "/".join(file_path.strip("/").split('/')[1:])
-        dest = f'gs://{self.hpro_bucket}/{dest_base}'
+        dest = f'{self.hpro_bucket}/{dest_base}'
         return dest
 
     def make_object(self, obj, dest):
         obj = self.dao.model_type(
             participant_id=obj.participant_id,
             consent_file_id=obj.id,
-            file_path=dest.split('gs://')[1] if 'gs://' in dest else dest,
+            file_path=dest,
             file_upload_time=datetime.utcnow()
         )
         return obj

--- a/tests/service_tests/test_hpro_consent_file.py
+++ b/tests/service_tests/test_hpro_consent_file.py
@@ -6,6 +6,7 @@ from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.dao.hpro_consent_dao import HealthProConsentDao
 from rdr_service.model.consent_file import ConsentSyncStatus
 from rdr_service.services.hpro_consent import HealthProConsentFile
+from rdr_service.storage import GoogleCloudStorageProvider
 
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -20,6 +21,7 @@ class HealthProConsentFileTest(BaseTestCase):
         self.hpro_consents = HealthProConsentFile()
         self.num_consents = 4
         self.sync_statuses = [ConsentSyncStatus.SYNC_COMPLETE, ConsentSyncStatus.READY_FOR_SYNC]
+        self.storage_provider_mock = mock.MagicMock(spec=GoogleCloudStorageProvider)
 
     @mock.patch('rdr_service.services.hpro_consent.HealthProConsentFile.cp_consent_files')
     def test_initialize_transfers(self, cp_mock):
@@ -45,7 +47,7 @@ class HealthProConsentFileTest(BaseTestCase):
         self.assertTrue(cp_mock.called)
 
         self.assertEqual(len(self.hpro_consents.consents_for_transfer), self.num_consents)
-        self.assertTrue(all(obj for obj in self.hpro_consents.consents_for_transfer if obj.id in consent_ids))
+        self.assertTrue(all(obj.id in consent_ids for obj in self.hpro_consents.consents_for_transfer))
 
     def test_getting_consent_records_for_transfer(self):
         self.hpro_consents.get_consents_for_transfer()
@@ -71,7 +73,7 @@ class HealthProConsentFileTest(BaseTestCase):
 
         self.assertNotEmpty(self.hpro_consents.consents_for_transfer)
 
-        self.assertTrue(all(obj for obj in self.hpro_consents.consents_for_transfer if obj.id in consent_ids))
+        self.assertTrue(all(obj.id in consent_ids for obj in self.hpro_consents.consents_for_transfer))
 
         self.assertEqual(len(self.consent_dao.get_all()), self.num_consents)
         self.assertEqual(len(self.hpro_consent_dao.get_all()), self.num_consents // 2)
@@ -80,7 +82,7 @@ class HealthProConsentFileTest(BaseTestCase):
         self.hpro_consents.get_consents_for_transfer()
 
         self.assertNotEmpty(self.hpro_consents.consents_for_transfer)
-        self.assertTrue(any(obj for obj in self.hpro_consents.consents_for_transfer if obj.id in consent_ids))
+        self.assertTrue(any(obj.id in consent_ids for obj in self.hpro_consents.consents_for_transfer))
         self.assertEqual(len(self.hpro_consents.consents_for_transfer), self.hpro_consents.transfer_limit)
 
     def test_destination_creation(self):
@@ -89,6 +91,7 @@ class HealthProConsentFileTest(BaseTestCase):
             self.data_generator.create_database_consent_file(
                 file_path=f'test_file_path/{num}',
                 file_exists=1,
+                sync_status=self.sync_statuses[0]
             )
 
         self.hpro_consents.get_consents_for_transfer()
@@ -102,19 +105,19 @@ class HealthProConsentFileTest(BaseTestCase):
             )
 
         for dest in destinations:
-            self.assertIn('gs://', dest)
+            self.assertNotIn('gs://', dest)
             self.assertIn(self.hpro_consent_bucket[0], dest)
 
-    @mock.patch('rdr_service.services.hpro_consent.gcp_cp')
-    def test_copying_consent_files_calls_transfer(self, gcp_cp_mock):
+    def test_copying_consent_files_calls_transfer(self):
+        self.hpro_consents.storage_provider = self.storage_provider_mock
+
         self.hpro_consents.get_consents_for_transfer()
 
         self.assertEmpty(self.hpro_consents.consents_for_transfer)
 
         self.hpro_consents.cp_consent_files()
 
-        self.assertFalse(gcp_cp_mock.called)
-        self.assertEqual(gcp_cp_mock.call_count, 0)
+        self.storage_provider_mock.copy_blob.assert_not_called()
 
         paths = []
 
@@ -125,7 +128,7 @@ class HealthProConsentFileTest(BaseTestCase):
                 sync_status=self.sync_statuses[0]
             )
             paths.append({
-                'src': f'gs://test_file_path/{num}',
+                'src': consent.file_path,
                 'dest': self.hpro_consents.create_path_destination(consent.file_path)
             })
 
@@ -135,10 +138,10 @@ class HealthProConsentFileTest(BaseTestCase):
 
         self.hpro_consents.cp_consent_files()
 
-        self.assertTrue(gcp_cp_mock.called)
-        self.assertEqual(gcp_cp_mock.call_count, self.num_consents)
+        self.assertTrue(self.storage_provider_mock.copy_blob.called)
+        self.assertEqual(self.storage_provider_mock.copy_blob.call_count, self.num_consents)
 
-        call_args = gcp_cp_mock.call_args_list
+        call_args = self.storage_provider_mock.call_args_list
 
         for i, val in enumerate(call_args):
             self.assertIsNotNone(paths[i]['src'])


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Needed to update the `cp` method used in transferring health pro consents to using a `GoogleStorageProvider` method instead of `gcp_cp` since it is only available when the GoogleSDK is present and with processes on the `app-engine` instances this is not the case. 


## Tests
- [x] unit tests


