### PR TITLE
Update Sendgrid to 6.9.1

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -99,7 +99,7 @@ requests-oauthlib==1.3.0  # via jira
 requests-toolbelt==0.9.1  # via jira
 requests[security]==2.25.1  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
 rsa==4.7.2                  # via google-auth, oauth2client
-sendgrid==6.3.1           # via -r requirements.in
+sendgrid==6.9.1           # via -r requirements.in
 simple-geometry==0.1.4  # geometry
 simplejson==3.17.0        # via -r requirements.in
 six==1.15.0               # via astroid, cryptography, flask-restful, geventhttpclient, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-python-cloud-debugger, google-resumable-media, grpcio, isodate, jira, oauth2client, packaging, pip-tools, protobuf, protorpc, pyopenssl, python-dateutil


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Circle CI safety checks are failing for older version of sendgrid

## Tests
- [] unit tests
** All existing tests should pass

