### PR TITLE
Renaming MayoLink Api class as MayoLink Client and moving to services directory

### DIFF
--- a/rdr_service/dao/biobank_order_dao.py
+++ b/rdr_service/dao/biobank_order_dao.py
@@ -11,7 +11,7 @@ from rdr_service.lib_fhir.fhirclient_1_0_6.models.address import Address
 from sqlalchemy import or_, cast, Date, and_
 from sqlalchemy.orm import subqueryload, joinedload
 from werkzeug.exceptions import BadRequest, Conflict, PreconditionFailed, ServiceUnavailable
-from rdr_service.api.mayolink_api import MayoLinkApi, MayoLinkOrder, MayolinkQuestion, MayoLinkTest
+from rdr_service.services.mayolink_client import MayoLinkClient, MayoLinkOrder, MayolinkQuestion, MayoLinkTest
 from rdr_service import clock
 from rdr_service.api_util import get_site_id_by_site_value as get_site, format_json_code
 from rdr_service.app_util import get_account_origin_id
@@ -568,7 +568,7 @@ class BiobankOrderDao(UpdatableDao):
         return order
 
     def _make_mayolink_order(self, participant_id, resource):
-        mayo = MayoLinkApi()
+        mayo = MayoLinkClient()
         summary = ParticipantSummaryDao().get(participant_id)
         if not summary:
             raise BadRequest("No summary for participant id: {}".format(participant_id))

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -8,7 +8,8 @@ from sqlalchemy.orm import load_only
 from werkzeug.exceptions import BadRequest, Conflict, NotFound
 from rdr_service.code_constants import UNMAPPED, UNSET
 from rdr_service import clock, app_util
-from rdr_service.api.mayolink_api import MayoLinkApi, MayoLinkOrder, MayoLinkTest, MayolinkTestPassthroughFields
+from rdr_service.services.mayolink_client import MayoLinkClient, MayoLinkOrder, MayoLinkTest,\
+    MayolinkTestPassthroughFields
 from rdr_service.api_util import (
     DV_BARCODE_URL,
     DV_FHIR_URL,
@@ -56,7 +57,7 @@ class MailKitOrderDao(UpdatableDao):
 
     def send_order(self, resource, pid):
         order, is_version_two = self._filter_order_fields(resource, pid)
-        mayo = MayoLinkApi(credentials_key='version_two' if is_version_two else 'default')
+        mayo = MayoLinkClient(credentials_key='version_two' if is_version_two else 'default')
         response = mayo.post(order)
         return self.to_client_json(response, for_update=True)
 

--- a/rdr_service/services/mayolink_client.py
+++ b/rdr_service/services/mayolink_client.py
@@ -55,7 +55,7 @@ class MayoLinkOrder:
     comments: str = ''
 
 
-class MayoLinkApi:
+class MayoLinkClient:
     def __init__(self, credentials_key='default'):
         self.namespace = "http://orders.mayomedicallaboratories.com"
         self.endpoint = config.getSetting(config.MAYOLINK_ENDPOINT)

--- a/tests/api_tests/test_biobank_order_api.py
+++ b/tests/api_tests/test_biobank_order_api.py
@@ -49,7 +49,7 @@ class BiobankOrderApiTest(BaseTestCase):
         }
 
         mayolinkapi_patcher = mock.patch(
-            "rdr_service.dao.biobank_order_dao.MayoLinkApi",
+            "rdr_service.dao.biobank_order_dao.MayoLinkClient",
             **{"return_value.post.return_value": self.mayolink_response}
         )
         mayolinkapi_patcher.start()

