### PR TITLE
Updating Google SDK version for CircleCI

### DIFF
--- a/ci/install_google_sdk.sh
+++ b/ci/install_google_sdk.sh
@@ -3,7 +3,7 @@
 #
 # Install the Google Cloud SDK
 #
-curl -o /tmp/cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-294.0.0-linux-x86_64.tar.gz
+curl -o /tmp/cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-367.0.0-linux-x86_64.tar.gz
 mkdir /tmp/cloud-sdk
 tar -xf /tmp/cloud-sdk.tar.gz --directory /tmp/cloud-sdk
 cd /tmp/cloud-sdk/google-cloud-sdk


### PR DESCRIPTION
## Resolves *no ticket*
Updates the Google SDK version that CircleCI uses. This will hopefully resolve some deployment issues we're seeing there. It seems like the SDK is expecting something to exist in setuptools that isn't there in newer versions.

## Tests
- [ ] unit tests


