### PR TITLE
[ROC-1259] fix_etl_omop_schema

### DIFF
--- a/rdr_service/etl/raw_sql/finalize_cdm_data.sql
+++ b/rdr_service/etl/raw_sql/finalize_cdm_data.sql
@@ -898,6 +898,7 @@ SELECT
     0                                           AS unit_concept_id,
     NULL                                        AS provider_id,
     NULL                                        AS visit_occurrence_id,
+    NULL                                        AS visit_detail_id,
     src_m.question_ppi_code                     AS observation_source_value,
     src_m.question_source_concept_id            AS observation_source_concept_id,
     NULL                                        AS unit_source_value,
@@ -1513,7 +1514,7 @@ WHERE cdm_meas.parent_id IS NOT NULL;
 
 DROP TABLE IF EXISTS cdm.pid_rid_mapping;
 CREATE TABLE cdm.pid_rid_mapping (
-    participant_id              bigint,
+    person_id                   bigint,
     research_id                 bigint,
     external_id                 bigint
 );

--- a/rdr_service/etl/raw_sql/partially_initialize_cdm.sql
+++ b/rdr_service/etl/raw_sql/partially_initialize_cdm.sql
@@ -235,6 +235,7 @@ CREATE TABLE cdm.condition_occurrence
     visit_detail_id bigint,
     condition_source_value varchar(50) NOT NULL,
     condition_source_concept_id bigint NOT NULL,
+    condition_status_source_value varchar(50) NOT NULL,
     unit_id varchar(50) NOT NULL,
     PRIMARY KEY (condition_occurrence_id),
     UNIQUE KEY (id)
@@ -288,6 +289,7 @@ CREATE TABLE cdm.observation
     unit_concept_id bigint NOT NULL,
     provider_id bigint,
     visit_occurrence_id bigint,
+    visit_detail_id bigint,
     observation_source_value varchar(255) NOT NULL,
     observation_source_concept_id bigint NOT NULL,
     unit_source_value varchar(50),
@@ -382,6 +384,7 @@ CREATE TABLE cdm.drug_exposure
     drug_exposure_start_datetime datetime,
     drug_exposure_end_date date,
     drug_exposure_end_datetime datetime,
+    verbatim_end_date date,
     drug_type_concept_id bigint NOT NULL,
     stop_reason varchar(20),
     refills int,

--- a/rdr_service/etl/raw_sql/partially_initialize_cdm.sql
+++ b/rdr_service/etl/raw_sql/partially_initialize_cdm.sql
@@ -235,7 +235,7 @@ CREATE TABLE cdm.condition_occurrence
     visit_detail_id bigint,
     condition_source_value varchar(50) NOT NULL,
     condition_source_concept_id bigint NOT NULL,
-    condition_status_source_value varchar(50) NOT NULL,
+    condition_status_source_value varchar(50),
     unit_id varchar(50) NOT NULL,
     PRIMARY KEY (condition_occurrence_id),
     UNIQUE KEY (id)


### PR DESCRIPTION
## Resolves *[ROC-1259](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1259)*
Fix ETL OMOP table schema based on the error log from Curation team

## Description of changes/additions
Update schema for observation, drug_exposure, condition_occurrence and pid_rid_mapping




