### PR TITLE
[PDR-658] Remove Employment_EmploymentStatus check from UBR calculation

### DIFF
--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -187,14 +187,15 @@ class ParticipantUBRCalculator:
     def ubr_disability(answers: dict):
         """
         Calculate the disability UBR value.
-        :param answers: Dict with keys and answer codes for 'Employment_EmploymentStatus', 'Disability_Blind',
+        :param answers: Dict with keys and answer codes for 'Disability_Blind',
                         'Disability_WalkingClimbing', 'Disability_DressingBathing', 'Disability_ErrandsAlone',
                         'Disability_Deaf' and 'Disability_DifficultyConcentrating' from "TheBasics" survey.
         :return: UBRValueEnum
         """
         if answers:
-            if answers.get('Employment_EmploymentStatus', None) == 'EmploymentStatus_UnableToWork' or \
-                    answers.get('Disability_Blind', None) == 'Blind_Yes' or \
+            # PDR-658:  The Employment_EmploymentStatus/EmploymentStatus_UnableToWork answer check was removed from the
+            # UBR Disability calculations per program decision
+            if answers.get('Disability_Blind', None) == 'Blind_Yes' or \
                     answers.get('Disability_WalkingClimbing', None) == 'WalkingClimbing_Yes' or \
                     answers.get('Disability_DressingBathing', None) == 'DressingBathing_Yes' or \
                     answers.get('Disability_ErrandsAlone', None) == 'ErrandsAlone_Yes' or \
@@ -203,9 +204,8 @@ class ParticipantUBRCalculator:
                 return UBRValueEnum.UBR
         # Check and see if all question answers are either Null or PMI_Skip.
         null_skip = True
-        for k in ['Employment_EmploymentStatus', 'Disability_Blind',
-                        'Disability_WalkingClimbing', 'Disability_DressingBathing', 'Disability_ErrandsAlone',
-                        'Disability_Deaf' and 'Disability_DifficultyConcentrating']:
+        for k in [ 'Disability_Blind', 'Disability_WalkingClimbing', 'Disability_DressingBathing',
+                   'Disability_ErrandsAlone', 'Disability_Deaf' and 'Disability_DifficultyConcentrating']:
             if answers.get(k, None) not in (None, 'PMI_Skip'):
                 null_skip = False
                 break

--- a/tests/resource_tests/calculator_tests/test_ubr_calculator.py
+++ b/tests/resource_tests/calculator_tests/test_ubr_calculator.py
@@ -300,6 +300,11 @@ class UBRCalculatorTest(BaseTestCase):
         # Bad or unknown value will default to NullSkip
         self.assertEqual(self.ubr.ubr_disability({'ABC': 123}), UBRValueEnum.NotAnswer_Skip)
 
+        # PDR-658:  Test that EmploymentStatus_UnableToWork no longer results in a UBR result
+        values = self.disability_answers
+        values['Employment_EmploymentStatus'] = 'EmploymentStatus_UnableToWork'
+        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.RBR)
+
     def test_ubr_age_at_consent(self):
         """
         UBR Calculator Test - Age at Consent


### PR DESCRIPTION
## Resolves *[PDR-658](https://precisionmedicineinitiative.atlassian.net/browse/PDR-658)*


## Description of changes/additions
Per program decision, the UBR Disability designation will no longer include a check for Employment_EmploymentStatus answers

## Tests
- [x] unit tests - updated


