### PR TITLE
Removing each unit test's logger when complete

### DIFF
--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -499,6 +499,7 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
         logger.addHandler(stream_handler)
+        self.addCleanup(logger.removeHandler, stream_handler)
 
         # Change this to logging.ERROR when you want to see API server errors.
         logger.setLevel(logging.CRITICAL)


### PR DESCRIPTION
## Resolves *no ticket*

Each unit test is adding a new output handler, so when a unit test runs that prints log statements we get a flood of them all at once.

<img width="500" alt="Screen Shot 2022-01-14 at 2 58 22 PM" src="https://user-images.githubusercontent.com/64044838/149584856-b9e33326-cdd5-404b-b425-e475b56dc77e.png">

I'm unsure why the stream handler was added in setup (rather than once at the start of the unittest run), but at the very least the stream handlers should be removed when the unit test is torn down. This will help keep the logs manageable in CI's output.


## Tests
- [ ] unit tests


