### PR TITLE
Setting project id for consent file PDR build tasks

### DIFF
--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -153,10 +153,13 @@ def batch_rebuild_user_event_metrics_task(payload):
 # endpoint-specific logic and/or some fancy code to dynamically populate the task.execute() args (or to allow for
 # local rebuilds vs. cloud tasks)
 def dispatch_rebuild_consent_metrics_tasks(id_list, in_seconds=15, quiet=True, batch_size=150,
-                                           project_id=config.GAE_PROJECT, build_locally=False):
+                                           project_id=None, build_locally=False):
     """
     Helper method to handle queuing batch rebuild requests for rebuilding consent metrics resource data
     """
+    if project_id is None:
+        project_id = config.GAE_PROJECT
+
     if not all(isinstance(id, int) for id in id_list):
         raise (ValueError, "Invalid id list; must be a list that contains only integer consent_file ids")
 

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -44,11 +44,12 @@ class ValidationOutputStrategy(ABC):
 
 
 class StoreResultStrategy(ValidationOutputStrategy):
-    def __init__(self, session, consent_dao: ConsentDao):
+    def __init__(self, session, consent_dao: ConsentDao, project_id=None):
         self._session = session
         self._results = []
         self._consent_dao = consent_dao
         self._max_batch_count = 500
+        self.project_id = project_id
 
     def add_result(self, result: ParsingResult):
         self._results.append(result)
@@ -75,16 +76,17 @@ class StoreResultStrategy(ValidationOutputStrategy):
         self._consent_dao.batch_update_consent_files(new_results_to_store, self._session)
         self._session.commit()
         if new_results_to_store:
-            dispatch_rebuild_consent_metrics_tasks([r.id for r in new_results_to_store])
+            dispatch_rebuild_consent_metrics_tasks([r.id for r in new_results_to_store], project_id=self.project_id)
 
 
 class ReplacementStoringStrategy(ValidationOutputStrategy):
-    def __init__(self, session, consent_dao: ConsentDao):
+    def __init__(self, session, consent_dao: ConsentDao, project_id=None):
         self.session = session
         self.consent_dao = consent_dao
         self.participant_ids = set()
         self.results = self._build_consent_list_structure()
         self._max_batch_count = 500
+        self.project_id = project_id
 
     def add_result(self, result: ParsingResult):
         self.results[result.participant_id][result.type].append(result)
@@ -127,7 +129,7 @@ class ReplacementStoringStrategy(ValidationOutputStrategy):
         self.consent_dao.batch_update_consent_files(results_to_update, self.session)
         self.session.commit()
         if results_to_update:
-            dispatch_rebuild_consent_metrics_tasks([r.id for r in results_to_update])
+            dispatch_rebuild_consent_metrics_tasks([r.id for r in results_to_update], project_id=self.project_id)
 
     @classmethod
     def _find_file_ready_for_sync(cls, results: List[ParsingResult]):

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -166,7 +166,11 @@ class ConsentTool(ToolBase):
         )
         with open(self.args.pid_file) as pid_file,\
                 self.get_session() as session,\
-                ReplacementStoringStrategy(session=session, consent_dao=controller.consent_dao) as store_strategy:
+                ReplacementStoringStrategy(
+                    session=session,
+                    consent_dao=controller.consent_dao,
+                    project_id=self.gcp_env.project
+                ) as store_strategy:
             # Get participant ids from the file in batches
             # (retrieving all their summaries at once, processing them before the next batch)
             participant_lookup_batch_size = 500

--- a/tests/service_tests/consent_tests/test_consent_validation.py
+++ b/tests/service_tests/consent_tests/test_consent_validation.py
@@ -326,7 +326,10 @@ class ConsentValidationTesting(BaseTestCase):
 
         # Verify that both records that provide new validation information were stored
         consent_dao_mock.batch_update_consent_files.assert_called_with([new_primary_result, new_gror_result], mock.ANY)
-        mock_consent_metrics_rebuild.assert_called_once_with([new_primary_result.id, new_gror_result.id])
+        mock_consent_metrics_rebuild.assert_called_once_with(
+            [new_primary_result.id, new_gror_result.id],
+            project_id=None
+        )
 
     def test_primary_update_agreement_check(self):
         self.participant_summary.consentForStudyEnrollmentAuthored = datetime.combine(


### PR DESCRIPTION
## Resolves *no ticket*
When running the consent tool locally, the `dispatch_rebuild_consent_metrics_tasks` method would default to building and storing the consent data for PDR locally and wouldn't reflect the changes in the prod environment for PDR. This updates the places where the method would be called through a tool script to use the target environment rather than the local.


## Tests
- [x] unit tests


