### PR TITLE
Only check contaminated sample if in regular genome types.

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -501,9 +501,10 @@ class GenomicFileIngester:
                 # If member found, validate new collection tube ID, set collection tube ID
                 if member:
                     if self._validate_collection_tube_id(row_copy['collectiontubeid'], bid):
-                        if member.collectionTubeId:
-                            with self.member_dao.session() as session:
-                                self._record_sample_as_contaminated(session, member.collectionTubeId)
+                        if member.genomeType in [GENOME_TYPE_ARRAY, GENOME_TYPE_WGS]:
+                            if member.collectionTubeId:
+                                with self.member_dao.session() as session:
+                                    self._record_sample_as_contaminated(session, member.collectionTubeId)
 
                         member.collectionTubeId = row_copy['collectiontubeid']
                 else:


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Adds logic to only write the collection tube ID to the contaminated sample table if the genomic_set_member record has the standard Array or WGS genome_type.

## Tests
- [x] unit tests


