### PR TITLE
[DA-2427] Update report state on consent removal

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -216,6 +216,7 @@
     "a1_manifest_workflow": 1,
     "a2_manifest_workflow": 1,
     "a3_manifest_workflow": 1,
+    "update_report_state_for_consent_removal": 1,
     "aw0_manifest_workflow": 1,
     "aw1_manifest_workflow": 1,
     "aw1c_manifest_workflow": 0,

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -77,6 +77,7 @@
     "a1_manifest_workflow": 1,
     "a2_manifest_workflow": 1,
     "a3_manifest_workflow": 1,
+    "update_report_state_for_consent_removal": 1,
     "aw0_manifest_workflow": 1,
     "aw1_manifest_workflow": 1,
     "aw1c_manifest_workflow": 0,

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -124,6 +124,11 @@ cron:
   timezone: America/New_York
   schedule: every sunday 12:00
   target: offline
+- description: Genomic Update Report State for Consent Removal
+  url: /offline/GenomicUpdateReportStateForConsentRemoval
+  timezone: America/New_York
+  schedule: every saturday 05:00
+  target: offline
 - description: Genomic CVL W1 Workflow (Manual)
   url: /offline/GenomicCvlW1Workflow
   timezone: America/New_York

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2024,13 +2024,17 @@ class GenomicOutreachDaoV2(BaseDao):
             'pgx': {
                 GenomicReportState.PGX_RPT_READY: "ready",
                 GenomicReportState.PGX_RPT_PENDING_DELETE: "pending_delete",
-                GenomicReportState.PGX_RPT_DELETED: "deleted"
+                GenomicReportState.PGX_RPT_DELETED: "deleted",
+                GenomicReportState.CVL_RPT_PENDING_DELETE: "pending_delete",
+                GenomicReportState.CVL_RPT_DELETED: "deleted"
             },
             'hdr': {
                 GenomicReportState.HDR_RPT_UNINFORMATIVE: "uninformative",
                 GenomicReportState.HDR_RPT_POSITIVE: "positive",
                 GenomicReportState.HDR_RPT_PENDING_DELETE: "pending_delete",
-                GenomicReportState.HDR_RPT_DELETED: "deleted"
+                GenomicReportState.HDR_RPT_DELETED: "deleted",
+                GenomicReportState.CVL_RPT_PENDING_DELETE: "pending_delete",
+                GenomicReportState.CVL_RPT_DELETED: "deleted"
             }
         }
         p_status, p_module = None, None

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -573,6 +573,8 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoUtils):
                                            ParticipantSummary.consentForStudyEnrollmentAuthored,
                                            ParticipantSummary.consentForGenomicsROR,
                                            ParticipantSummary.consentForGenomicsRORAuthored,
+                                           ParticipantSummary.withdrawalStatus,
+                                           ParticipantSummary.withdrawalAuthored
                                            ).filter(
                 ParticipantSummary.participantId == member.participantId,
             ).first()
@@ -587,6 +589,10 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoUtils):
         if consent_status.consentForStudyEnrollment != QuestionnaireStatus.SUBMITTED and \
             consent_status.consentForStudyEnrollmentAuthored:
             withdraw_dates.append(consent_status.consentForStudyEnrollmentAuthored)
+
+        if consent_status.withdrawalStatus != WithdrawalStatus.NOT_WITHDRAWN and \
+            consent_status.withdrawalAuthored:
+            withdraw_dates.append(consent_status.withdrawalAuthored)
 
         if withdraw_dates:
             return min([d for d in withdraw_dates if d is not None])

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -561,7 +561,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoUtils):
                 )
             return members_query.all()
 
-    def get_gem_consent_removal_date(self, member):
+    def get_consent_removal_date(self, member):
         """
         Calculates the earliest removal date between GROR or Primary Consent
         :param member

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2364,14 +2364,13 @@ class GenomicReconciler:
 
         return GenomicSubProcessResult.NO_FILES
 
-    def reconcile_gem_report_states(self, _last_run_time=None):
+    def update_report_states_for_consent_removal(self, workflow_states):
         """
