### PR TITLE
[DA-2356] Implement a1 block updates

### DIFF
--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -247,6 +247,7 @@ class GenomicQueryClass:
                 (GenomicGCValidationMetrics.ignoreFlag != 1) &
                 (GenomicSetMember.genomicWorkflowState == GenomicWorkflowState.GEM_READY) &
                 (GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE) &
+                (GenomicSetMember.genomeType == "aou_array") &
                 (GenomicSetMember.ignoreFlag == 0) &
                 (self.aliases['gsm'].id.is_(None)) &
                 (GenomicSetMember.blockResults == 0) &

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -227,18 +227,29 @@ class GenomicQueryClass:
                 ]
             ).select_from(
                 sqlalchemy.join(
-                    sqlalchemy.join(ParticipantSummary,
-                                    GenomicSetMember,
-                                    GenomicSetMember.participantId == ParticipantSummary.participantId),
+                    ParticipantSummary,
+                    GenomicSetMember,
+                    GenomicSetMember.participantId == ParticipantSummary.participantId
+                ).join(
                     GenomicGCValidationMetrics,
                     GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
+                ).outerjoin(
+                    self.aliases['gsm'],
+                    sqlalchemy.and_(
+                        self.aliases['gsm'].participantId == GenomicSetMember.participantId,
+                        self.aliases['gsm'].genomeType == "aou_array",
+                        self.aliases['gsm'].gemA1ManifestJobRunId.isnot(None),
+                        self.aliases['gsm'].ignoreFlag == 0,
+                    )
                 )
             ).where(
                 (GenomicGCValidationMetrics.processingStatus == 'pass') &
                 (GenomicGCValidationMetrics.ignoreFlag != 1) &
                 (GenomicSetMember.genomicWorkflowState == GenomicWorkflowState.GEM_READY) &
                 (GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE) &
-                (GenomicSetMember.genomeType == "aou_array") &
+                (GenomicSetMember.ignoreFlag == 0) &
+                (self.aliases['gsm'].id.is_(None)) &
+                (GenomicSetMember.blockResults == 0) &
                 (ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN) &
                 (ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED) &
                 (ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED) &

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -2586,6 +2586,48 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual(1, len(rows))
             self.assertEqual(test_member_1.biobankId, rows[0]['biobank_id'])
 
+    def test_gem_a1_block_results(self):
+        # Need GC Manifest for source query : run_id = 1
+        self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
+                                              startTime=clock.CLOCK.now(),
+                                              runStatus=GenomicSubProcessStatus.COMPLETED,
+                                              runResult=GenomicSubProcessResult.SUCCESS))
+
+        self._create_fake_datasets_for_gc_tests(4, arr_override=True,
+                                                array_participants=range(1, 5),
+                                                recon_gc_man_id=1,
+                                                genome_center='jh',
+                                                genomic_workflow_state=GenomicWorkflowState.GEM_READY)
+
+        self._update_test_sample_ids()
+
+        self._create_stored_samples([
+            (1, 1001),
+            (2, 1002),
+            (3, 1003)
+        ])
+
+        for i in range(1, 5):
+            self.data_generator.create_database_genomic_gc_validation_metrics(
+                genomicSetMemberId=i,
+                processingStatus='pass',
+            )
+
+        # update ignore_flags for test
+        members = self.member_dao.get_all()
+        members[2].ignoreFlag = 1
+        self.member_dao.update(members[2])
+
+        # update block_results for test
+        members[3].blockResults = 1
+        self.member_dao.update(members[3])
+
+        genomic_pipeline.gem_a1_manifest_workflow()  # run_id = 4
+
+        members = self.member_dao.get_all()
+        a1_members = [x for x in members if x.genomicWorkflowState == GenomicWorkflowState.A1]
+        self.assertEqual(2, len(a1_members))
+
     def test_gem_a2_manifest_workflow(self):
         # Create A1 manifest job run: id = 1
         self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.GEM_A1_MANIFEST,

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -2593,8 +2593,8 @@ class GenomicPipelineTest(BaseTestCase):
                                               runStatus=GenomicSubProcessStatus.COMPLETED,
                                               runResult=GenomicSubProcessResult.SUCCESS))
 
-        self._create_fake_datasets_for_gc_tests(4, arr_override=True,
-                                                array_participants=range(1, 5),
+        self._create_fake_datasets_for_gc_tests(5, arr_override=True,
+                                                array_participants=range(1, 6),
                                                 recon_gc_man_id=1,
                                                 genome_center='jh',
                                                 genomic_workflow_state=GenomicWorkflowState.GEM_READY)
@@ -2604,10 +2604,12 @@ class GenomicPipelineTest(BaseTestCase):
         self._create_stored_samples([
             (1, 1001),
             (2, 1002),
-            (3, 1003)
+            (3, 1003),
+            (4, 1004),
+            (5, 1005),
         ])
 
-        for i in range(1, 5):
+        for i in range(1, 6):
             self.data_generator.create_database_genomic_gc_validation_metrics(
                 genomicSetMemberId=i,
                 processingStatus='pass',
@@ -2621,6 +2623,12 @@ class GenomicPipelineTest(BaseTestCase):
         # update block_results for test
         members[3].blockResults = 1
         self.member_dao.update(members[3])
+
+        # Add participant that has already been sent
+        members[4].biobankId = 4
+        members[4].participantId = 4
+        members[4].gemA1ManifestJobRunId = 1
+        self.member_dao.update(members[4])
 
         genomic_pipeline.gem_a1_manifest_workflow()  # run_id = 4
 


### PR DESCRIPTION
## Resolves *[DA-2356](https://precisionmedicineinitiative.atlassian.net/browse/DA-2356)*


## Description of changes/additions
This PR adds additional conditions to the GEM A1 query:
- Participants cannot already have an A1 job run ID.
- `genomic_set_member` records must have `block_results` = 0.
- `genomic_set_member` records must have `ignore_flag` = 0.

## Tests
- [x] unit tests


