### PR TITLE
Edits to PDR reconcile

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -55,7 +55,7 @@ from rdr_service.genomic.genomic_mappings import genome_type_to_aw1_aw2_file_pre
 
 class GenomicDaoUtils:
 
-    def get_last_updated_records(self, from_date):
+    def get_last_updated_records(self, from_date, _ids=True):
         from_date = from_date.replace(microsecond=0)
 
         if not hasattr(self.model_type, 'created') or \
@@ -63,11 +63,15 @@ class GenomicDaoUtils:
             return []
 
         with self.session() as session:
-            return session.query(
-                self.model_type
-            ).filter(
+            if _ids:
+                records = session.query(self.model_type.id)
+            else:
+                records = session.query(self.model_type)
+
+            records = records.filter(
                 self.model_type.modified >= from_date
-            ).all()
+            )
+            return records.all()
 
 
 class GenomicSetDao(UpdatableDao, GenomicDaoUtils):

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -51,6 +51,7 @@ from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.query import FieldFilter, Operator, OrderBy, Query
 from rdr_service.genomic.genomic_mappings import genome_type_to_aw1_aw2_file_prefix as genome_type_map
+from rdr_service.resource.generators.genomics import genomic_user_event_metrics_batch_update
 
 
 class GenomicDaoUtils:
@@ -2941,6 +2942,8 @@ class UserEventMetricsDao(BaseDao, GenomicDaoUtils):
         } for i in id_list]
         with self.session() as session:
             session.bulk_update_mappings(UserEventMetrics, update_mappings)
+        # Batch update PDR resource records.
+        genomic_user_event_metrics_batch_update(id_list)
 
     def get_all_event_ids_for_pid_list(self, pid_list, module=None):
         with self.session() as session:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -22,6 +22,7 @@ from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import Code
 from rdr_service.model.participant_summary import ParticipantRaceAnswers, ParticipantSummary
 from rdr_service.model.config_utils import get_biobank_id_prefix
+from rdr_service.resource.generators.genomics import genomic_user_event_metrics_batch_update
 from rdr_service.services.jira_utils import JiraTicketHandler
 from rdr_service.api_util import (
     open_cloud_file,
@@ -995,6 +996,8 @@ class GenomicFileIngester:
                     # Use session add_all() so we can get the newly created primary key id values back.
                     session.add_all(batch)
                     session.commit()
+                    # Batch update PDR resource records.
+                    genomic_user_event_metrics_batch_update([r.id for r in batch])
 
                 item_count = 0
                 batch.clear()
@@ -1004,6 +1007,8 @@ class GenomicFileIngester:
                 # Use session add_all() so we can get the newly created primary key id values back.
                 session.add_all(batch)
                 session.commit()
+                # Batch update PDR resource records.
+                genomic_user_event_metrics_batch_update([r.id for r in batch])
 
         return GenomicSubProcessResult.SUCCESS
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -751,8 +751,7 @@ class GenomicJobController:
             self.file_processed_dao,
             self.metrics_dao,
             self.manifest_file_dao,
-            self.manifest_feedback_dao,
-            self.event_dao
+            self.manifest_feedback_dao
         ]
 
         for dao in reconcile_daos:

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -760,11 +760,11 @@ class GenomicJobController:
             if not hasattr(dao, 'get_last_updated_records'):
                 continue
 
-            records = dao.get_last_updated_records(from_date=last_job_run)
-            if not records:
+            record_ids = dao.get_last_updated_records(from_date=last_job_run)
+            if not record_ids:
                 continue
 
-            batch_ids = [obj.id for obj in records]
+            batch_ids = [obj.id for obj in record_ids]
 
             logging.info(f'Sending {table_name} {len(batch_ids)} records for rebuild cloud task.')
 

--- a/tests/genomics_tests/test_genomic_job_controller.py
+++ b/tests/genomics_tests/test_genomic_job_controller.py
@@ -743,12 +743,11 @@ class GenomicJobControllerTest(BaseTestCase):
             'genomic_gc_validation_metrics',
             'genomic_manifest_file',
             'genomic_manifest_feedback',
-            'user_event_metrics'
         ]
 
-        self.assertEqual(mock_cloud_task.call_count, 9)
+        self.assertEqual(mock_cloud_task.call_count, 8)
         call_args = mock_cloud_task.call_args_list
-        self.assertEqual(len(call_args), 9)
+        self.assertEqual(len(call_args), 8)
 
         mock_tables = set([obj[0][0]['table'] for obj in call_args])
         mock_endpoint = [obj[0][1] for obj in call_args]


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
In the genomic to PDR rebuild jobs, there might be memory limitations in requesting the entire object, especially in dealing with the user metric files daily drops, since there will be > 400k records created daily. Removed PDR metric rebuild job from cloud task workflow, and added method back into the genomic pipeline as it was initially in this PR https://github.com/all-of-us/raw-data-repository/pull/2785. Also edited `get_last_updated_records` to only supply ids in return list as to mitigate memory size for large record sets.

## Tests
- [x] unit tests


