### PR TITLE
[DA-2155 partial] Automate PDR consent metrics data rebuild from Cons…

### DIFF
--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -28,8 +28,11 @@ from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.site import Site
 from rdr_service.participant_enums import QuestionnaireStatus
+
+from rdr_service.resource.tasks import dispatch_rebuild_consent_metrics_tasks
 from rdr_service.services.gcp_utils import gcp_cp
 from rdr_service.storage import GoogleCloudStorageProvider
+
 
 SOURCE_BUCKET = {
     "vibrent": "ptc-uploads-all-of-us-rdr-prod",
@@ -175,6 +178,7 @@ class ConsentSyncController:
             hpo_names=hpo_names,
             org_names=org_names
         )
+        updated_rec_ids = list()
         pairing_info_map = self._build_participant_pairing_map(file_list)
 
         for file in file_list:
@@ -203,10 +207,14 @@ class ConsentSyncController:
 
                 file.sync_time = datetime.utcnow()
                 file.sync_status = ConsentSyncStatus.SYNC_COMPLETE
+                updated_rec_ids.append(file.id)
 
         self._zip_and_upload()
         with self.consent_dao.session() as session:
             self.consent_dao.batch_update_consent_files(file_list, session)
+
+        if len(updated_rec_ids):
+            dispatch_rebuild_consent_metrics_tasks(updated_rec_ids)
 
     def _zip_and_upload(self):
         if not os.path.isdir(TEMP_CONSENTS_PATH):

--- a/rdr_service/resource/constants.py
+++ b/rdr_service/resource/constants.py
@@ -5,7 +5,6 @@
 from datetime import datetime
 from enum import IntEnum
 
-
 class SchemaID(IntEnum):
     """
     Unique identifiers for each resource schema.  Schema id values should be grouped by schema types.

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -133,7 +133,7 @@ def dispatch_rebuild_consent_metrics_tasks(id_list, in_seconds=15, quiet=True, b
         task = GCPCloudTask()
         for batch in list_chunks(id_list, batch_size):
             payload = {'batch': batch}
-            task.execute('batch_rebuild_participants_task', payload=payload, in_seconds=in_seconds,
+            task.execute('batch_rebuild_consent_metrics_task', payload=payload, in_seconds=in_seconds,
                          queue='resource-rebuild', quiet=quiet, project_id=project_id)
             completed_batches += 1
 

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -6,14 +6,17 @@
 import logging
 from datetime import datetime
 
+import rdr_service.config as config
 
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao
 from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGenerator, rebuild_bq_participant
 from rdr_service.dao.bq_pdr_participant_summary_dao import BQPDRParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.model.bq_questionnaires import PDR_MODULE_LIST
+from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.resource import generators
 from rdr_service.resource.generators.participant import rebuild_participant_summary_resource
+from rdr_service.services.system_utils import list_chunks
 
 
 def batch_rebuild_participants_task(payload, project_id=None):
@@ -109,3 +112,29 @@ def batch_rebuild_consent_metrics_task(payload):
         res.save()
 
     logging.info(f'End time: {datetime.utcnow()}, rebuilt {len(results)} ConsentMetric records.')
+
+# TODO:  Look at consolidating dispatch_participant_rebuild_tasks() from offline/bigquery_sync.py and this into a
+# generic dispatch routine also available for other resource type rebuilds.  May need to have
+# endpoint-specific logic and/or some fancy code to dynamically populate the task.execute() args (or to allow for
+# local rebuilds vs. cloud tasks)
+def dispatch_rebuild_consent_metrics_tasks(id_list, in_seconds=15, quiet=True, batch_size=150,
+                                           project_id=config.GAE_PROJECT, build_locally=False):
+    """
+    Helper method to handle queuing batch rebuild requests for rebuilding consent metrics resource data
+    """
+    if not all(isinstance(id, int) for id in id_list):
+        raise (ValueError, "Invalid id list; must be a list that contains only integer consent_file ids")
+
+    if build_locally or project_id == 'localhost':
+        batch_rebuild_consent_metrics_task({'batch': id_list})
+
+    else:
+        completed_batches = 0
+        task = GCPCloudTask()
+        for batch in list_chunks(id_list, batch_size):
+            payload = {'batch': batch}
+            task.execute('batch_rebuild_participants_task', payload=payload, in_seconds=in_seconds,
+                         queue='resource-rebuild', quiet=quiet, project_id=project_id)
+            completed_batches += 1
+
+        logging.info(f'Dispatched {completed_batches} batch_rebuild_consent_metrics tasks of max size {batch_size}')

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -75,7 +75,6 @@ class StoreResultStrategy(ValidationOutputStrategy):
         self._session.commit()
 
 
-
 class ReplacementStoringStrategy(ValidationOutputStrategy):
     def __init__(self, session, consent_dao: ConsentDao):
         self.session = session

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -122,7 +122,6 @@ class ReplacementStoringStrategy(ValidationOutputStrategy):
                     else:
                         results_to_update.extend(new_results)
 
-
         self.consent_dao.batch_update_consent_files(results_to_update, self.session)
 
     @classmethod

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -75,6 +75,7 @@ class StoreResultStrategy(ValidationOutputStrategy):
         self._session.commit()
 
 
+
 class ReplacementStoringStrategy(ValidationOutputStrategy):
     def __init__(self, session, consent_dao: ConsentDao):
         self.session = session
@@ -120,6 +121,7 @@ class ReplacementStoringStrategy(ValidationOutputStrategy):
                         results_to_update.append(ready_for_sync)
                     else:
                         results_to_update.extend(new_results)
+
 
         self.consent_dao.batch_update_consent_files(results_to_update, self.session)
 

--- a/rdr_service/services/system_utils.py
+++ b/rdr_service/services/system_utils.py
@@ -337,6 +337,18 @@ def run_external_program(args, cwd=None, env=None, shell=False, debug=False):
     return p.returncode, stdoutdata, stderrdata
 
 
+def list_chunks(lst, chunk_size):
+    """
+    Yield successive chunk_size sublists from lst.  Useful for tools/process that need to adhere to size limits
+    when processing large lists of items (e.g., batching groups of records to be processed by a cloud task).  Example:
+            for batch_of_ids in list_chunks(big_list_of_ids, chunk_size):
+                <process the chunk-sized sublist of ids>
+    :param lst:  The list object to be broken into chunks
+    :param chunk_size:  int value of the desired sublist/chunk size
+    """
+    for i in range(0, len(lst), chunk_size):
+        yield lst[i:i + chunk_size]
+
 def is_valid_email(email):
     """
   Validate email parameter is a valid formatted email address

