### PR TITLE
[DA-2396] ps_api_support_unset_query_none_records

### DIFF
--- a/rdr_service/dao/base_dao.py
+++ b/rdr_service/dao/base_dao.py
@@ -19,13 +19,12 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 from werkzeug.exceptions import BadRequest, NotFound, PreconditionFailed, ServiceUnavailable
 
 from rdr_service import api_util
-from rdr_service.code_constants import ORIGINATING_SOURCES
+from rdr_service.code_constants import ORIGINATING_SOURCES, UNSET
 from rdr_service.dao import database_factory
 from rdr_service.model.participant import Participant
 from rdr_service.model.requests_log import RequestsLog
 from rdr_service.model.utils import get_property_type
 from rdr_service.query import FieldFilter, Operator, PropertyType, Results
-
 # Maximum number of times we will attempt to insert an entity with a random ID before
 # giving up.
 
@@ -285,6 +284,8 @@ class BaseDao(object):
             property_type = get_property_type(prop)
             filter_value = None
             operator = Operator.EQUALS
+            if property_type == PropertyType.ENUM and value == UNSET:
+                operator = Operator.EQUALS_OR_NONE
             # If we're dealing with a comparable property type, look for a prefix that indicates an
             # operator other than EQUALS and strip it off
             if property_type in _COMPARABLE_PROPERTY_TYPES:

--- a/rdr_service/query.py
+++ b/rdr_service/query.py
@@ -1,7 +1,6 @@
 """A query to run against a DAO (abstracted from the persistent level)."""
 from protorpc import messages
-from sqlalchemy import func, not_
-
+from sqlalchemy import func, not_, or_
 
 class Operator(messages.Enum):
     EQUALS = 0  # Case insensitive comparison for strings, exact comparison otherwise
@@ -10,6 +9,7 @@ class Operator(messages.Enum):
     LESS_THAN_OR_EQUALS = 3
     GREATER_THAN_OR_EQUALS = 4
     NOT_EQUALS = 5
+    EQUALS_OR_NONE = 6
     # Note: we don't support contains or exact string comparison at this stage
 
 
@@ -76,6 +76,7 @@ class FieldFilter(object):
             Operator.LESS_THAN_OR_EQUALS: query.filter(field <= self.value),
             Operator.GREATER_THAN_OR_EQUALS: query.filter(field >= self.value),
             Operator.NOT_EQUALS: query.filter(field != self.value),
+            Operator.EQUALS_OR_NONE: query.filter(or_(field == self.value, field == None)),
         }.get(self.operator)
         if not query:
             raise ValueError("Invalid operator: %r." % self.operator)


### PR DESCRIPTION
## Resolves *[DA-2396](https://precisionmedicineinitiative.atlassian.net/browse/DA-2396)*
We have NULL value records for ENUM columns in `participant_summary` table. This causes an issue that when user filter with `UNSET` in PS API, the records with NULL value will not be returned. But when user get records in PS API by participant_id or other filters, the NULL value will be shown as UNSET in the response(we convert None to UNSET in participant_summary_dao.to_client_json).  This makes user confused and also makes HealthPro shows the wrong total numbers for some filters criteria.

## Description of changes/additions
In PS API, when filter an ENUM column with UNSET value, make an `or` query for both UNSET and NONE

## Tests
- [x] unit tests