-        Scans GEM report states for changes
-        :param _last_run_time: the time when the current job last ran
+        Updates report states if gror or primary consent is not yes
+        :param workflow_states: list of GenomicWorkflowStates
         """
-
-        # Get unconsented members to update (consent > last run time of job_id)
-        unconsented_gror_members = self.member_dao.get_unconsented_gror_since_date(_last_run_time)
+        # Get unconsented members to update
+        unconsented_gror_members = self.member_dao.get_unconsented_gror_or_primary(workflow_states)
 
         # update each member with the new state and withdrawal time
         for member in unconsented_gror_members:
@@ -2383,10 +2382,17 @@ class GenomicReconciler:
 
                 # Handle withdrawal (gror/primary consent) for reportConsentRemovalDate
                 removal_date = self.member_dao.get_gem_consent_removal_date(member)
-                self.member_dao.update_report_consent_removal_date(member, removal_date)
+                if removal_date:
+                    self.member_dao.update_report_consent_removal_date(member, removal_date)
 
+    def update_report_state_for_reconsent(self, last_run_time):
+        """
+        This code is not currently executed, the reconsent has been deferred.
+        :param last_run_time:
+        :return:
+        """
         # Get reconsented members to update (consent > last run time of job_id)
-        reconsented_gror_members = self.member_dao.get_reconsented_gror_since_date(_last_run_time)
+        reconsented_gror_members = self.member_dao.get_reconsented_gror_since_date(last_run_time)
 
         # update each member with the new state
         for member in reconsented_gror_members:

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -2381,7 +2381,7 @@ class GenomicReconciler:
                 self.member_dao.update_member_state(member, new_state)
 
                 # Handle withdrawal (gror/primary consent) for reportConsentRemovalDate
-                removal_date = self.member_dao.get_gem_consent_removal_date(member)
+                removal_date = self.member_dao.get_consent_removal_date(member)
                 if removal_date:
                     self.member_dao.update_report_consent_removal_date(member, removal_date)
 

--- a/rdr_service/genomic/genomic_state_handler.py
+++ b/rdr_service/genomic/genomic_state_handler.py
@@ -202,6 +202,9 @@ class CVLReadyState(GenomicStateBase):
         if signal == 'manifest-generated':
             return GenomicWorkflowState.W1
 
+        if signal == 'unconsented':
+            return GenomicWorkflowState.CVL_RPT_PENDING_DELETE
+
         return GenomicWorkflowState.CVL_READY
 
 

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -112,6 +112,7 @@ class GenomicJob(messages.Enum):
     RECONCILE_PDR_DATA = 55
     DELETE_OLD_GP_USER_EVENT_METRICS = 56
     RETRY_MANIFEST_INGESTIONS = 57
+    UPDATE_REPORT_STATES_FOR_CONSENT_REMOVAL = 58
 
     # Data Quality Pipeline Jobs
     # Naming matters for reports (timeframe_level_report_target)
@@ -185,6 +186,9 @@ class GenomicWorkflowState(messages.Enum):
     # Replating
     EXTRACT_REQUESTED = 38
 
+    CVL_RPT_PENDING_DELETE = 39
+    CVL_RPT_DELETED = 40
+
 
 class GenomicReportState(messages.Enum):
 
@@ -205,6 +209,10 @@ class GenomicReportState(messages.Enum):
     HDR_RPT_POSITIVE = 8
     HDR_RPT_PENDING_DELETE = 9
     HDR_RPT_DELETED = 10
+
+    # CVL Generic Reporting States
+    CVL_RPT_PENDING_DELETE = 11
+    CVL_RPT_DELETED = 12
 
 
 class GenomicSubProcessStatus(messages.Enum):

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -251,6 +251,15 @@ def gem_metrics_ingest():
         controller.run_general_ingestion_workflow()
 
 
+def update_report_state_for_consent_removal():
+    """
+    Comprehensive update for report states without gRoR or Primary Consent
+    :return:
+    """
+    with GenomicJobController(GenomicJob.UPDATE_REPORT_STATES_FOR_CONSENT_REMOVAL) as controller:
+        controller.reconcile_report_states()
+
+
 def create_cvl_reconciliation_report():
     """
     Entrypoint for CVL reconciliation workflow

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -537,6 +537,13 @@ def genomic_gem_a2_workflow():
 @run_genomic_cron_job('a3_manifest_workflow')
 def genomic_gem_a3_workflow():
     genomic_pipeline.gem_a3_manifest_workflow()
+    return '{"success": "true"}'\
+
+
+@app_util.auth_required_cron
+@run_genomic_cron_job('update_report_state_for_consent_removal')
+def update_report_state_for_consent_removal():
+    genomic_pipeline.update_report_state_for_consent_removal()
     return '{"success": "true"}'
 
 
@@ -936,6 +943,12 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicGemA3Workflow",
         endpoint="genomic_gem_a3_workflow",
         view_func=genomic_gem_a3_workflow,
+        methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "GenomicUpdateReportStateForConsentRemoval",
+        endpoint="update_report_state_for_consent_removal",
+        view_func=update_report_state_for_consent_removal,
         methods=["GET"]
     )
     offline_app.add_url_rule(


### PR DESCRIPTION


## Resolves *[DA-2427](https://precisionmedicineinitiative.atlassian.net/browse/DA-2427)*


## Description of changes/additions
This PR creates a cron job for the updating the participant report state when gRoR and primary consent is removed. This PR modifies the query in `get_unconsented_gror_since_date()` to remove the date constraint. Methods that were previously specified for GEM only were renamed to be more generic. Logic was updated to check for the existence of consents to prevent value errors.

## Tests
- [x] unit tests


