### PR TITLE
Fix for consent file date parsing and a tweak for a storage strategy

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -307,7 +307,8 @@ class ConsentFile(ABC):
     def _get_date_signed_str(self):
         date_elements = self._get_date_elements()
         for element in date_elements:
-            if isinstance(element, LTFigure):
+            if isinstance(element, LTFigure) and len(element) > 0:
+                # Some files have empty Figures in the same place as the date
                 return ''.join([char_child.get_text() for char_child in element]).strip()
 
     def _get_signature_elements(self):

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -79,7 +79,7 @@ class StoreResultStrategy(ValidationOutputStrategy):
 
 
 class ReplacementStoringStrategy(ValidationOutputStrategy):
-    def __init__(self, session, consent_dao: ConsentDao, project_id):
+    def __init__(self, session, consent_dao: ConsentDao, project_id=None):
         self.session = session
         self.consent_dao = consent_dao
         self.participant_ids = set()

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -677,20 +677,21 @@ class ConsentFileParsingTest(BaseTestCase):
         element = mock.MagicMock(spec=LTFigure)
         self._set_bbox(bbox, element)
 
+        iterable_children = []
         if children:
-            element.__iter__.return_value = children
+            iterable_children = children
         else:
-            char_list = []
             for char_str in text:
                 char_element = mock.MagicMock(spec=LTChar)
                 char_element.get_text.return_value = char_str
-                char_list.append(char_element)
+                iterable_children.append(char_element)
             if text == '':
                 char_element = mock.MagicMock(spec=LTChar)
                 char_element.get_text.return_value = ''
-                char_list.append(char_element)
-            element.__iter__.return_value = char_list
+                iterable_children.append(char_element)
 
+        element.__iter__.return_value = iterable_children
+        element.__len__.return_value = len(iterable_children)
         return element
 
     def _set_bbox(self, bbox, element_mock):


### PR DESCRIPTION
## Resolves *no ticket*
Peggy found a file that was being incorrectly validated. The file had some empty Figure elements in the same area as the signing date. The validation code was trying to read the date from these figures and was missing the one that had the date.

I'm also adding another storage strategy that is almost the same as the ReplacementStorage strategy, but also adds the ability to modify existing validation records. This way records that were incorrectly validated (such as what was found) can be updated in place.


## Description of changes/additions
This adds a check to ensure that the figure being checked has sub-elements (characters) before using it as the signing date.


## Tests
- [ ] unit tests


