### PR TITLE
Remove decorator for OutreachV2

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -160,7 +160,6 @@ class GenomicOutreachApiV2(BaseApi):
         self.validate_params()
 
     @auth_required(RDR_AND_PTC)
-    @restrict_to_gae_project(PTC_ALLOWED_ENVIRONMENTS)
     def get(self):
         if not request.args.get('participant_id'):
             self._check_global_args(


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Remove decorator on outreach V2 for production usage.  
** Was initially added to block `GET` requests to the route until the MessageBroker API was live on the production environment for the GEM to GP launch. 

## Tests
- [] unit tests
** current tests should still pass

