### PR TITLE
[PDR-575] Correctly calulate UBR_Overall value.

### DIFF
--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -247,5 +247,5 @@ class ParticipantUBRCalculator:
         # Test each UBR value for a UBR status.
         for k, v in data.items():
             if k.startswith('ubr_') and v == UBRValueEnum.UBR:
-                result = 1
+                return UBRValueEnum.UBR
         return result

--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -18,7 +18,7 @@ class UBRValueEnum(IntEnum):
 
     RBR = 0
     UBR = 1
-    NullSkip = 2
+    NotAnswer_Skip = 2  # PMI_PreferNotToAnswer or PMI_Skip value.
 
 
 class ParticipantUBRCalculator:
@@ -35,7 +35,7 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         if answer is None or answer == 'PMI_Skip':
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         if answer in ('SexAtBirth_SexAtBirthNoneOfThese', 'SexAtBirth_Intersex'):
             return UBRValueEnum.UBR
         return UBRValueEnum.RBR
@@ -48,7 +48,7 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         if answer is None or answer == 'PMI_Skip':
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         if answer not in ['SexualOrientation_Straight', 'PMI_PreferNotToAnswer']:
             return UBRValueEnum.UBR
         return UBRValueEnum.RBR
@@ -65,7 +65,7 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         if gender_ident is None and gender_ident_closer is None:
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         # 'gender_ident' can be null, but 'gender_ident_other' can contain a valid answer.
         if not gender_ident:
             gender_ident = ''
@@ -86,7 +86,7 @@ class ParticipantUBRCalculator:
         if len(answers) == 1:
             answer = answers[0]
             if answer is None or answer == 'PMI_Skip':
-                return UBRValueEnum.NullSkip
+                return UBRValueEnum.NotAnswer_Skip
             if (answer == 'PMI_PreferNotToAnswer' or answer == 'GenderIdentity_PreferNotToAnswer') or \
                     (answer == 'GenderIdentity_Man' and birth_sex in ['SexAtBirth_Male', 'PMI_Skip', None]) or \
                     (answer == 'GenderIdentity_Woman' and birth_sex in ['SexAtBirth_Female', 'PMI_Skip', None]):
@@ -103,12 +103,12 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         # If both are NullSkip, return NullSkip.
-        if ubr_sexual_orientation == UBRValueEnum.NullSkip and ubr_gender_identity == UBRValueEnum.NullSkip:
-            return UBRValueEnum.NullSkip
+        if ubr_sexual_orientation == UBRValueEnum.NotAnswer_Skip and ubr_gender_identity == UBRValueEnum.NotAnswer_Skip:
+            return UBRValueEnum.NotAnswer_Skip
         # If either are NullSkip, convert them to RBR.
-        if ubr_sexual_orientation == UBRValueEnum.NullSkip:
+        if ubr_sexual_orientation == UBRValueEnum.NotAnswer_Skip:
             ubr_sexual_orientation = UBRValueEnum.RBR
-        if ubr_gender_identity == UBRValueEnum.NullSkip:
+        if ubr_gender_identity == UBRValueEnum.NotAnswer_Skip:
             ubr_gender_identity = UBRValueEnum.RBR
         return max([ubr_sexual_orientation, ubr_gender_identity])
 
@@ -120,13 +120,13 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         if answers is None:
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         # Note: assume UBR by default and check for exclusion criteria.
         answers = answers.split(',')
         if len(answers) == 1:
             answer = answers[0]
             if answer == 'PMI_Skip':
-                return UBRValueEnum.NullSkip
+                return UBRValueEnum.NotAnswer_Skip
             if answer in ('WhatRaceEthnicity_White', 'PMI_PreferNotToAnswer'):
                 return UBRValueEnum.RBR
         return UBRValueEnum.UBR
@@ -143,7 +143,7 @@ class ParticipantUBRCalculator:
         if isinstance(answer, str):
             answer = re.sub('[^0-9]', '', answer)
         if answer is None:
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         # Some participants provide ZIP+4 format.  Use 5-digit zipcode to check for rural zipcode match
         if len(answer) > 5:
             answer = answer.strip()[:5]
