### PR TITLE
PDR GROR fix to remove free text from new table

### DIFF
--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -97,7 +97,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRGeneralFeedbackView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPostPMBFeedbackView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPPIModuleFeedbackView'),
-    ('rdr_service.module.bq_questionnaires', 'BQPDRGRORView'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRGRORView'),
 
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherView'),
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherGenderView'),

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -474,6 +474,7 @@ class BQPDRGRORSchema(_BQModuleSchema):
     _module = 'GROR'
     _force_boolean_fields = (
         'ResultsConsent_Signature',
+        'HelpMeWithConsent_Name'
     )
 
 class BQPDRGROR(BQTable):

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -483,7 +483,7 @@ class BQPDRGRORSchema(_BQModuleSchema):
     )
     _force_boolean_fields = (
         'ResultsConsent_Signature',
-        # 'HelpMeWithConsent_Name'
+        'HelpMeWithConsent_Name'
     )
 
 class BQPDRGROR(BQTable):
@@ -498,62 +498,6 @@ class BQPDRGRORView(BQView):
     __table__ = BQPDRGROR
     __pk_id__ = ['participant_id', 'questionnaire_response_id']
     _show_created = True
-    # TEMPORARY:  Workaround until the pdr_mod_gror table is dropped/recreated with corrected forced boolean fields
-    # For now, this maps the STRING field to an integer value when populated.   Once the base BQ pdr_mod_gror table
-    # schema is corrected, custom SQL can be deleted for this view.
-    __sql__ = """
-        SELECT id,
-               created,
-               modified,
-               authored,
-               language,
-               participant_id,
-               questionnaire_response_id,
-               questionnaire_id,
-               external_id,
-               status,
-               status_id,
-               DNAQuiz_ResultsRequired,
-               DNAQuiz_DifficultToReceiveCare,
-               DNAQuiz_CheckChangesSoon,
-               DNAQuiz_LawsProtectMe,
-               DNAQuiz_AtRisk,
-               ConsentVideo_HelpMe,
-               ConsentVideo_TellMeWhat,
-               ConsentVideo_HowLong,
-               ConsentVideo_DNAChanges,
-               ConsentVideo_CheckForWhat,
-               ConsentVideo_Risks,
-               ResultsConsent_EmailMeCopy,
-               ResultsConsent_FloridaEmailMeCopy,
-               ResultsConsent_Signature,
-               ResultsConsent_CheckDNA,
-               ResultsConsent_HelpMeWithConsent,
-               CASE
-                  WHEN HelpMeWithConsent_Name IS NULL THEN 0 ELSE 1
-               END AS HelpMeWithConsent_Name,
-               DecideReceiveResults_BetterCareOfMe,
-               DecideReceiveResults_TimeOffWork,
-               DecideReceiveResults_NotUseful,
-               DecideReceiveResults_NotRelated,
-               DecideReceiveResults_HelpProviders,
-               DecideReceiveResults_ConfusedWorried,
-               DecideReceiveResults_RelativesHealth,
-               DecideReceiveResults_MoreExpensiveHealthcare,
-               DecideReceiveResults_HelpSortOut,
-               DecideReceiveResults_HardToGetInsurance,
-               DecideReceiveResults_Increased,
-               resultsconsent_signaturedate,
-               CheckDNA_No,
-               CheckDNA_Yes,
-               CheckDNA_NotSure,
-               ReviewAgain
-        FROM (
-                    SELECT *,
-                       ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY authored DESC) AS rn
-                FROM `{project}`.{dataset}.pdr_mod_gror ) gror
-        WHERE gror.rn = 1
-    """
 
 #
 # FamilyHistory


### PR DESCRIPTION
## Resolves *no ticket*


## Description of changes/additions
Found another field from the GROR response data that should be forced to boolean.  It should not contain PII, but is free text related to whether anyone helped them with the consent process.  Also found some fields that were being "discovered" when running the `migrate-bq` tool to add the table/view to stable, but that do not exist in the production `code` data.

Fixed a typo in the `module/__init__.py` list as well.

Note on commits to this branch:
[Previous commit](https://github.com/all-of-us/raw-data-repository/pull/2880/commits/fdc07a28e811ae3ca2e52de240459c7e4e47f260) was a workaround used to create the new BigQuery table and a temporary custom view with the RDR 1.116.1 code release/PDR data generators (with the `HelpMeWithConsent_Name` field not yet forced to boolean automatically), and do the initial build for GROR data.  Pushed this commit here in order to archive the workaround.

The commit at the head of this branch is the real fix to force the free text field to boolean.  Once this branch is merged to devel, then with the next RDR release, the BigQuery `pdr_mod_gror` table will need to have its schema updated (may require a DROP/CREATE to recreate the table), and all of the GROR data will need to be rebuilt so it reflects the updated table schema. 
## Tests
- [x] unit tests


