### PR TITLE
[DA-2327] Updating validation to check for any unvalidated files

### DIFF
--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -262,13 +262,12 @@ def check_for_consent_corrections():
 
 @app_util.auth_required_cron
 def validate_consent_files():
-    min_authored_timestamp = datetime.utcnow() - timedelta(hours=26)  # Overlap just to make sure we don't miss anything
     validation_controller = _build_validation_controller()
     with validation_controller.consent_dao.session() as session, StoreResultStrategy(
         session=session,
         consent_dao=validation_controller.consent_dao
     ) as store_strategy:
-        validation_controller.validate_recent_uploads(session, store_strategy, min_consent_date=min_authored_timestamp)
+        validation_controller.validate_consent_uploads(session, store_strategy)
     return '{"success": "true"}'
 
 

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -301,52 +301,56 @@ class ConsentValidationController:
             dispatch_rebuild_consent_metrics_tasks([v.id for v in validation_updates])
 
     def validate_participant_consents(self, summary: ParticipantSummary, output_strategy: ValidationOutputStrategy,
-                                      min_authored_date: date = None,
+                                      min_authored_date: date = None, max_authored_date: date = None,
                                       types_to_validate: Collection[ConsentType] = None):
         validator = self._build_validator(summary)
 
         if self._check_consent_type(ConsentType.PRIMARY, types_to_validate) and self._has_consent(
             consent_status=summary.consentForStudyEnrollment,
             authored=summary.consentForStudyEnrollmentFirstYesAuthored,
-            min_authored=min_authored_date
+            min_authored=min_authored_date,
+            max_authored=max_authored_date
         ):
             output_strategy.add_all(self._process_validation_results(validator.get_primary_validation_results()))
         if self._check_consent_type(ConsentType.CABOR, types_to_validate) and self._has_consent(
             consent_status=summary.consentForCABoR,
             authored=summary.consentForCABoRAuthored,
-            min_authored=min_authored_date
+            min_authored=min_authored_date,
+            max_authored=max_authored_date
         ):
             output_strategy.add_all(self._process_validation_results(validator.get_cabor_validation_results()))
         if self._check_consent_type(ConsentType.EHR, types_to_validate) and self._has_consent(
             consent_status=summary.consentForElectronicHealthRecords,
             authored=summary.consentForElectronicHealthRecordsAuthored,
-            min_authored=min_authored_date
+            min_authored=min_authored_date,
+            max_authored=max_authored_date
         ):
             output_strategy.add_all(self._process_validation_results(validator.get_ehr_validation_results()))
         if self._check_consent_type(ConsentType.GROR, types_to_validate) and self._has_consent(
             consent_status=summary.consentForGenomicsROR,
             authored=summary.consentForGenomicsRORAuthored,
-            min_authored=min_authored_date
+            min_authored=min_authored_date,
+            max_authored=max_authored_date
         ):
             output_strategy.add_all(self._process_validation_results(validator.get_gror_validation_results()))
         if self._check_consent_type(ConsentType.PRIMARY_UPDATE, types_to_validate) and self._has_primary_update_consent(
             summary=summary,
-            min_authored=min_authored_date
+            min_authored=min_authored_date,
+            max_authored=max_authored_date
         ):
             output_strategy.add_all(self._process_validation_results(validator.get_primary_update_validation_results()))
 
-    def validate_recent_uploads(self, session, output_strategy: ValidationOutputStrategy, min_consent_date,
-                                max_consent_date=None):
-        """Find all the expected consents since the minimum date and check the files that have been uploaded"""
-        for summary in self.consent_dao.get_participants_with_consents_in_range(
-            session,
-            start_date=min_consent_date,
-            end_date=max_consent_date
-        ):
+    def validate_consent_uploads(self, session, output_strategy: ValidationOutputStrategy, min_consent_date=None,
+                                 max_consent_date=None):
+        """
+        Find all the expected consents (filtering by dates if provided) and check the files that have been uploaded
+        """
+        for summary in self.consent_dao.get_participants_with_unvalidated_files(session):
             self.validate_participant_consents(
                 summary=summary,
                 output_strategy=output_strategy,
-                min_authored_date=min_consent_date
+                min_authored_date=min_consent_date,
+                max_authored_date=max_consent_date
             )
 
     def validate_all_for_participant(self, participant_id: int, output_strategy: ValidationOutputStrategy):
