### PR TITLE
[DA-2438] Script for invalidating repeated COPE vaccination questions

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -125,6 +125,25 @@ CONSENT_COPE_YES_CODE = "COPE_A_44"
 CONSENT_COPE_NO_CODE = "COPE_A_13"
 CONSENT_COPE_DEFERRED_CODE = "COPE_A_231"
 
+COPE_DOSE_RECEIVED_QUESTION = 'cdc_covid_xx'
+COPE_NUMBER_DOSES_QUESTION = 'cdc_covid_xx_a'
+COPE_ONE_DOSE_ANSWER = 'cope_a_332'
+COPE_TWO_DOSE_ANSWER = 'cope_a_333'
+COPE_DOSE_TYPE_QUESTION = 'cdc_covid_xx_b'
+COPE_FIRST_DOSE_QUESTION = 'cdc_covid_xx_firstdose'
+COPE_FIRST_DOSE_DATE_QUESTION = 'cdc_covid_xx_a_date1'
+COPE_FIRST_DOSE_TYPE_QUESTION = 'cdc_covid_xx_b_firstdose'
+COPE_FIRST_DOSE_TYPE_OTHER_QUESTION = 'cdc_covid_xx_b_firstdose_other'
+COPE_FIRST_DOSE_SYMPTOM_QUESTION = 'cdc_covid_xx_symptom'
+COPE_FIRST_DOSE_SYMPTOM_OTHER_QUESTION = 'cdc_covid_xx_symptom_cope_350'
+COPE_SECOND_DOSE_QUESTION = 'cdc_covid_xx_seconddose'
+COPE_SECOND_DOSE_DATE_QUESTION = 'cdc_covid_xx_a_date2'
+COPE_SECOND_DOSE_TYPE_QUESTION = 'cdc_covid_xx_b_seconddose'
+COPE_SECOND_DOSE_TYPE_OTHER_QUESTION = 'cdc_covid_xx_b_seconddose_other'
+COPE_SECOND_DOSE_SYMPTOM_QUESTION = 'cdc_covid_xx_symptom_seconddose'
+COPE_SECOND_DOSE_SYMPTOM_OTHER_QUESTION = 'cdc_covid_xx_symptom_seconddose_cope_350'
+
+
 # COPE Minute Survey Codes
 COPE_VACCINE_MINUTE_1_MODULE_CODE = "cope_vaccine1"
 COPE_VACCINE_MINUTE_2_MODULE_CODE = "cope_vaccine2"

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1278,7 +1278,10 @@ class QuestionnaireResponseDao(BaseDao):
 
         if not include_ignored_answers:
             query = query.filter(
-                QuestionnaireResponseAnswer.ignore.is_(False)
+                or_(
+                    QuestionnaireResponseAnswer.ignore.is_(False),
+                    QuestionnaireResponseAnswer.ignore.is_(None)
+                )
             )
 
         participant_response_map = {}  # dict with participant ids as keys and ParticipantResponse objects as values

--- a/rdr_service/domain_model/response.py
+++ b/rdr_service/domain_model/response.py
@@ -1,6 +1,9 @@
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List
+
+from rdr_service.model.questionnaire_response import QuestionnaireResponseStatus
 
 
 class ParticipantResponses:
@@ -24,7 +27,30 @@ class Response:
     id: int
     survey_code: str
     authored_datetime: datetime
-    answered_codes: Dict[str, str] = field(default_factory=dict)
+    status: QuestionnaireResponseStatus
+    answered_codes: Dict[str, List['Answer']] = field(default_factory=lambda: defaultdict(list))
 
     def has_answer_for(self, question_code_str):
         return question_code_str in self.answered_codes
+
+    def get_answers_for(self, question_code_str) -> List['Answer']:
+        if question_code_str not in self.answered_codes:
+            return None
+
+        return self.answered_codes[question_code_str]
+
+    def get_single_answer_for(self, question_code_str):
+        answers = self.get_answers_for(question_code_str)
+        if not answers:
+            return None
+
+        if len(answers) > 1:
+            raise Exception(f'Too many answers found for question "{question_code_str}"')
+        else:
+            return answers[0]
+
+
+@dataclass
+class Answer:
+    id: int
+    value: str

