### PR TITLE
Add ignore_flag to A1 and Outreach queries

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1834,7 +1834,8 @@ class GenomicOutreachDaoV2(BaseDao):
                         GenomicInformingLoop.decision_value.isnot(None),
                         GenomicInformingLoop.module_type.in_(self.module),
                         GenomicInformingLoop.event_authored_time.isnot(None),
-                        genomic_loop_alias.event_authored_time.is_(None)
+                        genomic_loop_alias.event_authored_time.is_(None),
+                        GenomicSetMember.ignoreFlag != 1
                     )
                 )
                 ready_loop = (
@@ -1897,7 +1898,8 @@ class GenomicOutreachDaoV2(BaseDao):
                     .filter(
                         ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
                         ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
-                        GenomicMemberReportState.genomic_report_state.in_(self.report_query_state)
+                        GenomicMemberReportState.genomic_report_state.in_(self.report_query_state),
+                        GenomicSetMember.ignoreFlag != 1
                     )
                 )
                 if pid:

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -245,7 +245,7 @@ class GenomicQueryClass:
             ).where(
                 (GenomicGCValidationMetrics.processingStatus == 'pass') &
                 (GenomicGCValidationMetrics.ignoreFlag != 1) &
-                (GenomicSetMember.ignoreFlag != 0) &
+                (GenomicSetMember.ignoreFlag != 1) &
                 (GenomicSetMember.genomicWorkflowState == GenomicWorkflowState.GEM_READY) &
                 (GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE) &
                 (GenomicSetMember.genomeType == "aou_array") &

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -245,6 +245,7 @@ class GenomicQueryClass:
             ).where(
                 (GenomicGCValidationMetrics.processingStatus == 'pass') &
                 (GenomicGCValidationMetrics.ignoreFlag != 1) &
+                (GenomicSetMember.ignoreFlag != 0) &
                 (GenomicSetMember.genomicWorkflowState == GenomicWorkflowState.GEM_READY) &
                 (GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE) &
                 (GenomicSetMember.genomeType == "aou_array") &


### PR DESCRIPTION
## Resolves *None*


## Description of changes/additions
This PR adds the new field `genomic_set_member.ignore_flag` to the A1 and OutreachAPI queries.

## Tests
- [x] unit tests


