### PR TITLE
[ROC-1237] Don't process if missing contamination

### DIFF
--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -101,6 +101,7 @@ class GenomicJob(messages.Enum):
     # Ingestion Reconciliatino Jobs
     RECONCILE_GC_DATA_FILE_TO_TABLE = 46
     RECONCILE_RAW_AW1_INGESTED = 47
+    RECONCILE_RAW_AW2_INGESTED = 48
 
     # Data Quality Pipeline Jobs
     # Naming matters for reports (timeframe_level_report_target)

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -290,7 +290,7 @@ def reconcile_raw_to_aw1_ingested():
 
 
 def reconcile_raw_to_aw2_ingested():
-    with GenomicJobController(GenomicJob.RECONCILE_RAW_AW1_INGESTED) as controller:
+    with GenomicJobController(GenomicJob.RECONCILE_RAW_AW2_INGESTED) as controller:
         controller.reconcile_raw_to_aw2_ingested()
 
 


### PR DESCRIPTION
## Resolves *[ROC-12-37](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1237)*


## Description of changes/additions
The Raw AW2 Reconciliation process is failing on the records that are missing contamination. This PR modifies this process to skip these raw records. Further investigation will need to occur as to how to handle the skipped raw records. 

## Tests
- [x] unit tests


