### PR TITLE
[ROC-1284] Switch identifier based on AW1 or AW2.

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2183,10 +2183,10 @@ class GenomicAW1RawDao(BaseDao):
                 GenomicAW1Raw.biobank_id != ""
             ).one_or_none()
 
-    def get_raw_record_from_bid_genome_type(self, *, biobank_id, genome_type):
+    def get_raw_record_from_identifier_genome_type(self, *, identifier, genome_type):
         with self.session() as session:
             record = session.query(GenomicAW1Raw).filter(
-                GenomicAW1Raw.biobank_id == biobank_id,
+                GenomicAW1Raw.biobank_id == identifier,
                 GenomicAW1Raw.file_path.like(f"%$_{genome_type_map[genome_type]}$_%", escape="$"),
                 GenomicAW1Raw.ignore_flag == 0
             ).order_by(
@@ -2251,10 +2251,10 @@ class GenomicAW2RawDao(BaseDao):
                 GenomicAW2Raw.file_path == filepath
             ).one_or_none()
 
-    def get_raw_record_from_bid_genome_type(self, *, biobank_id, genome_type):
+    def get_raw_record_from_identifier_genome_type(self, *, identifier, genome_type):
         with self.session() as session:
             record = session.query(GenomicAW2Raw).filter(
-                GenomicAW2Raw.biobank_id == biobank_id,
+                GenomicAW2Raw.sample_id == identifier,
                 GenomicAW2Raw.file_path.like(f"%$_{genome_type_map[genome_type]}$_%", escape="$"),
                 GenomicAW2Raw.ignore_flag == 0
             ).order_by(

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -312,9 +312,11 @@ class GenomicJobController:
 
         if self.job_id == GenomicJob.AW1_MANIFEST:
             raw_dao = GenomicAW1RawDao()
+            id_field = "biobankId"
 
         else:
             raw_dao = GenomicAW2RawDao()
+            id_field = "sampleId"
 
         # Get member records
         members = self.member_dao.get_members_from_member_ids(member_ids)
@@ -337,8 +339,8 @@ class GenomicJobController:
                 bid = member.biobankId
             # Get Raw AW1 Records for biobank IDs and genome_type
             try:
-                raw_rec = raw_dao.get_raw_record_from_bid_genome_type(
-                    biobank_id=bid,
+                raw_rec = raw_dao.get_raw_record_from_identifier_genome_type(
+                    identifier=bid if id_field == 'biobankId' else getattr(member, id_field),
                     genome_type=member.genomeType
                 )
             except MultipleResultsFound:

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -5187,7 +5187,7 @@ class GenomicPipelineTest(BaseTestCase):
         sorted_record = sorted_records[0]
 
         dao_record = self.aw1_raw_dao.get_raw_record_from_identifier_genome_type(
-            biobank_id=int(biobank_id),
+            identifier=int(biobank_id),
             genome_type='aou_array'
         )
         self.assertEqual(sorted_record.id, dao_record.id)

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -5186,7 +5186,7 @@ class GenomicPipelineTest(BaseTestCase):
         sorted_records = sorted(filtered_records, key=lambda record: record.created, reverse=True)
         sorted_record = sorted_records[0]
 
-        dao_record = self.aw1_raw_dao.get_raw_record_from_bid_genome_type(
+        dao_record = self.aw1_raw_dao.get_raw_record_from_identifier_genome_type(
             biobank_id=int(biobank_id),
             genome_type='aou_array'
         )


### PR DESCRIPTION
## Resolves *[ROC-1284](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1284)*


## Description of changes/additions
The targeted AW1/AW2 ingestion tool was updated to use `biobankId` for the AW1 ingestion and `sampleId` for the AW2 ingestion.

## Tests
- [x] unit tests