--- a/tests/cron_job_tests/test_consent_sync_controller.py
+++ b/tests/cron_job_tests/test_consent_sync_controller.py
@@ -193,7 +193,6 @@ class ConsentSyncControllerTest(BaseTestCase):
         # All files still had their sync_status updated
         mock_dispatch_rebuild.assert_called_once_with([self.bob_file.id, self.foo_file.id, self.bar_file.id])
 
-
     @classmethod
     def _build_expected_dest_path(cls, bucket_name, org_id, site_group, participant_id, file_name):
         return f'{bucket_name}/Participant/{org_id}/{site_group}/P{participant_id}/{file_name}'

--- a/tests/cron_job_tests/test_consent_sync_controller.py
+++ b/tests/cron_job_tests/test_consent_sync_controller.py
@@ -7,7 +7,7 @@ from rdr_service.offline.sync_consent_files import ConsentSyncController, DEFAUL
 from rdr_service.storage import GoogleCloudStorageProvider
 from tests.helpers.unittest_base import BaseTestCase
 
-
+@mock.patch('rdr_service.offline.sync_consent_files.dispatch_rebuild_consent_metrics_tasks')
 class ConsentSyncControllerTest(BaseTestCase):
     def __init__(self, *args, **kwargs):
         super(ConsentSyncControllerTest, self).__init__(*args, **kwargs)
@@ -54,16 +54,17 @@ class ConsentSyncControllerTest(BaseTestCase):
             (self.bar_participant_id, self.bar_hpo_name, None, None)
         ]
 
-        self.bob_file = ConsentFile(file_path='/source_bucket_a/bob.pdf', participant_id=self.bob_participant_id)
-        self.foo_file = ConsentFile(file_path='/source_bucket_b/foo.pdf', participant_id=self.foo_participant_id)
-        self.bar_file = ConsentFile(file_path='/source_bucket_b/bar.pdf', participant_id=self.bar_participant_id)
+        self.bob_file = ConsentFile(id=1, file_path='/source_bucket_a/bob.pdf', participant_id=self.bob_participant_id)
+        self.foo_file = ConsentFile(id=2, file_path='/source_bucket_b/foo.pdf', participant_id=self.foo_participant_id)
+        self.bar_file = ConsentFile(id=3, file_path='/source_bucket_b/bar.pdf', participant_id=self.bar_participant_id)
         self.consent_dao_mock.get_files_ready_to_sync.return_value = [self.bob_file, self.foo_file, self.bar_file]
 
-    def test_sync_of_ready_files(self):
+    def test_sync_of_ready_files(self, mock_dispatch_rebuild):
         """Test that files ready to sync are copied"""
