### PR TITLE
[DA-2421]  Retry AW1/AW2 manifest ingestions with deltas

### DIFF
--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -123,10 +123,10 @@ class IngestAW1ManifestTaskApi(BaseGenomicTaskApi):
             # Set up file/JSON
             task_data = {
                 "job": job,
-                "bucket": self.data["bucket_name"],
+                "bucket": self.data.get('bucket_name'),
                 "file_data": {
                     "create_feedback_record": create_fb,
-                    "upload_date": self.data["upload_date"],
+                    "upload_date": self.data.get("upload_date"),
                     "manifest_type": manifest_type,
                     "file_path": file_path,
                 }
@@ -155,10 +155,10 @@ class IngestAW2ManifestTaskApi(BaseGenomicTaskApi):
             # Set up file/JSON
             task_data = {
                 "job": GenomicJob.METRICS_INGESTION,
-                "bucket": self.data["bucket_name"],
+                "bucket": self.data.get('bucket_name'),
                 "file_data": {
                     "create_feedback_record": False,
-                    "upload_date": self.data["upload_date"],
+                    "upload_date": self.data.get("upload_date"),
                     "manifest_type": GenomicManifestTypes.AW2,
                     "file_path": file_path,
                 }

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -96,6 +96,7 @@
     "missing_files_resolve_workflow": 1,
     "reconcile_gc_data_file_to_table_workflow": 1,
     "reconcile_pdr_data": 1,
+    "retry_manifest_ingestion_failures": 1,
     "genomic_delete_old_gp_user_events": 1,
     "reconcile_raw_to_aw1_ingested_workflow": 1,
     "reconcile_raw_to_aw2_ingested_workflow": 1,

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -209,3 +209,8 @@ cron:
   timezone: America/New_York
   schedule: every day 04:00
   target: offline
+- description: Genomic Retry Manifest Ingestion Failures
+  url: /offline/GenomicRetryManifestIngestions
+  timezone: America/New_York
+  schedule: every day 02:00
+  target: offline

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -727,7 +727,7 @@ class GenomicQueryClass:
     def dq_report_ingestions_summary(from_date):
         query_sql = """
                 # AW1 Ingestions
-                SELECT count(distinct raw.id) record_count
+                SELECT count(distinct raw.id) as record_count
                     , count(distinct m.id) as ingested_count
                     , count(distinct i.id) as incident_count
                     , "aw1" as file_type
@@ -742,20 +742,20 @@ class GenomicQueryClass:
                             ) = "GEN"
                         THEN "aou_array"
                       END AS genome_type
-                    , raw.file_path
+                    ,raw.file_path
                 FROM genomic_aw1_raw raw
                     LEFT JOIN genomic_manifest_file mf ON mf.file_path = raw.file_path
                     LEFT JOIN genomic_file_processed f ON f.genomic_manifest_file_id = mf.id
                     LEFT JOIN genomic_set_member m ON m.aw1_file_processed_id = f.id
                     LEFT JOIN genomic_incident i ON i.source_file_processed_id = f.id
                 WHERE TRUE
-                    AND raw.created >=  :from_date
+                    AND raw.created >= :from_date
                     AND raw.ignore_flag = 0
                     AND raw.biobank_id <> ""
                 GROUP BY raw.file_path, file_type
                 UNION
                 # AW2 Ingestions
-                SELECT count(distinct raw.id) record_count
+                SELECT count(distinct raw.id) as record_count
                     , count(distinct m.id) as ingested_count
                     , count(distinct i.id) as incident_count
                     , "aw2" as file_type

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -2,7 +2,7 @@
 This module tracks and validates the status of Genomics Pipeline Subprocesses.
 """
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytz
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
@@ -773,6 +773,40 @@ class GenomicJobController:
             }, 'rebuild_genomic_table_records_task')
 
         self.job_result = GenomicSubProcessResult.SUCCESS
