### PR TITLE
[DA-2381] Reactivate Cohorts 1 & 2 AW0

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -79,6 +79,16 @@ cron:
   timezone: America/New_York
   schedule: every day 06:30
   target: offline
+- description: Genomic Pipeline AW0 (Cohort 2) Workflow
+  url: /offline/GenomicC2AW0Workflow
+  timezone: America/New_York
+  schedule: every tuesday 05:30
+  target: offline
+- description: Genomic Pipeline AW0 (Cohort 1) Workflow
+  url: /offline/GenomicC2AW0Workflow
+  timezone: America/New_York
+  schedule: every monday 05:30
+  target: offline
 - description: Genomic AW1C (CVL) Workflow (Manual)
   url: /offline/GenomicAW1CManifestWorkflow
   timezone: America/New_York

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -85,7 +85,7 @@ cron:
   schedule: every tuesday 05:30
   target: offline
 - description: Genomic Pipeline AW0 (Cohort 1) Workflow
-  url: /offline/GenomicC2AW0Workflow
+  url: /offline/GenomicC1AW0Workflow
   timezone: America/New_York
   schedule: every monday 05:30
   target: offline

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -369,64 +369,58 @@ class GenomicQueryClass:
     def remaining_c2_participants():
         return """
                 SELECT DISTINCT
-                    ps.biobank_id,
-                    ps.participant_id,
-                    0 AS biobank_order_id,
-                    0 AS collected_site_id,
-                    NULL as state_id,
-                    0 AS biobank_stored_sample_id,
-                    CASE
-                    WHEN ps.withdrawal_status = :withdrawal_param THEN 1 ELSE 0
-                    END as valid_withdrawal_status,
-                    CASE
-                    WHEN ps.suspension_status = :suspension_param THEN 1 ELSE 0
-                    END as valid_suspension_status,
-                    CASE
+                  ss.biobank_id,
+                  p.participant_id,
+                  o.biobank_order_id,
+                  o.collected_site_id,
+                  mk.state_id,
+                  ss.biobank_stored_sample_id,
+                  CASE
+                    WHEN p.withdrawal_status = :withdrawal_param THEN 1 ELSE 0
+                  END as valid_withdrawal_status,
+                  CASE
+                    WHEN p.suspension_status = :suspension_param THEN 1 ELSE 0
+                  END as valid_suspension_status,
+                  CASE
                     WHEN ps.consent_for_study_enrollment = :general_consent_param THEN 1 ELSE 0
-                    END as general_consent_given,
-                    CASE
+                  END as general_consent_given,
+                  CASE
                     WHEN ps.date_of_birth < DATE_SUB(now(), INTERVAL :dob_param YEAR) THEN 1 ELSE 0
-                    END AS valid_age,
-                    CASE
-                    WHEN c.value = "SexAtBirth_Male" THEN "M"
-                    WHEN c.value = "SexAtBirth_Female" THEN "F"
-                    ELSE "NA"
-                    END as sab,
-                    CASE
-                    WHEN ps.consent_for_genomics_ror = :general_consent_param THEN 1 ELSE 0
-                    END AS gror_consent,
-                    CASE
-                        WHEN native.participant_id IS NULL THEN 0 ELSE 1
-                    END AS is_ai_an
+                  END AS valid_age,
+                  CASE
+                    WHEN c.value = 'SexAtBirth_Male' THEN 'M'
+                    WHEN c.value = 'SexAtBirth_Female' THEN 'F'
+                    ELSE 'NA'
+                  END as sab,
+                  CASE
+                    WHEN ps.consent_for_genomics_ror = 1 THEN 1 ELSE 0
+                  END AS gror_consent,
+                  CASE
+                      WHEN native.participant_id IS NULL THEN 0 ELSE 1
+                  END AS is_ai_an,
+                  ss.status,
+                  ss.test
                 FROM
-                    participant_summary ps
+                    biobank_stored_sample ss
+                    JOIN participant p ON ss.biobank_id = p.biobank_id
+                    JOIN biobank_order_identifier oi ON ss.biobank_order_identifier = oi.value
+                    JOIN biobank_order o ON oi.biobank_order_id = o.biobank_order_id
+                    JOIN participant_summary ps ON ps.participant_id = p.participant_id
                     JOIN code c ON c.code_id = ps.sex_id
                     LEFT JOIN (
-                        SELECT ra.participant_id
-                        FROM participant_race_answers ra
-                            JOIN code cr ON cr.code_id = ra.code_id
-                                AND SUBSTRING_INDEX(cr.value, "_", -1) = "AIAN"
-                    ) native ON native.participant_id = ps.participant_id
+                      SELECT ra.participant_id
+                      FROM participant_race_answers ra
+                          JOIN code cr ON cr.code_id = ra.code_id
+                              AND SUBSTRING_INDEX(cr.value, "_", -1) = "AIAN"
+                    ) native ON native.participant_id = p.participant_id
                     LEFT JOIN genomic_set_member m ON m.participant_id = ps.participant_id
-                        AND m.genomic_workflow_state <> :ignore_param
+                            AND m.genomic_workflow_state <> 33
+                    LEFT JOIN biobank_mail_kit_order mk ON mk.participant_id = p.participant_id
                 WHERE TRUE
-                    AND (
-                            ps.sample_status_1ed04 = :sample_status_param
-                            OR
-                            ps.sample_status_1ed10 = :sample_status_param
-                            OR
-                            ps.sample_status_1sal2 = :sample_status_param
-                        )
-                    AND ps.consent_cohort = :cohort_2_param
+                    AND ss.test in ('1ED04', '1ED10', '1SAL2')
+                    AND ps.consent_cohort = :cohort_param
+                    AND ps.participant_origin != 'careevolution'
                     AND m.id IS NULL
-                    AND ps.participant_origin = "vibrent"
-                HAVING TRUE
-                    # Validations for Cohort 2
-                    AND valid_age = 1
-                    AND general_consent_given = 1
-                    AND valid_suspension_status = 1
-                    AND valid_withdrawal_status = 1
-                ORDER BY ps.biobank_id
             """
 
     @staticmethod
