### PR TITLE
[PDR-559] Fix UBR calculation issues and missing enrollment timestamps

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1443,7 +1443,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         """
         data = dict()
 
-        # ubr_geography - note: we only need a ConsentPII submission for ubr_geography.
+        #### ConsentPII UBR calculations.
+        # ubr_geography
         addresses = summary.get('addresses', [])
         consent_date = summary.get('enrl_participant_time', None)
         if addresses and consent_date:
@@ -1453,7 +1454,13 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     zip_code = addr.get('addr_zip', None)
                     break
             data['ubr_geography'] = ubr.ubr_geography(consent_date.date(), zip_code)
+        # ubr_age_at_consent
+        data['ubr_age_at_consent'] = \
+            ubr.ubr_age_at_consent(summary.get('enrl_participant_time', None), summary.get('date_of_birth', None))
+        # ubr_overall - This should be calculated here in case there is no TheBasics response available.
+        data['ubr_overall'] = max([v for v in data.values()])
 
+        #### TheBasics UBR calculations.
         # Note: Due to PDR-484 we can't rely on the summary having a record for each valid submission so we
         #       are going to do our own query to get the first TheBasics submission after consent. Due to
         #       the existence of responses with duplicate 'authored' and 'created' timestamps, we also include
@@ -1490,9 +1497,6 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         data['ubr_income'] = ubr.ubr_income(qnan.get('Income_AnnualIncome', None))
         # ubr_disability
         data['ubr_disability'] = ubr.ubr_disability(qnan)
-        # ubr_age_at_consent
-        data['ubr_age_at_consent'] = \
-            ubr.ubr_age_at_consent(summary.get('enrl_participant_time', None), summary.get('date_of_birth', None))
         # ubr_overall
         data['ubr_overall'] = max([v for v in data.values()])
 


### PR DESCRIPTION
## Resolves *[PDR-559](https://precisionmedicineinitiative.atlassian.net/browse/PDR-559)*


## Description of changes/additions
* Always calculate UBR overall, even if we don't have a 'TheBasics' response.
* Move UBR age at consent calculation to ConsentPII block.
* Ensure that all enrl_* timestamp fields are populated and not skipped.

## Tests
- [x] unit tests


