### PR TITLE
[DA-2366] Update consent metrics report tool to include CE metrics

### DIFF
--- a/rdr_service/tools/tool_libs/consent_validation_report.py
+++ b/rdr_service/tools/tool_libs/consent_validation_report.py
@@ -589,8 +589,6 @@ class DailyConsentReport(ConsentReport):
             # Default to yesterday's date as the filter for consent authored date
             self.report_date = datetime.now() - timedelta(days=1)
 
-        self.csv_filename = f'{self.report_date.strftime("%Y%m%d")}_consent_errors.csv'
-
         self.report_sql = CONSENT_REPORT_SQL_BODY + DAILY_CONSENTS_SQL_FILTER + ORIGIN_SQL_FILTER
 
         # Max columns for the daily sheet (max column index value from the CONSENT_ERROR_COUNT_COLUMNS tuples)

--- a/rdr_service/tools/tool_libs/consent_validation_report.py
+++ b/rdr_service/tools/tool_libs/consent_validation_report.py
@@ -172,7 +172,6 @@ ALL_RESOLVED_SQL = """
                  AND ps.is_test_participant = 0 and (ps.is_ghost_id is null or ps.is_ghost_id = 0) and ps.hpo_id != 21
 """
 
-# TODO:  Remove this when we expand consent validation to include CE consents
 ORIGIN_SQL_FILTER = ' AND ps.participant_origin = "{origin_filter}"'
 
 # Weekly report SQL for validation burndown counts

--- a/rdr_service/tools/tool_libs/consent_validation_report.py
+++ b/rdr_service/tools/tool_libs/consent_validation_report.py
@@ -588,10 +588,8 @@ class DailyConsentReport(ConsentReport):
         else:
             # Default to yesterday's date as the filter for consent authored date
             self.report_date = datetime.now() - timedelta(days=1)
-        if args.csv_file:
-            self.csv_filename = args.csv_file
-        else:
-            self.csv_filename = f'{self.report_date.strftime("%Y%m%d")}_consent_errors.csv'
+
+        self.csv_filename = f'{self.report_date.strftime("%Y%m%d")}_consent_errors.csv'
 
         self.report_sql = CONSENT_REPORT_SQL_BODY + DAILY_CONSENTS_SQL_FILTER + ORIGIN_SQL_FILTER
 
@@ -636,7 +634,9 @@ class DailyConsentReport(ConsentReport):
             output_rows.append(csv_values)
 
         # Write out the csv file to the local directory
-        with open(self.csv_filename, 'w', newline='') as f:
+        output_file = f'{self.origin_value}_{self.report_date.strftime("%Y%m%d")}_consent_errors.csv'
+        _logger.info(f'Writing errors to {output_file}...')
+        with open(output_file, 'w', newline='') as f:
             writer = csv.writer(f)
             writer.writerows(output_rows)
 
@@ -1090,9 +1090,6 @@ def run():
                         help="Start date of range for consents (authored) in YYYY-MM-DD format.  Default is 8 days ago")
     parser.add_argument("--end-date", type=lambda s: datetime.strptime(s, '%Y-%m-%d'),
                         help="End date of range for consents (authored) in YYYY-MM-DD format.  Default is 1 day ago")
-    parser.add_argument("--csv-file", type=str,
-                        help="output filename for the CSV error list. " +\
-                                           " Default is YYYYMMDD_consent_errors.csv where YYYYMMDD is the report date")
     parser.add_argument("--sheet-only", default=False, action="store_true",
                         help="Only generate the googlesheet report, skip generating the CSV file")
     parser.add_argument("--csv-only", default=False, action="store_true",

--- a/rdr_service/tools/tool_libs/consent_validation_report.py
+++ b/rdr_service/tools/tool_libs/consent_validation_report.py
@@ -75,9 +75,8 @@ CONSENT_PARTICIPANT_SUMMARY_FIELDS = {
     ConsentType.CABOR: ('consent_for_cabor', 'consent_for_cabor_authored'),
     ConsentType.EHR: ('consent_for_electronic_health_records',
                       'consent_for_electronic_health_records_first_yes_authored'),
-    ConsentType.GROR: ('consent_for_genomics_ror', 'consent_for_genomics_ror_authored')
-    # TODO:  Enable once the retrospective validations of the Cohort 1 consent update are vetted for false positives
-    # ConsentType.PRIMARY_UPDATE: ('consent_for_study_enrollment', 'consent_for_study_enrollment_authored')
+    ConsentType.GROR: ('consent_for_genomics_ror', 'consent_for_genomics_ror_authored'),
+    ConsentType.PRIMARY_UPDATE: ('consent_for_study_enrollment', 'consent_for_study_enrollment_authored')
 }
 
 # List of currently validated consent type values as ints, for pandas filtering of consent_file.type values


### PR DESCRIPTION
## Resolves *[DA-2366](https://precisionmedicineinitiative.atlassian.net/browse/DA-2366)*


## Description of changes/additions
It was requested that the consent metrics report be updated to include separate worksheets for both PTSC and CE consent validation metrics.  The tool will now loop through and run a report for each participant origin.  

Note:  The spreadsheet with consent metrics is intended to be obsoleted by the new consent metrics dashboards, so this is a stopgap until the dashboards are fully integrated

## Tests
- Manual testing 