@@ -519,88 +513,20 @@ class GenomicQueryClass:
         )
 
     @staticmethod
-    def new_c1_participants():
+    def remaining_c1_samples():
         return """
             SELECT DISTINCT
-              ps.biobank_id,
-              ps.participant_id,
-              0 AS biobank_order_id,
-              0 AS collected_site_id,
-              NULL as state_id,
-              0 AS biobank_stored_sample_id,
+              ss.biobank_id,
+              p.participant_id,
+              o.biobank_order_id,
+              o.collected_site_id,
+              mk.state_id,
+              ss.biobank_stored_sample_id,
               CASE
-                WHEN ps.withdrawal_status = :withdrawal_param THEN 1 ELSE 0
+                WHEN p.withdrawal_status = :withdrawal_param THEN 1 ELSE 0
               END as valid_withdrawal_status,
               CASE
-                WHEN ps.suspension_status = :suspension_param THEN 1 ELSE 0
-              END as valid_suspension_status,
-              CASE
-                WHEN ps.consent_for_study_enrollment = :general_consent_param THEN 1 ELSE 0
-              END as general_consent_given,
-              CASE
-                WHEN ps.date_of_birth < DATE_SUB(now(), INTERVAL :dob_param YEAR) THEN 1 ELSE 0
-              END AS valid_age,
-              CASE
-                WHEN c.value = "SexAtBirth_Male" THEN "M"
-                WHEN c.value = "SexAtBirth_Female" THEN "F"
-                ELSE "NA"
-              END as sab,
-              CASE
-                WHEN ps.consent_for_genomics_ror = :general_consent_param THEN 1 ELSE 0
-              END AS gror_consent,
-              CASE
-                WHEN native.participant_id IS NULL THEN 0 ELSE 1
-              END AS is_ai_an
-            FROM
-                participant_summary ps
-                JOIN code c ON c.code_id = ps.sex_id
-                LEFT JOIN (
-                  SELECT ra.participant_id
-                  FROM participant_race_answers ra
-                      JOIN code cr ON cr.code_id = ra.code_id
-                          AND SUBSTRING_INDEX(cr.value, "_", -1) = "AIAN"
-                ) native ON native.participant_id = ps.participant_id
-                LEFT JOIN genomic_set_member m ON m.participant_id = ps.participant_id
-                    AND m.genomic_workflow_state <> :ignore_param
-                JOIN questionnaire_response qr
-                    ON qr.participant_id = ps.participant_id
-                JOIN questionnaire_response_answer qra
-                    ON qra.questionnaire_response_id = qr.questionnaire_response_id
-                JOIN code recon ON recon.code_id = qra.value_code_id
-                    AND recon.value = :c1_reconsent_param
-            WHERE TRUE
-                AND (
-                        ps.sample_status_1ed04 = :sample_status_param
-                        OR
-                        ps.sample_status_1sal2 = :sample_status_param
-                    )
-                AND ps.consent_cohort = :cohort_1_param
-                AND qr.authored > :from_date_param
-                AND m.id IS NULL
-            HAVING TRUE
-                # Validations for Cohort 1
-                AND valid_age = 1
-                AND general_consent_given = 1
-                AND valid_suspension_status = 1
-                AND valid_withdrawal_status = 1
-            ORDER BY ps.biobank_id
-        """
-
-    @staticmethod
-    def new_c2_participants():
-        return """
-             SELECT DISTINCT
-              ps.biobank_id,
-              ps.participant_id,
-              0 AS biobank_order_id,
-              0 AS collected_site_id,
-              NULL as state_id,
-              0 AS biobank_stored_sample_id,
-              CASE
-                WHEN ps.withdrawal_status = :withdrawal_param THEN 1 ELSE 0
-              END as valid_withdrawal_status,
-              CASE
-                WHEN ps.suspension_status = :suspension_param THEN 1 ELSE 0
+                WHEN p.suspension_status = :suspension_param THEN 1 ELSE 0
               END as valid_suspension_status,
               CASE
                 WHEN ps.consent_for_study_enrollment = :general_consent_param THEN 1 ELSE 0
@@ -614,39 +540,40 @@ class GenomicQueryClass:
                 ELSE 'NA'
               END as sab,
               CASE
-                WHEN ps.consent_for_genomics_ror = :general_consent_param THEN 1 ELSE 0
+                WHEN ps.consent_for_genomics_ror = 1 THEN 1 ELSE 0
               END AS gror_consent,
               CASE
-                WHEN native.participant_id IS NULL THEN 0 ELSE 1
-              END AS is_ai_an
+                  WHEN native.participant_id IS NULL THEN 0 ELSE 1
+              END AS is_ai_an,
+              ss.status,
+              ss.test
             FROM
-                participant_summary ps
+                biobank_stored_sample ss
+                JOIN participant p ON ss.biobank_id = p.biobank_id
+                JOIN biobank_order_identifier oi ON ss.biobank_order_identifier = oi.value
+                JOIN biobank_order o ON oi.biobank_order_id = o.biobank_order_id
+                JOIN participant_summary ps ON ps.participant_id = p.participant_id
                 JOIN code c ON c.code_id = ps.sex_id
                 LEFT JOIN (
                   SELECT ra.participant_id
                   FROM participant_race_answers ra
                       JOIN code cr ON cr.code_id = ra.code_id
                           AND SUBSTRING_INDEX(cr.value, "_", -1) = "AIAN"
-                ) native ON native.participant_id = ps.participant_id
+                ) native ON native.participant_id = p.participant_id
                 LEFT JOIN genomic_set_member m ON m.participant_id = ps.participant_id
-                    AND m.genomic_workflow_state <> :ignore_param
+                        AND m.genomic_workflow_state <> 33
+                LEFT JOIN biobank_mail_kit_order mk ON mk.participant_id = p.participant_id
+                JOIN questionnaire_response qr
+                    ON qr.participant_id = ps.participant_id
+                JOIN questionnaire_response_answer qra
+                    ON qra.questionnaire_response_id = qr.questionnaire_response_id
+                JOIN code recon ON recon.code_id = qra.value_code_id
+                    AND recon.value = :c1_reconsent_param
             WHERE TRUE
-                AND (
-                        ps.sample_status_1ed04 = :sample_status_param
-                        OR
-                        ps.sample_status_1sal2 = :sample_status_param
-                    )
-                AND ps.consent_cohort = :cohort_2_param
-                AND ps.questionnaire_on_dna_program_authored > :from_date_param
-                AND ps.questionnaire_on_dna_program = :general_consent_param
+                AND ss.test in ('1ED04', '1ED10', '1SAL2')
+                AND ps.consent_cohort = :cohort_param
+                AND ps.participant_origin != 'careevolution'
                 AND m.id IS NULL
-            HAVING TRUE
-                # Validations for Cohort 2
-                AND valid_age = 1
-                AND general_consent_given = 1
-                AND valid_suspension_status = 1
-                AND valid_withdrawal_status = 1
-            ORDER BY ps.biobank_id
         """
 
     @staticmethod

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -904,14 +904,13 @@ class GenomicJobController:
     def run_c2_participant_workflow(self):
         """
         Creates new GenomicSet, GenomicSetMembers,
-        And manifest file for Cohort 2 participants
+        And manifest file for all remaining Cohort 2 participants
         """
         self.biobank_coupler = GenomicBiobankSamplesCoupler(self.job_run.id, controller=self)
 
         try:
