### PR TITLE
[DA-2455] Implement AW4 and AW5 ingestion for sample swap samples

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -388,20 +388,20 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoUtils):
             ).first()
         return member
 
-    def get_member_from_biobank_id_and_sample_id(self, biobank_id, sample_id, genome_type):
+    def get_member_from_biobank_id_and_sample_id(self, biobank_id, sample_id):
         """
         Retrieves a genomic set member record matching the biobank Id
         :param biobank_id:
         :param sample_id:
-        :param genome_type:
         :return: a GenomicSetMember object
         """
         with self.session() as session:
             member = session.query(GenomicSetMember).filter(
                 GenomicSetMember.biobankId == biobank_id,
                 GenomicSetMember.sampleId == sample_id,
-                GenomicSetMember.genomeType == genome_type,
-            ).first()
+                GenomicSetMember.ignoreFlag == 0,
+                GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
+            ).one_or_none()
         return member
 
     def get_member_from_biobank_id_in_state(self, biobank_id, genome_type, states):

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -478,21 +478,19 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoUtils):
             ).first()
         return member
 
-    def get_member_from_aw3_sample(self, sample_id, genome_type):
+    def get_member_from_aw3_sample(self, sample_id):
         """
         Retrieves a genomic set member record matching the sample_id
         The sample_id is supplied in AW1 manifest, not biobank_stored_sample_id
-        Needs a genome type.
-        :param genome_type: aou_wgs, aou_array, aou_cvl
         :param sample_id:
         :return: a GenomicSetMember object
         """
         with self.session() as session:
             member = session.query(GenomicSetMember).filter(
                 GenomicSetMember.sampleId == sample_id,
-                GenomicSetMember.genomeType == genome_type,
                 GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
-                GenomicSetMember.aw3ManifestJobRunID != None,
+                GenomicSetMember.ignoreFlag == 0,
+                GenomicSetMember.aw3ManifestJobRunID.isnot(None)
             ).one_or_none()
         return member
 

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -399,7 +399,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoUtils):
             member = session.query(GenomicSetMember).filter(
                 GenomicSetMember.biobankId == biobank_id,
                 GenomicSetMember.sampleId == sample_id,
-                GenomicSetMember.ignoreFlag == 0,
+                GenomicSetMember.ignoreFlag != 1,
                 GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
             ).one_or_none()
         return member

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1410,8 +1410,7 @@ class GenomicFileIngester:
                 biobank_id = biobank_id[1:] if biobank_id[0].isalpha() else biobank_id
                 sample_id = row_copy['sampleid']
 
-                member = self.member_dao.get_member_from_biobank_id_and_sample_id(biobank_id, sample_id,
-                                                                                  self.file_validator.genome_type)
+                member = self.member_dao.get_member_from_biobank_id_and_sample_id(biobank_id, sample_id)
                 if not member:
                     logging.warning(f'Can not find genomic member record for biobank_id: '
                                     f'{biobank_id} and sample_id: {sample_id}, skipping...')

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -982,11 +982,8 @@ class GenomicFileIngester:
                 row_copy = dict(zip([key.lower().replace(' ', '').replace('_', '')
                                      for key in row], row.values()))
                 sample_id = row_copy['sampleid']
-                genome_type = GENOME_TYPE_ARRAY \
-                    if self.job_id == GenomicJob.AW4_ARRAY_WORKFLOW else GENOME_TYPE_WGS
 
-                member = self.member_dao.get_member_from_aw3_sample(sample_id,
-                                                                    genome_type)
+                member = self.member_dao.get_member_from_aw3_sample(sample_id)
                 if member is None:
                     logging.warning(f'Invalid sample ID: {sample_id}')
                     continue

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -4823,6 +4823,12 @@ class GenomicPipelineTest(BaseTestCase):
             record.genomicSetMemberId = member.id
             self.metrics_dao.upsert(record)
 
+            # Change sample 2 to aou_array_investigation
+            if member.id == 2:
+                member.genomeType = "aou_array_investigation"
+                self.member_dao.update(member)
+
+
         # Set up test AW4 manifest
         bucket_name = config.getSetting(config.DRC_BROAD_BUCKET_NAME)
         sub_folder = config.getSetting(config.DRC_BROAD_AW4_SUBFOLDERS[0])
@@ -4896,8 +4902,11 @@ class GenomicPipelineTest(BaseTestCase):
                 i = int(file_row['biobank_id'])-1
                 for field in file_row.keys():
                     self.assertEqual(file_row[field], getattr(raw_records[i], field.lower()))
+                expected_genome_type = "aou_array"
+                if i == 1:
+                    expected_genome_type += "_investigation"
 
-                self.assertEqual("aou_array", raw_records[i].genome_type)
+                self.assertEqual(expected_genome_type, raw_records[i].genome_type)
 
         # Test the job result
         run_obj = self.job_run_dao.get(2)
@@ -4924,6 +4933,11 @@ class GenomicPipelineTest(BaseTestCase):
             record.id = i + 1
             record.genomicSetMemberId = member.id
             self.metrics_dao.upsert(record)
+
+            # Change sample 2 to aou_array_investigation
+            if member.id == 2:
+                member.genomeType = "aou_wgs_investigation"
+                self.member_dao.update(member)
 
         # Set up test AW4 manifest
         bucket_name = config.getSetting(config.DRC_BROAD_BUCKET_NAME)
@@ -5000,7 +5014,11 @@ class GenomicPipelineTest(BaseTestCase):
                 for field in file_row.keys():
                     self.assertEqual(file_row[field], getattr(raw_records[i], field.lower()))
 
-                self.assertEqual("aou_wgs", raw_records[i].genome_type)
+                expected_genome_type = "aou_wgs"
+                if i == 1:
+                    expected_genome_type += "_investigation"
+
+                self.assertEqual(expected_genome_type, raw_records[i].genome_type)
 
         # Test the job result
         run_obj = self.job_run_dao.get(2)

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -807,6 +807,12 @@ class GenomicPipelineTest(BaseTestCase):
             }
         }
 
+        # Test investigation genome types still ingest
+        for member in self.member_dao.get_all():
+            if member.id in (2, 4):
+                member.genomeType += "_investigation"
+                self.member_dao.update(member)
+
         # Execute from cloud task
         genomic_pipeline.execute_genomic_manifest_file_pipeline(task_data_aw5_wgs)
         genomic_pipeline.execute_genomic_manifest_file_pipeline(task_data_aw5_array)


### PR DESCRIPTION
## Resolves *[DA-2455](https://precisionmedicineinitiative.atlassian.net/browse/DA-2455)*


## Description of changes/additions
This PR updates the sample look-ups on the AW4 and AW5 ingestion workflows to be genome_type agnostic. Ignore flags and states were added as well.

## Tests
- [x] unit tests


