### PR TITLE
[ROC-1254] Fixing survey code export

### DIFF
--- a/rdr_service/dao/code_dao.py
+++ b/rdr_service/dao/code_dao.py
@@ -1,12 +1,10 @@
 import logging
-from typing import Set
 from werkzeug.exceptions import BadRequest
 
 from rdr_service import clock
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.cache_all_dao import CacheAllDao
 from rdr_service.model.code import Code, CodeBook, CodeHistory, CodeType
-from rdr_service.model.survey import Survey, SurveyQuestion, SurveyQuestionOption
 from rdr_service.singletons import CODE_CACHE_INDEX
 
 _CODE_TYPE_MAP = {
@@ -226,58 +224,6 @@ class CodeDao(CacheAllDao):
             )
         else:
             return result_map
-
-    @staticmethod
-    def get_parent_codes(code: Code, session) -> Set[Code]:
-        parent_codes = set()
-
-        # Add the codes for the questions that use this code as an answer
-        question_codes = session.query(Code).join(
-            SurveyQuestion
-        ).join(
-            SurveyQuestionOption
-        ).filter(
-            SurveyQuestionOption.code == code
-        ).all()
-        parent_codes.update(question_codes)
-
-        # Add the codes for the surveys that use this code as a question
-        module_codes = session.query(Code).join(
-            Survey
-        ).join(
-            SurveyQuestion
-        ).filter(
-            SurveyQuestion.code == code
-        ).all()
-        parent_codes.update(module_codes)
-
-        return parent_codes
-
-    @staticmethod
-    def get_module_codes(code: Code, session) -> Set[Code]:
-        module_codes = set()
-
-        survey_codes_joined_with_questions = session.query(Code).join(
-            Survey
-        ).join(
-            SurveyQuestion
-        )
-
-        # Find all modules where this code is used as an answer option
-        module_codes_where_is_answer = survey_codes_joined_with_questions.join(
-            SurveyQuestionOption
-        ).filter(
-            SurveyQuestionOption.code == code
-        ).all()
-        module_codes.update(module_codes_where_is_answer)
-
-        # Find all modules where this code is used as a question
-        module_codes_where_is_question = survey_codes_joined_with_questions.filter(
-            SurveyQuestion.code == code
-        ).all()
-        module_codes.update(module_codes_where_is_question)
-
-        return module_codes
 
 
 class CodeHistoryDao(BaseDao):

--- a/rdr_service/dao/code_dao.py
+++ b/rdr_service/dao/code_dao.py
@@ -1,10 +1,15 @@
+from collections import defaultdict
 import logging
+from typing import Dict, List, Optional, Set
 from werkzeug.exceptions import BadRequest
+
+from sqlalchemy.orm import joinedload, Session
 
 from rdr_service import clock
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.cache_all_dao import CacheAllDao
 from rdr_service.model.code import Code, CodeBook, CodeHistory, CodeType
+from rdr_service.model.survey import Survey, SurveyQuestion, SurveyQuestionOption
 from rdr_service.singletons import CODE_CACHE_INDEX
 
 _CODE_TYPE_MAP = {
@@ -133,6 +138,10 @@ class CodeDao(CacheAllDao):
         self.silent = silent
         self.use_cache = use_cache
 
+        # Initialize fields to hold dictionaries that map code ids to module and parent values
+        self._code_module_map: Optional[Dict[int, List[str]]] = None
+        self._code_parent_map: Optional[Dict[int, List[str]]] = None
+
     def _load_cache(self):
         result = super(CodeDao, self)._load_cache()
         for code in list(result.id_to_entity.values()):
@@ -224,6 +233,62 @@ class CodeDao(CacheAllDao):
             )
         else:
             return result_map
