### PR TITLE
[DA-2226] Curation ETL OMOP schema update

### DIFF
--- a/rdr_service/etl/raw_sql/finalize_cdm_data.sql
+++ b/rdr_service/etl/raw_sql/finalize_cdm_data.sql
@@ -530,9 +530,10 @@ SELECT
     NULL                                        AS quantity,
     NULL                                        AS provider_id,
     NULL                                        AS visit_occurrence_id,
+    NULL                                        AS visit_detail_id,
     stcm.source_code                            AS procedure_source_value,
     COALESCE(stcm.source_concept_id, 0)         AS procedure_source_concept_id,
-    NULL                                        AS qualifier_source_value,
+    NULL                                        AS modifier_source_value,
     'procedure'                                 AS unit_id
 FROM cdm.src_mapped src_m1
 INNER JOIN cdm.source_to_concept_map stcm
@@ -977,6 +978,7 @@ SELECT
     meas.cv_concept_id                      AS measurement_concept_id,
     DATE(meas.measurement_time)             AS measurement_date,
     meas.measurement_time                   AS measurement_datetime,
+    NULL                                    AS measurement_time,
     44818701                                AS measurement_type_concept_id, -- 44818701, From physical examination
     0                                       AS operator_concept_id,
     meas.value_decimal                      AS value_as_number,
@@ -986,6 +988,7 @@ SELECT
     NULL                                    AS range_high,
     NULL                                    AS provider_id,
     meas.physical_measurements_id           AS visit_occurrence_id,
+    NULL                                    AS visit_detail_id,
     meas.code_value                         AS measurement_source_value,
     meas.cv_source_concept_id               AS measurement_source_concept_id,
     meas.value_unit                         AS unit_source_value,
@@ -1036,6 +1039,7 @@ SELECT
     0                                       AS encoding_concept_id,
     4180186                                 AS language_concept_id,     -- 4180186 - 'English language'
     NULL                                    AS provider_id,
+    NULL                                    AS visit_detail_id,
     meas.code_value                         AS note_source_value,
     meas.physical_measurements_id           AS visit_occurrence_id,
     'note'                                  AS unit_id

