### PR TITLE
[PDR-688] Add pdr_mod_gror table to PDR BigQuery

### DIFF
--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -32,6 +32,7 @@ BQ_TABLES = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRGeneralFeedback'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPostPMBFeedback'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPPIModuleFeedback'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRGROR'),
 
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummary'),
 
@@ -96,6 +97,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRGeneralFeedbackView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPostPMBFeedbackView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPPIModuleFeedbackView'),
+    ('rdr_service.module.bq_questionnaires', 'BQPDRGRORView'),
 
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherView'),
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherGenderView'),

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -472,7 +472,6 @@ class BQPDRDVEHRSharingView(BQModuleView):
 class BQPDRGRORSchema(_BQModuleSchema):
     """ GROR Consent Module """
     _module = 'GROR'
-    # TBD:
     _force_boolean_fields = (
         'ResultsConsent_Signature',
     )

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -466,6 +466,29 @@ class BQPDRDVEHRSharingView(BQModuleView):
     __pk_id__ = ['participant_id', 'questionnaire_response_id']
     _show_created = True
 
+#
+#  GROR
+#
+class BQPDRGRORSchema(_BQModuleSchema):
+    """ GROR Consent Module """
+    _module = 'GROR'
+    # TBD:
+    _force_boolean_fields = (
+        'ResultsConsent_Signature',
+    )
+
+class BQPDRGROR(BQTable):
+    """ GROR BigQuery Table """
+    __tablename__ = 'pdr_mod_gror'
+    __schema__ = BQPDRGRORSchema
+
+class BQPDRGRORView(BQView):
+    """ PDR GROR BiqQuery View """
+    __viewname__ = 'v_pdr_mod_gror'
+    __viewdescr__ = 'PDR GROR Consent Module View'
+    __table__ = BQPDRGROR
+    __pk_id__ = ['participant_id', 'questionnaire_response_id']
+    _show_created = True
 
 #
 # FamilyHistory
@@ -1278,6 +1301,7 @@ PDR_MODULE_LIST = (
     BQPDROverallHealth,
     BQPDREHRConsentPII,
     BQPDRDVEHRSharing,
+    BQPDRGROR,
     BQPDRCOPEMay,
     BQPDRCOPENov,
     BQPDRCOPEDec,

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -361,8 +361,6 @@ class ParticipantResourceClass(object):
 
         return 1
 
-
-
 class CodeResourceClass(object):
 
     def __init__(self, args, gcp_env: GCPEnvConfigObject):


### PR DESCRIPTION
## Resolves *[PDR-688](https://precisionmedicineinitiative.atlassian.net/browse/PDR-688)*


## Description of changes/additions
Fullfill a request from PTSC to add the GROR question/answer data to PDR.
Requires migration to be applied to BigQuery to create the BigQuery table and view, and corresponding table/materialized view to be added to PostgreSQL.

## Tests
Manual tests including building a `bigquery_sync` record in `pmi-drc-api-test`  for the new `pdr_mod_gror table_id`. (`pk_id `= 934140733)


