### PR TITLE
fix_time_parse_issue_for_fitbit_reconciliation

### DIFF
--- a/rdr_service/offline/ce_health_data_reconciliation_pipeline.py
+++ b/rdr_service/offline/ce_health_data_reconciliation_pipeline.py
@@ -119,7 +119,7 @@ class CeHealthDataReconciliationPipeline:
                 for item in content['FileKeys']:
                     health_file_path_list.append(self.bucket_name + '/' + item)
             if 'TransferTime' in content:
-                file_transferred_time = parse_datetime_from_iso_format(content['TransferTime'])
+                file_transferred_time = parse_datetime_from_iso_format(content['TransferTime'][:26] + 'Z')
 
         return health_file_path_list, file_transferred_time
 

--- a/tests/test-data/fitbit_reconciliation_report_1.json
+++ b/tests/test-data/fitbit_reconciliation_report_1.json
@@ -3,6 +3,6 @@
     "raw/health/2021/11/18/FITBIT/activities-heart-intraday/P1234567890/activities_heart_date_2021-11-10_1d_1sec.json",
     "raw/health/2021/11/18/FITBIT/activities-heart-intraday/P1234567890/activities_heart_date_2021-11-07_1d_1sec.json"
   ],
-  "TransferTime": "2021-11-18T17:24:27.325256+00:00",
+  "TransferTime": "2021-11-18T17:24:27.3252561Z",
   "BucketName": "rdr-careevo-test-ce-digital-health"
 }

--- a/tests/test-data/fitbit_reconciliation_report_2.json
+++ b/tests/test-data/fitbit_reconciliation_report_2.json
@@ -2,6 +2,6 @@
   "FileKeys": [
     "raw/health/2021/11/18/FITBIT/activities-heart-intraday/P1234567890/activities_heart_date_2021-11-05_1d_1sec.json"
   ],
-  "TransferTime": "2021-11-18T17:24:27.325256+00:00",
+  "TransferTime": "2021-11-18T17:24:27.3252561Z",
   "BucketName": "rdr-careevo-test-ce-digital-health"
 }

--- a/tests/test-data/fitbit_reconciliation_report_3.json
+++ b/tests/test-data/fitbit_reconciliation_report_3.json
@@ -2,6 +2,6 @@
   "FileKeys": [
     "raw/health/2021/11/18/FITBIT/activities-heart-intraday/P1234567890/activities_heart_date_2021-11-20_1d_1sec.json"
   ],
-  "TransferTime": "2021-11-18T17:24:27.325256+00:00",
+  "TransferTime": "2021-11-18T17:24:27.3252561Z",
   "BucketName": "rdr-careevo-test-ce-digital-health"
 }


### PR DESCRIPTION
## Resolves
This is an error found in Stable env, the error message is:
```
File "/workspace/rdr_service/dao/database_utils.py", line 36, in parse_datetime_from_iso_format
    return datetime.strptime(datetime_str, _ISO_FORMAT)
  File "/opt/python3.7/lib/python3.7/_strptime.py", line 577, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/opt/python3.7/lib/python3.7/_strptime.py", line 359, in _strptime
    (data_string, format))
ValueError("time data '2022-01-03T21:30:40.3693702Z' does not match format '%Y-%m-%dT%H:%M:%S.%f%z'")
```

The `TransferTime` field in CE Fitbit reconciliation file is in a format like ` "TransferTime": "2022-01-03T21:30:40.3693702Z"`,  it's ISO 8601 compliant but just a greater precision than python supports, it has 7 digits of milliseconds. This fix truncate the time string first before parse it. 

## Tests
- [x] unit tests


