### PR TITLE
[DA-2264] use_most_recent_snapshot_for_inactive_workspace

### DIFF
--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -350,12 +350,12 @@ class WorkbenchWorkspaceDao(UpdatableDao):
 
             if workspace_id:
                 query = query.filter(WorkbenchWorkspaceSnapshot.workspaceSourceId == workspace_id)\
-                    .order_by(desc(WorkbenchWorkspaceSnapshot.id)).limit(1)
+                    .order_by(desc(subquery.c.id)).limit(1)
             elif snapshot_id:
-                query = query.filter(WorkbenchWorkspaceSnapshot.id == snapshot_id)
+                query = query.filter(subquery.c.id == snapshot_id)
             elif last_snapshot_id:
-                query = query.filter(WorkbenchWorkspaceSnapshot.id > last_snapshot_id)\
-                    .order_by(WorkbenchWorkspaceSnapshot.id)
+                query = query.filter(subquery.c.id > last_snapshot_id)\
+                    .order_by(subquery.c.id)
             items = query.all()
 
             for workspace, researcher, current_id, current_status in items:

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -3,8 +3,8 @@ import json
 from werkzeug.exceptions import BadRequest
 from dateutil.parser import parse
 import pytz
-from sqlalchemy import desc, or_, and_, func, distinct
-from sqlalchemy.orm import subqueryload, joinedload
+from sqlalchemy import desc, or_, and_, func, distinct, case
+from sqlalchemy.orm import subqueryload, joinedload, aliased
 from rdr_service.dao.base_dao import UpdatableDao
 from rdr_service import clock
 from datetime import timedelta
@@ -320,12 +320,32 @@ class WorkbenchWorkspaceDao(UpdatableDao):
 
         results = []
         with self.session() as session:
+            workbench_workspace_snapshot_alias = aliased(WorkbenchWorkspaceSnapshot)
+            active_id = session.query(func.max(WorkbenchWorkspaceSnapshot.id))\
+                .filter(WorkbenchWorkspaceSnapshot.status == WorkbenchWorkspaceStatus.ACTIVE)\
+                .filter(WorkbenchWorkspaceSnapshot.workspaceSourceId ==
+                        workbench_workspace_snapshot_alias.workspaceSourceId)\
+                .as_scalar()
+            case_stmt = case(
+                [
+                    (and_(workbench_workspace_snapshot_alias.status == WorkbenchWorkspaceStatus.INACTIVE,
+                          active_id != None),
+                     active_id)
+                ],
+                else_=workbench_workspace_snapshot_alias.id
+            )
+            subquery = session.query(case_stmt.label('active_id'), workbench_workspace_snapshot_alias).subquery()
             query = (
-                session.query(WorkbenchWorkspaceSnapshot, WorkbenchResearcherHistory)
+                session.query(WorkbenchWorkspaceSnapshot,
+                              WorkbenchResearcherHistory,
+                              subquery.c.id.label('current_id'),
+                              subquery.c.status.label('current_status'))
+                    .distinct()
                     .options(joinedload(WorkbenchWorkspaceSnapshot.workbenchWorkspaceUser),
                              joinedload(WorkbenchResearcherHistory.workbenchInstitutionalAffiliations))
                     .filter(WorkbenchWorkspaceUserHistory.researcherId == WorkbenchResearcherHistory.id,
-                            WorkbenchWorkspaceSnapshot.id == WorkbenchWorkspaceUserHistory.workspaceId)
+                            WorkbenchWorkspaceSnapshot.id == subquery.c.active_id,
+                            subquery.c.active_id == WorkbenchWorkspaceUserHistory.workspaceId)
             )
 
             if workspace_id:
@@ -336,9 +356,9 @@ class WorkbenchWorkspaceDao(UpdatableDao):
             elif last_snapshot_id:
                 query = query.filter(WorkbenchWorkspaceSnapshot.id > last_snapshot_id)\
                     .order_by(WorkbenchWorkspaceSnapshot.id)
-
             items = query.all()
-            for workspace, researcher in items:
+
+            for workspace, researcher, current_id, current_status in items:
                 verified_institutional_affiliation = {}
                 affiliations = []
                 if researcher.workbenchInstitutionalAffiliations:
@@ -374,19 +394,19 @@ class WorkbenchWorkspaceDao(UpdatableDao):
 
                 exist = False
                 for result in results:
-                    if result['snapshotId'] == workspace.id:
+                    if result['snapshotId'] == current_id:
                         result['workspaceResearchers'].append(workspace_researcher)
                         exist = True
                         break
                 if exist:
                     continue
                 record = {
-                    'snapshotId': workspace.id,
+                    'snapshotId': current_id,
                     'workspaceId': workspace.workspaceSourceId,
                     'name': workspace.name,
                     'creationTime': workspace.creationTime,
                     'modifiedTime': workspace.modifiedTime,
-                    'status': str(WorkbenchWorkspaceStatus(workspace.status)),
+                    'status': str(WorkbenchWorkspaceStatus(current_status)),
                     'workspaceUsers': [
                         {
                             "userId": user.userId,

--- a/tests/api_tests/test_workspace_audit_and_research_directory_api.py
+++ b/tests/api_tests/test_workspace_audit_and_research_directory_api.py
@@ -1467,6 +1467,13 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        'cdrVersion': 'irving'
                        }, result)
 
+        result = self.send_get('workbench/audit/workspace/snapshots?last_snapshot_id=1')
+        self.assertEqual(len(result), 1)
+
+        result = self.send_get('workbench/audit/workspace/snapshots?snapshot_id=2')
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['status'], 'INACTIVE')
+
     def test_hide_workspace_without_verified_institution_from_RH(self):
         # create researchers
         researchers_json = [


### PR DESCRIPTION
## Resolves *[DA-2264](https://precisionmedicineinitiative.atlassian.net/browse/DA-2264)*
Workbench removed all the users info for an INACTIVE workspace. REDCap requests RDR to use the most recent  ACTIVE workspace snapshot for the INACTIVE workspaces, so they can get the users info.

## Description of changes/additions
For the workspace REDCap audit API, modify the query to use the most recent  ACTIVE workspace snapshot for the INACTIVE workspaces.

## Tests
- [x] unit tests