@@ -380,12 +384,19 @@ class ConsentValidationController:
             return results
 
     @classmethod
-    def _has_consent(cls, consent_status, authored=None, min_authored=None):
-        return consent_status == QuestionnaireStatus.SUBMITTED and (min_authored is None or authored > min_authored)
+    def _has_consent(cls, consent_status, authored=None, min_authored=None, max_authored=None):
+        return (
+            consent_status == QuestionnaireStatus.SUBMITTED
+            and (min_authored is None or authored > min_authored)
+            and (max_authored is None or authored < max_authored)
+        )
 
     @classmethod
-    def _has_primary_update_consent(cls, summary: ParticipantSummary, min_authored=None):
-        if min_authored is None or summary.consentForStudyEnrollmentAuthored > min_authored:
+    def _has_primary_update_consent(cls, summary: ParticipantSummary, min_authored=None, max_authored=None):
+        if (
+            (min_authored is None or summary.consentForStudyEnrollmentAuthored > min_authored)
+            and (max_authored is None or summary.consentForStudyEnrollmentAuthored < max_authored)
+        ):
             return (
                 summary.consentCohort == ParticipantCohort.COHORT_1 and
                 summary.consentForStudyEnrollmentAuthored.date() !=

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -132,7 +132,7 @@ class ConsentControllerTest(BaseTestCase):
             )
         ]
 
-        self.consent_controller.validate_recent_uploads(
+        self.consent_controller.validate_consent_uploads(
             session=mock.MagicMock(),
             output_strategy=self.store_strategy,
             min_consent_date=min_consent_date_checked
@@ -174,7 +174,7 @@ class ConsentControllerTest(BaseTestCase):
             )
         ]
 
-        self.consent_controller.validate_recent_uploads(
+        self.consent_controller.validate_consent_uploads(
             session=mock.MagicMock(),
             output_strategy=self.store_strategy,
             min_consent_date=min_consent_date_checked

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -107,7 +107,7 @@ class ConsentControllerTest(BaseTestCase):
         ]
 
         min_consent_date_checked = datetime(2020, 4, 1)
-        self.consent_dao_mock.get_participants_with_consents_in_range.return_value = [
+        self.consent_dao_mock.get_participants_with_unvalidated_files.return_value = [
             ParticipantSummary(
                 consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
                 consentForStudyEnrollmentAuthored=min_consent_date_checked,  # Needs to be set for PrimaryUpdate check
@@ -166,7 +166,7 @@ class ConsentControllerTest(BaseTestCase):
         ]
 
         min_consent_date_checked = datetime(2020, 4, 1)
-        self.consent_dao_mock.get_participants_with_consents_in_range.return_value = [
+        self.consent_dao_mock.get_participants_with_unvalidated_files.return_value = [
             ParticipantSummary(
                 consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
                 consentForStudyEnrollmentAuthored=datetime(2020, 5, 1),  # Needs to be set for PrimaryUpdate check


### PR DESCRIPTION
## Resolves *[DA-2327](https://precisionmedicineinitiative.atlassian.net/browse/DA-2327)*
The nightly consent file validation script is set up to check for any consent files that have been authored within the last day or so. This is missing any consents that are received that have older authored dates.

This PR updates the participant summaries that are checked nightly. Instead of any consents authored within the last day, the script will now validate any consents that haven't yet been validated.

## Description of changes/additions
The script will now load any participant summaries that have expected consents (such as a SUBMITTED gror, or a questionnaire response that indicates they should have a Primary Update consent) but don't yet have validation records for that consent type.

## Tests
- [x] unit tests


