### PR TITLE
[DA-2471] Adding "Change Management" component to auto-generated PD release tickets

### DIFF
--- a/rdr_service/services/jira_utils.py
+++ b/rdr_service/services/jira_utils.py
@@ -114,21 +114,25 @@ class JiraTicketHandler:
             raise ValueError('Invalid JIRA ticket ID value.')
         return self._jira_connection.issue(ticket_id)
 
-    def create_ticket(self, summary, descr, issue_type="Task", board_id=_JIRA_BOARD_ID):
+    def create_ticket(self, summary, descr, issue_type="Task", board_id=_JIRA_BOARD_ID, components=None):
         """
         Create a new ticket in a Jira project.
         :param summary: Ticket summary to search for.
         :param descr: Summary description for ticket.
         :param issue_type: Type of ticket to create.
         :param board_id: Jira board id, IE: PD.
+        :param components: Components to add to the ticket, defaults to not adding any components
         """
+        if components is None:
+            components = []
+
         if not summary:
             raise ValueError('Jira ticket summary may not be empty')
         if not descr:
             raise ValueError('Jira ticket description may not be empty')
 
         ticket = self._jira_connection.create_issue(
-            project=board_id, summary=summary, description=descr, issuetype={"name": issue_type}
+            project=board_id, summary=summary, description=descr, issuetype={"name": issue_type}, components=components
         )
 
         # pylint: disable=W0511

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -205,7 +205,7 @@ class DeployAppClass(ToolBase):
             if os.path.exists(c):
                 os.remove(c)
 
-    def create_jira_ticket(self, summary, descr=None, board_id=None):
+    def create_jira_ticket(self, summary, descr=None, board_id=None, components=None):
         """
         Create a Jira ticket.
         """
@@ -252,7 +252,7 @@ class DeployAppClass(ToolBase):
         if not board_id:
             board_id = self.jira_board
 
-        ticket = self._jira_handler.create_ticket(summary, descr, board_id=board_id)
+        ticket = self._jira_handler.create_ticket(summary, descr, board_id=board_id, components=components)
         return ticket
 
     def add_jira_comment(self, comment):
@@ -277,7 +277,10 @@ class DeployAppClass(ToolBase):
         else:
             # Determine if this is a CircleCI deploy.
             if self.gcp_env.project == 'all-of-us-rdr-staging':
-                ticket = self.create_jira_ticket(summary)
+                ticket = self.create_jira_ticket(
+                    summary,
+                    components=[{'id': '10074'}]  # "Change Management" component
+                )
                 if not ticket:
                     _logger.error('Failed to create JIRA ticket')
                 else:


### PR DESCRIPTION
## Resolves *[DA-2471](https://precisionmedicineinitiative.atlassian.net/browse/DA-2471)*
The security team would like to use Jira Components to organize the PD board. This updates the code that automatically creates the release ticket for the PD board. These changes will tag the tickets with the "Change Management" component.

## Description of changes/additions
It is possible to refer to the component by name. While that would be clearer in the code, it's more likely that the name would change (which would require an update in the code) rather than the id changing.

## Tests
- [ ] unit tests