--- a/rdr_service/domain_model/response.py
+++ b/rdr_service/domain_model/response.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List
+
+
+class ParticipantResponses:
+    def __init__(self):
+        self.responses: Dict[int, 'Response'] = {}
+        self._responses_in_order = None
+
+    @property
+    def in_authored_order(self) -> List['Response']:
+        if not self._responses_in_order:
+            self._responses_in_order = sorted(
+                self.responses.values(),
+                key=lambda response: response.authored_datetime or False
+            )
+
+        return self._responses_in_order
+
+
+@dataclass
+class Response:
+    id: int
+    survey_code: str
+    authored_datetime: datetime
+    answered_codes: Dict[str, str] = field(default_factory=dict)
+
+    def has_answer_for(self, question_code_str):
+        return question_code_str in self.answered_codes

--- a/rdr_service/tools/tool_libs/cope_answer_filter.py
+++ b/rdr_service/tools/tool_libs/cope_answer_filter.py
@@ -1,0 +1,225 @@
+from typing import Optional
+
+from rdr_service import code_constants
+from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao
+from rdr_service.domain_model.response import Answer, Response, ParticipantResponses
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.questionnaire_response import QuestionnaireResponseAnswer
+from rdr_service.services.system_utils import list_chunks
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
+
+tool_cmd = 'cope_filter'
+tool_desc = 'Script for marking repeated answers to COPE questions that should have only been asked once as invalid'
+
+
+class _CopeUtils:
+    @classmethod
+    def is_yes_answer(cls, answer: Optional[Answer]):
+        if answer is None:
+            return False
+
+        return answer.value == code_constants.CONSENT_COPE_YES_CODE
+
+
+class InvalidAnswers(Exception):
+    def __init__(self, *args, answer_ids: set):
+        super(InvalidAnswers, self).__init__(*args)
+        self.invalid_answer_ids = answer_ids
+
+
+class CodeRepeatedTracker:
+    def __init__(self, question_codes):
+        self._codes = question_codes
+        self.has_previously_responded_to_code_group = False
+
+    def visit_response(self, response: Response):
+        invalid_ids_found = set()
+        for code in self._codes:
+            if response.has_answer_for(code):
+                if self.has_previously_responded_to_code_group:
+                    invalid_ids_found.update({answer.id for answer in response.get_answers_for(code)})
+                else:
+                    self.has_previously_responded_to_code_group = True
+
+        if invalid_ids_found:
+            raise InvalidAnswers(
+                f'Invalid answers found for one or more of "{self._codes}"',
+                answer_ids=invalid_ids_found
+            )
+
+
+class DosesReceivedTracker:
+    """
+    This is all needed in one rule check because of how the number of doses question affects first and second dose
+    questions later.
+
+    Feb COPE survey asks if the vaccine was taken and how many doses, answers to this could potentially invalidate
+    subsequent answers for the first and second doses in the COPE Minute surveys.
+    """
+    def __init__(self):
+        self.first_dose_tracker = _MinuteSurveyDoseTracking(
+            dose_received_question_code=code_constants.COPE_FIRST_DOSE_QUESTION,
+            dose_type_question_code=code_constants.COPE_FIRST_DOSE_TYPE_QUESTION,
+            dose_type_other_question_code=code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION
+        )
+        self.second_dose_tracker = _MinuteSurveyDoseTracking(
+            dose_received_question_code=code_constants.COPE_SECOND_DOSE_QUESTION,
+            dose_type_question_code=code_constants.COPE_SECOND_DOSE_TYPE_QUESTION,
+            dose_type_other_question_code=code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION
+        )
+
+    def visit_response(self, response: Response):
+        if response.survey_code == code_constants.COPE_FEB_MODULE:
+            self._visit_cope_feb(response)
+        else:
+            self._visit_minute_response(response)
+
+    def _visit_cope_feb(self, response: Response):
+        received_vaccine_answer = response.get_single_answer_for(code_constants.COPE_DOSE_RECEIVED_QUESTION)
+        if _CopeUtils.is_yes_answer(received_vaccine_answer):
+            number_of_doses_answer = response.get_single_answer_for(code_constants.COPE_NUMBER_DOSES_QUESTION)
+            number_doses_value = number_of_doses_answer.value if number_of_doses_answer else None
+
+            responding_for_first_dose = False
+            responding_for_second_dose = False
+            if number_doses_value == code_constants.COPE_TWO_DOSE_ANSWER:
+                responding_for_first_dose = True
+                responding_for_second_dose = True
+            elif number_doses_value == code_constants.COPE_ONE_DOSE_ANSWER:
+                responding_for_first_dose = True
+                responding_for_second_dose = False
+
+            has_answer_for_type = response.has_answer_for(code_constants.COPE_DOSE_TYPE_QUESTION)
+            if responding_for_first_dose:
+                self.first_dose_tracker.previously_confirmed_dose_received = True
+                self.first_dose_tracker.previously_answered_dose_type = has_answer_for_type
+            if responding_for_second_dose:
+                self.second_dose_tracker.previously_confirmed_dose_received = True
+                self.second_dose_tracker.previously_answered_dose_type = has_answer_for_type
+
+    def _visit_minute_response(self, response: Response):
+        self.first_dose_tracker.check_minute_response(response)
+        self.second_dose_tracker.check_minute_response(response)
+
+        invalid_answer_ids = set.union(
+            self.first_dose_tracker.get_and_clear_ids(),
+            self.second_dose_tracker.get_and_clear_ids(),
+        )
+
+        if invalid_answer_ids:
+            raise InvalidAnswers(f'Invalid answers found for dose questions', answer_ids=invalid_answer_ids)
+
+
+class _MinuteSurveyDoseTracking:
+    def __init__(self, dose_received_question_code, dose_type_question_code, dose_type_other_question_code):
+        self.dose_received_question_code = dose_received_question_code
+        self.dose_type_question_code = dose_type_question_code
+        self.dose_type_other_question_code = dose_type_other_question_code
+
+        self.previously_confirmed_dose_received = False
+        self.previously_answered_dose_type = False
+        self.invalid_ids = set()
+
+    def get_and_clear_ids(self):
+        ids = self.invalid_ids
+        self.invalid_ids = set()
+        return ids
+
+    def check_minute_response(self, response: Response):
+        dose_received_answer = response.get_single_answer_for(self.dose_received_question_code)
+        if dose_received_answer and self.previously_confirmed_dose_received:
+            self.invalid_ids.add(dose_received_answer.id)
+
+        dose_type_answer = response.get_single_answer_for(self.dose_type_question_code)
+        if dose_type_answer and self.previously_answered_dose_type:
+            self.invalid_ids.add(dose_type_answer.id)
+
+        dose_type_other_answer = response.get_single_answer_for(self.dose_type_other_question_code)
+        if dose_type_other_answer and self.previously_answered_dose_type:
+            self.invalid_ids.add(dose_type_other_answer.id)
+
+        if _CopeUtils.is_yes_answer(dose_received_answer):
+            self.previously_confirmed_dose_received = True
+            if dose_type_answer:
+                self.previously_answered_dose_type = True
+            else:
+                raise Exception('No answer on dose type, is this ok?')
+
+            if dose_type_other_answer and not dose_type_answer:
+                raise Exception('bad')
+        else:
+            if dose_type_answer:
+                raise Exception('Got a response on the type of dose, but not that they took it')
+            if dose_type_other_answer:
+                raise Exception('Got a response on the type of dose, but not that they took it')
+
+
+class CopeFilterTool(ToolBase):
+    def run(self):
+        super(CopeFilterTool, self).run()
+
+        with self.get_session() as session:
+            participant_ids = self._get_all_consented_participant_ids(session)
+            cope_survey_codes = ['cope_feb', 'cope_vaccine1', 'cope_vaccine2', 'cope_vaccine3', 'cope_vaccine4']
+            invalid_answer_ids = set()
+
+            for id_chunk in list_chunks(participant_ids, chunk_size=1000):
+                responses = QuestionnaireResponseDao.get_responses_to_surveys(
+                    survey_codes=cope_survey_codes,
+                    participant_ids=id_chunk,
+                    session=session
+                )
+                for responses in responses.values():
+                    invalid_answers_for_participant = self._get_invalid_answers_in_cope_responses(responses)
+                    invalid_answer_ids.update(invalid_answers_for_participant)
+
+            for invalid_id_chunk in list_chunks(list(invalid_answer_ids), chunk_size=1000):
+                session.query(
+                    QuestionnaireResponseAnswer
+                ).filter(
+                    QuestionnaireResponseAnswer.questionnaireResponseAnswerId.in_(invalid_id_chunk)
+                ).update(
+                    {
+                        QuestionnaireResponseAnswer.ignore: True,
+                        QuestionnaireResponseAnswer.ignore_reason:
+                            'previously received answer providing cope information (DA-2438)'
+                    },
+                    syncronize_session=False
+                )
+                session.commit()
+
+        print('aoeuaoe')
+
+    @classmethod
+    def _get_all_consented_participant_ids(cls, session):
+        db_results = session.query(ParticipantSummary.participantId).all()
+        return [obj.participantId for obj in db_results]
+
+    @classmethod
+    def _get_invalid_answers_in_cope_responses(cls, responses: ParticipantResponses):
+        invalid_answer_ids = set()
+        validation_rule_trackers = [
+            DosesReceivedTracker(),  # covers first and second dose "received", "type", and "type-other" questions
+            CodeRepeatedTracker([code_constants.COPE_FIRST_DOSE_DATE_QUESTION]),
+            CodeRepeatedTracker([code_constants.COPE_SECOND_DOSE_DATE_QUESTION]),
+            CodeRepeatedTracker([
+                code_constants.COPE_FIRST_DOSE_SYMPTOM_QUESTION,
+                code_constants.COPE_FIRST_DOSE_SYMPTOM_OTHER_QUESTION
+            ]),
+            CodeRepeatedTracker([
+                code_constants.COPE_SECOND_DOSE_SYMPTOM_QUESTION,
+                code_constants.COPE_SECOND_DOSE_SYMPTOM_OTHER_QUESTION
+            ])
+        ]
+        for response in responses.in_authored_order:
+            for tracker in validation_rule_trackers:
+                try:
+                    tracker.visit_response(response)
+                except InvalidAnswers as err:
+                    invalid_answer_ids.update(err.invalid_answer_ids)
+
+        return invalid_answer_ids
+
+
+def run():
+    return cli_run(tool_cmd, tool_desc, CopeFilterTool)

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -1564,7 +1564,7 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             survey_code='test_survey',
             question_codes=[
                 't_1',
-                't_2'
+                'T_2'
             ]
         )
         participant_id = self.data_generator.create_database_participant().participantId

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -1556,6 +1556,80 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
         self.questionnaire_response_dao.insert(qr)
         self.assertEqual(mock_gcloud_check.call_count, 2)
 
