### PR TITLE
[DA-2467] Sending "invalid" concept id for questionnaire responses that have been set to be ignored

### DIFF
--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Column, DateTime, Index, String, SmallInteger
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Index, String, SmallInteger
 from sqlalchemy.dialects.mysql import DECIMAL, TINYINT
 
 from rdr_service.model.base import Base
@@ -41,6 +41,7 @@ class SrcClean(Base):
     questionnaire_response_id = Column(BigInteger)
     unit_id = Column(String(50))
     filter = Column(SmallInteger)
+    is_invalid = Column(Boolean)
     __table_args__ = (Index('idx_src_clean_participant_id', participant_id), )
 
 

--- a/rdr_service/etl/raw_sql/finalize_cdm_data.sql
+++ b/rdr_service/etl/raw_sql/finalize_cdm_data.sql
@@ -121,7 +121,10 @@ SELECT
     src_c.topic_value                   AS topic_value,
     src_c.value_code_id                 AS value_code_id,
     COALESCE(vc3.concept_id, 0)         AS value_source_concept_id,
-    COALESCE(vc4.concept_id, 0)         AS value_concept_id,
+    CASE
+        WHEN src_c.is_invalid = 1 THEN 2000000010
+        ELSE COALESCE(vc4.concept_id, 0)
+    END                                 AS value_concept_id,
     src_c.value_number                  AS value_number,
     src_c.value_boolean                 AS value_boolean,
     CASE

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -297,6 +297,7 @@ class CurationExportClass(ToolBase):
             SrcClean.question_code_id: QuestionnaireQuestion.codeId,
             SrcClean.value_ppi_code: answer_code.value,
             SrcClean.topic_value: answer_code.topic,
+            SrcClean.is_invalid: QuestionnaireResponseAnswer.ignore.is_(True),
             SrcClean.value_code_id: cls._null_if_answer_ignored(else_value=QuestionnaireResponseAnswer.valueCodeId),
             SrcClean.value_number: cls._null_if_answer_ignored(else_value=case([(
                 # Only set value number if the question code is not one of the zip codes to re-map


### PR DESCRIPTION
## Resolves *[DA-2467](https://precisionmedicineinitiative.atlassian.net/browse/DA-2467)*
Rather than receiving empty rows for invalid answers, curation would like to receive the concept id that specifies an invalid answer was given. This PR updates the ETL to set the answer as invalid in the src_clean table if we've set the answer to "ignore" in the response answer table. Then in the SQL the concept id that specifies an answer is invalid is used for the answers that were ignored.


## Tests
- [ ] unit tests


