### PR TITLE
Preventing locks and fixing map for invalid response codes

### DIFF
--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -406,8 +406,11 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
         src_clean_answers = self.session.query(SrcClean).all()
         self.assertEqual(0, len(src_clean_answers))
 
-    def test_ignored_answers_are_nulled(self):
-        """Any answers that have the ignore field set to True should give null answers in the result"""
+    def test_ignored_answers_are_marked_invalid(self):
+        """
+        Any answers that have the ignore field set to True should give the skip code
+        (to be marked invalid in the finalization step)
+        """
         questionnaire_response = self._setup_questionnaire_response(
             self.participant,
             self.questionnaire,
@@ -440,7 +443,7 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
                         answer.value_number,
                         answer.value_date,
                         answer.value_boolean,
-                        answer.value_code_id,
-                        answer.value_ppi_code
+                        answer.value_code_id
                     ]
                 ]))
+                self.assertEqual(PMI_SKIP_CODE, answer.value_ppi_code)


### PR DESCRIPTION
## Resolves *no ticket*
When running the ETL process the questionnaire response table was locked up while pulling all the metadata into the new tables. This sets the isolation level to prevent the locks when that's happening.

Also, for questions that needed to be marked as invalid, the ETL process wasn't sending the invalid concept code when the answer was anything other than a code (from radio or checkbox question). This updates the input to the ETL to trigger the concept codes to be mapped correctly. There were also issues with the unit being set to null in the observation table, so this uses a new unit for invalid answers.


## Tests
- [ ] unit tests


