### PR TITLE
Add user event metrics to PDR sync 

### DIFF
--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -20,7 +20,7 @@ from rdr_service.model.genomics import GenomicSetMember, GenomicGCValidationMetr
 from rdr_service.offline import genomic_pipeline
 from rdr_service.resource.generators.genomics import genomic_set_batch_update, genomic_set_member_batch_update, \
     genomic_job_run_batch_update, genomic_file_processed_batch_update, genomic_gc_validation_metrics_batch_update, \
-    genomic_manifest_file_batch_update, genomic_manifest_feedback_batch_update
+    genomic_manifest_file_batch_update, genomic_manifest_feedback_batch_update, genomic_user_event_metrics_batch_update
 from rdr_service.services.system_utils import JSONObject
 
 
@@ -487,7 +487,8 @@ class RebuildGenomicTableRecordsApi(BaseGenomicTaskApi):
             'genomic_manifest_feedback': [
                 bq_genomic_manifest_feedback_batch_update,
                 genomic_manifest_feedback_batch_update
-            ]
+            ],
+            'user_event_metrics': [genomic_user_event_metrics_batch_update]
         }
 
         try:

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2866,7 +2866,7 @@ class GemToGpMigrationDao(BaseDao):
             session.bulk_insert_mappings(self.model_type, batch)
 
 
-class UserEventMetricsDao(BaseDao):
+class UserEventMetricsDao(BaseDao, GenomicDaoUtils):
     def __init__(self):
         super(UserEventMetricsDao, self).__init__(
             UserEventMetrics, order_by_ending=['id'])

--- a/tests/genomics_tests/test_genomic_job_controller.py
+++ b/tests/genomics_tests/test_genomic_job_controller.py
@@ -682,6 +682,8 @@ class GenomicJobControllerTest(BaseTestCase):
         self.assertEqual(call_args[0].args[0]['ids'], [obj.id for obj in first_run])
         self.assertEqual(call_args[0].args[1], cloud_task_endpoint)
 
+        participant = self.data_generator.create_database_participant()
+
         gen_set = self.data_generator.create_database_genomic_set(
             genomicSetName=".",
             genomicSetCriteria=".",
@@ -723,6 +725,12 @@ class GenomicJobControllerTest(BaseTestCase):
                     feedbackRecordCount=2
                 )
 
+                self.data_generator.create_database_genomic_user_event_metrics(
+                    participant_id=participant.participantId,
+                    event_name='test_event',
+                    run_id=1,
+                )
+
         # gets new records that were created with last job run from above
         with GenomicJobController(GenomicJob.RECONCILE_PDR_DATA) as controller:
             controller.reconcile_pdr_data()
@@ -734,12 +742,13 @@ class GenomicJobControllerTest(BaseTestCase):
             'genomic_file_processed',
             'genomic_gc_validation_metrics',
             'genomic_manifest_file',
-            'genomic_manifest_feedback'
+            'genomic_manifest_feedback',
+            'user_event_metrics'
         ]
 
-        self.assertEqual(mock_cloud_task.call_count, 8)
+        self.assertEqual(mock_cloud_task.call_count, 9)
         call_args = mock_cloud_task.call_args_list
-        self.assertEqual(len(call_args), 8)
+        self.assertEqual(len(call_args), 9)
 
         mock_tables = set([obj[0][0]['table'] for obj in call_args])
         mock_endpoint = [obj[0][1] for obj in call_args]


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
In the previous PR(s), https://github.com/all-of-us/raw-data-repository/pull/2823 / https://github.com/all-of-us/raw-data-repository/pull/2827, I missed a method that needed to be added to the PDR sync workflow.

## Tests
- [x] unit tests