-            last_run_date = self._get_last_successful_run_time()
             logging.info('Running C2 Participant Workflow.')
-            self.job_result = self.biobank_coupler.create_c2_genomic_participants(last_run_date)
+            self.job_result = self.biobank_coupler.create_c2_genomic_participants()
         except RuntimeError:
             self.job_result = GenomicSubProcessResult.ERROR
 
@@ -923,9 +922,8 @@ class GenomicJobController:
         self.biobank_coupler = GenomicBiobankSamplesCoupler(self.job_run.id, controller=self)
 
         try:
-            last_run_date = self._get_last_successful_run_time()
             logging.info('Running C1 Participant Workflow.')
-            self.job_result = self.biobank_coupler.create_c1_genomic_participants(last_run_date)
+            self.job_result = self.biobank_coupler.create_c1_genomic_participants()
         except RuntimeError:
             self.job_result = GenomicSubProcessResult.ERROR
 

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -29,7 +29,6 @@ def new_participant_workflow():
 def c2_participant_workflow():
     """
     Entrypoint for Cohort 2 Participant Workflow,
-    Sources from Cohort 2 participants that have reconsented.
     """
     with GenomicJobController(GenomicJob.C2_PARTICIPANT_WORKFLOW) as controller:
         controller.run_c2_participant_workflow()

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -1609,7 +1609,7 @@ class GenomicPipelineTest(BaseTestCase):
             if member.biobankId == '100001':
                 # 100001 : Included, Valid
                 self.assertEqual(0, member.nyFlag)