-        first_file = ConsentFile(file_path='/source_bucket/test/one.pdf', participant_id=self.bob_participant_id)
-        second_file = ConsentFile(file_path='/source_bucket/test/two.pdf', participant_id=self.bob_participant_id)
-        third_file = ConsentFile(file_path='/source_bucket/test/three.pdf', participant_id=self.bob_participant_id)
+        first_file = ConsentFile(id=4, file_path='/source_bucket/test/one.pdf', participant_id=self.bob_participant_id)
+        second_file = ConsentFile(id=5, file_path='/source_bucket/test/two.pdf', participant_id=self.bob_participant_id)
+        third_file = ConsentFile(id=6, file_path='/source_bucket/test/three.pdf',
+                                 participant_id=self.bob_participant_id)
         self.consent_dao_mock.get_files_ready_to_sync.return_value = [first_file, second_file, third_file]
 
         self.sync_controller.sync_ready_files()
@@ -75,8 +76,9 @@ class ConsentSyncControllerTest(BaseTestCase):
             ],
             any_order=True
         )
+        mock_dispatch_rebuild.assert_called_once_with([first_file.id, second_file.id, third_file.id])
 
-    def test_file_destinations(self):
+    def test_file_destinations(self, mock_dispatch_rebuild):
         """Test that consent files sync to the correct destinations based on participant data"""
 
         self.sync_controller.sync_ready_files()
@@ -115,8 +117,9 @@ class ConsentSyncControllerTest(BaseTestCase):
             ],
             any_order=True
         )
+        mock_dispatch_rebuild.assert_called_once_with([self.bob_file.id, self.foo_file.id, self.bar_file.id])
 
-    def test_zipping_specified_orgs(self):
+    def test_zipping_specified_orgs(self, mock_dispatch_rebuild):
         """Test that the controller zips consents for organizations that give that they should be zipped"""
         self.temporarily_override_config_setting(
             key=config.CONSENT_SYNC_BUCKETS,
@@ -149,8 +152,9 @@ class ConsentSyncControllerTest(BaseTestCase):
             source_file=mock.ANY,  # Uploading archive generated from temp directory
             path=f'{self.foo_bucket_name}/Participant/{self.foo_org_name}/{DEFAULT_GOOGLE_GROUP}.zip'
         )
+        mock_dispatch_rebuild.assert_called_once_with([self.bob_file.id, self.foo_file.id])
 
-    def test_unpaired_participants(self):
+    def test_unpaired_participants(self, mock_dispatch_rebuild):
         """Test that any participants that aren't paired are ignored"""
         # Return empty list, indicating that the participants are not paired to organizations
         self.participant_dao_mock.get_pairing_data_for_ids.return_value = []
@@ -159,8 +163,9 @@ class ConsentSyncControllerTest(BaseTestCase):
 
         # If no participants are paired, then nothing should sync
         self.storage_provider_mock.copy_blob.assert_not_called()
+        self.assertEqual(mock_dispatch_rebuild.call_count, 0)
 
-    def test_ignore_unrecognized_orgs(self):
+    def test_ignore_unrecognized_orgs(self, mock_dispatch_rebuild):
         """Test that the sync ignores participants paired to an organization that isn't specified in the config"""
         # Return empty list, indicating that the participants are not paired to organizations
         self.participant_dao_mock.get_pairing_data_for_ids.return_value = [
@@ -171,8 +176,9 @@ class ConsentSyncControllerTest(BaseTestCase):
 
         # If no participants are paired, then nothing should sync
         self.storage_provider_mock.copy_blob.assert_not_called()
+        self.assertEqual(mock_dispatch_rebuild.call_count, 0)
 
-    def test_only_loading_consents_that_will_sync(self):
+    def test_only_loading_consents_that_will_sync(self, mock_dispatch_rebuild):
         """
         Currently there are only a few organizations in the config to sync.
         For performance, we just load the files that will be copied.
@@ -183,6 +189,10 @@ class ConsentSyncControllerTest(BaseTestCase):
         org_name_keys = self.consent_dao_mock.get_files_ready_to_sync.call_args.kwargs['org_names']
         for expected_key in [self.bob_org_name, self.foo_org_name]:
             self.assertIn(expected_key, org_name_keys)
+
+        # All files still had their sync_status updated
+        mock_dispatch_rebuild.assert_called_once_with([self.bob_file.id, self.foo_file.id, self.bar_file.id])
+
 
     @classmethod
     def _build_expected_dest_path(cls, bucket_name, org_id, site_group, participant_id, file_name):


### PR DESCRIPTION
…entSyncController / cron job

## Resolves *[DA-2155 (partial)](https://precisionmedicineinitiative.atlassian.net/browse/DA-2155)*


## Description of changes/additions
Trigger queueing of resource data rebuild tasks for PDR consent metrics data when RDR `consent_file` records are updated by the consent file sync cron job

## Tests
- [x] unit tests
Updated unit tests to confirm invocation of the dispatcher method that will queue the cloud tasks with the expected list of `consent_file` ids