@@ -159,7 +159,7 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         if answer is None or answer == 'PMI_Skip':
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         if answer in (
                 'HighestGrade_NeverAttended',
                 'HighestGrade_OneThroughFour',
@@ -176,7 +176,7 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         if answer is None or answer == 'PMI_Skip':
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         if answer in (
                 'AnnualIncome_less10k',
                 'AnnualIncome_10k25k'):
@@ -210,7 +210,7 @@ class ParticipantUBRCalculator:
                 null_skip = False
                 break
         if null_skip is True:
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         return UBRValueEnum.RBR
 
     @staticmethod
@@ -222,7 +222,7 @@ class ParticipantUBRCalculator:
         :return: UBRValueEnum
         """
         if answer is None or answer == 'PMI_Skip':
-            return UBRValueEnum.NullSkip
+            return UBRValueEnum.NotAnswer_Skip
         if not consent_time:
             return UBRValueEnum.RBR
         # Convert date string to date object if needed.
@@ -233,3 +233,19 @@ class ParticipantUBRCalculator:
         if not 18 <= rd.years < 65:
             return UBRValueEnum.UBR
         return UBRValueEnum.RBR
+
+    @staticmethod
+    def ubr_overall(data: dict):
+        """
+        Calculate the UBR overall value from a dictionary of UBR values.
+        :param data:
+        :return: 0 or 1
+        """
+        result = UBRValueEnum.RBR
+        if data is None:
+            return result
+        # Test each UBR value for a UBR status.
+        for k, v in data.items():
+            if k.startswith('ubr_') and v == UBRValueEnum.UBR:
+                result = 1
+        return result

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1471,7 +1471,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         data['ubr_age_at_consent'] = \
             ubr.ubr_age_at_consent(summary.get('enrl_participant_time', None), summary.get('date_of_birth', None))
         # ubr_overall - This should be calculated here in case there is no TheBasics response available.
-        data['ubr_overall'] = max([v for v in data.values()])
+        data['ubr_overall'] = ubr.ubr_overall(data)
 
         #### TheBasics UBR calculations.
         # Note: Due to PDR-484 we can't rely on the summary having a record for each valid submission so we
@@ -1511,7 +1511,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # ubr_disability
         data['ubr_disability'] = ubr.ubr_disability(qnan)
         # ubr_overall
-        data['ubr_overall'] = max([v for v in data.values()])
+        data['ubr_overall'] = ubr.ubr_overall(data)
 
         return data
 

--- a/tests/resource_tests/calculator_tests/test_ubr_calculator.py
+++ b/tests/resource_tests/calculator_tests/test_ubr_calculator.py
@@ -32,8 +32,8 @@ class UBRCalculatorTest(BaseTestCase):
         Note: Single Value UBR Calculation
         """
         # Test with Null and PMI_Skip values
-        self.assertEqual(self.ubr.ubr_sex(None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_sex('PMI_Skip'), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_sex(None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_sex('PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR value
         self.assertEqual(self.ubr.ubr_sex('SexAtBirth_SexAtBirthNoneOfThese'), UBRValueEnum.UBR)
@@ -53,8 +53,8 @@ class UBRCalculatorTest(BaseTestCase):
         Note: Multiple Value UBR Calculation
         """
         # Test with Null and PMI_Skip values
-        self.assertEqual(self.ubr.ubr_sexual_orientation(None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_sexual_orientation('PMI_Skip'), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_sexual_orientation(None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_sexual_orientation('PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR value
         self.assertEqual(self.ubr.ubr_sexual_orientation('SexualOrientation_Bisexual'), UBRValueEnum.UBR)
@@ -78,12 +78,12 @@ class UBRCalculatorTest(BaseTestCase):
         Note: Multiple Value UBR Calculation
         """
         # Test with Null and PMI_Skip values
-        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Female', None, None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Male', None, None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Intersex', None, None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Female', 'PMI_Skip', 'PMI_Skip'), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Male', None, 'PMI_Skip'), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Intersex', 'PMI_Skip', None), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Female', None, None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Male', None, None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Intersex', None, None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Female', 'PMI_Skip', 'PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Male', None, 'PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_gender_identity('SexAtBirth_Intersex', 'PMI_Skip', None), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR values
         self.assertEqual(self.ubr.ubr_gender_identity(
@@ -140,7 +140,7 @@ class UBRCalculatorTest(BaseTestCase):
         self.assertEqual(UBRValueEnum.RBR,
                          self.ubr.ubr_sexual_gender_minority(UBRValueEnum.RBR, UBRValueEnum.RBR))
         self.assertEqual(UBRValueEnum.RBR,
-                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.RBR, UBRValueEnum.NullSkip))
+                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.RBR, UBRValueEnum.NotAnswer_Skip))
         self.assertEqual(0,
                          self.ubr.ubr_sexual_gender_minority(UBRValueEnum.RBR, UBRValueEnum.RBR))
 
@@ -150,15 +150,15 @@ class UBRCalculatorTest(BaseTestCase):
         self.assertEqual(UBRValueEnum.UBR,
                          self.ubr.ubr_sexual_gender_minority(UBRValueEnum.RBR, UBRValueEnum.UBR))
         self.assertEqual(UBRValueEnum.UBR,
-                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.NullSkip, UBRValueEnum.UBR))
+                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.NotAnswer_Skip, UBRValueEnum.UBR))
         self.assertEqual(1,
                          self.ubr.ubr_sexual_gender_minority(UBRValueEnum.RBR, UBRValueEnum.UBR))
 
         # Test with Null/Skip Values. int(NullSkip) == 2.
