### PR TITLE
[DA-2418] Genome type => AW2 Manifests

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1579,6 +1579,7 @@ class GenomicFileValidator:
                 "arrayconcordance",
                 "processingstatus",
                 "notes",
+                "genometype"
             ),
             GENOME_TYPE_ARRAY: (
                 "biobankid",
@@ -1593,6 +1594,7 @@ class GenomicFileValidator:
                 "processingstatus",
                 "notes",
                 "pipelineid",
+                "genometype"
             ),
         }
         self.VALID_GENOME_CENTERS = ('uw', 'bam', 'bcm', 'bi', 'jh', 'rdr')

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -742,10 +742,16 @@ class GenomicPipelineTest(BaseTestCase):
         self._create_stored_samples([(1, 1001), (2, 1002), (3, 1003), (4, 1004)])
 
         with clock.FakeClock(test_date):
-            test_file_name_seq = create_ingestion_test_file('RDR_AoU_SEQ_TestDataManifest_for_aw5.csv',
-                                                                  bucket_name, folder=subfolder)
-            test_file_name_gen = create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest_for_aw5.csv',
-                                                                  bucket_name, folder=subfolder)
+            test_file_name_seq = create_ingestion_test_file(
+                'RDR_AoU_SEQ_TestDataManifest_for_aw5.csv',
+                bucket_name,
+                folder=subfolder
+            )
+            test_file_name_gen = create_ingestion_test_file(
+                'RDR_AoU_GEN_TestDataManifest_for_aw5.csv',
+                bucket_name,
+                folder=subfolder
+            )
 
         task_data_seq = {
             "job": GenomicJob.METRICS_INGESTION,
@@ -4941,9 +4947,11 @@ class GenomicPipelineTest(BaseTestCase):
         aw2_bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
         aw2_subfolder = config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1])
 
-        create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest_3.csv',
-                                         aw2_bucket_name,
-                                         folder=aw2_subfolder)
+        create_ingestion_test_file(
+            'RDR_AoU_GEN_TestDataManifest_3.csv',
+            aw2_bucket_name,
+            folder=aw2_subfolder
+        )
 
         self._update_test_sample_ids()
 
@@ -5098,9 +5106,11 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Continue test for AW2F remainder
         # AW2 data
-        new_aw2 = create_ingestion_test_file('RDR_AoU_GEN_TestDataManifest_4.csv',
-                                                   aw2_bucket_name,
-                                                   folder=aw2_subfolder)
+        new_aw2 = create_ingestion_test_file(
+            'RDR_AoU_GEN_TestDataManifest_4.csv',
+            aw2_bucket_name,
+            folder=aw2_subfolder
+        )
 
         # Ingest AW2 for samples 3 & 4
         # Set up file/JSON
@@ -5443,6 +5453,7 @@ class GenomicPipelineTest(BaseTestCase):
                 self.assertEqual(row["Processing Status"], aw2_raw_records[index].processing_status)
                 self.assertEqual(row["Notes"], aw2_raw_records[index].notes)
                 self.assertEqual(row["Pipeline ID"], aw2_raw_records[index].pipeline_id)
+                self.assertEqual(row["Genome Type"], aw2_raw_records[index].genome_type)
                 index += 1
 
         self.assertEqual(index, len(aw2_raw_records))
@@ -5504,6 +5515,7 @@ class GenomicPipelineTest(BaseTestCase):
                 self.assertEqual(row["Notes"], aw2_raw_records[index].notes)
                 self.assertEqual(row["Sample Source"], aw2_raw_records[index].sample_source)
                 self.assertEqual(row["Mapped Reads pct"], aw2_raw_records[index].mapped_reads_pct)
+                self.assertEqual(row["Genome Type"], aw2_raw_records[index].genome_type)
                 index += 1
 
         self.assertEqual(index, len(aw2_raw_records))

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest.csv
@@ -1,9 +1,9 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample Source,Processing Status,Notes,Pipeline ID
-T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1
-T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T3,1003,T2_1993,10003,10003_R01C03,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T4,1004,T2_1994,10004,10004_R01C04,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T5,1005,T2_1995,10005,10005_R01C05,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T6,1006,T2_1996,10006,10006_R01C06,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T7,1007,T2_1997,10007,10007_R01C07,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T8,1008,T3_1998,10008,10008_R01C08,0.3456789012,True,,Whole Blood,Fail,This sample failed,cidr_egt_1
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample Source,Processing Status,Notes,Pipeline ID,Genome Type
+T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T3,1003,T2_1993,10003,10003_R01C03,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T4,1004,T2_1994,10004,10004_R01C04,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T5,1005,T2_1995,10005,10005_R01C05,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T6,1006,T2_1996,10006,10006_R01C06,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T7,1007,T2_1997,10007,10007_R01C07,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T8,1008,T3_1998,10008,10008_R01C08,0.3456789012,True,,Whole Blood,Fail,This sample failed,cidr_egt_1,aou_array

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifestWithFailure.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifestWithFailure.csv
@@ -1,4 +1,4 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID
-T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,8.67812390,Whole Blood,Pass,This sample passed,cidr_egt_1
-T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T3,1003,T3_1993,10003,10003_R01C02,0.3456789012,True,0.1345,Whole Blood,Abandoned,Bad sample,cidr_egt_1
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID,Genome Type
+T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,8.67812390,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T3,1003,T3_1993,10003,10003_R01C02,0.3456789012,True,0.1345,Whole Blood,Abandoned,Bad sample,cidr_egt_1,aou_array

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest_2.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest_2.csv
@@ -1,4 +1,4 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID
-T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1
-T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T3,1003,T1_1993,10003,10003_R01C03,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID,Genome Type
+T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T3,1003,T1_1993,10003,10003_R01C03,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest_3.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest_3.csv
@@ -1,3 +1,3 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID
-T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1
-T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID,Genome Type
+T1,1001,T1_1991,10001,10001_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T2,1002,T2_1992,10002,10002_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest_4.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest_4.csv
@@ -1,3 +1,3 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID
-T3,1003,T3_1003,10003,10003_R01C03,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
-T4,1004,T4_1004,10004,10004_R01C04,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID,Genome Type
+T3,1003,T3_1003,10003,10003_R01C03,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T4,1004,T4_1004,10004,10004_R01C04,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array

