### PR TITLE
Filter via config for array file(s) reconcile 

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -90,6 +90,7 @@ GENOMIC_MAX_NUM_INGEST = "genomic_max_num_ingest"
 GENOMIC_DAILY_VALIDATION_EMAILS = "genomic_daily_validation_emails"
 GENOMIC_MEMBER_BLOCKLISTS = "genomic_set_member_blocklists"
 GENOMIC_INGESTIONS = "genomic_ingestions"
+GENOMIC_PIPELINE_IDS = "genomic_pipeline_ids"
 DRC_BROAD_BUCKET_NAME = "drc_broad_bucket_name"
 DRC_BROAD_AW4_SUBFOLDERS = ("aw4_array_subfolder_name", "aw4_wgs_subfolder_name")
 BIOBANK_AW2F_SUBFOLDER = "aw2f_manifests"

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -148,5 +148,8 @@
     "aw4_wgs_manifest": 1,
     "aw5_array_manifest": 1,
     "aw5_wgs_manifest": 1
+  },
+  "genomic_pipeline_ids": {
+    "aou_array": ["cidr_egt_1"]
   }
 }

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -148,8 +148,5 @@
     "aw4_wgs_manifest": 1,
     "aw5_array_manifest": 1,
     "aw5_wgs_manifest": 1
-  },
-  "genomic_pipeline_ids": {
-    "aou_array": ["cidr_egt_1"]
   }
 }


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
With the new array reprocessing workflow we need to be able to filter on the newest `pipeline_id` that is sent for targeting the newest files only to reconcile.

## Tests
- [x] unit tests


