### PR TITLE
[DA-2241] Renaming 'gender' to 'sex' for MayoLINK API

### DIFF
--- a/rdr_service/api/mayolink_api.py
+++ b/rdr_service/api/mayolink_api.py
@@ -123,7 +123,7 @@ class MayoLinkApi:
                     'last_name': order.last_name,
                     'middle_name': '',
                     'birth_date': '3/3/1933',
-                    'gender': order.sex,
+                    'sex': order.sex,
                     'address1': order.address1,
                     'address2': order.address2,
                     'city': order.city,

--- a/rdr_service/api/mayolink_api.py
+++ b/rdr_service/api/mayolink_api.py
@@ -13,6 +13,13 @@ from rdr_service.app_util import check_auth
 
 
 @dataclass
+class MayolinkQuestion:
+    code: str
+    prompt: str
+    answer: str
+
+
+@dataclass
 class MayolinkTestPassthroughFields:
     field1: str = ''
     field2: str = ''
@@ -26,6 +33,7 @@ class MayoLinkTest:
     name: str
     comments: str = None
     passthrough_fields: MayolinkTestPassthroughFields = None
+    questions: List[MayolinkQuestion] = None
 
 
 @dataclass
@@ -145,6 +153,17 @@ class MayoLinkApi:
             'comments': test.comments
         }
 