+
+    def _init_hierarchy_maps(self, session: Session):
+        """Constructs a set of data structures for accessing the parent and module code values for a given code id"""
+        # Load all surveys with the question and option codes used
+        query = session.query(
+            Survey
+        ).options(
+            joinedload(Survey.code),
+            joinedload(Survey.questions).joinedload(SurveyQuestion.code),
+            joinedload(Survey.questions).joinedload(SurveyQuestion.options).joinedload(SurveyQuestionOption.code)
+        )
+
+        # For each question and option code id, store the parent and module code values
+        module_map: Dict[int, Set[str]] = defaultdict(lambda: set())
+        parent_map: Dict[int, Set[str]] = defaultdict(lambda: set())
+        for survey in query.all():
+            module_code_value = survey.code.value
+            for question in survey.questions:
+                question_code_id = question.code.codeId
+                module_map[question_code_id].add(module_code_value)
+                parent_map[question_code_id].add(module_code_value)
+
+                question_code_value = question.code.value
+                for option in question.options:
+                    option_code_id = option.code.codeId
+                    module_map[option_code_id].add(module_code_value)
+                    parent_map[option_code_id].add(question_code_value)
+
+        # Go back through the sets of code values and sort them
+        self._code_module_map: Dict[int, List[str]] = defaultdict(lambda: list())
+        self._code_module_map.update(
+            {code_id: sorted(module_value_set) for code_id, module_value_set in module_map.items()}
+        )
+        self._code_parent_map: Dict[int, List[str]] = defaultdict(lambda: list())
+        self._code_parent_map.update(
+            {code_id: sorted(parent_value_set) for code_id, parent_value_set in parent_map.items()}
+        )
+
+    def get_parent_values(self, code_id: int, session: Session) -> List[str]:
+        """
+        Returns the code values that have the given code id as a direct child.
+        That will include any module code values where the given code is used as a question,
+        and any any question code values where the given code is used as an option.
+        """
+        if not self._code_parent_map:
+            self._init_hierarchy_maps(session)
+        return self._code_parent_map[code_id]
+
+    def get_module_values(self, code_id: int, session: Session) -> List[str]:
+        """
+        Returns the module code values where the given code id is used
+        (either as a question or as an option to a question).
+        """
+        if not self._code_module_map:
+            self._init_hierarchy_maps(session)
+        return self._code_module_map[code_id]
 
 
 class CodeHistoryDao(BaseDao):

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -1,19 +1,16 @@
-from collections import defaultdict
 import csv
 from datetime import datetime
 from oauth2client.service_account import ServiceAccountCredentials
 import os
-from typing import Dict, List, Set
 
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
-from sqlalchemy.orm import Session, joinedload
 
-from rdr_service.services.gcp_utils import gcp_get_iam_service_key_info
+from rdr_service.dao.code_dao import CodeDao
 from rdr_service.model.code import Code
-from rdr_service.model.survey import Survey, SurveyQuestion, SurveyQuestionOption
 from rdr_service.offline.codebook_importer import CodebookImporter
 from rdr_service.services.gcp_config import GCP_INSTANCES
+from rdr_service.services.gcp_utils import gcp_get_iam_service_key_info
 from rdr_service.services.redcap_client import RedcapClient
 from rdr_service.tools.tool_libs.tool_base import cli_run, logger, ToolBase
 
@@ -131,7 +128,7 @@ class CodesSyncClass(ToolBase):
 
     @staticmethod
     def write_export_file(session):
-        code_map = CodeHierarchyMap(session)
+        code_dao = CodeDao()
 
         with open(code_export_file_path, 'w') as output_file:
             code_csv_writer = csv.writer(output_file)
@@ -145,11 +142,11 @@ class CodesSyncClass(ToolBase):
             for code in codes:
                 row_data = [code.value, code.display]
 
-                parent_code_values = code_map.get_parents(code.codeId)
+                parent_code_values = code_dao.get_parent_values(code.codeId, session=session)
                 if parent_code_values:
                     row_data.append('|'.join(parent_code_values))
 
-                    module_code_values = code_map.get_modules(code.codeId)
+                    module_code_values = code_dao.get_module_values(code.codeId, session=session)
                     if module_code_values:
                         row_data.append('|'.join(module_code_values))
                 code_csv_writer.writerow(row_data)
@@ -226,57 +223,6 @@ class CodesSyncClass(ToolBase):
                     self.write_export_file(session)
 
         return exit_code
-
-
-class CodeHierarchyMap:
-    """Constructs a data structure for accessing the parent and module code values for a given code id"""
-
-    def __init__(self, session: Session):
-        # Load all surveys with the question and option codes used
-        query = session.query(
-            Survey
-        ).options(
-            joinedload(Survey.code),
-            joinedload(Survey.questions).joinedload(SurveyQuestion.code),
-            joinedload(Survey.questions).joinedload(SurveyQuestion.options).joinedload(SurveyQuestionOption.code)
-        )
-
-        # For each question and option code id, store the parent and module code values
-        module_map: Dict[int, Set[str]] = defaultdict(lambda: set())
-        parent_map: Dict[int, Set[str]] = defaultdict(lambda: set())
-        for survey in query.all():
-            module_code_value = survey.code.value
-            for question in survey.questions:
-                question_code_id = question.code.codeId
-                module_map[question_code_id].add(module_code_value)
-                parent_map[question_code_id].add(module_code_value)
-
-                question_code_value = question.code.value
-                for option in question.options:
-                    option_code_id = option.code.codeId
-                    module_map[option_code_id].add(module_code_value)
-                    parent_map[option_code_id].add(question_code_value)
-
-        # Go back through the sets of code values and sort them
-        self._module_map: Dict[int, List[str]] = defaultdict(lambda: list())
-        self._module_map.update({code_id: sorted(module_value_set) for code_id, module_value_set in module_map.items()})
-        self._parent_map: Dict[int, List[str]] = defaultdict(lambda: list())
-        self._parent_map.update({code_id: sorted(parent_value_set) for code_id, parent_value_set in parent_map.items()})
-
-    def get_parents(self, code_id: int) -> List[str]:
-        """
-        Returns the code values that have the given code id as a direct child.
-        That will include any module code values where the given code is used as a question,
-        and any any question code values where the given code is used as an option.
-        """
-        return self._parent_map[code_id]
-
-    def get_modules(self, code_id: int) -> List[str]:
-        """
-        Returns the module code values where the given code id is used
-        (either as a question or as an option to a question).
-        """
-        return self._module_map[code_id]
 
 
 def add_additional_arguments(parser):

