### PR TITLE
Generating biobank withdrawal report with two digit months

### DIFF
--- a/rdr_service/tools/tool_libs/biobank_report.py
+++ b/rdr_service/tools/tool_libs/biobank_report.py
@@ -109,7 +109,7 @@ class BiobankReportTool(ToolBase):
     @classmethod
     def _get_default_withdrawal_name(cls):
         one_month_ago = clock.CLOCK.now() - timedelta(weeks=4)
-        return f'report_{one_month_ago.year}-{one_month_ago.month}_withdrawals.csv'
+        return f'report_{one_month_ago.year}-{str(one_month_ago.month).zfill(2)}_withdrawals.csv'
 
 
 def add_additional_arguments(parser: argparse.ArgumentParser):

--- a/tests/tool_tests/test_biobank_report_tool.py
+++ b/tests/tool_tests/test_biobank_report_tool.py
@@ -141,7 +141,7 @@ class BiobankReportToolTest(ToolTestMixin, BaseTestCase):
             # Check file name generated when generating report at the start of the month
             with clock.FakeClock(datetime(2021, 3, 1)):
                 self.run_withdrawal_report()
-                open_mock.assert_called_with('report_2021-2_withdrawals.csv', 'w')
+                open_mock.assert_called_with('report_2021-02_withdrawals.csv', 'w')
                 get_query_mock.assert_called_with(start_date=datetime(2021, 1, 27))
 
             # Check file name generated when generating report later in the month
@@ -174,7 +174,7 @@ class BiobankReportToolTest(ToolTestMixin, BaseTestCase):
             ])
             storage_instance_mock.upload_from_file.assert_called_with(
                 source_file='test_file.txt',
-                path='test_bucket_name/reconciliation/report_2020-4_withdrawals.csv'
+                path='test_bucket_name/reconciliation/report_2020-04_withdrawals.csv'
             )
 
     def _assert_participant_in_report_rows(self, participant: Participant, rows, withdrawal_date_str,


### PR DESCRIPTION
## Resolves *no ticket*
The Biobank didn't automatically import the January withdrawal report because it didn't have a zero-padded digit for the month. This updates the script to have it use two digits in the month part of the file name.


## Tests
- [x] unit tests


