### PR TITLE
[DA-2268] - Ops Data API filter by sites attached to service account

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -335,7 +335,7 @@ def get_validated_user_info():
     """Returns a valid (user email, user info), or raises Unauthorized or Forbidden."""
     user_email = get_oauth_id()
 
-    # Allow clients to simulate an unauthentiated request (for testing)
+    # Allow clients to simulate an unauthenticated request (for testing)
     # because we haven't found another way to create an unauthenticated request
     # when using dev_appserver. When client tests are checking to ensure that an
     # unauthenticated requests gets rejected, they helpfully add this header.

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -628,10 +628,8 @@ class ParticipantSummaryDao(UpdatableDao):
             if not code:
                 raise BadRequest(f"No code found: {value}")
             return super(ParticipantSummaryDao, self).make_query_filter(field_name + "Id", code.codeId)
-
         if field_name == "patientStatus":
             return self._make_patient_status_field_filter(field_name, value)
-
         if field_name == "participantOrigin":
             if value not in ORIGINATING_SOURCES:
                 raise BadRequest(f"No origin source found for {value}")

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -3773,7 +3773,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
         self.overwrite_test_user_site(google_group)
 
-        bad_message = f"No site found with google group {google_group}"
+        bad_message = f"No site found with google group {google_group}, that is attached to request user"
 
         response = self.send_get(f"ParticipantSummary?firstName={first_name}",
                                  expected_status=http.client.BAD_REQUEST)
@@ -3781,6 +3781,24 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual(bad_message, response.json['message'])
         self.assertEqual(response.status_code, 400)
 
+    def test_single_participant_with_conflicting_sites_throws_exception(self):
+        google_group = 'hpo-site-monroeville'
 
+        ps = self.data_generator \
+            .create_database_participant_summary(
+                firstName="Testy",
+                lastName="Tester",
+                siteId=3
+        )
+
+        self.overwrite_test_user_site(google_group)
+
+        bad_message = f"Site attached to the request user, {google_group} is forbidden from accessing this participant"
+
+        response = self.send_get(f"Participant/P{ps.participantId}/Summary",
+                                 expected_status=403)
+
+        self.assertEqual(bad_message, response.json['message'])
+        self.assertEqual(response.status_code, 403)
 
 

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -21,6 +21,7 @@ from rdr_service.concepts import Concept
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.dao.site_dao import SiteDao
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import CodeType
 from rdr_service.model.consent_file import ConsentType
@@ -227,13 +228,14 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
     def setUp(self):
         super().setUp()
+        self.faker = faker.Faker()
         self.hpo_dao = HPODao()
+        self.ps_dao = ParticipantSummaryDao()
+        self.site_dao = SiteDao()
         # Needed by test_switch_to_test_account
         self.hpo_dao.insert(
             HPO(hpoId=TEST_HPO_ID, name=TEST_HPO_NAME, displayName="Test", organizationType=OrganizationType.UNSET)
         )
-        self.ps_dao = ParticipantSummaryDao()
-        self.faker = faker.Faker()
 
         # Patching to prevent consent validation checks from running
         build_validator_patch = mock.patch(
@@ -251,6 +253,11 @@ class ParticipantSummaryApiTest(BaseTestCase):
     def overwrite_test_user_roles(self, roles):
         new_user_info = deepcopy(config.getSettingJson(config.USER_INFO))
         new_user_info['example@example.com']['roles'] = roles
+        self.temporarily_override_config_setting(config.USER_INFO, new_user_info)
+
+    def overwrite_test_user_site(self, site):
+        new_user_info = deepcopy(config.getSettingJson(config.USER_INFO))
+        new_user_info['example@example.com']['site'] = site
         self.temporarily_override_config_setting(config.USER_INFO, new_user_info)
 
     def create_demographics_questionnaire(self):
@@ -3690,3 +3697,90 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
         self.assertEqual(bad_message, response.json['message'])
         self.assertEqual(response.status_code, 400)
+
+    def test_site_in_roles_gives_correct_response(self):
+        google_group = 'hpo-site-monroeville'
+        monroe = self.site_dao.get_by_google_group(google_group)
+
+        num_summary, first_name, second_pid = 10, "Testy", None
+
+        for num in range(num_summary):
+            ps = self.data_generator \
+                .create_database_participant_summary(
+                    firstName=first_name,
+                    lastName="Tester",
+                    siteId=monroe.siteId if num % 2 == 0 else 3
+                )
+
+            if num == 2:
+                second_pid = ps.participantId
+
+        response = self.send_get(f"Participant/P{second_pid}/Summary")
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response['site'], google_group)
+
+        response = self.send_get(f"ParticipantSummary?firstName={first_name}")
+        responses = response['entry']
+
+        self.assertEqual(len(responses), num_summary)
+        self.assertFalse(all(obj['resource']['site'] == monroe.googleGroup for obj in responses))
+
+        self.overwrite_test_user_site(google_group)
+
+        response = self.send_get(f"Participant/P{second_pid}/Summary")
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response['site'], google_group)
+
+        response = self.send_get(f"ParticipantSummary?firstName={first_name}")
+        responses = response['entry']
+
+        self.assertEqual(len(responses), num_summary // 2)
+        self.assertTrue(all(obj['resource']['site'] == monroe.googleGroup for obj in responses))
+        self.assertFalse(any(obj['resource']['site'] != monroe.googleGroup for obj in responses))
+
+    def test_list_to_first_site_in_roles(self):
+        google_group = 'hpo-site-monroeville'
+        monroe = self.site_dao.get_by_google_group(google_group)
+
+        num_summary, first_name = 10, "Testy"
+
+        for _ in range(num_summary):
+            self.data_generator \
+                .create_database_participant_summary(
+                    firstName=first_name,
+                    lastName="Tester",
+                    siteId=monroe.siteId
+                )
+
+        self.overwrite_test_user_site([google_group])
+
+        response = self.send_get(f"ParticipantSummary?firstName={first_name}")
+        responses = response['entry']
+        self.assertEqual(len(responses), num_summary)
+
+    def test_bad_site_in_roles_throws_exception(self):
+        google_group, num_summary, first_name = 'fake-hpo-site', 10, "Testy"
+
+        for _ in range(num_summary):
+            self.data_generator \
+                .create_database_participant_summary(
+                    firstName=first_name,
+                    lastName="Tester",
+                    siteId=1
+                )
+
+        self.overwrite_test_user_site(google_group)
+
+        bad_message = f"No site found with google group {google_group}"
+
+        response = self.send_get(f"ParticipantSummary?firstName={first_name}",
+                                 expected_status=http.client.BAD_REQUEST)
+
+        self.assertEqual(bad_message, response.json['message'])
+        self.assertEqual(response.status_code, 400)
+
+
+
+


### PR DESCRIPTION
## Resolves *[ticket DA-2268]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2268

## Description of changes/additions
Need to be able to leverage site denotations attached to the service accounts in the Ops Data API GET requests for implicit filtering on the site id attached to final query.

## Tests
- [x] unit tests