--- a/rdr_service/tools/tool_libs/codes_management.py
+++ b/rdr_service/tools/tool_libs/codes_management.py
@@ -66,12 +66,11 @@ class CodesExportClass(ToolBase):
         media = MediaFileUpload(code_export_file_path, mimetype='text/csv')
         drive_service.files().create(body=file_metadata, media_body=media, supportsAllDrives=True).execute()
 
-    @staticmethod
-    def initialize_process_context(tool_name, project, account, service_account):
+    def initialize_process_context(self, tool_name=None, project=None, account=None, service_account=None):
         if project == '_all':
             project = 'all-of-us-rdr-prod'
 
-        return ToolBase.initialize_process_context(tool_name, project, account, service_account)
+        return super(CodesExportClass, self).initialize_process_context(tool_name, project, account, service_account)
 
     def run(self):
         # Intentionally not calling super's run

--- a/tests/helpers/tool_test_mixin.py
+++ b/tests/helpers/tool_test_mixin.py
@@ -18,9 +18,9 @@ class ToolTestMixin:
 
     @classmethod
     def run_tool(cls, tool_class: Type[ToolBase], tool_args: dict = None, server_config: dict = None,
-                 mock_session=False):
+                 mock_session=False, project='localhost'):
         gcp_env = mock.MagicMock()
-        gcp_env.project = 'localhost'
+        gcp_env.project = project
 
         tool_args = ToolTestMixin._build_args(tool_args)
 

--- a/tests/tool_tests/test_codes_management.py
+++ b/tests/tool_tests/test_codes_management.py
@@ -36,7 +36,8 @@ class CodesManagementTest(ToolTestMixin, BaseTestCase):
         }
 
     @staticmethod
-    def run_code_import(redcap_data_dictionary, project_info=None, reuse_codes=[], dry_run=False, export_only=False):
+    def run_code_import(redcap_data_dictionary, project_info=None, reuse_codes=[], dry_run=False, export_only=False,
+                        project=None):
         if project_info is None:
             project_info = {
                 'project_id': 1,
@@ -52,6 +53,10 @@ class CodesManagementTest(ToolTestMixin, BaseTestCase):
 
             mock_csv_writerow = mock_csv.writer.return_value.writerow
 
+            optional_run_params = {}
+            if project:
+                optional_run_params['project'] = project
+
             tool_run_result = CodesManagementTest.run_tool(CodesSyncClass, tool_args={
                 'redcap_project': 'project_one',
                 'dry_run': dry_run,
@@ -63,7 +68,7 @@ class CodesManagementTest(ToolTestMixin, BaseTestCase):
                 },
                 DRIVE_EXPORT_FOLDER_ID: '1a789',
                 EXPORT_SERVICE_ACCOUNT_NAME: 'exporter@example.com'
-            })
+            }, **optional_run_params)
             return tool_run_result, mock_redcap_instance, mock_csv_writerow
 
     def assertCodeHasExpectedData(self, code: Code, expected_data):
@@ -346,7 +351,7 @@ class CodesManagementTest(ToolTestMixin, BaseTestCase):
             self._get_mock_dictionary_item('participant_id', 'Participant ID', 'text'),
             self._get_mock_dictionary_item('radio', 'multi-select', 'radio',
                                            answers='A1, One | A2, Two | A3, Three | A4, Etc.')
-        ])
+        ], project='test_prod_export')
 
         mock_csv_writerow.assert_has_calls([
             mock.call(['Code Value', 'Display', 'Parent Values', 'Module Values']),


### PR DESCRIPTION
## Resolves *[ROC-1254](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1254)*
The codebook sync script has a process for exporting a file of the codes in RDR to Google Drive, but this process has been broken for the last few codebook imports.

This PR fixes the error that occurs when trying to export the file. `CodesExportClass.initialize_process_context` needed to be updated to match some previous changes (`initialize_process_context` is no longer a static method).

This PR also speeds up the export process by retrieving the parent and module code data for all the codes and processes it in memory, rather than making a database call for each code individually.

## Tests
- [ ] unit tests
Existing unit tests cover the code for finding module and parent codes.