+    def test_loading_response_collections(self):
+        # Create a questionnaire, and some responses that have different answers to the questions
+        questionnaire = self._generate_questionnaire(
+            survey_code='test_survey',
+            question_codes=[
+                't_1',
+                't_2'
+            ]
+        )
+        participant_id = self.data_generator.create_database_participant().participantId
+        self._generate_response(
+            questionnaire,
+            ['one', 'two'],
+            participant_id=participant_id,
+            authored_date=datetime.datetime(2021, 10, 1),
+            created_date=datetime.datetime(2021, 10, 1)
+        )
+        self._generate_response(
+            questionnaire,
+            ['nine', 'ten'],
+            participant_id=participant_id,
+            authored_date=datetime.datetime(2022, 3, 5),
+            created_date=datetime.datetime(2022, 3, 5)
+        )
+
+        participant_responses_map = QuestionnaireResponseDao.get_responses_to_surveys(
+            survey_codes=['test_survey'],
+            participant_ids=[participant_id],
+            session=self.session
+        )
+
+        responses = participant_responses_map[participant_id]
+        self.assertEqual({
+            't_1': 'one',
+            't_2': 'two'
+        }, responses.in_authored_order[0].answered_codes)
+        self.assertEqual({
+            't_1': 'nine',
+            't_2': 'ten'
+        }, responses.in_authored_order[1].answered_codes)
+
+    def _generate_response(self, questionnaire, answers, participant_id=None, authored_date=None, created_date=None):
+        response = self.data_generator.create_database_questionnaire_response(
+            questionnaireId=questionnaire.questionnaireId,
+            questionnaireVersion=questionnaire.version,
+            participantId=participant_id,
+            authored=authored_date,
+            created=created_date
+        )
+        for index, answer in enumerate(answers):
+            self.data_generator.create_database_questionnaire_response_answer(
+                questionnaireResponseId=response.questionnaireResponseId,
+                questionId=questionnaire.questions[index].questionnaireQuestionId,
+                valueString=answer
+            )
+        return response
+
+    def _generate_questionnaire(self, survey_code, question_codes):
+        questionnaire = self.data_generator.create_database_questionnaire_history()
+        for code_str in question_codes:
+            self.data_generator.create_database_questionnaire_question(
+                questionnaireId=questionnaire.questionnaireId,
+                questionnaireVersion=questionnaire.version,
+                code=self.data_generator.create_database_code(value=code_str)
+            )
+
+        self.data_generator.create_database_questionnaire_concept(
+            questionnaireId=questionnaire.questionnaireId,
+            questionnaireVersion=questionnaire.version,
+            codeId=self.data_generator.create_database_code(value=survey_code).codeId
+        )
+
+        return questionnaire
+
 
 class QuestionnaireResponseDaoCloudCheckTest(BaseTestCase):
     def __init__(self, *args, **kwargs):

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -23,8 +23,8 @@ from rdr_service.code_constants import (
     THE_BASICS_PPI_MODULE, COPE_VACCINE_MINUTE_4_MODULE_CODE,
     BASICS_PROFILE_UPDATE_QUESTION_CODES
 )
