### PR TITLE
Fix resource tool import path

### DIFF
--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -14,7 +14,7 @@ import sys
 
 from werkzeug.exceptions import NotFound
 
-from model.genomics import UserEventMetrics
+from rdr_service.model.genomics import UserEventMetrics
 from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao
 from rdr_service.dao.bq_participant_summary_dao import rebuild_bq_participant


### PR DESCRIPTION
Use correct import path prefix for importing a sqlalchemy model.


