### PR TITLE
[DA-2155 (partial)] Trigger PDR data rebuild tasks on consent_file upserts

### DIFF
--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -213,6 +213,7 @@ class ConsentSyncController:
         with self.consent_dao.session() as session:
             self.consent_dao.batch_update_consent_files(file_list, session)
 
+        # Queue tasks to rebuild consent metrics resource data records (for PDR)
         if len(updated_rec_ids):
             dispatch_rebuild_consent_metrics_tasks(updated_rec_ids)
 

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -127,7 +127,6 @@ def dispatch_rebuild_consent_metrics_tasks(id_list, in_seconds=15, quiet=True, b
 
     if build_locally or project_id == 'localhost':
         batch_rebuild_consent_metrics_task({'batch': id_list})
-
     else:
         completed_batches = 0
         task = GCPCloudTask()

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -12,6 +12,7 @@ from rdr_service.model.consent_file import ConsentFile as ParsingResult, Consent
     ConsentOtherErrors
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.participant_enums import ParticipantCohort, QuestionnaireStatus
+from rdr_service.resource.tasks import dispatch_rebuild_consent_metrics_tasks
 from rdr_service.services.consent import files
 from rdr_service.storage import GoogleCloudStorageProvider
 
@@ -73,6 +74,8 @@ class StoreResultStrategy(ValidationOutputStrategy):
         )
         self._consent_dao.batch_update_consent_files(new_results_to_store, self._session)
         self._session.commit()
+        if new_results_to_store:
+            dispatch_rebuild_consent_metrics_tasks([r.id for r in new_results_to_store])
 
 
 class ReplacementStoringStrategy(ValidationOutputStrategy):
@@ -122,6 +125,9 @@ class ReplacementStoringStrategy(ValidationOutputStrategy):
                         results_to_update.extend(new_results)
 
         self.consent_dao.batch_update_consent_files(results_to_update, self.session)
+        self.session.commit()
+        if results_to_update:
+            dispatch_rebuild_consent_metrics_tasks([r.id for r in results_to_update])
 
     @classmethod
     def _find_file_ready_for_sync(cls, results: List[ParsingResult]):
@@ -290,6 +296,9 @@ class ConsentValidationController:
                             validation_updates.append(new_result)
 
         self.consent_dao.batch_update_consent_files(validation_updates, session)
+        session.commit()
+        if validation_updates:
+            dispatch_rebuild_consent_metrics_tasks([v.id for v in validation_updates])
 
     def validate_participant_consents(self, summary: ParticipantSummary, output_strategy: ValidationOutputStrategy,
                                       min_authored_date: date = None,

--- a/tests/service_tests/consent_tests/test_consent_validation.py
+++ b/tests/service_tests/consent_tests/test_consent_validation.py
@@ -276,7 +276,10 @@ class ConsentValidationTesting(BaseTestCase):
             self.validator.get_gror_validation_results()
         )
 
-    def test_missing_file_validation_storage(self):
+    @mock.patch(
+        'rdr_service.services.consent.validation.dispatch_rebuild_consent_metrics_tasks'
+    )
+    def test_missing_file_validation_storage(self, mock_consent_metrics_rebuild):
         """
         A bug was found with the validation storage strategies. This ensures that any records that indicate
         missing files don't interfere with each other and all the needed records get stored.
@@ -290,22 +293,25 @@ class ConsentValidationTesting(BaseTestCase):
         new_gror_participant_id = 1234
         new_primary_participant_id = 5678
         consent_dao_mock.get_validation_results_for_participants.return_value = [
-            ConsentFile(participant_id=new_gror_participant_id, type=ConsentType.PRIMARY, file_exists=False),
-            ConsentFile(participant_id=new_primary_participant_id, type=ConsentType.EHR, file_exists=False)
+            ConsentFile(id=1, participant_id=new_gror_participant_id, type=ConsentType.PRIMARY, file_exists=False),
+            ConsentFile(id=2, participant_id=new_primary_participant_id, type=ConsentType.EHR, file_exists=False)
         ]
 
         # Create some results to provide to the output strategy for each participant
         new_primary_result = ConsentFile(
+            id=3,
             participant_id=new_primary_participant_id,
             type=ConsentType.PRIMARY,
             file_exists=False
         )
         previous_ehr_result = ConsentFile(
+            id=2,
             participant_id=new_primary_participant_id,
             type=ConsentType.EHR,
             file_exists=False
         )
         new_gror_result = ConsentFile(
+            id=4,
             participant_id=new_gror_participant_id,
             type=ConsentType.GROR,
             file_exists=False
@@ -320,6 +326,7 @@ class ConsentValidationTesting(BaseTestCase):
 
         # Verify that both records that provide new validation information were stored
         consent_dao_mock.batch_update_consent_files.assert_called_with([new_primary_result, new_gror_result], mock.ANY)
+        mock_consent_metrics_rebuild.assert_called_once_with([new_primary_result.id, new_gror_result.id])
 
     def test_primary_update_agreement_check(self):
         self.participant_summary.consentForStudyEnrollmentAuthored = datetime.combine(


### PR DESCRIPTION
## Resolves *[DA-2155 partial](https://precisionmedicineinitiative.atlassian.net/browse/DA-2155)*

## Description of changes/additions
Add calls to the dispatch method that queues resource rebuild tasks for the consent metrics resource data, whenever the RDR `consent_file`  table content is updated (generally via `ConsentDao.batch_update_consent_files() `calls)

Included a fix for a typo found in the `test_new_consent_validation` test case's expected results data

## Tests
- [x] unit tests
All unit tests that execute the `batch_update_consent_files()` path were updated with a mock for the dispatch method, with parameter validation on the mock call

