### PR TITLE
Fix PDR ConsentMetric data generator when filtering false positives

### DIFF
--- a/rdr_service/resource/generators/consent_metrics.py
+++ b/rdr_service/resource/generators/consent_metrics.py
@@ -120,12 +120,13 @@ class ConsentMetricGenerator(generators.BaseGenerator):
             missing signatures.  Returns True if all the following conditions exist:
                 expected_sign_date < 2018-07-13 AND
                 signing_date is null AND
-                resource data dict has no other errors set besides signature_missing
+                resource data dict has no other errors set besides signature_missing and/or invalid_signing_date
             """
             if (resource['sync_status'] != str(ConsentSyncStatus.NEEDS_CORRECTING)
                     or signing_date
                     or (expected_sign_date and expected_sign_date >= MISSING_SIGNATURE_FALSE_POSITIVE_CUTOFF_DATE)
-                    or ConsentMetricGenerator.has_errors(resource, exclude=['signature_missing'])):
+                    or ConsentMetricGenerator.has_errors(resource, exclude=['signature_missing',
+                                                                            'invalid_signing_date'])):
                 return False
 
             return True


### PR DESCRIPTION
## Resolves *no ticket*

## Description of changes/additions
The PDR data generator uses an `ignore` flag to denote `consent_metric` records that should be filtered out of our unresolved error counts due to known potential false positive cases.  The logic for the "missing signature" false positive case for consents authored prior to 2018-07-13 was incomplete in the generator and was not setting the `ignore` flag when the signature itself was valid but the signing date was missing.

## Tests
- [x] unit tests
Added a new unit test case for the scenario that was being missed (`is_signature_valid` was true in the `consent_file` rec, but `signing_date` was invalid/missing).  Cleaned up comments after cutting/pasting from other tests

