### PR TITLE
[DA-2473] Removing "enrollmentSiteId" from ParticipantSummary docs

### DIFF
--- a/doc/_ext/rdrhtml.py
+++ b/doc/_ext/rdrhtml.py
@@ -28,7 +28,7 @@ class RdrHtml5Translator(HTML5Translator):
 
 
 class RdrHtmlBuilder(StandaloneHTMLBuilder):
-    name = 'readthedocs'  # Name must match the builder we're trying to override
+    name = 'html'  # Name must match the builder we're trying to override
 
     @property
     def default_translator_class(self):

--- a/doc/api_workflows/field_reference/enumerated_fields.rst
+++ b/doc/api_workflows/field_reference/enumerated_fields.rst
@@ -222,4 +222,6 @@ DeceasedReportDenialReason
 RetentionStatus
 ------------------------------------------------------------
 .. autoclass:: rdr_service.participant_enums.RetentionStatus
+    :members:
+    :undoc-members:
     :exclude-members: name, number

--- a/doc/api_workflows/field_reference/enumerated_fields.rst
+++ b/doc/api_workflows/field_reference/enumerated_fields.rst
@@ -221,7 +221,5 @@ DeceasedReportDenialReason
 
 RetentionStatus
 ------------------------------------------------------------
-.. autoclass:: rdr_service.participant_enums.RetentionStatus
-    :members:
-    :undoc-members:
-    :exclude-members: name, number
+  * NOT_ELIGIBLE
+  * ELIGIBLE

--- a/doc/api_workflows/field_reference/participant_summary_field_list.rst
+++ b/doc/api_workflows/field_reference/participant_summary_field_list.rst
@@ -8,4 +8,4 @@ Participant Summary Field List
     :exclude-members: stateId, recontactMethodId, languageId, genderIdentityId, sexId, sexualOrientationId, educationId,
                       incomeId, physicalMeasurementsCreatedSiteId, physicalMeasurementsFinalizedSiteId, organizationId,
                       siteId, biospecimenSourceSiteId, biospecimenCollectedSiteId, biospecimenProcessedSiteId,
-                      biospecimenFinalizedSiteId, participant
+                      biospecimenFinalizedSiteId, participant, enrollmentSiteId


### PR DESCRIPTION
## Resolves *[DA-2473](https://precisionmedicineinitiative.atlassian.net/browse/DA-2473)*
This adds `enrollmentSiteId` to the list of fields to ignore on participant summary when auto generating the docs. It's not available on the API, so could be a little confusing to see it listed.

This also adds the RetentionStatus possible values since the autodoc for them wasn't filling them in.

## Tests
- [ ] unit tests


