### PR TITLE
Fixing some formatting for the biobank withdrawal report generation

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -347,10 +347,7 @@ def get_withdrawal_report_query(start_date: datetime):
             Organization.externalId.label('paired_org'),
             Site.googleGroup.label('paired_site'),
             Participant.withdrawalReasonJustification.label('withdrawal_reason_justification'),
-            case(
-                [(ParticipantSummary.deceasedStatus.is_(None), 'UNSET')],
-                else_=ParticipantSummary.deceasedStatus  # TODO: test that the status string gets used
-            ).label('deceased_status')
+            ParticipantSummary.deceasedStatus.label('deceased_status')
         ])
         .select_from(Participant)
         .outerjoin(ceremony_answer_subquery, ceremony_answer_subquery.c.participant_id == Participant.participantId)

--- a/rdr_service/tools/tool_libs/biobank_report.py
+++ b/rdr_service/tools/tool_libs/biobank_report.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from rdr_service import clock, config
 from rdr_service.model.utils import to_client_participant_id
 from rdr_service.offline.biobank_samples_pipeline import get_withdrawal_report_query
+from rdr_service.participant_enums import DeceasedStatus
 from rdr_service.storage import GoogleCloudStorageProvider
 from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
 
@@ -56,6 +57,10 @@ class BiobankReportTool(ToolBase):
             report_query = get_withdrawal_report_query(start_date=start_date)
             result_list = session.execute(report_query)
             for result in result_list:
+                deceased_status = result.deceased_status
+                if result.deceased_status is None:  # Can be None if the summary doesn't exist
+                    deceased_status = DeceasedStatus.UNSET
+
                 csv_writer.writerow({
                     'participant_id': to_client_participant_id(result.participant_id),
                     'biobank_id': f'{server_config[config.BIOBANK_ID_PREFIX][0]}{result.biobank_id}',
@@ -67,7 +72,7 @@ class BiobankReportTool(ToolBase):
                     'paired_org': result.paired_org,
                     'paired_site': result.paired_site,
                     'withdrawal_reason_justification': result.withdrawal_reason_justification,
-                    'deceased_status': result.deceased_status
+                    'deceased_status': str(DeceasedStatus(int(deceased_status)))
                 })
 
         logger.info(f'SUCCESS: report written to {file_path}')

--- a/rdr_service/tools/tool_libs/biobank_report.py
+++ b/rdr_service/tools/tool_libs/biobank_report.py
@@ -72,7 +72,7 @@ class BiobankReportTool(ToolBase):
                     'paired_org': result.paired_org,
                     'paired_site': result.paired_site,
                     'withdrawal_reason_justification': result.withdrawal_reason_justification,
-                    'deceased_status': str(DeceasedStatus(int(deceased_status)))
+                    'deceased_status': str(deceased_status)
                 })
 
         logger.info(f'SUCCESS: report written to {file_path}')

--- a/tests/tool_tests/test_biobank_report_tool.py
+++ b/tests/tool_tests/test_biobank_report_tool.py
@@ -3,7 +3,7 @@ import mock
 
 from rdr_service import clock, config
 from rdr_service.model.participant import Participant
-from rdr_service.participant_enums import WithdrawalAIANCeremonyStatus, WithdrawalStatus
+from rdr_service.participant_enums import DeceasedStatus, WithdrawalAIANCeremonyStatus, WithdrawalStatus
 from rdr_service.tools.tool_libs.biobank_report import BiobankReportTool
 from tests.helpers.tool_test_mixin import ToolTestMixin
 from tests.helpers.unittest_base import BaseTestCase
@@ -103,6 +103,29 @@ class BiobankReportToolTest(ToolTestMixin, BaseTestCase):
             rows=rows_written,
             withdrawal_date_str=twenty_days_ago.strftime('%Y-%m-%dT%H:%M:%SZ'),
             withdrawal_reason_justification='withdraw before delivery'
+        )
+
+    def test_deceased_status_string(self):
+        """Check that the withdrawal status displays as a string rather than an int."""
+        five_days_ago = self._datetime_n_days_ago(5)
+
+        # Create a participant that has a deceased status
+        withdrawn_participant = self.data_generator.create_withdrawn_participant(
+            withdrawal_reason_justification='deceased participant',
+            withdrawal_time=five_days_ago
+        )
+        self.data_generator.create_database_participant_summary(
+            deceasedStatus=DeceasedStatus.APPROVED,
+            participantId=withdrawn_participant.participantId
+        )
+
+        rows_written = self.run_withdrawal_report()
+        self._assert_participant_in_report_rows(
+            withdrawn_participant,
+            rows=rows_written,
+            withdrawal_date_str=five_days_ago.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            withdrawal_reason_justification='deceased participant',
+            deceased_status='APPROVED'
         )
 
     def test_default_date_calculations(self):


### PR DESCRIPTION
## Resolves *no ticket*
The withdrawal report was writing the deceased status as an integer to the CSV. This converts it to its string value instead.


## Tests
- [x] unit tests


