### PR TITLE
[DA-2300] Refactoring MailKit order code

### DIFF
--- a/rdr_service/dao/biobank_order_dao.py
+++ b/rdr_service/dao/biobank_order_dao.py
@@ -597,8 +597,7 @@ class BiobankOrderDao(UpdatableDao):
         order = MayoLinkOrder(
             collected_datetime_utc=resource.samples[0].collected.date,
             number=kit_id,
-            medical_record_number=str(to_client_biobank_id(summary.biobankId)),
-            last_name=str(to_client_biobank_id(summary.biobankId)),
+            biobank_id=summary.biobankId,
             sex=gender_val,
             address1=summary.streetAddress,
             address2=summary.streetAddress2,

--- a/rdr_service/dao/biobank_order_dao.py
+++ b/rdr_service/dao/biobank_order_dao.py
@@ -589,17 +589,13 @@ class BiobankOrderDao(UpdatableDao):
         if not resource.samples:
             raise BadRequest("No sample found in the payload")
 
-        # Convert to Central Timezone for Mayo
-        collected_time_utc = resource.samples[0].collected.date.replace(tzinfo=_UTC)
-        collected_time = collected_time_utc.astimezone(_US_CENTRAL)
-
         kit_id = None
         for item in resource.identifier:
             if item.system == KIT_ID_SYSTEM:
                 kit_id = item.value
 
         order = MayoLinkOrder(
-            collected=str(collected_time),
+            collected_datetime_utc=resource.samples[0].collected.date,
             number=kit_id,
             medical_record_number=str(to_client_biobank_id(summary.biobankId)),
             last_name=str(to_client_biobank_id(summary.biobankId)),

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -1,13 +1,15 @@
+from datetime import datetime
 import json
 import logging
-import pytz
 import re
-from dateutil import parser
+from typing import Optional
 
-from sqlalchemy.orm import load_only
+import pytz
+from sqlalchemy.orm import load_only, Session
 from werkzeug.exceptions import BadRequest, Conflict, NotFound
+
 from rdr_service.code_constants import UNMAPPED, UNSET
-from rdr_service import clock, app_util
+from rdr_service import clock
 from rdr_service.services.mayolink_client import MayoLinkClient, MayoLinkOrder, MayoLinkTest,\
     MayolinkTestPassthroughFields
 from rdr_service.api_util import (
@@ -29,7 +31,6 @@ from rdr_service.model.biobank_mail_kit_order import BiobankMailKitOrder
 from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderIdentifier, BiobankOrderedSample, \
     MayolinkCreateOrderHistory
 from rdr_service.model.participant import Participant
-from rdr_service.model.config_utils import to_client_biobank_id
 from rdr_service.model.utils import to_client_participant_id
 from rdr_service.offline.biobank_samples_pipeline import _PMI_OPS_SYSTEM
 from rdr_service.participant_enums import BiobankOrderStatus, OrderShipmentStatus, OrderShipmentTrackingStatus,\
@@ -55,17 +56,21 @@ class MailKitOrderDao(UpdatableDao):
             "use": "work",
         }
 
-    def send_order(self, resource, pid):
-        order, is_version_two = self._filter_order_fields(resource, pid)
+    def send_order(self, portal_order_id: int, participant_id: int, collected_time_utc: datetime, report_notes: str):
+        order, is_version_two = self._create_mayolink_order(
+            participant_id=participant_id,
+            portal_order_id=portal_order_id,
+            collected_time_utc=collected_time_utc,
+            report_notes=report_notes
+        )
         mayo = MayoLinkClient(credentials_key='version_two' if is_version_two else 'default')
         response = mayo.post(order)
         return self.to_client_json(response, for_update=True)
 
-    def _filter_order_fields(self, resource, pid):
-        fhir_resource = SimpleFhirR4Reader(resource)
-        summary = ParticipantSummaryDao().get(pid)
+    def _create_mayolink_order(self, participant_id: int, portal_order_id: int, collected_time_utc, report_notes: str):
+        summary = ParticipantSummaryDao().get(participant_id)
         if not summary:
-            raise BadRequest("No summary for participant id: {}".format(pid))
+            raise BadRequest("No summary for participant id: {}".format(participant_id))
         code_dict = summary.asdict()
         format_json_code(code_dict, self.code_dao, "genderIdentityId")
         format_json_code(code_dict, self.code_dao, "stateId")
@@ -79,28 +84,24 @@ class MailKitOrderDao(UpdatableDao):
         else:
             gender_val = "U"
 
-        order_id = int(fhir_resource.basedOn[0].identifier.value)
         with self.session() as session:
-            result = session.query(BiobankMailKitOrder.barcode).filter(BiobankMailKitOrder.order_id == order_id).first()
-            barcode = None if not result else result if isinstance(result, str) else result.barcode
+            barcode = session.query(BiobankMailKitOrder.barcode).filter(
+                BiobankMailKitOrder.order_id == portal_order_id
+            ).scalar()
 
         # We should have the barcode at this point.
         # Put an error message in the logs if not so this order can be investigated.
         if not barcode:
-            logging.error(f'Barcode missing for order {order_id}')
-
-        # Convert to Central Timezone for Mayo
-        collected_time = parser.parse(fhir_resource.occurrenceDateTime)
+            logging.error(f'Barcode missing for order {portal_order_id}')
 
         order_test = MayoLinkTest(
             code='1SAL2',
             name='PMI Saliva, FDA Kit'
         )
         order = MayoLinkOrder(
-            collected_datetime_utc=collected_time,
+            collected_datetime_utc=collected_time_utc,
             number=barcode,
-            medical_record_number=str(to_client_biobank_id(summary.biobankId)),
-            last_name=str(to_client_biobank_id(summary.biobankId)),
+            biobank_id=summary.biobankId,
             sex=gender_val,
             address1=summary.streetAddress,
             address2=summary.streetAddress2,
@@ -109,7 +110,7 @@ class MailKitOrderDao(UpdatableDao):
             postal_code=str(summary.zipCode),
             phone=str(summary.phoneNumber),
             race=str(summary.race),
-            report_notes=fhir_resource.extension.get(url=DV_ORDER_URL).valueString,
+            report_notes=report_notes,
             tests=[order_test],
             comments='Salivary Kit Order, direct from participant'
         )
@@ -290,75 +291,65 @@ class MailKitOrderDao(UpdatableDao):
 
         return order
 
-    def insert_biobank_order(self, pid, resource, session=None):
+    def insert_biobank_order(self, participant_id: int, mail_kit_order: BiobankMailKitOrder, session,
+                             order_origin_client_id: str, biobank_order_id: str, mayo_reference_number: str,
+                             additional_identifiers=None):
         obj = BiobankOrder()
-        obj.participantId = int(pid)
+        obj.participantId = participant_id
         obj.created = clock.CLOCK.now()
         obj.finalizedTime = obj.created
         obj.orderStatus = BiobankOrderStatus.UNSET
-        obj.biobankOrderId = resource["biobankOrderId"]
-        obj.orderOrigin = resource.get("orderOrigin")
-        test = self.get(resource["id"])
-        obj.mailKitOrders = [test]
+        obj.biobankOrderId = biobank_order_id
+        obj.orderOrigin = order_origin_client_id
+        obj.mailKitOrders = [mail_kit_order]
         obj.samples = [BiobankOrderedSample(test="1SAL2", processingRequired=False, description="salivary pilot kit")]
-        self._add_identifiers_and_main_id(obj, app_util.ObjectView(resource))
+        self._add_identifiers_and_main_id(
+            order=obj,
+            mayo_reference_number=mayo_reference_number,
+            portal_order_id=mail_kit_order.order_id,
+            order_origin_client_id=order_origin_client_id,
+            additional_identifiers=additional_identifiers
+        )
         biobank_order_dao = BiobankOrderDao()
-        if session is None:
-            biobank_order_dao.insert(obj)
-        else:
-            biobank_order_dao.insert_with_session(session, obj)
+        biobank_order_dao.insert_with_session(session, obj)
 
-    def insert_mayolink_create_order_history(self, pid, resource, request_payload, response_payload):
+    def insert_mayolink_create_order_history(self, participant_id: int, biobank_order_id: str,
+                                             mayolink_order_status: str, response_payload, request_payload=None):
         mayolink_create_order_history = MayolinkCreateOrderHistory()
-        mayolink_create_order_history.requestParticipantId = pid
+        mayolink_create_order_history.requestParticipantId = participant_id
         mayolink_create_order_history.requestTestCode = '1SAL2'
-        mayolink_create_order_history.requestOrderId = resource.get("biobankOrderId")
-        mayolink_create_order_history.requestOrderStatus = resource.get("biobankStatus")
+        mayolink_create_order_history.requestOrderId = biobank_order_id
+        mayolink_create_order_history.requestOrderStatus = mayolink_order_status
         try:
-            mayolink_create_order_history.requestPayload = json.dumps(request_payload)
+            mayolink_create_order_history.requestPayload = json.dumps(request_payload) if request_payload else None
             mayolink_create_order_history.responsePayload = json.dumps(response_payload)
         except TypeError:
             logging.info(f"TypeError when create mayolink_create_order_history")
         biobank_order_dao = BiobankOrderDao()
         biobank_order_dao.insert_mayolink_create_order_history(mayolink_create_order_history)
 
-    def _add_identifiers_and_main_id(self, order, resource):
+    def _add_identifiers_and_main_id(self, order, mayo_reference_number: str, order_origin_client_id: str,
+                                     portal_order_id: int, additional_identifiers=None):
+        try:
+            portal_id_system = BiobankMailKitOrder.ID_SYSTEM[order_origin_client_id]
+        except KeyError:
+            raise BadRequest(
+                f"No identifier for clientID {order_origin_client_id}"
+            )
+
         order.identifiers = [
-            BiobankOrderIdentifier(system=_PMI_OPS_SYSTEM, value=resource.barcode)
+            BiobankOrderIdentifier(system=_PMI_OPS_SYSTEM, value=mayo_reference_number),
+            BiobankOrderIdentifier(system=portal_id_system, value=str(portal_order_id))
         ]
-        client_id = app_util.lookup_user_info(resource.auth_user).get('clientId')
-        for i in resource.identifier:
+
+        for i in additional_identifiers or []:
             try:
                 if i["system"].lower() == DV_FHIR_URL + "trackingid":
                     order.identifiers.append(
-                        BiobankOrderIdentifier(
-                            system=BiobankMailKitOrder._ID_SYSTEM[client_id] + "/trackingId", value=i["value"]
-                        )
+                        BiobankOrderIdentifier(system=f"{portal_id_system}/trackingId", value=i["value"])
                     )
             except AttributeError:
-                raise BadRequest(
-                    f"No identifier for system {BiobankMailKitOrder._ID_SYSTEM[client_id]}, required for primary key."
-                )
-            except KeyError:
-                raise BadRequest(
-                    f"No identifier for clientID {client_id}"
-                )
-        for i in resource.basedOn:
-            try:
-                if i["identifier"]["system"].lower() == DV_FHIR_URL + "orderid":
-                    order.identifiers.append(
-                        BiobankOrderIdentifier(
-                            system=BiobankMailKitOrder._ID_SYSTEM[client_id], value=i["identifier"]["value"]
-                        )
-                    )
-            except AttributeError:
-                raise BadRequest(
-                    f"No identifier for system {BiobankMailKitOrder._ID_SYSTEM[client_id]}, required for primary key."
-                )
-            except KeyError:
-                raise BadRequest(
-                    f"No identifier for clientID {client_id}"
-                )
+                raise BadRequest(f"No identifier for system {portal_id_system}, required for primary key.")
 
     def get_etag(self, id_, pid):
         with self.session() as session:
@@ -407,3 +398,6 @@ class MailKitOrderDao(UpdatableDao):
             return OrderShipmentTrackingStatus.DELIVERED
         else:
             return OrderShipmentTrackingStatus.UNSET
+
+    def get_with_barcode(self, barcode, session: Session) -> Optional[BiobankMailKitOrder]:
+        return session.query(BiobankMailKitOrder).filter(BiobankMailKitOrder.barcode == barcode).one_or_none()

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -90,15 +90,14 @@ class MailKitOrderDao(UpdatableDao):
             logging.error(f'Barcode missing for order {order_id}')
 
         # Convert to Central Timezone for Mayo
-        collected_time_utc = parser.parse(fhir_resource.occurrenceDateTime).replace(tzinfo=_UTC)
-        collected_time_central = collected_time_utc.astimezone(_US_CENTRAL)
+        collected_time = parser.parse(fhir_resource.occurrenceDateTime)
 
         order_test = MayoLinkTest(
             code='1SAL2',
             name='PMI Saliva, FDA Kit'
         )
         order = MayoLinkOrder(
-            collected=str(collected_time_central),
+            collected_datetime_utc=collected_time,
             number=barcode,
             medical_record_number=str(to_client_biobank_id(summary.biobankId)),
             last_name=str(to_client_biobank_id(summary.biobankId)),

--- a/rdr_service/model/biobank_mail_kit_order.py
+++ b/rdr_service/model/biobank_mail_kit_order.py
@@ -12,7 +12,7 @@ from rdr_service.participant_enums import OrderShipmentStatus, OrderShipmentTrac
 
 class BiobankMailKitOrder(Base):
     # mapping a user_info.clientID (from config) to a system identifier
-    _ID_SYSTEM = {
+    ID_SYSTEM = {
         'vibrent': "http://vibrenthealth.com",
         'careevolution': "http://carevolution.be",
         'example': "system-test"

--- a/rdr_service/services/biobank_order.py
+++ b/rdr_service/services/biobank_order.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+import logging
+
+from dateutil.parser import parse
+
+from rdr_service.dao.mail_kit_order_dao import MailKitOrderDao
+from rdr_service.dao.participant_dao import raise_if_withdrawn
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.model.biobank_mail_kit_order import BiobankMailKitOrder
+from rdr_service.model.participant_summary import ParticipantSummary
+
+
+class BiobankOrderService:
+    @classmethod
+    def post_mailkit_order_delivery(cls, mailkit_order: BiobankMailKitOrder, collected_time_utc: datetime,
+                                    order_origin_client_id: str, report_notes: str, request_json: dict = None):
+        summary_dao = ParticipantSummaryDao()
+        mailkit_dao = MailKitOrderDao()
+        with summary_dao.session() as session:
+            summary: ParticipantSummary = summary_dao.get_for_update(
+                session=session,
+                obj_id=mailkit_order.participantId
+            )
+            if summary is not None:  # Later code handles the error if it's missing
+                raise_if_withdrawn(summary)
+
+            logging.info(f"Sending salivary order to biobank for participant: {summary.participantId}")
+            mayolink_response = mailkit_dao.send_order(
+                participant_id=summary.participantId,
+                portal_order_id=mailkit_order.order_id,
+                collected_time_utc=collected_time_utc,
+                report_notes=report_notes
+            )
+            mayo_order_id = mayolink_response['biobankOrderId']
+
+            mailkit_dao.insert_biobank_order(
+                participant_id=summary.participantId,
+                mail_kit_order=mailkit_order,
+                session=session,
+                order_origin_client_id=order_origin_client_id,
+                biobank_order_id=mayo_order_id,
+                mayo_reference_number=mayolink_response['barcode'],
+                additional_identifiers=request_json.get('identifier') if request_json else None
+            )
+            mailkit_dao.insert_mayolink_create_order_history(
+                participant_id=summary.participantId,
+                biobank_order_id=mayo_order_id,
+                mayolink_order_status=mayolink_response['biobankStatus'],
+                request_payload=request_json,
+                response_payload=mayolink_response
+            )
+
+            mailkit_order.biobankStatus = mayolink_response['biobankStatus']
+            mailkit_order.biobankReceived = parse(mayolink_response['received'])
+            mailkit_order.biobankOrderId = mayo_order_id
+            mailkit_order.biobankTrackingId = mayolink_response['biobankTrackingId']

--- a/rdr_service/services/mayolink_client.py
+++ b/rdr_service/services/mayolink_client.py
@@ -13,6 +13,7 @@ import pytz
 from rdr_service import config
 from rdr_service.api_util import RDR_AND_PTC, open_cloud_file
 from rdr_service.app_util import check_auth
+from rdr_service.model.config_utils import to_client_biobank_id
 
 
 @dataclass
@@ -43,8 +44,7 @@ class MayoLinkTest:
 class MayoLinkOrder:
     collected_datetime_utc: datetime
     number: str
-    medical_record_number: str
-    last_name: str
+    biobank_id: int
     sex: str
     address1: str
     address2: str
@@ -115,15 +115,17 @@ class MayoLinkClient:
         return request
 
     def _dict_from_order(self, order: MayoLinkOrder):
+        biobank_id_display_str = to_client_biobank_id(order.biobank_id)
+
         order_dict = {
             'order': {
                 'collected': str(self._convert_to_central_time(order.collected_datetime_utc)),
                 'account': self.account,
                 'number': order.number,
                 'patient': {
-                    'medical_record_number': order.medical_record_number,
+                    'medical_record_number': biobank_id_display_str,
                     'first_name': '*',
-                    'last_name': order.last_name,
+                    'last_name': biobank_id_display_str,
                     'middle_name': '',
                     'birth_date': '3/3/1933',
                     'sex': order.sex,

--- a/tests/api_tests/test_mayolink_client.py
+++ b/tests/api_tests/test_mayolink_client.py
@@ -93,7 +93,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<account>1122</account><number>12345</number>'
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
-            b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
+            b'<first_name>*</first_name><last_name>Z6789</last_name><middle_name />'
             b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
@@ -132,7 +132,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<account>1122</account><number>12345</number>'
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
-            b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
+            b'<first_name>*</first_name><last_name>Z6789</last_name><middle_name />'
             b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
@@ -172,7 +172,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<account>1122</account><number>12345</number>'
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
-            b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
+            b'<first_name>*</first_name><last_name>Z6789</last_name><middle_name />'
             b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
@@ -216,7 +216,7 @@ class MayolinkClientTest(BaseTestCase):
             b'<account>1122</account><number>12345</number>'
             b'<patient>'
             b'<medical_record_number>Z6789</medical_record_number>'
-            b'<first_name>*</first_name><last_name>Smith</last_name><middle_name />'
+            b'<first_name>*</first_name><last_name>Z6789</last_name><middle_name />'
             b'<birth_date>3/3/1933</birth_date><sex>U</sex>'
             b'<address1>1234 Main</address1><address2>Apt C</address2>'
             b'<city>Test</city><state>TN</state><postal_code>11223</postal_code>'
@@ -258,8 +258,7 @@ class MayolinkClientTest(BaseTestCase):
         return MayoLinkOrder(
             collected_datetime_utc=datetime(2020, 12, 3, 17, 9, tzinfo=pytz.utc),
             number='12345',
-            medical_record_number='Z6789',
-            last_name='Smith',
+            biobank_id=6789,
             sex='U',
             address1='1234 Main',
             address2='Apt C',

--- a/tests/dao_tests/test_mail_kit_order_dao.py
+++ b/tests/dao_tests/test_mail_kit_order_dao.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import http.client
 import json
 
@@ -260,13 +261,17 @@ class MailKitOrderDaoTestBase(BaseTestCase):
 
     @mock.patch("rdr_service.dao.mail_kit_order_dao.MayoLinkClient")
     def test_service_unavailable(self, mocked_api):
-        # pylint: disable=unused-argument
-        def raises(*args):
+        def raises(*_):
             raise ServiceUnavailable()
 
         with self.assertRaises(ServiceUnavailable):
             mocked_api.return_value.post.side_effect = raises
-            self.dao.send_order(self.post_delivery, self.participant.participantId)
+            self.dao.send_order(
+                portal_order_id=1234,
+                participant_id=self.participant.participantId,
+                collected_time_utc=datetime.utcnow(),
+                report_notes='testing api failure'
+            )
 
     def build_expected_resource_type_data(self, resource_type):
         """Helper function to build the data we are expecting from the test-data file."""


### PR DESCRIPTION
## Partially Resolves *[DA-2300](https://precisionmedicineinitiative.atlassian.net/browse/DA-2300)*
This sets the code up to be able to reuse some of the logic for sending orders to MayoLINK and storing the data from the response. Most of the code for sending the order and saving the response data required the initial SupplyDelivery request payload, these changes remove that dependency (sending the relevant data instead of the entire JSON). The logic for creating the BiobankOrder and MayolinkCreateOrderHistory were also moved into a service layer class (so it can be reused by a script in a later PR).


## Tests
- [x] unit tests
Existing unit tests should cover refactor