-from rdr_service.dao.code_dao import CodeDao
 from rdr_service.concepts import Concept
+from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.questionnaire_dao import QuestionnaireDao
@@ -33,11 +33,13 @@ from rdr_service.dao.questionnaire_response_dao import (
     QuestionnaireResponseDao,
     _raise_if_gcloud_file_missing,
 )
+from rdr_service.domain_model.response import Answer
 from rdr_service.model.code import Code, CodeType
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.questionnaire import Questionnaire, QuestionnaireConcept, QuestionnaireQuestion
-from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
+from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer, \
+    QuestionnaireResponseStatus
 from rdr_service.model.resource_data import ResourceData
 from rdr_service.participant_enums import GenderIdentity, QuestionnaireStatus, WithdrawalStatus, ParticipantCohort
 from tests import test_data
@@ -1589,12 +1591,12 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
 
         responses = participant_responses_map[participant_id]
         self.assertEqual({
-            't_1': 'one',
-            't_2': 'two'
+            't_1': [Answer(id=mock.ANY, value='one')],
+            't_2': [Answer(id=mock.ANY, value='two')]
         }, responses.in_authored_order[0].answered_codes)
         self.assertEqual({
-            't_1': 'nine',
-            't_2': 'ten'
+            't_1': [Answer(id=mock.ANY, value='nine')],
+            't_2': [Answer(id=mock.ANY, value='ten')]
         }, responses.in_authored_order[1].answered_codes)
 
     def _generate_response(self, questionnaire, answers, participant_id=None, authored_date=None, created_date=None):
