### PR TITLE
Add str fields to aw1/aw2 state update

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -760,6 +760,7 @@ class GenomicFileIngester:
         # Only update the member's genomicWorkflowState if it was AW0
         if member.genomicWorkflowState == GenomicWorkflowState.AW0:
             member.genomicWorkflowState = GenomicWorkflowState.AW1
+            member.genomicWorkflowStateStr = GenomicWorkflowState.AW1.name
             member.genomicWorkflowStateModifiedTime = clock.CLOCK.now()
 
         # Update member in DB

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -710,6 +710,7 @@ class GenomicJobController:
                     self.file_processed_dao.get_max_file_processed_for_filepath(record.file_path).id
                 )
                 member.genomicWorkflowState = GenomicWorkflowState.AW1
+                member.genomicWorkflowStateStr = GenomicWorkflowState.AW1.name
 
                 with self.member_dao.session() as session:
                     session.merge(member)
@@ -817,6 +818,7 @@ class GenomicJobController:
         # Only update the state if it was AW1
         if member.genomicWorkflowState == GenomicWorkflowState.AW1:
             member.genomicWorkflowState = GenomicWorkflowState.AW2
+            member.genomicWorkflowStateStr = GenomicWorkflowState.AW2.name
             member.genomicWorkflowStateModifiedTime = clock.CLOCK.now()
 
         # Truncate call rate


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR adds an update to the `genomic_workflow_state_str` field when updating the states to AW1 and AW2.

## Tests
- [x] unit tests
Current unit tests pass.

