### PR TITLE
[DA-2436] Script for comparing Biobank API data to nightly inventory reports

### DIFF
--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -440,3 +440,20 @@ class BatchManager:
         if len(self._collected_objects) == self._batch_size:
             self._callback(self._collected_objects)
             self._collected_objects = []
+
+
+def is_datetime_equal(first: datetime, second: datetime, difference_allowed_seconds: int = 0) -> bool:
+    """
+    Compares two datetimes to determine whether they're equivalent or not.
+    :param first: First date.
+    :param second: Second date.
+    :param difference_allowed_seconds: The number of seconds that the two dates can be different before they're
+        determined to be different. Defaults to 0.
+    :return: False if they're more than the specified number of seconds apart.
+    """
+    if first is None and second is None:
+        return True
+    elif first is None or second is None:
+        return False
+    else:
+        return abs((first - second).total_seconds()) <= difference_allowed_seconds

--- a/rdr_service/app_util.py
+++ b/rdr_service/app_util.py
@@ -448,7 +448,7 @@ def is_datetime_equal(first: datetime, second: datetime, difference_allowed_seco
     :param first: First date.
     :param second: Second date.
     :param difference_allowed_seconds: The number of seconds that the two dates can be different before they're
-        determined to be different. Defaults to 0.
+        determined to not be a match. Defaults to 0.
     :return: False if they're more than the specified number of seconds apart.
     """
     if first is None and second is None:

--- a/rdr_service/tools/tool_libs/biobank_data_comparison.py
+++ b/rdr_service/tools/tool_libs/biobank_data_comparison.py
@@ -1,10 +1,10 @@
-import argparse
 from dataclasses import dataclass
 from datetime import datetime
-from dateutil.parser import parse
 from protorpc import messages
 from typing import List, Optional
 
+import argparse
+from dateutil.parser import parse
 from sqlalchemy.orm import Session
 
 from rdr_service.app_util import is_datetime_equal
@@ -88,7 +88,7 @@ class BiobankSampleComparator:
                     type=DifferenceType.DISPOSAL_DATE,
                     sample_pair=SamplePair(report_data=self.report_data, api_data=self.api_data)
                 )))
-            if not self.status_field_match():
+            if not self.does_status_field_match():
                 discrepancies_found.append(DifferenceFound(
                     type=DifferenceType.STATUS,
                     sample_pair=SamplePair(report_data=self.report_data, api_data=self.api_data)
@@ -96,7 +96,7 @@ class BiobankSampleComparator:
 
         return discrepancies_found
 
-    def status_field_match(self):
+    def does_status_field_match(self):
         report_status = self.report_data.status
         api_status = self.api_data.status
         api_disposal_reason = self.api_data.disposalReason
@@ -171,6 +171,8 @@ class BiobankDataCheckTool(ToolBase):
             for pair in sample_pairs:
                 comparator = BiobankSampleComparator(pair)
                 differences_found.extend(comparator.get_differences())
+
+        self._print_differences_found(differences=differences_found)
 
     @classmethod
     def _get_report_samples(cls, session: Session, start_date: datetime, end_date: datetime) \

--- a/rdr_service/tools/tool_libs/biobank_data_comparison.py
+++ b/rdr_service/tools/tool_libs/biobank_data_comparison.py
@@ -1,0 +1,241 @@
+import argparse
+from dataclasses import dataclass
+from datetime import datetime
+from dateutil.parser import parse
+from protorpc import messages
+from typing import Collection, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from rdr_service.app_util import is_datetime_equal
+from rdr_service.model.biobank_order import BiobankSpecimen
+from rdr_service.model.biobank_stored_sample import BiobankStoredSample, SampleStatus
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
+
+
+tool_cmd = 'api-check'
+tool_desc = 'Run a comparison of the API data to the Sample Inventory Report data.'
+
+
+class DifferenceType(messages.Enum):
+    MISSING_FROM_SIR = 1
+    MISSING_FROM_API_DATA = 2
+    DISPOSAL_DATE = 3
+    CONFIRMED_DATE = 4
+    BIOBANK_ID = 5
+    TEST_CODE = 6
+    ORDER_ID = 7
+    STATUS = 8
+
+
+@dataclass
+class DifferenceFound:
+    report_data: Optional[BiobankStoredSample]
+    api_data: Optional[BiobankSpecimen]
+    type: int
+
+
+class BiobankSampleComparator:
+    def __init__(self, api_data: Optional[BiobankSpecimen], report_data: Optional[BiobankStoredSample]):
+        self.api_data = api_data
+        self.report_data = report_data
+
+    def get_differences(self) -> List[DifferenceFound]:
+        discrepancies_found: List[DifferenceFound] = []
+
+        if self.report_data is None:
+            discrepancies_found.append(DifferenceFound(
+                type=DifferenceType.MISSING_FROM_SIR,
+                report_data=self.report_data, api_data=self.api_data
+            ))
+        elif self.api_data is None:
+            discrepancies_found.append(DifferenceFound(
+                type=DifferenceType.MISSING_FROM_API_DATA,
+                report_data=self.report_data, api_data=self.api_data
+            ))
+        else:
+            if self.report_data.biobankId != self.api_data.biobankId:
+                discrepancies_found.append(DifferenceFound(
+                    type=DifferenceType.BIOBANK_ID,
+                    report_data=self.report_data, api_data=self.api_data
+                ))
+            if self.report_data.test != self.api_data.testCode:
+                discrepancies_found.append(DifferenceFound(
+                    type=DifferenceType.TEST_CODE,
+                    report_data=self.report_data, api_data=self.api_data
+                ))
+            if self.report_data.biobankOrderIdentifier != self.api_data.orderId:
+                discrepancies_found.append(DifferenceFound(
+                    type=DifferenceType.ORDER_ID,
+                    report_data=self.report_data, api_data=self.api_data
+                ))
+            if not is_datetime_equal(
+                self.report_data.confirmed, self.api_data.confirmedDate, difference_allowed_seconds=3600
+            ):
+                discrepancies_found.append(DifferenceFound(
+                    type=DifferenceType.CONFIRMED_DATE,
+                    report_data=self.report_data, api_data=self.api_data
+                ))
+            if not is_datetime_equal(
+                self.report_data.disposed, self.api_data.disposalDate, difference_allowed_seconds=3600
+            ):
+                discrepancies_found.append((DifferenceFound(
+                    type=DifferenceType.DISPOSAL_DATE,
+                    report_data=self.report_data, api_data=self.api_data
+                )))
+            if not self.status_field_match():
+                discrepancies_found.append(DifferenceFound(
+                    type=DifferenceType.STATUS,
+                    report_data=self.report_data, api_data=self.api_data
+                ))
+
+        return discrepancies_found
+
+    def status_field_match(self):
+        report_status = self.report_data.status
+        api_status = self.api_data.status
+        api_disposal_reason = self.api_data.disposalReason
+
+        if report_status == SampleStatus.CONSUMED and api_status == 'Disposed' and api_disposal_reason == 'Consumed':
+            return True
+        elif report_status == SampleStatus.QNS_FOR_PROCESSING and \
+                api_status == 'Disposed' and api_disposal_reason == 'QNS for Processing':
+            return True
+        elif report_status == SampleStatus.UNKNOWN and (
+            (api_status == 'Disposed' and api_disposal_reason == 'Could Not Process')
+            or (api_status == 'Disposed' and api_disposal_reason == 'Consumed')
+            or (api_status == 'Disposed' and api_disposal_reason == 'Damaged')
+            or (api_status == 'Disposed' and api_disposal_reason == 'No Consent')
+            or (api_status == 'Disposed' and api_disposal_reason == 'Missing')
+            or (api_status == 'In Circulation' and self.report_data.test == '1PXR2')
+        ):
+            return True
+        elif report_status == SampleStatus.RECEIVED and api_status == 'In Circulation':
+            return True
+        # elif report_status == SampleStatus.RECEIVED and api_status == 'Disposed':
+        #     # TODO: make sure this is actually something we want to do
+        #     #  (ignore samples that haven't been updated in a SIR)
+        #     return True
+        elif report_status == SampleStatus.QUALITY_ISSUE and (
+            api_status == 'Disposed' and api_disposal_reason == 'Quality Issue'
+        ):
+            return True
+        elif report_status == SampleStatus.ACCESSINGING_ERROR and (
+            api_status == 'Disposed' and api_disposal_reason == 'Accessioning Error'
+        ):
+            return True
+        elif report_status == SampleStatus.LAB_ACCIDENT and (
+            api_status == 'Disposed' and api_disposal_reason == 'Lab Accident'
+        ):
+            return True
+        elif report_status == SampleStatus.DISPOSED and (
+            api_status == 'Disposed' and api_disposal_reason == 'Disposed'
+        ):
+            return True
+        elif report_status == SampleStatus.SAMPLE_NOT_PROCESSED and (
+            api_status == 'Disposed' and api_disposal_reason == 'Sample Not Processed'
+        ):
+            return True
+        else:
+            return False
+
+
+class BiobankDataCheckTool(ToolBase):
+    def run(self):
+        super(BiobankDataCheckTool, self).run()
+
+        # Parse supplied date range
+        start_date = parse(self.args.start)
+        end_date = parse(self.args.end)
+
+        with self.get_session() as session:
+            stored_samples = self._get_stored_samples(session=session, start_date=start_date, end_date=end_date)
+            specimens_dict = self._get_corresponding_api_data(session=session, stored_samples=stored_samples)
+            discrepancies_found: List[DifferenceFound] = []
+            for sample in stored_samples:
+                specimen = specimens_dict.get(sample.biobankStoredSampleId)
+                discrepancies_found.extend(self.check_specimen_against_sample(specimen=specimen, sample=sample))
+
+            specimen_without_inventory = self._get_specimen_without_inventory_counterpart(
+                session=session,
+                start_date=start_date,
+                end_date=end_date
+            )
+            discrepancies_found.extend([
+                DifferenceFound(api_data=specimen, report_data=None, type=DifferenceType.MISSING_FROM_SIR)
+                for specimen in specimen_without_inventory
+            ])
+
+        for difference in discrepancies_found:
+            specimen = difference.api_data
+            sample = difference.report_data
+            if difference.type == DifferenceType.STATUS:
+                print(f'{specimen.rlimsId} STATUS -- '
+                      f'API: "{specimen.status}, {specimen.disposalReason}" '
+                      f'SIR: "{str(sample.status)}"')
+            elif difference.type == DifferenceType.DISPOSAL_DATE:
+                if difference.report_data.status == SampleStatus.RECEIVED and difference.api_data.status == 'Disposed':
+                    ...
+                else:
+                    print(f'{specimen.rlimsId} DISPOSAL DATE -- API: {specimen.disposalDate} SIR: {sample.disposed}')
+            elif difference.type == DifferenceType.CONFIRMED_DATE:
+                print(f'{specimen.rlimsId} CONFIRMED DATE -- API: {specimen.confirmedDate} SIR: {sample.confirmed}')
+            else:
+                sample_id = sample.biobankStoredSampleId if sample else specimen.rlimsId
+                print(f'{sample_id} -- {str(difference.type)}')
+
+        # TODO: samples that are 1SAL2 and disposed on the API but still with a status of 1 on the SIR...
+        #       these wouldn't get updated on the SIR when the biobank gets it 6weeks later
+
+    @classmethod
+    def _get_stored_samples(cls, session: Session, start_date: datetime, end_date: datetime) \
+            -> Collection[BiobankStoredSample]:
+        return list(
+            session.query(BiobankStoredSample).filter(
+                BiobankStoredSample.rdrCreated.between(start_date, end_date)
+            )
+        )
+
+    @classmethod
+    def _get_specimen_without_inventory_counterpart(cls, session: Session, start_date: datetime, end_date: datetime) \
+            -> Collection[BiobankSpecimen]:
+        return list(
+            session.query(BiobankSpecimen).outerjoin(
+                BiobankStoredSample,
+                BiobankStoredSample.biobankStoredSampleId == BiobankSpecimen.rlimsId
+            ).filter(
+                BiobankSpecimen.created.between(start_date, end_date),
+                BiobankStoredSample.biobankStoredSampleId.is_(None)
+            )
+        )
+
+    @classmethod
+    def _get_corresponding_api_data(cls, session: Session, stored_samples: Collection[BiobankStoredSample])\
+            -> Dict[str, BiobankSpecimen]:
+        """
+        Get the corresponding parent specimen for each stored sample given.
+        Return the specimens in a dict that uses the provided rlimsid for a specimen as the key, and the
+        matching specimen object as the value.
+        """
+        stored_sample_ids = [specimen.biobankStoredSampleId for specimen in stored_samples]
+        specimen_dict = {sample_id: None for sample_id in stored_sample_ids}
+
+        # Fill in the dictionary with the stored samples we can retrieve from the database
+        stored_samples: Collection[BiobankSpecimen] = session.query(
+            BiobankSpecimen
+        ).filter(
+            BiobankSpecimen.rlimsId.in_(stored_sample_ids)
+        )
+        for specimen in stored_samples:
+            specimen_dict[specimen.rlimsId] = specimen
+
+        return specimen_dict
+
+
+def add_additional_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument('--start', required=True)
+    parser.add_argument('--end', required=True)
+
+
+def run():
+    cli_run(tool_cmd, tool_desc, BiobankDataCheckTool, add_additional_arguments)

--- a/tests/tool_tests/test_biobank_data_comparison.py
+++ b/tests/tool_tests/test_biobank_data_comparison.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timedelta
+
+from rdr_service.model.biobank_order import BiobankSpecimen
+from rdr_service.model.biobank_stored_sample import BiobankStoredSample, SampleStatus
+from rdr_service.tools.tool_libs.biobank_data_comparison import BiobankSampleComparator, DifferenceType
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class BiobankDataComparisonTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(BiobankDataComparisonTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs):
+        super(BiobankDataComparisonTest, self).setUp(*args, **kwargs)
+
+        biobank_id = 123123123
+        test_code = '1U25'
+        order_id = 'KIT-7890'
+        confirmed_time = datetime(2017, 11, 5, 18, 14)
+        disposed_time = datetime(2017, 11, 7, 7, 0)
+
+        self.api_data = BiobankSpecimen(
+            biobankId=biobank_id,
+            testCode=test_code,
+            orderId=order_id,
+            confirmedDate=confirmed_time,
+            disposalDate=disposed_time,
+            status='Disposed',
+            disposalReason='Consumed'
+        )
+        self.report_data = BiobankStoredSample(
+            biobankId=biobank_id,
+            test=test_code,
+            biobankOrderIdentifier=order_id,
+            confirmed=confirmed_time,
+            disposed=disposed_time,
+            status=SampleStatus.CONSUMED
+        )
+        self.comparator = BiobankSampleComparator(api_data=self.api_data, report_data=self.report_data)
+
+    def test_no_difference_in_defaults(self):
+        """No discrepancies should be found in the default data"""
+        self.assertEqual([], self.comparator.get_differences())
+
+    def test_biobank_id_comparison(self):
+        """Test finding difference in biobank id"""
+        self.report_data.biobankId = 1122
+
+        differences = self.comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.BIOBANK_ID, differences[0].type)
+
+    def test_code_comparison(self):
+        """Check that a difference of test codes is found"""
+        self.api_data.testCode = '5bob'
+
+        differences = self.comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.TEST_CODE, differences[0].type)
+
+    def test_order_id_comparison(self):
+        """Test that a difference of order ids is found"""
+        self.api_data.orderId = '7878787'
+
+        differences = self.comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.ORDER_ID, differences[0].type)
+
+    def test_confirmed_date_comparison(self):
+        # Check that the confirmed dates can be slightly different
+        self.report_data.confirmed = self.api_data.confirmedDate + timedelta(minutes=3)
+        self.assertEqual([], self.comparator.get_differences())
+
+        # Check that a few hours difference is flagged
+        self.report_data.confirmed = self.api_data.confirmedDate + timedelta(hours=3)
+        differences = self.comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.CONFIRMED_DATE, differences[0].type)
+
+    def test_disposed_date_comparison(self):
+        self.report_data.disposed = self.api_data.disposalDate + timedelta(days=3)
+        differences = self.comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.DISPOSAL_DATE, differences[0].type)
+
+    def test_missing_from_report(self):
+        comparator = BiobankSampleComparator(report_data=None, api_data=self.api_data)
+        differences = comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.MISSING_FROM_SIR, differences[0].type)
+
+    def test_missing_from_api(self):
+        comparator = BiobankSampleComparator(report_data=self.report_data, api_data=None)
+        differences = comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.MISSING_FROM_API_DATA, differences[0].type)
+
+    def test_status_difference(self):
+        """Check that a difference in status is found"""
+        self.report_data.status = SampleStatus.ACCESSINGING_ERROR
+
+        differences = self.comparator.get_differences()
+        self.assertEqual(1, len(differences))
+        self.assertEqual(DifferenceType.STATUS, differences[0].type)
+
+    def test_status_differences_allowed(self):
+        # 1PXR2 samples show as "Unknown" from the reports, but are in circulation according to the API
+        self.api_data.testCode = self.report_data.test = '1PXR2'
+        self.report_data.status = SampleStatus.UNKNOWN
+        self.api_data.status = 'In Circulation'
+        self.assertEqual([], self.comparator.get_differences())

--- a/tests/tool_tests/test_biobank_data_comparison.py
+++ b/tests/tool_tests/test_biobank_data_comparison.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from rdr_service.model.biobank_order import BiobankSpecimen
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample, SampleStatus
-from rdr_service.tools.tool_libs.biobank_data_comparison import BiobankSampleComparator, DifferenceType
+from rdr_service.tools.tool_libs.biobank_data_comparison import BiobankSampleComparator, DifferenceType, SamplePair
 from tests.helpers.unittest_base import BaseTestCase
 
 
@@ -37,7 +37,7 @@ class BiobankDataComparisonTest(BaseTestCase):
             disposed=disposed_time,
             status=SampleStatus.CONSUMED
         )
-        self.comparator = BiobankSampleComparator(api_data=self.api_data, report_data=self.report_data)
+        self.comparator = BiobankSampleComparator(SamplePair(api_data=self.api_data, report_data=self.report_data))
 
     def test_no_difference_in_defaults(self):
         """No discrepancies should be found in the default data"""
@@ -85,13 +85,13 @@ class BiobankDataComparisonTest(BaseTestCase):
         self.assertEqual(DifferenceType.DISPOSAL_DATE, differences[0].type)
 
     def test_missing_from_report(self):
-        comparator = BiobankSampleComparator(report_data=None, api_data=self.api_data)
+        comparator = BiobankSampleComparator(SamplePair(report_data=None, api_data=self.api_data))
         differences = comparator.get_differences()
         self.assertEqual(1, len(differences))
         self.assertEqual(DifferenceType.MISSING_FROM_SIR, differences[0].type)
 
     def test_missing_from_api(self):
-        comparator = BiobankSampleComparator(report_data=self.report_data, api_data=None)
+        comparator = BiobankSampleComparator(SamplePair(report_data=self.report_data, api_data=None))
         differences = comparator.get_differences()
         self.assertEqual(1, len(differences))
         self.assertEqual(DifferenceType.MISSING_FROM_API_DATA, differences[0].type)


### PR DESCRIPTION
## Partially Resolves *[DA-2436](https://precisionmedicineinitiative.atlassian.net/browse/DA-2436)*
The biobank sends us data on samples in two ways: nightly Sample Inventory Reports, and through the specimen API. This PR creates a script that compares the data and reports on differences found between the data we have through each process for a given sample.


## Tests
- [x] unit tests