--- a/tests/test-data/RDR_AoU_GEN_TestDataManifest_for_aw5.csv
+++ b/tests/test-data/RDR_AoU_GEN_TestDataManifest_for_aw5.csv
@@ -1,3 +1,3 @@
-Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID
-T3,1003,T3_1991,10003,10003_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1
-T4,1004,T3_1992,10004,10004_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1
+Biobank ID,Sample ID,Biobankid Sampleid,LIMS ID,Chipwellbarcode,Call Rate,Sex Concordance,Contamination,Sample_Source,Processing Status,Notes,Pipeline ID,Genome Type
+T3,1003,T3_1991,10003,10003_R01C01,0.3456789012,True,0.01,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array
+T4,1004,T3_1992,10004,10004_R01C02,0.3456789012,True,0.1345,Whole Blood,Pass,This sample passed,cidr_egt_1,aou_array

--- a/tests/test-data/RDR_AoU_SEQ_TestDataManifest.csv
+++ b/tests/test-data/RDR_AoU_SEQ_TestDataManifest.csv
@@ -1,6 +1,6 @@
-Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,AoU HDR Coverage,Sex Concordance,Contamination,Sample Source,Mapped Reads pct,Sex Ploidy,Aligned Q30 Bases,Array Concordance,Processing Status,Notes
-T2,1002,2_1992,10002,2,2,2,True,3,Whole Blood,88.888888888888,XY,1000000000004,True,Pass,This sample passed
-T3,1003,3_1993,10003,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed
-T4,1004,4_1994,10004,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed
-T5,1005,5_1995,10005,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed
-T6,1006,6_1996,10006,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed
+Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,AoU HDR Coverage,Sex Concordance,Contamination,Sample Source,Mapped Reads pct,Sex Ploidy,Aligned Q30 Bases,Array Concordance,Processing Status,Notes,Genome Type
+T2,1002,2_1992,10002,2,2,2,True,3,Whole Blood,88.888888888888,XY,1000000000004,True,Pass,This sample passed,aou_wgs
+T3,1003,3_1993,10003,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed,aou_wgs
+T4,1004,4_1994,10004,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed,aou_wgs
+T5,1005,5_1995,10005,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed,aou_wgs
+T6,1006,6_1996,10006,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed,aou_wgs

--- a/tests/test-data/RDR_AoU_SEQ_TestDataManifestWithFailure.csv
+++ b/tests/test-data/RDR_AoU_SEQ_TestDataManifestWithFailure.csv
@@ -1,3 +1,3 @@
-Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,AoU HDR Coverage,Contamination,Sample_Source,Mapped_Reads_pct,Sex Concordance,Sex Ploidy,Aligned Q30 Bases,Array Concordance,Processing Status,Notes
-T2,1002,2_1992,10002,2,2,2,3,Whole Blood,88,True,XY,1000000000004,True,Pass,This sample passed
-T3,1003,3_1993,10003,2,2,2,3,Whole Blood,88,True,XY,1000000000004,True,Abandoned,This sample was abandoned
+Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,AoU HDR Coverage,Contamination,Sample_Source,Mapped_Reads_pct,Sex Concordance,Sex Ploidy,Aligned Q30 Bases,Array Concordance,Processing Status,Notes,Genome Type
+T2,1002,2_1992,10002,2,2,2,3,Whole Blood,88,True,XY,1000000000004,True,Pass,This sample passed,aou_wgs
+T3,1003,3_1993,10003,2,2,2,3,Whole Blood,88,True,XY,1000000000004,True,Abandoned,This sample was abandoned,aou_wgs

--- a/tests/test-data/RDR_AoU_SEQ_TestDataManifest_for_aw5.csv
+++ b/tests/test-data/RDR_AoU_SEQ_TestDataManifest_for_aw5.csv
@@ -1,3 +1,3 @@
-Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,AoU HDR Coverage,Sex Concordance,Contamination,Sample_Source,Mapped_Reads_pct,Sex Ploidy,Aligned Q30 Bases,Array Concordance,Processing Status,Notes
-T1,1001,2_1992,10001,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed
-T2,1002,2_1992,10002,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed
+Biobank ID,Sample ID,BiobankidSampleid,LIMS ID,Mean Coverage,Genome Coverage,AoU HDR Coverage,Sex Concordance,Contamination,Sample_Source,Mapped_Reads_pct,Sex Ploidy,Aligned Q30 Bases,Array Concordance,Processing Status,Notes,Genome Type
+T1,1001,2_1992,10001,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed,aou_wgs
+T2,1002,2_1992,10002,2,2,2,True,3,Whole Blood,88,XY,1000000000004,True,Pass,This sample passed,aou_wgs


### PR DESCRIPTION
## Resolves *[ticket DA-2418]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2418

## Description of changes/additions
Adding genome type to AW2 manifests as to add more functionality in being able to better automate sample swap solutions between the GCs and the RDR 

## Tests
- [x] unit tests