--- a/tests/api_tests/test_mail_kit_order_api.py
+++ b/tests/api_tests/test_mail_kit_order_api.py
@@ -48,7 +48,7 @@ class MailKitOrderApiTestBase(BaseTestCase):
         self.summary_dao.insert(self.summary)
 
         mayolinkapi_patcher = mock.patch(
-            "rdr_service.dao.mail_kit_order_dao.MayoLinkApi", **{"return_value.post.return_value": self.mayolink_response}
+            "rdr_service.dao.mail_kit_order_dao.MayoLinkClient", **{"return_value.post.return_value": self.mayolink_response}
         )
         self.mock_mayolink_api = mayolinkapi_patcher.start()
         self.addCleanup(mayolinkapi_patcher.stop)

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -1,6 +1,6 @@
 import mock
 
-from rdr_service.api.mayolink_api import MayoLinkApi, MayoLinkOrder, MayolinkQuestion, MayoLinkTest, \
+from rdr_service.services.mayolink_client import MayoLinkClient, MayoLinkOrder, MayolinkQuestion, MayoLinkTest, \
     MayolinkTestPassthroughFields
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -13,7 +13,7 @@ class MayolinkClientTest(BaseTestCase):
     def setUp(self, *args, **kwargs) -> None:
         super(MayolinkClientTest, self).setUp(*args, **kwargs)
 
-        open_cloud_file_patch = mock.patch('rdr_service.api.mayolink_api.open_cloud_file')
+        open_cloud_file_patch = mock.patch('rdr_service.services.mayolink_client.open_cloud_file')
         self.open_cloud_file_mock = open_cloud_file_patch.start()
         self.addCleanup(open_cloud_file_patch.stop)
 
@@ -34,14 +34,14 @@ class MayolinkClientTest(BaseTestCase):
 
     def test_default_credentials(self):
         """Test that the client uses the default account by default"""
-        mayolink_client = MayoLinkApi()
+        mayolink_client = MayoLinkClient()
         self.assertEqual('test_user', mayolink_client.username)
         self.assertEqual('1234', mayolink_client.pw)
         self.assertEqual(1122, mayolink_client.account)
 
     def test_specific_account_credentials(self):
         """Test that the client switches to the new credentials when specified"""
-        mayolink_client = MayoLinkApi(credentials_key='version_two')
+        mayolink_client = MayoLinkClient(credentials_key='version_two')
         self.assertEqual('v2_user', mayolink_client.username)
         self.assertEqual('9876', mayolink_client.pw)
         self.assertEqual(8765, mayolink_client.account)