+        if test.questions:
+            test_data['questions'] = [
+                {
+                    'question': {
+                        'code': question.code,
+                        'prompt': question.prompt,
+                        'answer': question.answer
+                    }
+                }
+                for question in test.questions
+            ]
         if test.passthrough_fields:
             test_data['client_passthrough_fields'] = {
                 'field1': test.passthrough_fields.field1,

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -83,7 +83,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
             b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
-            b'<birth_date>3/3/1933</birth_date><gender>U</gender>'
+            b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
             b'<phone>442-123-4567</phone>'
@@ -128,7 +128,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
             b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
-            b'<birth_date>3/3/1933</birth_date><gender>U</gender>'
+            b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
             b'<phone>442-123-4567</phone>'
@@ -148,28 +148,17 @@ class MayolinkClientTest(BaseTestCase):
     @mock.patch('rdr_service.api.mayolink_api.httplib2')
     def test_passthrough_fields(self, http_mock):
         """Test the data structure with passthrough fields added in"""
-        order = MayoLinkOrder(
-            collected='2021-05-01',
-            number='12345',
-            medical_record_number='Z6789',
-            last_name='Smith',
-            sex='U',
-            address1='1234 Main',
-            address2='Apt C',
-            city='Test',
-            state='TN',
-            postal_code='11223',
-            phone='442-123-4567',
-            race='NA',
-            tests=[MayoLinkTest(
+        order = self._get_default_order()
+        order.tests = [
+            MayoLinkTest(
                 code='1SAL',
                 name='Unittest',
                 comments='Test object for testing',
                 passthrough_fields=MayolinkTestPassthroughFields(
                     field3='testing third pass-through field'
                 )
-            )]
-        )
+            )
+        ]
 
         client = MayoLinkApi()
         request_mock = http_mock.Http.return_value.request
@@ -185,14 +174,14 @@ class MayolinkClientTest(BaseTestCase):
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
             b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
-            b'<birth_date>3/3/1933</birth_date><gender>U</gender>'
+            b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
             b'<phone>442-123-4567</phone>'
             b'<account_number /><race>NA</race><ethnic_group />'
             b'</patient>'
             b'<physician><name>None</name><phone /><npi /></physician>'
-            b'<report_notes />'
+            b'<report_notes>testing notes</report_notes>'
             b'<tests><test>'
             b'<code>1SAL</code><name>Unittest</name><comments>Test object for testing</comments>'
             b'<client_passthrough_fields>'
@@ -235,7 +224,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
             b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
-            b'<birth_date>3/3/1933</birth_date><gender>U</gender>'
+            b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
             b'<phone>442-123-4567</phone>'

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -67,22 +67,7 @@ class MayolinkClientTest(BaseTestCase):
     @mock.patch('rdr_service.api.mayolink_api.httplib2')
     def test_order_xml_structure(self, http_mock):
         """Make sure the resulting xml lines up with the order object sent using the client interface"""
-        order = MayoLinkOrder(
-            collected='2021-05-01',
-            number='12345',
-            medical_record_number='Z6789',
-            last_name='Smith',
-            sex='U',
-            address1='1234 Main',
-            address2='Apt C',
-            city='Test',
-            state='TN',
-            postal_code='11223',
-            phone='442-123-4567',
-            race='NA',
-            comments='test data',
-            report_notes='testing notes'
-        )
+        order = self._get_default_order()
 
         client = MayoLinkApi()
         request_mock = http_mock.Http.return_value.request
@@ -114,49 +99,25 @@ class MayolinkClientTest(BaseTestCase):
     @mock.patch('rdr_service.api.mayolink_api.httplib2')
     def test_order_test_collection_data(self, http_mock):
         """Test the data structure with a test object provided (following the process used for mailkit orders)"""
-        order = MayoLinkOrder(
-            collected='2021-05-01',
-            number='12345',
-            medical_record_number='Z6789',
-            last_name='Smith',
-            sex='U',
-            address1='1234 Main',
-            address2='Apt C',
-            city='Test',
-            state='TN',
-            postal_code='11223',
-            phone='442-123-4567',
-            race='NA',
-            tests=[
-                MayoLinkTest(
-                    code='1SAL',
-                    name='Unittest',
-                    comments='Test object for testing'
-                ),
-                MayoLinkTest(
-                    code='1ED04',
-                    name='blood test',
-                    comments='Another object for testing'
-                ),
-            ]
-        )
+        order = self._get_default_order()
+        order.tests = [
+            MayoLinkTest(
+                code='1SAL',
+                name='Unittest',
+                comments='Test object for testing'
+            ),
+            MayoLinkTest(
+                code='1ED04',
+                name='blood test',
+                comments='Another object for testing'
+            ),
+        ]
 
         client = MayoLinkApi()
         request_mock = http_mock.Http.return_value.request
         request_mock.return_value = ({'status': '201'}, b'<result></result>')
         with mock.patch('rdr_service.api.mayolink_api.check_auth'):
             client.post(order)
-
-        b'<orders xmlns="http://orders.mayomedicallaboratories.com"><order><collected>2021-05-01</collected><account>1122</account>' \
-        b'<number>12345</number><patient><medical_record_number>Z6789</medical_record_number>' \
-        b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />' \
-        b'<birth_date>3/3/1933</birth_date><gender>U</gender>' \
-        b'<address1>1234 Main</address1><address2>Apt C</address2>' \
-        b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>' \
-        b'<phone>442-123-4567</phone><account_number /><race>NA</race><ethnic_group />' \
-        b'</patient>' \
-        b'<physician><name>None</name><phone /><npi /></physician>' \
-        b'<report_notes /><tests><code>1SAL</code><name>Unittest</name><comments>Test object for testing</comments><code>1ED04</code><name>blood test</name><comments>Another object for testing</comments></tests><comments /></order></orders>'
 
         sent_xml = request_mock.call_args.kwargs['body']
         self.assertEqual(
@@ -248,29 +209,16 @@ class MayolinkClientTest(BaseTestCase):
     @mock.patch('rdr_service.api.mayolink_api.httplib2')
     def test_question_fields(self, http_mock):
         """Test the data structure with questions fields added in"""
-        order = MayoLinkOrder(
-            collected='2021-05-01',
-            number='12345',
-            medical_record_number='Z6789',
-            last_name='Smith',
-            sex='U',
-            address1='1234 Main',
-            address2='Apt C',
-            city='Test',
-            state='TN',
-            postal_code='11223',
-            phone='442-123-4567',
-            race='NA',
-            tests=[MayoLinkTest(
-                code='1SAL',
-                name='Unittest',
-                comments='Test object for testing',
-                questions=[
-                    MayolinkQuestion(code='Q1', prompt='Question 1', answer='Answer 1'),
-                    MayolinkQuestion(code='Q2', prompt='Question 2', answer='Answer 2')
-                ]
-            )]
-        )
+        order = self._get_default_order()
+        order.tests = [MayoLinkTest(
+            code='1SAL',
+            name='Unittest',
+            comments='Test object for testing',
+            questions=[
+                MayolinkQuestion(code='Q1', prompt='Question 1', answer='Answer 1'),
+                MayolinkQuestion(code='Q2', prompt='Question 2', answer='Answer 2')
+            ]
+        )]
 
         client = MayoLinkApi()
         request_mock = http_mock.Http.return_value.request
@@ -304,4 +252,22 @@ class MayolinkClientTest(BaseTestCase):
             b'<comments />'
             b'</order></orders>',
             sent_xml
+        )
+
+    def _get_default_order(self):
+        return MayoLinkOrder(
+            collected='2021-05-01',
+            number='12345',
+            medical_record_number='Z6789',
+            last_name='Smith',
+            sex='U',
+            address1='1234 Main',
+            address2='Apt C',
+            city='Test',
+            state='TN',
+            postal_code='11223',
+            phone='442-123-4567',
+            race='NA',
+            comments='test data',
+            report_notes='testing notes'
         )

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -100,6 +100,7 @@ class MayolinkClientTest(BaseTestCase):
     def test_order_test_collection_data(self, http_mock):
         """Test the data structure with a test object provided (following the process used for mailkit orders)"""
         order = self._get_default_order()
+        order.report_notes = ''
         order.tests = [
             MayoLinkTest(
                 code='1SAL',
@@ -110,7 +111,7 @@ class MayolinkClientTest(BaseTestCase):
                 code='1ED04',
                 name='blood test',
                 comments='Another object for testing'
-            ),
+            )
         ]
 
         client = MayoLinkApi()

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -1,6 +1,7 @@
 import mock
 