+
+    def retry_manifest_ingestions(self, from_days=1):
+        from_date = clock.CLOCK.now() - timedelta(days=from_days)
+        from_date = from_date.replace(microsecond=0)
+        results_found = False
+
+        ingestion_task_api_map = {
+            GenomicJob.AW1_MANIFEST: 'ingest_aw1_manifest_task',
+            GenomicJob.METRICS_INGESTION: 'ingest_aw2_manifest_task'
+        }
+
+        try:
+            for ingestion_type, cloud_task in ingestion_task_api_map.items():
+                results = self.file_processed_dao.get_ingestion_deltas_from_date(
+                    from_date=from_date,
+                    ingestion_type=ingestion_type)
+
+                for result in results:
+                    if result.raw_record_count > result.ingested_count:
+                        results_found = True
+                        logging.info(f'Sending {result.file_type}: {result.file_path} '
+                                     f'to cloud task ingestion for deltas')
+
+                        self.execute_cloud_task({
+                            'bucket_name': result.file_path.split('/')[0],
+                            'upload_date': datetime.utcnow(),
+                            'file_path': result.file_path
+                        }, cloud_task)
+
+            self.job_result = GenomicSubProcessResult.NO_FILES if not results_found else \
+                GenomicSubProcessResult.SUCCESS
+
+        except RuntimeError:
+            self.job_result = GenomicSubProcessResult.ERROR
 
     @staticmethod
     def set_aw1_attributes_from_raw(rec: tuple):

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -111,6 +111,7 @@ class GenomicJob(messages.Enum):
     LOAD_AW4_TO_RAW_TABLE = 54
     RECONCILE_PDR_DATA = 55
     DELETE_OLD_GP_USER_EVENT_METRICS = 56
+    RETRY_MANIFEST_INGESTIONS = 57
 
     # Data Quality Pipeline Jobs
     # Naming matters for reports (timeframe_level_report_target)

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -367,6 +367,11 @@ def reconcile_pdr_data():
         controller.reconcile_pdr_data()
 
 
+def retry_manifest_ingestions():
+    with GenomicJobController(GenomicJob.RETRY_MANIFEST_INGESTIONS) as controller:
+        controller.retry_manifest_ingestions()
+
+
 def create_aw2f_manifest(feedback_record):
     with GenomicJobController(GenomicJob.AW2F_MANIFEST,
                               bucket_name=config.BIOBANK_SAMPLES_BUCKET_NAME,
@@ -440,7 +445,6 @@ def dispatch_genomic_job_from_task(_task_data: JSONObject, project_id=None):
 
             controller.bucket_name = _task_data.bucket
             file_name = '/'.join(_task_data.file_data.file_path.split('/')[1:])
-
             controller.ingest_specific_manifest(file_name)
 
         if _task_data.job == GenomicJob.AW1_MANIFEST:

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -681,6 +681,12 @@ def genomic_delete_old_gp_user_events():
     return '{"success": "true"}'
 
 
+@run_genomic_cron_job('retry_manifest_ingestion_failures')
+def genomic_retry_manifest_ingestion_failures():
+    # genomic_pipeline
+    pass
+
+
 @app_util.auth_required_cron
 @run_genomic_cron_job('daily_ingestion_summary')
 def genomic_data_quality_daily_ingestion_summary():
@@ -1036,6 +1042,12 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicDeleteOldGPUserEvents",
         endpoint="genomic_delete_old_gp_user_events",
         view_func=genomic_delete_old_gp_user_events, methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicRetryManifestIngestions",
+        endpoint="retry_manifest_ingestion_failures",
+        view_func=genomic_retry_manifest_ingestion_failures,
+        methods=["GET"]
     )
     # END Genomic Pipeline Jobs
 

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -668,6 +668,13 @@ def genomic_reconcile_informing_loop_responses():
 
 
 @app_util.auth_required_cron
+@run_genomic_cron_job('retry_manifest_ingestion_failures')
+def genomic_retry_manifest_ingestion_failures():
+    genomic_pipeline.retry_manifest_ingestions()
+    return '{"success": "true"}'
+
+
+@app_util.auth_required_cron
 @run_genomic_cron_job('reconcile_pdr_data')
 def genomic_reconcile_pdr_data():
     genomic_pipeline.reconcile_pdr_data()
@@ -679,12 +686,6 @@ def genomic_reconcile_pdr_data():
 def genomic_delete_old_gp_user_events():
     genomic_pipeline.delete_old_gp_user_events(days=7)
     return '{"success": "true"}'
-
-
-@run_genomic_cron_job('retry_manifest_ingestion_failures')
-def genomic_retry_manifest_ingestion_failures():
-    # genomic_pipeline
-    pass
 
 
 @app_util.auth_required_cron


### PR DESCRIPTION
## Resolves *[ticket DA-2421]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2421

## Description of changes/additions
Having issues sometimes with large manifest ingestions having deltas when compared to the RAW tables, so to mitigate this we manually re-ingest the manifests. This job checks for previous days' ingestion deltas, for AW1 & AW2,  and automatically sends manifest to cloud task ingestion.

## Tests
- [x] unit tests