@@ -59,20 +59,20 @@ class MayolinkClientTest(BaseTestCase):
             }
         """
 
-        mayolink_client = MayoLinkApi()
+        mayolink_client = MayoLinkClient()
         self.assertEqual('legacy_user', mayolink_client.username)
         self.assertEqual('9283', mayolink_client.pw)
         self.assertEqual(7676, mayolink_client.account)
 
-    @mock.patch('rdr_service.api.mayolink_api.httplib2')
+    @mock.patch('rdr_service.services.mayolink_client.httplib2')
     def test_order_xml_structure(self, http_mock):
         """Make sure the resulting xml lines up with the order object sent using the client interface"""
         order = self._get_default_order()
 
-        client = MayoLinkApi()
+        client = MayoLinkClient()
         request_mock = http_mock.Http.return_value.request
         request_mock.return_value = ({'status': '201'}, b'<result></result>')
-        with mock.patch('rdr_service.api.mayolink_api.check_auth'):
+        with mock.patch('rdr_service.services.mayolink_client.check_auth'):
             client.post(order)
 
         sent_xml = request_mock.call_args.kwargs['body']
@@ -96,7 +96,7 @@ class MayolinkClientTest(BaseTestCase):
             sent_xml
         )
 
-    @mock.patch('rdr_service.api.mayolink_api.httplib2')
+    @mock.patch('rdr_service.services.mayolink_client.httplib2')
     def test_order_test_collection_data(self, http_mock):
         """Test the data structure with a test object provided (following the process used for mailkit orders)"""
         order = self._get_default_order()
@@ -114,10 +114,10 @@ class MayolinkClientTest(BaseTestCase):
             )
         ]
 
-        client = MayoLinkApi()
+        client = MayoLinkClient()
         request_mock = http_mock.Http.return_value.request
         request_mock.return_value = ({'status': '201'}, b'<result></result>')
-        with mock.patch('rdr_service.api.mayolink_api.check_auth'):
+        with mock.patch('rdr_service.services.mayolink_client.check_auth'):
             client.post(order)
 
         sent_xml = request_mock.call_args.kwargs['body']
@@ -145,7 +145,7 @@ class MayolinkClientTest(BaseTestCase):
             sent_xml
         )
 
-    @mock.patch('rdr_service.api.mayolink_api.httplib2')
+    @mock.patch('rdr_service.services.mayolink_client.httplib2')
     def test_passthrough_fields(self, http_mock):
         """Test the data structure with passthrough fields added in"""
         order = self._get_default_order()
@@ -160,10 +160,10 @@ class MayolinkClientTest(BaseTestCase):
             )
         ]
 
-        client = MayoLinkApi()
+        client = MayoLinkClient()
         request_mock = http_mock.Http.return_value.request
         request_mock.return_value = ({'status': '201'}, b'<result></result>')
-        with mock.patch('rdr_service.api.mayolink_api.check_auth'):
+        with mock.patch('rdr_service.services.mayolink_client.check_auth'):
             client.post(order)
 
         sent_xml = request_mock.call_args.kwargs['body']
@@ -196,7 +196,7 @@ class MayolinkClientTest(BaseTestCase):
             sent_xml
         )
 
-    @mock.patch('rdr_service.api.mayolink_api.httplib2')
+    @mock.patch('rdr_service.services.mayolink_client.httplib2')
     def test_question_fields(self, http_mock):
         """Test the data structure with questions fields added in"""
         order = self._get_default_order()
@@ -210,10 +210,10 @@ class MayolinkClientTest(BaseTestCase):
             ]
         )]
 
-        client = MayoLinkApi()
+        client = MayoLinkClient()
         request_mock = http_mock.Http.return_value.request
         request_mock.return_value = ({'status': '201'}, b'<result></result>')
-        with mock.patch('rdr_service.api.mayolink_api.check_auth'):
+        with mock.patch('rdr_service.services.mayolink_client.check_auth'):
             client.post(order)
 
         sent_xml = request_mock.call_args.kwargs['body']

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -61,7 +61,7 @@ class MailKitOrderDaoTestBase(BaseTestCase):
         }
 
         mayolinkapi_patcher = mock.patch(
-            'rdr_service.dao.mail_kit_order_dao.MayoLinkApi',
+            'rdr_service.dao.mail_kit_order_dao.MayoLinkClient',
             **{'return_value.post.return_value': self.mayolink_response}
         )
         self.mock_mayolinkapi = mayolinkapi_patcher.start()
@@ -258,7 +258,7 @@ class MailKitOrderDaoTestBase(BaseTestCase):
             self.make_supply_posts(test_case)
             run_db_test(expected_data)
 
-    @mock.patch("rdr_service.dao.mail_kit_order_dao.MayoLinkApi")
+    @mock.patch("rdr_service.dao.mail_kit_order_dao.MayoLinkClient")
     def test_service_unavailable(self, mocked_api):
         # pylint: disable=unused-argument
         def raises(*args):


### PR DESCRIPTION
## Resolves *no ticket*
It's helpful to have a naming convention to distinguish between classes responsible for acting as an API that we provide to downstream users, and classes that contain logic for interacting with an external API. I've been naming classes that interact with external APIs as 'Client' to help better articulate their purpose. This updates the MayoLinkAPI class to MayoLinkClient so that it matches that convention. These changes also move the file out of the `api` directory and into the `services` directory.

Follow up PRs will further clean up the logic for sending orders to MayoLink so that a utility can be built that can reuse the same code.


## Tests
Existing unit tests updated.


