### PR TITLE
GP user event metrics job fixes

### DIFF
--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -94,6 +94,7 @@
     "missing_files_resolve_workflow": 1,
     "reconcile_gc_data_file_to_table_workflow": 1,
     "reconcile_pdr_data": 1,
+    "genomic_delete_old_gp_user_events": 1,
     "reconcile_raw_to_aw1_ingested_workflow": 1,
     "reconcile_raw_to_aw2_ingested_workflow": 1,
     "members_state_resolved_workflow": 1,

--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -84,4 +84,9 @@ cron:
   timezone: America/New_York
   schedule: every 6 hours
   target: offline
+- description: Genomic Delete Old GP User Events
+  url: /offline/GenomicDeleteOldGPUserEvents
+  timezone: America/New_York
+  schedule: every day 13:30
+  target: offline
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1264,6 +1264,9 @@ class GenomicJobController:
                                                     job_run_id=self.job_run.id,
                                                     module=module)
 
+    def delete_old_gp_user_event_metrics(self, days=7):
+        self.event_dao.delete_old_events(days=days)
+
     def run_general_ingestion_workflow(self):
         """
         Ingests A single genomic file

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -110,6 +110,7 @@ class GenomicJob(messages.Enum):
     LOAD_AW3_TO_RAW_TABLE = 53
     LOAD_AW4_TO_RAW_TABLE = 54
     RECONCILE_PDR_DATA = 55
+    DELETE_OLD_GP_USER_EVENT_METRICS = 56
 
     # Data Quality Pipeline Jobs
     # Naming matters for reports (timeframe_level_report_target)

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -302,6 +302,11 @@ def reconcile_informing_loop_responses():
         controller.reconcile_informing_loop_responses()
 
 
+def delete_old_gp_user_events(days=7):
+    with GenomicJobController(GenomicJob.DELETE_OLD_GP_USER_EVENT_METRICS) as controller:
+        controller.delete_old_gp_user_event_metrics(days=days)
+
+
 def reconcile_gc_data_file_to_table():
     with GenomicJobController(GenomicJob.RECONCILE_GC_DATA_FILE_TO_TABLE) as controller:
         controller.reconcile_gc_data_file_to_table()

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -662,6 +662,13 @@ def genomic_reconcile_informing_loop_responses():
 @run_genomic_cron_job('reconcile_pdr_data')
 def genomic_reconcile_pdr_data():
     genomic_pipeline.reconcile_pdr_data()
+    return '{"success": "true"}'\
+
+
+@app_util.auth_required_cron
+@run_genomic_cron_job('genomic_delete_old_gp_user_events')
+def genomic_delete_old_gp_user_events():
+    genomic_pipeline.delete_old_gp_user_events(days=7)
     return '{"success": "true"}'
 
 
@@ -1003,6 +1010,11 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicDataPdrReconcile",
         endpoint="genomic_data_pdr_reconcile",
         view_func=genomic_reconcile_pdr_data, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicDeleteOldGPUserEvents",
+        endpoint="genomic_delete_old_gp_user_events",
+        view_func=genomic_delete_old_gp_user_events, methods=["GET"]
     )
     # END Genomic Pipeline Jobs
 

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -662,7 +662,7 @@ def genomic_reconcile_informing_loop_responses():
 @run_genomic_cron_job('reconcile_pdr_data')
 def genomic_reconcile_pdr_data():
     genomic_pipeline.reconcile_pdr_data()
-    return '{"success": "true"}'\
+    return '{"success": "true"}'
 
 
 @app_util.auth_required_cron

--- a/rdr_service/storage.py
+++ b/rdr_service/storage.py
@@ -240,7 +240,7 @@ class GoogleCloudStorageFile(ContextDecorator):
     def __iter__(self):
         return self.iter_lines()
 
-    def iter_chunks(self, chunk_size=1024):
+    def iter_chunks(self, chunk_size=26214400):
         i = 0
         while True:
             try:

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -6439,6 +6439,7 @@ class GenomicPipelineTest(BaseTestCase):
         )
 
         # Run reconcile job
+
         genomic_pipeline.reconcile_informing_loop_responses()
 
         # Test data ingested correctly
@@ -6451,5 +6452,16 @@ class GenomicPipelineTest(BaseTestCase):
         updated_events = event_dao.get_all_event_objects_for_pid_list(pid_list, module='gem')
         for event in updated_events:
             self.assertEqual(2, event.reconcile_job_run_id)
+
+        old_event = event_dao.get(1)
+
+        old_event.created = old_event.created - datetime.timedelta(days=8)
+        with event_dao.session() as session:
+            session.merge(old_event)
+
+        genomic_pipeline.delete_old_gp_user_events()
+
+        all_events = event_dao.get_all()
+        self.assertEqual(17, len(all_events))
 
 


### PR DESCRIPTION
## Resolves *[DA-2441](https://precisionmedicineinitiative.atlassian.net/browse/DA-2441)*


## Description of changes/additions
Color's user event metrics file is larger than expected. Google App Engine is terminating the ingestion job before it completes. This PR expands the `storage.py` default chunk size to 25 MB, which will allow for faster file reads and prevent similar issues in the future. 
Color's file is also cumulative, which is leading to data duplication. Since the RDR is ingesting the entire file every time, a new daily job was created to remove data from `user_event_metrics` that is older than 7 days.

## Tests
- [x] unit tests


