### PR TITLE
Appending P to participant id when making requests to Vibrent API

### DIFF
--- a/rdr_service/services/ptsc_client.py
+++ b/rdr_service/services/ptsc_client.py
@@ -56,7 +56,7 @@ class PtscClient:
     def get_participant_lookup(self, participant_id: int = None, start_date: date = None, end_date: date = None):
         url_params = {}
         if participant_id:
-            url_params['drcId'] = participant_id
+            url_params['drcId'] = f'P{participant_id}'
         if start_date:
             url_params['startDate'] = start_date.strftime("%Y-%m-%d")
             url_params['pageSize'] = 1000

--- a/tests/service_tests/test_ptsc_client.py
+++ b/tests/service_tests/test_ptsc_client.py
@@ -54,3 +54,15 @@ class PtscClientTest(BaseTestCase):
 
         self.assertEqual('got status code 401. Message: error content', str(expected_exception.exception))
         self.assertEqual(2, requests_mock.get.call_count)
+
+    def test_participant_lookup_by_drc_id(self, requests_mock):
+        """Make sure the drc id uses P when interacting with the Vibrent API"""
+        def get_response(**_):
+            mock_response = mock.MagicMock()
+            mock_response.status_code = 200
+            return mock_response
+        requests_mock.get.side_effect = get_response
+        self.ptsc_client.get_participant_lookup(participant_id=1234)
+
+        request_url = requests_mock.get.call_args.kwargs['url']
+        self.assertIn('drcId=P1234', request_url)


### PR DESCRIPTION
## Resolves *no ticket*
Vibrent's API expects the DRC ID for a participant to appear as `P123...` rather than just as the number. This updates the client class to add the prefix to the request.

## Tests
- [x] unit tests


