### PR TITLE
Fix genomic tools and GEM to GP migration

### DIFF
--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -2019,7 +2019,7 @@ class GemToGpMigrationClass(GenomicManifestBase):
         with GenomicJobController(GenomicJob.GEM_GP_MIGRATION_EXPORT,
                                   bq_project_id=self.gcp_env.project) as controller:
 
-            results = self.gem_gp_dao.get_data_for_export(controller.job_run, limit=self.args.limit )
+            results = self.gem_gp_dao.get_data_for_export(controller.job_run.id, limit=self.args.limit)
 
             self.export_to_gem_gp_table(controller.job_run, results)
 

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -2008,12 +2008,13 @@ class GemToGpMigrationClass(GenomicManifestBase):
     def __init__(self, args, gcp_env: GCPEnvConfigObject):
         super(GemToGpMigrationClass, self).__init__(args, gcp_env)
 
-        self.gem_gp_dao = GemToGpMigrationDao()
+        self.gem_gp_dao = None
 
     def run(self):
 
         # Activate the SQL Proxy
         self.gcp_env.activate_sql_proxy()
+        self.gem_gp_dao = GemToGpMigrationDao()
 
         with GenomicJobController(GenomicJob.GEM_GP_MIGRATION_EXPORT,
                                   bq_project_id=self.gcp_env.project) as controller:

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -2040,7 +2040,7 @@ class GemToGpMigrationClass(GenomicManifestBase):
             batch.append(obj)
 
             # write to table in batches
-            if len(batch) % batch_size == 0 and batch:
+            if len(batch) % batch_size == 0:
                 if not self.args.dryrun:
                     _logger.info(f'Inserting batch starting with: {batch[0].participantId}')
                     self.gem_gp_dao.insert_bulk(batch)

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -2021,7 +2021,10 @@ class GemToGpMigrationClass(GenomicManifestBase):
 
             results = self.gem_gp_dao.get_data_for_export(controller.job_run.id, limit=self.args.limit)
 
-            self.export_to_gem_gp_table(controller.job_run, results)
+            if results:
+                self.export_to_gem_gp_table(controller.job_run, results)
+            else:
+                _logger.info('No data to export.')
 
         return 0
 
@@ -2037,7 +2040,7 @@ class GemToGpMigrationClass(GenomicManifestBase):
             batch.append(obj)
 
             # write to table in batches
-            if len(batch) % batch_size == 0:
+            if len(batch) % batch_size == 0 and batch:
                 if not self.args.dryrun:
                     _logger.info(f'Inserting batch starting with: {batch[0].participantId}')
                     self.gem_gp_dao.insert_bulk(batch)
@@ -2047,11 +2050,12 @@ class GemToGpMigrationClass(GenomicManifestBase):
                 batch = []
 
         # Insert remainder
-        if not self.args.dryrun:
-            print(f'Inserting batch starting with: {batch[0].participantId}')
-            self.gem_gp_dao.insert_bulk(batch)
-        else:
-            print(f'Would insert batch starting with: {batch[0].participantId}')
+        if batch:
+            if not self.args.dryrun:
+                print(f'Inserting batch starting with: {batch[0].participantId}')
+                self.gem_gp_dao.insert_bulk(batch)
+            else:
+                print(f'Would insert batch starting with: {batch[0].participantId}')
 
 
 def get_process_for_run(args, gcp_env):

--- a/rdr_service/tools/tool_libs/genomic_utils.py
+++ b/rdr_service/tools/tool_libs/genomic_utils.py
@@ -2022,7 +2022,7 @@ class GemToGpMigrationClass(GenomicManifestBase):
             results = self.gem_gp_dao.get_data_for_export(controller.job_run.id, limit=self.args.limit)
 
             if results:
-                self.export_to_gem_gp_table(controller.job_run, results)
+                self.export_to_gem_gp_table(controller.job_run.id, results)
             else:
                 _logger.info('No data to export.')
 


### PR DESCRIPTION
## Resolves *No Ticket*

## Description of changes/additions
This PR fixes a bug that prevented other genomic tools from connecting to the DB. Some tweaks were made to the `gem-to-gp` tool after testing on Sandbox.