@@ -1603,7 +1605,8 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             questionnaireVersion=questionnaire.version,
             participantId=participant_id,
             authored=authored_date,
-            created=created_date
+            created=created_date,
+            status=QuestionnaireResponseStatus.COMPLETED
         )
         for index, answer in enumerate(answers):
             self.data_generator.create_database_questionnaire_response_answer(

--- a/tests/tool_tests/test_validation_tracker.py
+++ b/tests/tool_tests/test_validation_tracker.py
@@ -1,0 +1,190 @@
+from datetime import datetime
+from typing import Dict, List
+
+from rdr_service import code_constants
+from rdr_service.domain_model import response as response_domain_model
+from rdr_service.model.questionnaire_response import QuestionnaireResponseStatus
+from rdr_service.tools.tool_libs.cope_answer_filter import CodeRepeatedTracker, DosesReceivedTracker, InvalidAnswers
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class TestValidationTracker(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestValidationTracker, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def test_flags_same_code(self):
+        tracker = CodeRepeatedTracker(question_codes=['test_b'])
+
+        tracker.visit_response(response=self._build_response(answers={
+            'test': [response_domain_model.Answer(id=23, value='any')],
+            'test_b': [response_domain_model.Answer(id=72, value='any')]
+        }))
+
+        with self.assertRaises(InvalidAnswers) as invalid_error:
+            tracker.visit_response(response=self._build_response(answers={
+                'test': [response_domain_model.Answer(id=128, value='any')],
+                'test_b': [
+                    response_domain_model.Answer(id=321, value='any'),
+                    response_domain_model.Answer(id=743, value='test other')
+                ]
+            }))
+        self.assertEqual({321, 743}, invalid_error.exception.invalid_answer_ids)
+
+    def test_flags_other_codes_in_group(self):
+        tracker = CodeRepeatedTracker(question_codes=['test_b', 'test_b_x'])
+
+        tracker.visit_response(response=self._build_response(answers={
+            'test_b': [response_domain_model.Answer(id=72, value='any')]
+        }))
+
+        with self.assertRaises(InvalidAnswers) as invalid_error:
+            tracker.visit_response(response=self._build_response(answers={
+                'test_b': [response_domain_model.Answer(id=321, value='any')],
+                'test_b_x': [response_domain_model.Answer(id=743, value='any')]
+            }))
+        self.assertEqual({321, 743}, invalid_error.exception.invalid_answer_ids)
+
+    def test_two_dose_answer_shows_later_dose_answers_as_invalid(self):
+        tracker = DosesReceivedTracker()
+
+        tracker.visit_response(response=self._build_response(
+            answers={
+                code_constants.COPE_DOSE_RECEIVED_QUESTION: [
+                    response_domain_model.Answer(id=23, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_NUMBER_DOSES_QUESTION: [
+                    response_domain_model.Answer(id=72, value=code_constants.COPE_TWO_DOSE_ANSWER)
+                ],
+                code_constants.COPE_DOSE_TYPE_QUESTION: [
+                    response_domain_model.Answer(id=73, value='any')
+                ]
+            },
+            survey_code=code_constants.COPE_FEB_MODULE
+        ))
+
+        with self.assertRaises(InvalidAnswers) as invalid_error:
+            tracker.visit_response(response=self._build_response(answers={
+                code_constants.COPE_FIRST_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=129, value='any')],
+                code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=130, value='any')],
+                code_constants.COPE_SECOND_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=354, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_SECOND_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=355, value='any')],
+                code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=356, value='any')]
+            }))
+        self.assertEqual({128, 129, 130, 354, 355, 356}, invalid_error.exception.invalid_answer_ids)
+
+    def test_one_dose_answer_shows_later_dose_answers_as_invalid(self):
+        tracker = DosesReceivedTracker()
+
+        tracker.visit_response(response=self._build_response(
+            answers={
+                code_constants.COPE_DOSE_RECEIVED_QUESTION: [
+                    response_domain_model.Answer(id=23, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_NUMBER_DOSES_QUESTION: [
+                    response_domain_model.Answer(id=72, value=code_constants.COPE_ONE_DOSE_ANSWER)
+                ],
+                code_constants.COPE_DOSE_TYPE_QUESTION: [
+                    response_domain_model.Answer(id=73, value='any')
+                ]
+            },
+            survey_code=code_constants.COPE_FEB_MODULE
+        ))
+
+        with self.assertRaises(InvalidAnswers) as invalid_error:
+            tracker.visit_response(response=self._build_response(answers={
+                code_constants.COPE_FIRST_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=129, value='any')],
+                code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=130, value='any')],
+                code_constants.COPE_SECOND_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=354, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_SECOND_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=355, value='any')],
+                code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=356, value='any')]
+            }))
+        self.assertEqual({128, 129, 130}, invalid_error.exception.invalid_answer_ids)
+
+    def test_minute_dose_answers_flagged(self):
+        tracker = DosesReceivedTracker()
+
+        tracker.visit_response(response=self._build_response(
+            answers={
+                code_constants.COPE_FIRST_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=129, value='any')],
+                code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=130, value='any')]
+            }
+        ))
+
+        with self.assertRaises(InvalidAnswers) as invalid_error:
+            tracker.visit_response(response=self._build_response(answers={
+                code_constants.COPE_FIRST_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=233, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=268, value='any')],
+                code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=297, value='any')],
+                code_constants.COPE_SECOND_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=354, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_SECOND_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=355, value='any')],
+                code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=356, value='any')]
+            }))
+        self.assertEqual({233, 268, 297}, invalid_error.exception.invalid_answer_ids)
+
+    def test_can_answer_no_then_yes(self):
+        tracker = DosesReceivedTracker()
+
+        tracker.visit_response(response=self._build_response(
+            answers={
+                code_constants.COPE_FIRST_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_NO_CODE)
+                ]
+            }
+        ))
+
+        tracker.visit_response(response=self._build_response(answers={
+            code_constants.COPE_FIRST_DOSE_QUESTION: [
+                response_domain_model.Answer(id=233, value=code_constants.CONSENT_COPE_YES_CODE)
+            ],
+            code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=268, value='any')],
+            code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=297, value='any')]
+        }))
+
+    def test_yes_flags_later_no(self):
+        tracker = DosesReceivedTracker()
+
+        tracker.visit_response(response=self._build_response(
+            answers={
+                code_constants.COPE_FIRST_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=233, value=code_constants.CONSENT_COPE_YES_CODE)
+                ],
+                code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=268, value='any')],
+                code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=297, value='any')]
+            }
+        ))
+
+        with self.assertRaises(InvalidAnswers) as invalid_error:
+            tracker.visit_response(response=self._build_response(answers={
+                code_constants.COPE_FIRST_DOSE_QUESTION: [
+                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_NO_CODE)
+                ]
+            }))
+        self.assertEqual({128}, invalid_error.exception.invalid_answer_ids)
+
+    @classmethod
+    def _build_response(cls, answers: Dict[str, List[response_domain_model.Answer]], survey_code='test'):
+        return response_domain_model.Response(
+            id=1,
+            survey_code=survey_code,
+            authored_datetime=datetime.utcnow(),
+            status=QuestionnaireResponseStatus.COMPLETED,
+            answered_codes=answers
+        )

