### PR TITLE
Adding module code to log for when a participant responds when suspended

### DIFF
--- a/rdr_service/services/data_quality.py
+++ b/rdr_service/services/data_quality.py
@@ -195,7 +195,7 @@ class ResponseQualityChecker(_ModelQualityChecker):
                         f'but participant signed up at {participant_signup_time}'
                     )
                 if suspension_datetime and authored_time > suspension_datetime:
-                    logging.error(f'Response {response_id} authored for suspended participant')
+                    logging.error(f'Response {response_id} authored for suspended participant (module: {module_code})')
                 if withdrawal_datetime and authored_time > withdrawal_datetime:
                     logging.error(f'Response {response_id} authored for withdrawn participant')
                 if min_questionnaire_created_time and min_questionnaire_created_time > authored_time:

--- a/tests/service_tests/test_data_quality_checker.py
+++ b/tests/service_tests/test_data_quality_checker.py
@@ -66,15 +66,22 @@ class DataQualityCheckerTest(BaseTestCase):
         )
         now = datetime.now().replace(microsecond=0)
 
+        module_code = self.data_generator.create_database_code(value='test_module')
         response_authored_after_suspension = self.data_generator.create_database_questionnaire_response(
             participantId=suspended_participant.participantId,
             authored=now,
             created=now
         )
+        self.data_generator.create_database_questionnaire_concept(
+            questionnaireId=response_authored_after_suspension.questionnaireId,
+            questionnaireVersion=response_authored_after_suspension.questionnaireVersion,
+            codeId=module_code.codeId
+        )
 
         self.checker.run_data_quality_checks()
         mock_logging.error.assert_any_call(
-            f'Response {response_authored_after_suspension.questionnaireResponseId} authored for suspended participant'
+            f'Response {response_authored_after_suspension.questionnaireResponseId} '
+            f'authored for suspended participant (module: test_module)'
         )
 
     def test_response_after_withdrawal(self, mock_logging):


### PR DESCRIPTION
## Resolves *no ticket*
Suspended participants are able to withdraw, so it's valid to receive a survey response from them when they do (when they're responding to the withdrawal screens). This adds the module they responded to so it's easy to see what the response was for and know if there's something wrong or if it was just for the withdrawal screens.


## Tests
- [x] unit tests


