### PR TITLE
[DA-2438] Fixes for issues encountered when running it against all COPE data

### DIFF
--- a/rdr_service/tools/tool_libs/cope_answer_filter.py
+++ b/rdr_service/tools/tool_libs/cope_answer_filter.py
@@ -69,12 +69,36 @@ class DosesReceivedTracker:
         self.first_dose_tracker = _MinuteSurveyDoseTracking(
             dose_received_question_code=code_constants.COPE_FIRST_DOSE_QUESTION,
             dose_type_question_code=code_constants.COPE_FIRST_DOSE_TYPE_QUESTION,
-            dose_type_other_question_code=code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION
+            dose_type_other_question_code=code_constants.COPE_FIRST_DOSE_TYPE_OTHER_QUESTION,
+            dose_symptom_question_code=code_constants.COPE_FIRST_DOSE_SYMPTOM_QUESTION,
+            dose_symptom_other_question_code=code_constants.COPE_FIRST_DOSE_SYMPTOM_OTHER_QUESTION,
+            dose_date_question_code=code_constants.COPE_FIRST_DOSE_DATE_QUESTION
         )
         self.second_dose_tracker = _MinuteSurveyDoseTracking(
             dose_received_question_code=code_constants.COPE_SECOND_DOSE_QUESTION,
             dose_type_question_code=code_constants.COPE_SECOND_DOSE_TYPE_QUESTION,
-            dose_type_other_question_code=code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION
+            dose_type_other_question_code=code_constants.COPE_SECOND_DOSE_TYPE_OTHER_QUESTION,
+            dose_symptom_question_code=code_constants.COPE_SECOND_DOSE_SYMPTOM_QUESTION,
+            dose_symptom_other_question_code=code_constants.COPE_SECOND_DOSE_SYMPTOM_OTHER_QUESTION,
+            dose_date_question_code=code_constants.COPE_SECOND_DOSE_DATE_QUESTION
+        )
+        # Create dose question trackers that track answers for doses 3 through 17
+        self.additional_dose_trackers = [
+            self._build_numbered_dose_tracker(number)
+            for number in range(3, 18)
+        ]
+
+    @classmethod
+    def _build_numbered_dose_tracker(cls, number):
+        return _MinuteSurveyDoseTracking(
+            dose_received_question_code=f'cdc_covid_xx_dose{number}',
+            dose_type_question_code=f'cdc_covid_xx_b_dose{number}',
+            dose_type_other_question_code=f'cdc_covid_xx_b_dose{number}_other',
+            dose_symptom_question_code=f'cdc_covid_xx_symptom_dose{number}',
+            dose_symptom_other_question_code=f'cdc_covid_xx_symptom_cope_350_dose{number}',
+            dose_vol_question_code=f'cdc_covid_xx_type_dose{number}',
+            dose_vol_other_question_code=f'cdc_covid_xx_type_dose{number}_other',
+            dose_date_question_code=f'cdc_covid_xx_a_date{number}'
         )
 
     def visit_response(self, response: Response):
@@ -114,19 +138,28 @@ class DosesReceivedTracker:
             self.first_dose_tracker.get_and_clear_ids(),
             self.second_dose_tracker.get_and_clear_ids(),
         )
+        for tracker in self.additional_dose_trackers:
+            tracker.check_minute_response(response)
+            invalid_answer_ids.update(tracker.get_and_clear_ids())
 
         if invalid_answer_ids:
             raise InvalidAnswers(f'Invalid answers found for dose questions', answer_ids=invalid_answer_ids)
 
 
 class _MinuteSurveyDoseTracking:
-    def __init__(self, dose_received_question_code, dose_type_question_code, dose_type_other_question_code):
+    def __init__(self, dose_received_question_code, dose_type_question_code, dose_type_other_question_code,
+                 dose_symptom_question_code, dose_symptom_other_question_code, dose_date_question_code,
+                 dose_vol_question_code=None, dose_vol_other_question_code=None):
         self.dose_received_question_code = dose_received_question_code
         self.dose_type_question_code = dose_type_question_code
         self.dose_type_other_question_code = dose_type_other_question_code