--- a/rdr_service/etl/raw_sql/partially_initialize_cdm.sql
+++ b/rdr_service/etl/raw_sql/partially_initialize_cdm.sql
@@ -123,10 +123,10 @@ DROP TABLE IF EXISTS cdm.death;
 CREATE TABLE cdm.death
 (
     id bigint NOT NULL,
-    person_id bigint NOT NULL,
-    death_date date NOT NULL,
+    person_id bigint,
+    death_date date,
     death_datetime datetime,
-    death_type_concept_id bigint NOT NULL,
+    death_type_concept_id bigint,
     cause_concept_id bigint NOT NULL,
     cause_source_value varchar(50),
     cause_source_concept_id bigint NOT NULL,
@@ -164,9 +164,19 @@ CREATE TABLE cdm.payer_plan_period
     person_id bigint NOT NULL,
     payer_plan_period_start_date date NOT NULL,
     payer_plan_period_end_date date NOT NULL,
+    payer_concept_id bigint,
     payer_source_value varchar(50),
+    payer_source_concept_id bigint,
+    plan_concept_id bigint,
     plan_source_value varchar(50),
+    plan_source_concept_id bigint,
+    sponsor_concept_id bigint,
+    sponsor_source_value  varchar(50),
+    sponsor_source_concept_id bigint,
     family_source_value varchar(50),
+    stop_reason_concept_id bigint,
+    stop_reason_source_value  varchar(50),
+    stop_reason_source_concept_id bigint,
     unit_id varchar(50) NOT NULL,
     PRIMARY KEY (payer_plan_period_id),
     UNIQUE KEY (id)
@@ -218,9 +228,11 @@ CREATE TABLE cdm.condition_occurrence
     condition_end_date date,
     condition_end_datetime datetime,
     condition_type_concept_id bigint NOT NULL,
+    condition_status_concept_id bigint,
     stop_reason varchar(20),
     provider_id bigint,
     visit_occurrence_id bigint,
+    visit_detail_id bigint,
     condition_source_value varchar(50) NOT NULL,
     condition_source_concept_id bigint NOT NULL,
     unit_id varchar(50) NOT NULL,
@@ -246,9 +258,10 @@ CREATE TABLE cdm.procedure_occurrence
     quantity int,
     provider_id bigint,
     visit_occurrence_id bigint,
+    visit_detail_id bigint,
     procedure_source_value varchar(1024) NOT NULL,
     procedure_source_concept_id bigint NOT NULL,
-    qualifier_source_value varchar(50),
+    modifier_source_value varchar(50),
     unit_id varchar(50) NOT NULL,
     PRIMARY KEY (procedure_occurrence_id),
     UNIQUE KEY (id)
@@ -303,6 +316,7 @@ CREATE TABLE cdm.measurement
     measurement_concept_id bigint NOT NULL,
     measurement_date date NOT NULL,
     measurement_datetime datetime,
+    measurement_time varchar(50),
     measurement_type_concept_id bigint NOT NULL,
     operator_concept_id bigint NOT NULL,
     value_as_number decimal(20,6),
@@ -312,6 +326,7 @@ CREATE TABLE cdm.measurement
     range_high decimal(20,6),
     provider_id bigint,
     visit_occurrence_id bigint,
+    visit_detail_id bigint,
     measurement_source_value varchar(50),
     measurement_source_concept_id bigint NOT NULL,
     unit_source_value varchar(50),
@@ -344,6 +359,7 @@ CREATE TABLE cdm.note
     encoding_concept_id bigint NOT NULL,
     language_concept_id bigint NOT NULL,
     provider_id bigint,
+    visit_detail_id bigint,
     note_source_value varchar(50),
     visit_occurrence_id bigint,
     unit_id varchar(50) NOT NULL,
@@ -376,6 +392,7 @@ CREATE TABLE cdm.drug_exposure
     lot_number varchar(50),
     provider_id bigint,
     visit_occurrence_id bigint,
+    visit_detail_id bigint,
     drug_source_value varchar(50) NOT NULL,
     drug_source_concept_id bigint,
     route_source_value varchar(50),
@@ -405,6 +422,7 @@ CREATE TABLE cdm.device_exposure
     quantity decimal(20,6),
     provider_id bigint,
     visit_occurrence_id bigint,
+    visit_detail_id bigint,
     device_source_value varchar(50) NOT NULL,
     device_source_concept_id bigint,
     unit_id varchar(50) NOT NULL,
@@ -440,7 +458,7 @@ CREATE TABLE cdm.cost
     amount_allowed decimal(20,6),
     revenue_code_concept_id bigint NOT NULL,
     revenue_code_source_value varchar(50),
-    drg_concept_id bigint NOT NULL,
+    drg_concept_id bigint,
     drg_source_value varchar(50),
     unit_id varchar(50) NOT NULL,
     PRIMARY KEY (cost_id),
@@ -521,4 +539,73 @@ CREATE TABLE cdm.dose_era
     unit_id varchar(50) NOT NULL,
     PRIMARY KEY (dose_era_id),
     UNIQUE KEY (id)
+);
+
+-- -----------------------------------------------
+-- metadata
+-- -----------------------------------------------
+DROP TABLE IF EXISTS cdm.metadata;
+
+CREATE TABLE cdm.metadata
+(
+    metadata_concept_id bigint NOT NULL,
+    metadata_type_concept_id bigint NOT NULL,
+    name varchar(256) NOT NULL,
+    value_as_string varchar(1024),
+    value_as_concept_id bigint,
+    metadata_date date,
+    metadata_datetime datetime
+);
+
+-- -----------------------------------------------
+-- note_nlp
+-- -----------------------------------------------
+DROP TABLE IF EXISTS cdm.note_nlp;
+
+CREATE TABLE cdm.note_nlp
+(
+    note_nlp_id bigint NOT NULL,
+    note_id bigint NOT NULL,
+    section_concept_id bigint,
+    snippet varchar(512),
+    offset varchar(256),
+    lexical_variant varchar(1024) NOT NULL,
+    note_nlp_concept_id bigint,
+    note_nlp_source_concept_id bigint,
+    nlp_system varchar(256),
+    nlp_date date NOT NULL,
+    nlp_datetime datetime,
+    term_exists varchar(256),
+    term_temporal varchar(256),
+    term_modifiers  varchar(256),
+    PRIMARY KEY (note_nlp_id)
+);
+
+-- -----------------------------------------------
+-- visit_detail
+-- -----------------------------------------------
+DROP TABLE IF EXISTS cdm.visit_detail;
+
+CREATE TABLE cdm.visit_detail
+(
+    visit_detail_id bigint NOT NULL,
+    person_id bigint NOT NULL,
+    visit_detail_concept_id bigint NOT NULL,
+    visit_detail_start_date date NOT NULL,
+    visit_detail_start_datetime datetime,
+    visit_detail_end_date date NOT NULL,
+    visit_detail_end_datetime datetime,
+    visit_detail_type_concept_id bigint NOT NULL,
+    provider_id bigint,
+    care_site_id bigint,
+    visit_detail_source_value varchar(256),
+    visit_detail_source_concept_id bigint,
+    admitting_source_value  varchar(256),
+    admitting_source_concept_id bigint,
+    discharge_to_source_value varchar(256),
+    discharge_to_concept_id bigint,
+    preceding_visit_detail_id bigint,
+    visit_detail_parent_id bigint,
+    visit_occurrence_id bigint NOT NULL,
+    PRIMARY KEY (visit_detail_id)
 );

--- a/rdr_service/message_broker/message_broker.py
+++ b/rdr_service/message_broker/message_broker.py
@@ -45,7 +45,8 @@ class BaseMessageBroker:
                 self.dest_auth_dao.update(auth_info)
                 return r_json['access_token']
             else:
-                raise BadGateway(f'can not get access token for dest: {self.message.messageDest}')
+                raise BadGateway(f'can not get access token for dest: {self.message.messageDest}, '
+                                 f'response error: {str(response.status_code)}')
 
     def _get_message_dest_url(self):
         dest_url = self.message_metadata_dao.get_dest_url(self.message.eventType, self.message.messageDest)

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -45,8 +45,8 @@ class CurationExportClass(ToolBase):
     """
     tables = ['pid_rid_mapping', 'care_site', 'condition_era', 'condition_occurrence', 'cost', 'death',
               'device_exposure', 'dose_era', 'drug_era', 'drug_exposure', 'fact_relationship',
-              'location', 'measurement', 'observation_period', 'payer_plan_period',
-              'person', 'procedure_occurrence', 'provider', 'visit_occurrence']
+              'location', 'measurement', 'observation_period', 'payer_plan_period', 'visit_detail',
+              'person', 'procedure_occurrence', 'provider', 'visit_occurrence', 'metadata', 'note_nlp']
 
     # Observation takes a while and ends up timing the client out. The server will continue to process and the client
     # will print out a message describing how to continue to track it, but for now it crashes the script so it has


### PR DESCRIPTION
## Resolves *[DA-2226](https://precisionmedicineinitiative.atlassian.net/browse/DA-2226)*
Update OMOP schemas based on the changes in https://github.com/all-of-us/curation/commit/2f07cf5d58b04fafd1ffab804adedb42314f375f

For the new tables metadata, note_nlp and visit_detail, we only create empty tables.


## Tests
- [x] unit tests