-                self.assertEqual('10000102', member.collectionTubeId)
+                self.assertEqual('10000101', member.collectionTubeId)
                 self.assertEqual('F', member.sexAtBirth)
                 self.assertEqual(GenomicSetMemberStatus.VALID, member.validationStatus)
                 self.assertEqual('N', member.ai_an)
@@ -1645,7 +1645,7 @@ class GenomicPipelineTest(BaseTestCase):
                 rows = list(csv_reader)
 
                 self.assertEqual("T100001", rows[0][ExpectedCsvColumns.BIOBANK_ID])
-                self.assertEqual(10000102, int(rows[0][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
+                self.assertEqual(10000101, int(rows[0][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
                 self.assertEqual("F", rows[0][ExpectedCsvColumns.SEX_AT_BIRTH])
                 self.assertEqual("N", rows[0][ExpectedCsvColumns.NY_FLAG])
                 self.assertEqual("Y", rows[0][ExpectedCsvColumns.VALIDATION_PASSED])
@@ -1653,7 +1653,7 @@ class GenomicPipelineTest(BaseTestCase):
                 self.assertEqual("aou_array", rows[0][ExpectedCsvColumns.GENOME_TYPE])
 
                 self.assertEqual("T100001", rows[1][ExpectedCsvColumns.BIOBANK_ID])
-                self.assertEqual(10000102, int(rows[1][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
+                self.assertEqual(10000101, int(rows[1][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
                 self.assertEqual("F", rows[1][ExpectedCsvColumns.SEX_AT_BIRTH])
                 self.assertEqual("N", rows[1][ExpectedCsvColumns.NY_FLAG])
                 self.assertEqual("Y", rows[1][ExpectedCsvColumns.VALIDATION_PASSED])
@@ -1703,7 +1703,7 @@ class GenomicPipelineTest(BaseTestCase):
             if member.biobankId == '100001':
                 # 100001 : Included, Valid
                 self.assertEqual(0, member.nyFlag)
-                self.assertEqual('10000102', member.collectionTubeId)
+                self.assertEqual('10000101', member.collectionTubeId)
                 self.assertEqual('F', member.sexAtBirth)
                 self.assertEqual(GenomicSetMemberStatus.VALID, member.validationStatus)
                 self.assertEqual('N', member.ai_an)
@@ -1739,7 +1739,7 @@ class GenomicPipelineTest(BaseTestCase):
                 rows = list(csv_reader)
 
                 self.assertEqual("T100001", rows[0][ExpectedCsvColumns.BIOBANK_ID])
-                self.assertEqual(10000102, int(rows[0][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
+                self.assertEqual(10000101, int(rows[0][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
                 self.assertEqual("F", rows[0][ExpectedCsvColumns.SEX_AT_BIRTH])
                 self.assertEqual("N", rows[0][ExpectedCsvColumns.NY_FLAG])
                 self.assertEqual("Y", rows[0][ExpectedCsvColumns.VALIDATION_PASSED])
@@ -1747,7 +1747,7 @@ class GenomicPipelineTest(BaseTestCase):
                 self.assertEqual("aou_array", rows[0][ExpectedCsvColumns.GENOME_TYPE])
 
                 self.assertEqual("T100001", rows[1][ExpectedCsvColumns.BIOBANK_ID])
-                self.assertEqual(10000102, int(rows[1][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
+                self.assertEqual(10000101, int(rows[1][ExpectedCsvColumns.COLLECTION_TUBE_ID]))
                 self.assertEqual("F", rows[1][ExpectedCsvColumns.SEX_AT_BIRTH])
                 self.assertEqual("N", rows[1][ExpectedCsvColumns.NY_FLAG])
                 self.assertEqual("Y", rows[1][ExpectedCsvColumns.VALIDATION_PASSED])


### PR DESCRIPTION
## Resolves *[DA-2381](https://precisionmedicineinitiative.atlassian.net/browse/DA-2381)*


## Description of changes/additions
This PR reactivates the Cohorts 1 and 2 AW0 manifest workflows. The criteria has been updated to match the Cohort 3, except that Cohort 1 also requires the Cohort 1 reconsent. 

## Tests
- [x] unit tests