+        self.dose_symptom_question_code = dose_symptom_question_code
+        self.dose_symptom_other_question_code = dose_symptom_other_question_code
+        self.dose_vol_question_code = dose_vol_question_code
+        self.dose_vol_other_question_code = dose_vol_other_question_code
+        self.dose_date_question_code = dose_date_question_code
 
         self.previously_confirmed_dose_received = False
-        self.previously_answered_dose_type = False
         self.invalid_ids = set()
 
     def get_and_clear_ids(self):
@@ -140,27 +173,50 @@ class _MinuteSurveyDoseTracking:
             self.invalid_ids.add(dose_received_answer.id)
 
         dose_type_answer = response.get_single_answer_for(self.dose_type_question_code)
-        if dose_type_answer and self.previously_answered_dose_type:
+        if dose_type_answer and self.previously_confirmed_dose_received:
             self.invalid_ids.add(dose_type_answer.id)
 
         dose_type_other_answer = response.get_single_answer_for(self.dose_type_other_question_code)
-        if dose_type_other_answer and self.previously_answered_dose_type:
+        if dose_type_other_answer and self.previously_confirmed_dose_received:
             self.invalid_ids.add(dose_type_other_answer.id)
+
+        dose_symptom_answer = response.get_answers_for(self.dose_symptom_question_code)
+        if dose_symptom_answer and self.previously_confirmed_dose_received:
+            self.invalid_ids.update({answer.id for answer in dose_symptom_answer})
+
+        dose_symptom_other_answer = response.get_single_answer_for(self.dose_symptom_other_question_code)
+        if dose_symptom_other_answer and self.previously_confirmed_dose_received:
+            self.invalid_ids.update({answer.id for answer in dose_symptom_answer})
+
+        dose_vol_answer = response.get_single_answer_for(self.dose_vol_question_code)
+        if self.dose_vol_question_code and dose_vol_answer and self.previously_confirmed_dose_received:
+            self.invalid_ids.add(dose_vol_answer.id)
+
+        dose_vol_other_answer = response.get_single_answer_for(self.dose_vol_other_question_code)
+        if self.dose_vol_other_question_code and dose_vol_other_answer and self.previously_confirmed_dose_received:
+            self.invalid_ids.add(dose_vol_other_answer.id)
+
+        dose_date_answer = response.get_single_answer_for(self.dose_date_question_code)
+        if dose_date_answer and self.previously_confirmed_dose_received:
+            self.invalid_ids.add(dose_date_answer.id)
 
         if _CopeUtils.is_yes_answer(dose_received_answer):
             self.previously_confirmed_dose_received = True
+        elif dose_received_answer is None or dose_received_answer.value != 'pmi_skip':
             if dose_type_answer:
-                self.previously_answered_dose_type = True
-            else:
-                raise Exception('No answer on dose type, is this ok?')
-
-            if dose_type_other_answer and not dose_type_answer:
-                raise Exception('investigate this')
-        else:
-            if dose_type_answer:
-                raise Exception('Got a response on the type of dose, but not that they took it')
+                print('ERROR: Got a response on the type of dose, but not that they took it')
             if dose_type_other_answer:
-                raise Exception('Got a response on the type of dose, but not that they took it')
+                print('ERROR: Got a response on the other type of dose, but not that they took it')
+            if dose_symptom_answer:
+                print('ERROR: Got a response on the symptom of dose, but not that they took it')
+            if dose_symptom_other_answer:
+                print('ERROR: Got a response on the other symptom of dose, but not that they took it')
+            if dose_vol_answer:
+                print('ERROR: Got a response on the vol of dose, but not that they took it')
+            if dose_vol_other_answer:
+                print('ERROR: Got a response on the other vol of dose, but not that they took it')
+            if dose_date_answer:
+                print('ERROR: Got a response on the date of dose, but not that they took it')
 
 
 class CopeFilterTool(ToolBase):