-        self.assertEqual(UBRValueEnum.NullSkip,
-                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.NullSkip, UBRValueEnum.NullSkip))
+        self.assertEqual(UBRValueEnum.NotAnswer_Skip,
+                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.NotAnswer_Skip, UBRValueEnum.NotAnswer_Skip))
         self.assertEqual(2,
-                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.NullSkip, UBRValueEnum.NullSkip))
+                         self.ubr.ubr_sexual_gender_minority(UBRValueEnum.NotAnswer_Skip, UBRValueEnum.NotAnswer_Skip))
 
     def test_ubr_ethnicity(self):
         """
@@ -167,8 +167,8 @@ class UBRCalculatorTest(BaseTestCase):
         """
         # Test with Null and PMI_Skip values
         # Note: Multiple choice question, pass comma-delimited string.
-        self.assertEqual(self.ubr.ubr_ethnicity(None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_ethnicity('PMI_Skip'), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_ethnicity(None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_ethnicity('PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR value
         self.assertEqual(self.ubr.ubr_ethnicity('WhatRaceEthnicity_AIAN'), UBRValueEnum.UBR)
@@ -200,8 +200,8 @@ class UBRCalculatorTest(BaseTestCase):
         zip_none = '58493'  # Zip code not in either file.
 
         # Test with Null values, there are no PMI_Skip values currently for a zip code value.
-        self.assertEqual(self.ubr.ubr_geography(consent_2014, None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_geography(consent_2020, None), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_geography(consent_2014, None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_geography(consent_2020, None), UBRValueEnum.NotAnswer_Skip)
 
         # Test zip codes in specific files for UBR
         self.assertEqual(self.ubr.ubr_geography(consent_2014, zip_2014), UBRValueEnum.UBR)
@@ -230,8 +230,8 @@ class UBRCalculatorTest(BaseTestCase):
         UBR Calculator Test - Education
         """
         # Test with Null and PMI_Skip values
-        self.assertEqual(self.ubr.ubr_education(None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_education('PMI_Skip'), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_education(None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_education('PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR value
         self.assertEqual(self.ubr.ubr_education('HighestGrade_NeverAttended'), UBRValueEnum.UBR)
@@ -253,8 +253,8 @@ class UBRCalculatorTest(BaseTestCase):
         UBR Calculator Test - Income
         """
         # Test with Null and PMI_Skip values
-        self.assertEqual(self.ubr.ubr_income(None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_income('PMI_Skip'), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_income(None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_income('PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR value
         self.assertEqual(self.ubr.ubr_income('AnnualIncome_less10k'), UBRValueEnum.UBR)
@@ -279,12 +279,12 @@ class UBRCalculatorTest(BaseTestCase):
         """
         # Test with Null and PMI_Skip values
         values = self.disability_answers
-        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NotAnswer_Skip)
         values['Disability_Deaf'] = 'PMI_Skip'
-        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NotAnswer_Skip)
         for k in self.disability_answers.keys():
             values[k] = 'PMI_Skip'
-        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR value
         values = self.disability_answers
@@ -298,7 +298,7 @@ class UBRCalculatorTest(BaseTestCase):
         self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.RBR)
 
         # Bad or unknown value will default to NullSkip
-        self.assertEqual(self.ubr.ubr_disability({'ABC': 123}), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_disability({'ABC': 123}), UBRValueEnum.NotAnswer_Skip)
 
     def test_ubr_age_at_consent(self):
         """
@@ -308,8 +308,8 @@ class UBRCalculatorTest(BaseTestCase):
         consent = consent_ts.date()
 
         # Test with Null and PMI_Skip values
-        self.assertEqual(self.ubr.ubr_age_at_consent(consent, None), UBRValueEnum.NullSkip)
-        self.assertEqual(self.ubr.ubr_age_at_consent(consent, 'PMI_Skip'), UBRValueEnum.NullSkip)
+        self.assertEqual(self.ubr.ubr_age_at_consent(consent, None), UBRValueEnum.NotAnswer_Skip)
+        self.assertEqual(self.ubr.ubr_age_at_consent(consent, 'PMI_Skip'), UBRValueEnum.NotAnswer_Skip)
 
         # Test UBR value
         dob = (consent_ts - relativedelta(years=17)).date()
@@ -327,3 +327,61 @@ class UBRCalculatorTest(BaseTestCase):
         self.assertEqual(self.ubr.ubr_age_at_consent(None, dob), UBRValueEnum.RBR)
         dob = (consent_ts - relativedelta(years=70)).date()
         self.assertEqual(self.ubr.ubr_age_at_consent(None, dob), UBRValueEnum.RBR)
+
+    def test_ubr_overall(self):
+        """
+        UBR Calculator Test - UBR Overall
+        """
+        # Test RBR with Null value.
+        data = {'ubr_age_at_consent': None}
+        overall = self.ubr.ubr_overall(data)
+        self.assertEqual(overall, UBRValueEnum.RBR)
+
+        # Test RBR with RBR value
+        data = {'ubr_age_at_consent': UBRValueEnum.RBR}
+        overall = self.ubr.ubr_overall(data)
+        self.assertEqual(overall, UBRValueEnum.RBR)
+
+        # Test RBR with PMI_Skip value
+        data = {'ubr_age_at_consent': UBRValueEnum.NotAnswer_Skip}
+        overall = self.ubr.ubr_overall(data)
+        self.assertEqual(overall, UBRValueEnum.RBR)
+
+        # Test RBR with mixed values, but no UBR value.
+        data = {
+            'ubr_age_at_consent': None,
+            'ubr_disability': UBRValueEnum.RBR,
+            'ubr_education': UBRValueEnum.NotAnswer_Skip
+        }
+        overall = self.ubr.ubr_overall(data)
+        self.assertEqual(overall, UBRValueEnum.RBR)
+
+        # Test UBR with mixed values, with UBR value.
+        data = {
+            'ubr_age_at_consent': None,
+            'ubr_disability': UBRValueEnum.RBR,
+            'ubr_education': UBRValueEnum.NotAnswer_Skip,
+            'ubr_ethnicity': UBRValueEnum.UBR
+        }
+        overall = self.ubr.ubr_overall(data)
+        self.assertEqual(overall, UBRValueEnum.UBR)
+
+        # Test UBR with all UBR values.
+        data = {
+            'ubr_age_at_consent': UBRValueEnum.UBR,
+            'ubr_disability': UBRValueEnum.UBR,
+            'ubr_education': UBRValueEnum.UBR,
+            'ubr_ethnicity': UBRValueEnum.UBR
+        }
+        overall = self.ubr.ubr_overall(data)
+        self.assertEqual(overall, UBRValueEnum.UBR)
+
+        # Test RBR with all NotAnswered/Skip values.
+        data = {
+            'ubr_age_at_consent': UBRValueEnum.NotAnswer_Skip,
+            'ubr_disability': UBRValueEnum.NotAnswer_Skip,
+            'ubr_education': UBRValueEnum.NotAnswer_Skip,
+            'ubr_ethnicity': UBRValueEnum.NotAnswer_Skip
+        }
+        overall = self.ubr.ubr_overall(data)
+        self.assertEqual(overall, UBRValueEnum.RBR)


### PR DESCRIPTION
## Resolves *[PDR-575](https://precisionmedicineinitiative.atlassian.net/browse/PDR-575)*


## Description of changes/additions
The UBR Overall value calculation should only be testing for a UBR value across all UBR values.
Change enum name to represent only ‘PMI_PreferNotToAnswer’ and ‘PMI_Skip’.


## Tests
- [x] unit tests


