### PR TITLE
migration_mismatch_retention_eligible_metrics

### DIFF
--- a/rdr_service/model/retention_eligible_metrics.py
+++ b/rdr_service/model/retention_eligible_metrics.py
@@ -16,7 +16,7 @@ class RetentionEligibleMetrics(Base):
     modified = Column("modified", UTCDateTime6, nullable=True)
 
     participantId = Column("participant_id", Integer, ForeignKey("participant.participant_id"), nullable=False,
-                           index=True)
+                           index=True, unique=True)
     retentionEligible = Column("retention_eligible", Boolean)
     retentionEligibleTime = Column("retention_eligible_time", UTCDateTime6)
     lastActiveRetentionActivityTime = Column("last_active_retention_activity_time", UTCDateTime6)


### PR DESCRIPTION
## Resolves

Fix the mismatch between `retention_eligible_metrics` table schema definition and the migration file. 




