### PR TITLE
[ROC-1261] Modify AW2 logic for empty string contamination values.

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -713,6 +713,15 @@ class GenomicFileIngester:
         row['member_id'] = member.id
         row['file_id'] = self.file_obj.id
 
+        # handle mapped reads in case they are longer than field length
+        if 'mappedreadspct' in row.keys():
+            if len(row['mappedreadspct']) > 10:
+                row['mappedreadspct'] = row['mappedreadspct'][0:10]
+
+        # Set default values in case they upload "" and processing status of "fail"
+        row['contamination_category'] = GenomicContaminationCategory.UNSET
+        row['contamination_category_str'] = "UNSET"
+
         # Truncate call rate
         try:
             row['callrate'] = row['callrate'][:10]
@@ -753,11 +762,6 @@ class GenomicFileIngester:
         )
         row['contamination_category'] = category
         row['contamination_category_str'] = category.name
-
-        # handle mapped reads in case they are longer than field length
-        if 'mappedreadspct' in row.keys():
-            if len(row['mappedreadspct']) > 10:
-                row['mappedreadspct'] = row['mappedreadspct'][0:10]
 
         return row
 


### PR DESCRIPTION
If samples fail and have an empty string for contamination, we need to set a default contamination category.

## Resolves *[ticket #](link to ticket)*


## Description of changes/additions


## Tests
- [x] unit tests


