### PR TITLE
[PDR-400] Handle less ordered samples than stored samples case.

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1005,6 +1005,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     if bss.biobank_order_id == row.biobank_order_id:
                         bbo_samples.append(_make_sample_dict_from_row(bss=bss, bos=None))
                         stored_count += 1
+            # PDR-400: There are about 20 participants that have less ordered samples than stored samples.
+            elif len(bss_results) > 0 and len(bos_results) < len(bss_results):
+                for bss in bss_results:
+                    if bss.biobank_order_id == row.biobank_order_id:
+                        bbo_samples.append(_make_sample_dict_from_row(bss=bss, bos=bos_results[0]))
+                        stored_count += 1
             else:
                 for ordered_sample in bos_results:
                     # Look for a matching stored sample result based on the biobank order id and test type


### PR DESCRIPTION
## Resolves *[PDR-400](https://precisionmedicineinitiative.atlassian.net/browse/PDR-400)*


## Description of changes/additions
There are about 20 participants that have less Biobank ordered samples than the Biobank reports in the stored sample table. In this case, we want to make sure that we report all of the stored sample records.

## Tests
- [x] unit tests


