### PR TITLE
[DA-2499] Add gvcf files to wgs reconciliation query

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1542,7 +1542,6 @@ class GenomicGCValidationMetricsDao(UpsertableDao, GenomicDaoUtils):
                     GenomicSetMember.gcSiteId == _gc_site_id,
                     GenomicGCValidationMetrics.genomicFileProcessedId.isnot(None),
                     func.lower(GenomicGCValidationMetrics.processingStatus) == "pass",
-                    #GenomicSetMember.sampleId.in_([20297003836, 20281002851, 20207002978, 20281002822]),
                     GenomicGcDataFileMissing.id.is_(None),
                     GenomicGCValidationMetrics.ignoreFlag == 0,
                     (GenomicGCValidationMetrics.hfVcfReceived == 0) |

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1542,11 +1542,14 @@ class GenomicGCValidationMetricsDao(UpsertableDao, GenomicDaoUtils):
                     GenomicSetMember.gcSiteId == _gc_site_id,
                     GenomicGCValidationMetrics.genomicFileProcessedId.isnot(None),
                     func.lower(GenomicGCValidationMetrics.processingStatus) == "pass",
+                    #GenomicSetMember.sampleId.in_([20297003836, 20281002851, 20207002978, 20281002822]),
                     GenomicGcDataFileMissing.id.is_(None),
                     GenomicGCValidationMetrics.ignoreFlag == 0,
                     (GenomicGCValidationMetrics.hfVcfReceived == 0) |
                     (GenomicGCValidationMetrics.hfVcfTbiReceived == 0) |
                     (GenomicGCValidationMetrics.hfVcfMd5Received == 0) |
+                    (GenomicGCValidationMetrics.gvcfReceived == 0) |
+                    (GenomicGCValidationMetrics.gvcfMd5Received == 0) |
                     (GenomicGCValidationMetrics.cramReceived == 0) |
                     (GenomicGCValidationMetrics.cramMd5Received == 0) |
                     (GenomicGCValidationMetrics.craiReceived == 0)


### PR DESCRIPTION
## Resolves *[DA-2499](https://precisionmedicineinitiative.atlassian.net/browse/DA-2499)*


## Description of changes/additions
This PR adds the gVCF file received flags to the WGS GC data file reconciliation query. This ensures that if records have all GC data files except the gVCF files, they will still be reconciled.

## Tests
- [x] unit tests; current tests pass