@@ -206,17 +262,7 @@ class CopeFilterTool(ToolBase):
     def _get_invalid_answers_in_cope_responses(cls, responses: ParticipantResponses):
         invalid_answer_ids = set()
         validation_rule_trackers = [
-            DosesReceivedTracker(),  # covers first and second dose "received", "type", and "type-other" questions
-            CodeRepeatedTracker([code_constants.COPE_FIRST_DOSE_DATE_QUESTION]),
-            CodeRepeatedTracker([code_constants.COPE_SECOND_DOSE_DATE_QUESTION]),
-            CodeRepeatedTracker([
-                code_constants.COPE_FIRST_DOSE_SYMPTOM_QUESTION,
-                code_constants.COPE_FIRST_DOSE_SYMPTOM_OTHER_QUESTION
-            ]),
-            CodeRepeatedTracker([
-                code_constants.COPE_SECOND_DOSE_SYMPTOM_QUESTION,
-                code_constants.COPE_SECOND_DOSE_SYMPTOM_OTHER_QUESTION
-            ])
+            DosesReceivedTracker()  # covers all questions related to doses received
         ]
         for response in responses.in_authored_order:
             for tracker in validation_rule_trackers:

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -1560,23 +1560,30 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
 
     def test_loading_response_collections(self):
         # Create a questionnaire, and some responses that have different answers to the questions
-        questionnaire = self._generate_questionnaire(
+        questionnaire1 = self._generate_questionnaire(
             survey_code='test_survey',
             question_codes=[
                 't_1',
                 'T_2'
             ]
         )
+        questionnaire2 = self._generate_questionnaire(
+            survey_code='another_survey',
+            question_codes=[
+                'x_1',
+                'x_2'
+            ]
+        )
         participant_id = self.data_generator.create_database_participant().participantId
         self._generate_response(
-            questionnaire,
+            questionnaire1,
             ['one', 'two'],
             participant_id=participant_id,
             authored_date=datetime.datetime(2021, 10, 1),
             created_date=datetime.datetime(2021, 10, 1)
         )
         self._generate_response(
-            questionnaire,
+            questionnaire2,
             ['nine', 'ten'],
             participant_id=participant_id,
             authored_date=datetime.datetime(2022, 3, 5),
@@ -1584,7 +1591,7 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
         )
 
         participant_responses_map = QuestionnaireResponseDao.get_responses_to_surveys(
-            survey_codes=['test_survey'],
+            survey_codes=['test_survey', 'another_survey'],
             participant_ids=[participant_id],
             session=self.session
         )
@@ -1595,8 +1602,8 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             't_2': [Answer(id=mock.ANY, value='two')]
         }, responses.in_authored_order[0].answered_codes)
         self.assertEqual({
-            't_1': [Answer(id=mock.ANY, value='nine')],
-            't_2': [Answer(id=mock.ANY, value='ten')]
+            'x_1': [Answer(id=mock.ANY, value='nine')],
+            'x_2': [Answer(id=mock.ANY, value='ten')]
         }, responses.in_authored_order[1].answered_codes)
 
     def _generate_response(self, questionnaire, answers, participant_id=None, authored_date=None, created_date=None):


### PR DESCRIPTION
## More changes for *[DA-2438](https://precisionmedicineinitiative.atlassian.net/browse/DA-2438)*
There were a few issues that were causing issues when running the COPE answer invalidation script against the whole set of data. Because of time constraints, these changes were in place when running the script on Friday.
- Some participants had multiple responses to the same release of the survey (they should only be able to answer each one once). For this I've updated the response collection domain model to return one version of a survey, using the latest authored version if there are multiple responses.
- At least one participant had two answers in one survey for a question that should only be able to have one option selected. But it appears that all the selections were for the same option (so there wasn't any conflicting data). The fix for this was to only raise an exception if there are more than one distinct answer to a question.
- This found several instances of questions being answered that shouldn't have been answered because of other branching logic issues. Those issues have been ignored for now (changing the exceptions to print statements).

Also, when looking at the data. I noticed there are questions in some of the minute surveys asking about doses 3 through 17. This PR adds validation checking for those sets of questions.

Lastly, the dose questions should be dependent on previously being asked about that dose, so if a participant already answered questions about dose 2, then they shouldn't answer any questions about dose 2 again (such as the symptom question). This PR brings all of the checking into the DoseReceivedTracker and makes sure any questions for a dose don't appear again in a survey after the participant confirms they've received that dose.


## Tests
- [ ] unit tests


