### PR TITLE
[PDR-690] Fix bad input data and prevent setting core timestamps.

### DIFF
--- a/rdr_service/resource/calculators/participant_enrollment_status.py
+++ b/rdr_service/resource/calculators/participant_enrollment_status.py
@@ -137,8 +137,8 @@ class EnrollmentStatusCalculator:
         if status == PDREnrollmentStatusEnum.CoreParticipantMinusPM and not self.core_participant_minus_pm_time and \
                 self._biobank_samples and self._baseline_modules:
             self.core_participant_minus_pm_time = max([self._biobank_samples.first_ts, self._baseline_modules.last_ts])
-        if not self.core_participant_time and self._biobank_samples and self._baseline_modules and \
-                    self._physical_measurements:
+        if status == PDREnrollmentStatusEnum.CoreParticipant and not self.core_participant_time and \
+                self._biobank_samples and self._baseline_modules and self._physical_measurements:
             self.core_participant_time = \
                 max([self._biobank_samples.first_ts, self._baseline_modules.last_ts,
                         self._physical_measurements.first_ts])

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1092,7 +1092,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     # Find minimum confirmed date of DNA tests if we have any.
                     if order['isolate_dna']:
                         try:
-                            tmp_ts = min([r['created'] for r in order['samples'] if r['created'] is not None])
+                            tmp_ts = min([r['confirmed'] for r in order['samples'] if r['confirmed'] is not None])
                             act_key = ParticipantEventEnum.BiobankConfirmed
                             act_ts = tmp_ts
                         except ValueError:  # No confirmed timestamps in list.

--- a/tests/resource_tests/calculator_tests/test_enrollment_status_calculator.py
+++ b/tests/resource_tests/calculator_tests/test_enrollment_status_calculator.py
@@ -257,3 +257,19 @@ class EnrollmentStatusCalculatorTest(BaseTestCase):
         self.assertEqual(self.esc.registered_time, datetime(2018, 3, 5, 16, 35, 55))
         self.assertEqual(self.esc.participant_time, datetime(2018, 3, 5, 16, 35, 55))
         self.assertEqual(self.esc.participant_plus_ehr_time, datetime(2018, 3, 5, 16, 43, 50))
+
+    def test_no_core_timestamps_for_participant_status(self):
+        """ Test that none of the ehr or core timestamps are populated when EHR Consent is No """
+        activity = get_basic_activity()
+        # Change EHR Consent from Yes to No
+        for item in activity:
+            if item['event'] == p_event.EHRConsentPII:
+                item['answer'] = 'ConsentPermission_No'
+
+        self.esc.run(activity)
+        self.assertEqual(self.esc.status, PDREnrollmentStatusEnum.Participant)
+        self.assertEqual(self.esc.registered_time, datetime(2018, 3, 6, 20, 20, 57))
+        self.assertEqual(self.esc.participant_time, datetime(2018, 3, 6, 20, 35, 12))
+        self.assertEqual(self.esc.participant_plus_ehr_time, None)
+        self.assertEqual(self.esc.core_participant_minus_pm_time, None)
+        self.assertEqual(self.esc.core_participant_time, None)


### PR DESCRIPTION
## Resolves *[PDR-690](https://precisionmedicineinitiative.atlassian.net/browse/PDR-690)*


## Description of changes/additions
Fix bad biobank timestamp input in participant activity list.
Core enrollment timestamps should not be set if participant has not reached a EHR or Core status.

## Tests
- [x] unit tests