-from rdr_service.api.mayolink_api import MayoLinkApi, MayoLinkOrder, MayoLinkTest, MayolinkTestPassthroughFields
+from rdr_service.api.mayolink_api import MayoLinkApi, MayoLinkOrder, MayolinkQuestion, MayoLinkTest, \
+    MayolinkTestPassthroughFields
 from tests.helpers.unittest_base import BaseTestCase
 
 
@@ -198,14 +199,14 @@ class MayolinkClientTest(BaseTestCase):
             postal_code='11223',
             phone='442-123-4567',
             race='NA',
-            test=MayoLinkTest(
+            tests=[MayoLinkTest(
                 code='1SAL',
                 name='Unittest',
                 comments='Test object for testing',
                 passthrough_fields=MayolinkTestPassthroughFields(
                     field3='testing third pass-through field'
                 )
-            )
+            )]
         )
 
         client = MayoLinkApi()
@@ -238,6 +239,67 @@ class MayolinkClientTest(BaseTestCase):
             b'<field3>testing third pass-through field</field3>'
             b'<field4 />'
             b'</client_passthrough_fields>'
+            b'</test></tests>'
+            b'<comments />'
+            b'</order></orders>',
+            sent_xml
+        )
+
+    @mock.patch('rdr_service.api.mayolink_api.httplib2')
+    def test_question_fields(self, http_mock):
+        """Test the data structure with questions fields added in"""
+        order = MayoLinkOrder(
+            collected='2021-05-01',
+            number='12345',
+            medical_record_number='Z6789',
+            last_name='Smith',
+            sex='U',
+            address1='1234 Main',
+            address2='Apt C',
+            city='Test',
+            state='TN',
+            postal_code='11223',
+            phone='442-123-4567',
+            race='NA',
+            tests=[MayoLinkTest(
+                code='1SAL',
+                name='Unittest',
+                comments='Test object for testing',
+                questions=[
+                    MayolinkQuestion(code='Q1', prompt='Question 1', answer='Answer 1'),
+                    MayolinkQuestion(code='Q2', prompt='Question 2', answer='Answer 2')
+                ]
+            )]
+        )
+
+        client = MayoLinkApi()
+        request_mock = http_mock.Http.return_value.request
+        request_mock.return_value = ({'status': '201'}, b'<result></result>')
+        with mock.patch('rdr_service.api.mayolink_api.check_auth'):
+            client.post(order)
+
+        sent_xml = request_mock.call_args.kwargs['body']
+        self.assertEqual(
+            b'<orders xmlns="http://orders.mayomedicallaboratories.com"><order>'
+            b'<collected>2021-05-01</collected>'
+            b'<account>1122</account><number>12345</number>'
+            b'<patient>'
+            b'<medical_record_number>Z6789</medical_record_number>'
+            b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
+            b'<birth_date>3/3/1933</birth_date><gender>U</gender>'
+            b'<address1>1234 Main</address1><address2>Apt C</address2>'
+            b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
+            b'<phone>442-123-4567</phone>'
+            b'<account_number /><race>NA</race><ethnic_group />'
+            b'</patient>'
+            b'<physician><name>None</name><phone /><npi /></physician>'
+            b'<report_notes />'
+            b'<tests><test>'
+            b'<code>1SAL</code><name>Unittest</name><comments>Test object for testing</comments>'
+            b'<questions>'
+            b'<question><code>Q1</code><prompt>Question 1</prompt><answer>Answer 1</answer></question>'
+            b'<question><code>Q2</code><prompt>Question 2</prompt><answer>Answer 2</answer></question>'
+            b'</questions>'
             b'</test></tests>'
             b'<comments />'
             b'</order></orders>',

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -231,7 +231,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<account_number /><race>NA</race><ethnic_group />'
             b'</patient>'
             b'<physician><name>None</name><phone /><npi /></physician>'
-            b'<report_notes />'
+            b'<report_notes>testing notes</report_notes>'
             b'<tests><test>'
             b'<code>1SAL</code><name>Unittest</name><comments>Test object for testing</comments>'
             b'<questions>'


### PR DESCRIPTION
## Resolves *[DA-2241](https://precisionmedicineinitiative.atlassian.net/browse/DA-2241)*
MayoLINK is changing a field name from `gender` to `sex` in their `create` endpoint. This updates the BiobankOrderDao and MailkitOrderDao to reflect that change.

## Description of changes/additions
The PR also encapsulates the logic for building the request structure for MayoLINK out into the same class for making the request to the server.

## Tests
- [x] unit tests


