### PR TITLE
PTSC test process should add gem_pass flag for integration test.

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1492,6 +1492,7 @@ class GenomicOutreachDao(BaseDao):
                                   genomicSetId=1,
                                   genomeType=genome_type,
                                   genomicWorkflowState=report_state,
+                                  gemPass='Y',
                                   genomicWorkflowStateModifiedTime=modified_date)
 
         return member


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Need to add the gem_pass flag to the Outreach API test participant creation workflow so that Color can see PTSC's test participants.

## Tests
- [x] unit tests