--- a/tests/tool_tests/test_validation_tracker.py
+++ b/tests/tool_tests/test_validation_tracker.py
@@ -14,6 +14,7 @@ class TestValidationTracker(BaseTestCase):
         self.uses_database = False
 
     def test_flags_same_code(self):
+        """Make sure the tracker detects that it's code has ben answered again"""
         tracker = CodeRepeatedTracker(question_codes=['test_b'])
 
         tracker.visit_response(response=self._build_response(answers={
@@ -32,7 +33,7 @@ class TestValidationTracker(BaseTestCase):
         self.assertEqual({321, 743}, invalid_error.exception.invalid_answer_ids)
 
     def test_flags_other_codes_in_group(self):
-        tracker = CodeRepeatedTracker(question_codes=['test_b', 'test_b_x'])
+        tracker = CodeRepeatedTracker(question_codes=['test_b', 'test_b_x', 'test_b_c'])
 
         tracker.visit_response(response=self._build_response(answers={
             'test_b': [response_domain_model.Answer(id=72, value='any')]
@@ -40,10 +41,18 @@ class TestValidationTracker(BaseTestCase):
 
         with self.assertRaises(InvalidAnswers) as invalid_error:
             tracker.visit_response(response=self._build_response(answers={
-                'test_b': [response_domain_model.Answer(id=321, value='any')],
+                'test_b_c': [response_domain_model.Answer(id=321, value='any')],
                 'test_b_x': [response_domain_model.Answer(id=743, value='any')]
             }))
         self.assertEqual({321, 743}, invalid_error.exception.invalid_answer_ids)
+
+    def test_does_not_flag_in_same_response(self):
+        tracker = CodeRepeatedTracker(question_codes=['test_b', 'test_b_x'])
+
+        tracker.visit_response(response=self._build_response(answers={
+            'test_b': [response_domain_model.Answer(id=321, value='any')],
+            'test_b_x': [response_domain_model.Answer(id=743, value='any')]
+        }))
 
     def test_two_dose_answer_shows_later_dose_answers_as_invalid(self):
         tracker = DosesReceivedTracker()

--- a/tests/tool_tests/test_validation_tracker.py
+++ b/tests/tool_tests/test_validation_tracker.py
@@ -13,6 +13,9 @@ class TestValidationTracker(BaseTestCase):
         super(TestValidationTracker, self).__init__(*args, **kwargs)
         self.uses_database = False
 
+        self.cope_yes_answer_code_str = code_constants.CONSENT_COPE_YES_CODE.lower()
+        self.cope_no_answer_code_str = code_constants.CONSENT_COPE_NO_CODE.lower()
+
     def test_flags_same_code(self):
         """Make sure the tracker detects that it's code has ben answered again"""
         tracker = CodeRepeatedTracker(question_codes=['test_b'])
@@ -60,7 +63,7 @@ class TestValidationTracker(BaseTestCase):
         tracker.visit_response(response=self._build_response(
             answers={
                 code_constants.COPE_DOSE_RECEIVED_QUESTION: [
-                    response_domain_model.Answer(id=23, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=23, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_NUMBER_DOSES_QUESTION: [
                     response_domain_model.Answer(id=72, value=code_constants.COPE_TWO_DOSE_ANSWER)
@@ -75,12 +78,12 @@ class TestValidationTracker(BaseTestCase):
         with self.assertRaises(InvalidAnswers) as invalid_error:
             tracker.visit_response(response=self._build_response(answers={
                 code_constants.COPE_FIRST_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=128, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=129, value='any')],
                 code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=130, value='any')],
                 code_constants.COPE_SECOND_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=354, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=354, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_SECOND_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=355, value='any')],
                 code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=356, value='any')]
@@ -93,7 +96,7 @@ class TestValidationTracker(BaseTestCase):
         tracker.visit_response(response=self._build_response(
             answers={
                 code_constants.COPE_DOSE_RECEIVED_QUESTION: [
-                    response_domain_model.Answer(id=23, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=23, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_NUMBER_DOSES_QUESTION: [
                     response_domain_model.Answer(id=72, value=code_constants.COPE_ONE_DOSE_ANSWER)
@@ -108,12 +111,12 @@ class TestValidationTracker(BaseTestCase):
         with self.assertRaises(InvalidAnswers) as invalid_error:
             tracker.visit_response(response=self._build_response(answers={
                 code_constants.COPE_FIRST_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=128, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=129, value='any')],
                 code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=130, value='any')],
                 code_constants.COPE_SECOND_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=354, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=354, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_SECOND_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=355, value='any')],
                 code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=356, value='any')]
@@ -126,7 +129,7 @@ class TestValidationTracker(BaseTestCase):
         tracker.visit_response(response=self._build_response(
             answers={
                 code_constants.COPE_FIRST_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=128, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=129, value='any')],
                 code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=130, value='any')]
@@ -136,12 +139,12 @@ class TestValidationTracker(BaseTestCase):
         with self.assertRaises(InvalidAnswers) as invalid_error:
             tracker.visit_response(response=self._build_response(answers={
                 code_constants.COPE_FIRST_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=233, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=233, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=268, value='any')],
                 code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=297, value='any')],
                 code_constants.COPE_SECOND_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=354, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=354, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_SECOND_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=355, value='any')],
                 code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=356, value='any')]
@@ -154,14 +157,14 @@ class TestValidationTracker(BaseTestCase):
         tracker.visit_response(response=self._build_response(
             answers={
                 code_constants.COPE_FIRST_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_NO_CODE)
+                    response_domain_model.Answer(id=128, value=self.cope_no_answer_code_str)
                 ]
             }
         ))
 
         tracker.visit_response(response=self._build_response(answers={
             code_constants.COPE_FIRST_DOSE_QUESTION: [
-                response_domain_model.Answer(id=233, value=code_constants.CONSENT_COPE_YES_CODE)
+                response_domain_model.Answer(id=233, value=self.cope_yes_answer_code_str)
             ],
             code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=268, value='any')],
             code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=297, value='any')]
