### PR TITLE
Improvements for data quality checks

### DIFF
--- a/rdr_service/services/data_quality.py
+++ b/rdr_service/services/data_quality.py
@@ -1,13 +1,16 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 import logging
-from sqlalchemy import func, or_
+from sqlalchemy import and_, func, or_
+from sqlalchemy.orm import aliased
 from typing import List, Type
 
+from rdr_service.model.code import Code
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.participant import Participant
 from rdr_service.model.patient_status import PatientStatus
-from rdr_service.model.questionnaire import Questionnaire, QuestionnaireHistory, QuestionnaireQuestion
+from rdr_service.model.questionnaire import Questionnaire, QuestionnaireConcept, QuestionnaireHistory, \
+    QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 
 
@@ -112,6 +115,10 @@ class QuestionnaireQualityChecker(_ModelQualityChecker):
 
 class ResponseQualityChecker(_ModelQualityChecker):
     def run_data_quality_checks(self, for_data_since: datetime = None):
+        # Alias fields used to determine the earliest release of a questionnaire with the same module code
+        all_matching_concepts: QuestionnaireConcept = aliased(QuestionnaireConcept)
+        all_matching_questionnaire: QuestionnaireHistory = aliased(QuestionnaireHistory)
+
         query = (
             self.session.query(
                 QuestionnaireResponse.questionnaireResponseId,
@@ -121,18 +128,43 @@ class ResponseQualityChecker(_ModelQualityChecker):
                 Participant.suspensionTime,
                 Participant.withdrawalAuthored,
                 func.count(QuestionnaireResponseAnswer.questionnaireResponseAnswerId),
-                QuestionnaireHistory.created
+                func.min(all_matching_questionnaire.created),
+                func.group_concat(Code.value.distinct())
             )
             .join(Participant)
-            .join(QuestionnaireHistory)
-            .outerjoin(QuestionnaireResponseAnswer)
+            .outerjoin(
+                QuestionnaireConcept,
+                and_(
+                    QuestionnaireConcept.questionnaireId == QuestionnaireResponse.questionnaireId,
+                    QuestionnaireConcept.questionnaireVersion == QuestionnaireResponse.questionnaireVersion
+                )
+            )
+            .outerjoin(
+                Code,
+                Code.codeId == QuestionnaireConcept.codeId
+            )
+            .outerjoin(
+                all_matching_concepts,
+                all_matching_concepts.codeId == Code.codeId
+            )
+            .outerjoin(
+                all_matching_questionnaire,
+                and_(
+                    all_matching_questionnaire.questionnaireId == all_matching_concepts.questionnaireId,
+                    all_matching_questionnaire.version == all_matching_concepts.questionnaireVersion
+                )
+            )
+            .outerjoin(
+                QuestionnaireResponseAnswer,
+                QuestionnaireResponseAnswer.questionnaireResponseId == QuestionnaireResponse.questionnaireResponseId
+            )
             .group_by(QuestionnaireResponse.questionnaireResponseId)
         )
         if for_data_since is not None:
             query = query.filter(QuestionnaireResponse.created >= for_data_since)
 
         for response_id, created_time, authored_time, participant_signup_time, suspension_datetime,\
-                withdrawal_datetime, answer_count, questionnaire_created_time in query.all():
+                withdrawal_datetime, answer_count, min_questionnaire_created_time, module_code in query.all():
             if authored_time is not None:
                 if not self._date_less_than_or_equal(
                     earlier_date=authored_time,
@@ -152,8 +184,8 @@ class ResponseQualityChecker(_ModelQualityChecker):
                     logging.error(f'Response {response_id} authored for suspended participant')
                 if withdrawal_datetime and authored_time > withdrawal_datetime:
                     logging.error(f'Response {response_id} authored for withdrawn participant')
-                if questionnaire_created_time > authored_time:
-                    logging.error(f'Response {response_id} authored before questionnaire released')
+                if min_questionnaire_created_time and min_questionnaire_created_time > authored_time:
+                    logging.error(f'Response {response_id} to {module_code} authored before survey released')
             if answer_count == 0:
                 logging.warning(f'Response {response_id} has no answers')
 

--- a/tests/service_tests/test_data_quality_checker.py
+++ b/tests/service_tests/test_data_quality_checker.py
@@ -26,11 +26,6 @@ class DataQualityCheckerTest(BaseTestCase):
             created=now
         )
 
-        response_without_answers = self.data_generator.create_database_questionnaire_response(
-            participantId=participant.participantId
-        )
-        # None of the responses created have answers, but I'm relying on this one not getting flagged for anything else
-
         self.checker.run_data_quality_checks()
 
         mock_logging.error.assert_any_call(
@@ -40,9 +35,6 @@ class DataQualityCheckerTest(BaseTestCase):
         mock_logging.error.assert_any_call(
             f'Response {response_authored_in_the_future.questionnaireResponseId} authored with future date '
             f'of {response_authored_in_the_future.authored} (received at {response_authored_in_the_future.created})'
-        )
-        mock_logging.warning.assert_called_with(
-            f'Response {response_without_answers.questionnaireResponseId} has no answers'
         )
 
     def test_response_fuzzy_future_check(self, mock_logging):


### PR DESCRIPTION
## Resolves *no ticket*
The data quality checks are still flagging some responses that aren't really errors. Vibrent sends responses to later versions of the Questionnaires but for the same concept. The way the quality checks were set up they all look like they're authored earlier than they should have been.

This also removes the check for responses with no answers, since the Health Data Consent modules don't have answers within them.

## Description of changes/additions
This looks for the earliest version of a questionnaire with the same module code. I think this is the best approximation of the release date that we have for now. If the authored date is earlier than that, then the response is flagged.

## Tests
- [x] unit tests


