### PR TITLE
[DA-2314] Update AW2 to only lookup on sample id

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1050,10 +1050,8 @@ class GenomicFileIngester:
                                  for key in row],
                                 row.values()))
 
-            genome_type = self.file_validator.genome_type
             member = self.member_dao.get_member_from_sample_id(
                 int(row_copy['sampleid']),
-                genome_type
             )
 
             if member:
@@ -1075,11 +1073,12 @@ class GenomicFileIngester:
                         metric_id = existing_metrics_obj.id
                 else:
                     metric_id = None
+                    if member.genomeType in [GENOME_TYPE_ARRAY, GENOME_TYPE_WGS]:
 
-                    if row_copy['contamination_category'] in [GenomicContaminationCategory.EXTRACT_WGS,
-                                                              GenomicContaminationCategory.EXTRACT_BOTH]:
-                        # Insert a new member
-                        self.insert_member_for_replating(member, row_copy['contamination_category'])
+                        if row_copy['contamination_category'] in [GenomicContaminationCategory.EXTRACT_WGS,
+                                                                  GenomicContaminationCategory.EXTRACT_BOTH]:
+                            # Insert a new member
+                            self.insert_member_for_replating(member, row_copy['contamination_category'])
 
                 upserted_obj = self.metrics_dao.upsert_gc_validation_metrics_from_dict(row_copy, metric_id)
 


### PR DESCRIPTION
## Resolves *[DA-2314](https://precisionmedicineinitiative.atlassian.net/browse/DA-2314)*


## Description of changes/additions
This PR changes the AW2 genomic_set_member lookup to only use sample_id instead of sample_id and genome_type. The contamination category calculation is only performed if the member's genome_type is one of the standard ones.

## Tests
- [x] unit tests