@@ -173,7 +176,7 @@ class TestValidationTracker(BaseTestCase):
         tracker.visit_response(response=self._build_response(
             answers={
                 code_constants.COPE_FIRST_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=233, value=code_constants.CONSENT_COPE_YES_CODE)
+                    response_domain_model.Answer(id=233, value=self.cope_yes_answer_code_str)
                 ],
                 code_constants.COPE_FIRST_DOSE_TYPE_QUESTION: [response_domain_model.Answer(id=268, value='any')],
                 code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION: [response_domain_model.Answer(id=297, value='any')]
@@ -183,7 +186,7 @@ class TestValidationTracker(BaseTestCase):
         with self.assertRaises(InvalidAnswers) as invalid_error:
             tracker.visit_response(response=self._build_response(answers={
                 code_constants.COPE_FIRST_DOSE_QUESTION: [
-                    response_domain_model.Answer(id=128, value=code_constants.CONSENT_COPE_NO_CODE)
+                    response_domain_model.Answer(id=128, value=self.cope_no_answer_code_str)
                 ]
             }))
         self.assertEqual({128}, invalid_error.exception.invalid_answer_ids)


### PR DESCRIPTION
## Resolves *[DA-2438](https://precisionmedicineinitiative.atlassian.net/browse/DA-2438)*
First off... sorry this is as big of a PR as it is. I'd break it apart if there was a bit more time 😅 

The February and all Minute COPE surveys ask about whether or not the participant got the covid vaccine (as well as when and what manufacturer if they did say they got it). Once we have an answer for the first or second dose, the participant isn't supposed to see that question again. There are multiple instances of participants seeing and responding to the questions about each dose of the vaccine several times when they shouldn't have been able to. This PR sets up a script for detecting those invalid answers and marking them as such.


## Description of changes/additions
As part of this effort, I added a method to the dao for loading a batch of responses. It filters them by survey code and participant id. I also added a domain model layer on top of questionnaire responses. This makes the data of a response a little easier to work with (atleast for me).


## Tests
- [x] unit tests 


