### PR TITLE
[DA-2474] Setting May 2020 date filter for workbench workspaces

### DIFF
--- a/tests/api_tests/test_workspace_audit_and_research_directory_api.py
+++ b/tests/api_tests/test_workspace_audit_and_research_directory_api.py
@@ -13,8 +13,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         researchers_json = [
             {
                 "userId": 0,
-                "creationTime": "2019-11-26T21:21:13.056Z",
-                "modifiedTime": "2019-11-26T21:21:13.056Z",
+                "creationTime": "2020-11-26T21:21:13.056Z",
+                "modifiedTime": "2020-11-26T21:21:13.056Z",
                 "givenName": "given name 1",
                 "familyName": "family name 1",
                 "streetAddress1": "string",
@@ -45,8 +45,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             },
             {
                 "userId": 1,
-                "creationTime": "2019-11-27T21:21:13.056Z",
-                "modifiedTime": "2019-11-27T21:21:13.056Z",
+                "creationTime": "2020-11-27T21:21:13.056Z",
+                "modifiedTime": "2020-11-27T21:21:13.056Z",
                 "givenName": "given name 2",
                 "familyName": "family name 2",
                 "streetAddress1": "string2",
@@ -85,8 +85,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             {
                 "workspaceId": 0,
                 "name": "workspace name str",
-                "creationTime": "2019-11-25T17:43:41.085Z",
-                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
                 "status": "ACTIVE",
                 "workspaceUsers": [
                     {
@@ -141,8 +141,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             {
                 "workspaceId": 1,
                 "name": "workspace name str 2",
-                "creationTime": "2019-11-25T17:43:41.085Z",
-                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
                 "status": "INACTIVE",
                 "workspaceUsers": [
                     {
@@ -188,8 +188,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         result = self.send_get('researchHub/projectDirectory')
         self.assertEqual(len(result['data']), 2)
         self.assertIn({'workspaceId': 0, 'snapshotId': 1, 'name': 'workspace name str',
-                       'creationTime': '2019-11-25T17:43:41.085000',
-                       'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'ACTIVE',
+                       'creationTime': '2020-11-25T17:43:41.085000',
+                       'modifiedTime': '2020-11-25T17:43:41.085000', 'status': 'ACTIVE',
                        'workspaceUsers': [
                            {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
                             'affiliations': [
@@ -252,8 +252,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
                        },
                       result['data'])
         self.assertIn({'workspaceId': 1, 'snapshotId': 2, 'name': 'workspace name str 2',
-                       'creationTime': '2019-11-25T17:43:41.085000',
-                       'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'INACTIVE',
+                       'creationTime': '2020-11-25T17:43:41.085000',
+                       'modifiedTime': '2020-11-25T17:43:41.085000', 'status': 'INACTIVE',
                        'workspaceUsers': [
                            {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
                             'affiliations': [
@@ -340,8 +340,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         result = self.send_get('researchHub/projectDirectory')
         self.assertEqual(len(result['data']), 1)
         self.assertIn({'workspaceId': 0, 'snapshotId': 1, 'name': 'workspace name str',
-                       'creationTime': '2019-11-25T17:43:41.085000',
-                       'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'ACTIVE',
+                       'creationTime': '2020-11-25T17:43:41.085000',
+                       'modifiedTime': '2020-11-25T17:43:41.085000', 'status': 'ACTIVE',
                        'workspaceUsers': [
                            {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
                             'affiliations': [
@@ -409,8 +409,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         result = self.send_get('researchHub/projectDirectory?status=ACTIVE')
         self.assertEqual(len(result['data']), 1)
         self.assertIn({'workspaceId': 0, 'snapshotId': 1, 'name': 'workspace name str',
-                       'creationTime': '2019-11-25T17:43:41.085000',
-                       'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'ACTIVE',
+                       'creationTime': '2020-11-25T17:43:41.085000',
+                       'modifiedTime': '2020-11-25T17:43:41.085000', 'status': 'ACTIVE',
                        'workspaceUsers': [
                            {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
                             'affiliations': [
@@ -497,8 +497,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         result = self.send_get('researchHub/projectDirectory')
         self.assertEqual(len(result['data']), 1)
         self.assertIn({'workspaceId': 1, 'snapshotId': 2, 'name': 'workspace name str 2',
-                       'creationTime': '2019-11-25T17:43:41.085000',
-                       'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'INACTIVE',
+                       'creationTime': '2020-11-25T17:43:41.085000',
+                       'modifiedTime': '2020-11-25T17:43:41.085000', 'status': 'INACTIVE',
                        'workspaceUsers': [
                            {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
                             'affiliations': [
@@ -560,8 +560,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         researchers_json = [
             {
                 "userId": 0,
-                "creationTime": "2019-11-26T21:21:13.056Z",
-                "modifiedTime": "2019-11-26T21:21:13.056Z",
+                "creationTime": "2020-11-26T21:21:13.056Z",
+                "modifiedTime": "2020-11-26T21:21:13.056Z",
                 "givenName": "givenname1",
                 "familyName": "familyname1",
                 "streetAddress1": "string",
@@ -592,8 +592,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             },
             {
                 "userId": 1,
-                "creationTime": "2019-11-27T21:21:13.056Z",
-                "modifiedTime": "2019-11-27T21:21:13.056Z",
+                "creationTime": "2020-11-27T21:21:13.056Z",
+                "modifiedTime": "2020-11-27T21:21:13.056Z",
                 "givenName": "givenname2",
                 "familyName": "familyname2",
                 "streetAddress1": "string2",
@@ -632,8 +632,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             {
                 "workspaceId": 0,
                 "name": "workspace name str Search test",
-                "creationTime": "2019-11-25T17:43:41.085Z",
-                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
                 "status": "ACTIVE",
                 "workspaceUsers": [
                     {
@@ -682,8 +682,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             {
                 "workspaceId": 1,
                 "name": "workspace name str 2",
-                "creationTime": "2019-11-25T17:43:41.085Z",
-                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
                 "status": "INACTIVE",
                 "workspaceUsers": [
                     {
@@ -826,8 +826,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             {
                 "workspaceId": 0,
                 "name": "workspace name str",
-                "creationTime": "2019-11-25T17:43:41.085Z",
-                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
                 "status": "ACTIVE",
                 "workspaceUsers": [
                     {
@@ -1479,8 +1479,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         researchers_json = [
             {
                 "userId": 0,
-                "creationTime": "2019-11-26T21:21:13.056Z",
-                "modifiedTime": "2019-11-26T21:21:13.056Z",
+                "creationTime": "2020-11-26T21:21:13.056Z",
+                "modifiedTime": "2020-11-26T21:21:13.056Z",
                 "givenName": "given name 1",
                 "familyName": "family name 1",
                 "streetAddress1": "string",
@@ -1510,8 +1510,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             },
             {
                 "userId": 1,
-                "creationTime": "2019-11-27T21:21:13.056Z",
-                "modifiedTime": "2019-11-27T21:21:13.056Z",
+                "creationTime": "2020-11-27T21:21:13.056Z",
+                "modifiedTime": "2020-11-27T21:21:13.056Z",
                 "givenName": "given name 2",
                 "familyName": "family name 2",
                 "streetAddress1": "string2",
@@ -1545,8 +1545,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             {
                 "workspaceId": 0,
                 "name": "workspace name str",
-                "creationTime": "2019-11-25T17:43:41.085Z",
-                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
                 "status": "ACTIVE",
                 "workspaceUsers": [
                     {
@@ -1590,8 +1590,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
             {
                 "workspaceId": 1,
                 "name": "workspace name str 2",
-                "creationTime": "2019-11-25T17:43:41.085Z",
-                "modifiedTime": "2019-11-25T17:43:41.085Z",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
                 "status": "INACTIVE",
                 "workspaceUsers": [
                     {
@@ -1637,8 +1637,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         result = self.send_get('researchHub/projectDirectory')
         self.assertEqual(len(result['data']), 1)
         self.assertIn({'workspaceId': 1, 'snapshotId': 2, 'name': 'workspace name str 2',
-                       'creationTime': '2019-11-25T17:43:41.085000',
-                       'modifiedTime': '2019-11-25T17:43:41.085000', 'status': 'INACTIVE',
+                       'creationTime': '2020-11-25T17:43:41.085000',
+                       'modifiedTime': '2020-11-25T17:43:41.085000', 'status': 'INACTIVE',
                        'workspaceUsers': [
                            {'userId': 0, 'userName': 'given name 1 family name 1', 'degree': ['PHD', 'MPH'],
                             'affiliations': [
@@ -1694,8 +1694,8 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         researchers_json = [
             {
                 "userId": 1,
-                "creationTime": "2019-11-27T21:21:13.056Z",
-                "modifiedTime": "2019-11-27T21:21:14.056Z",
+                "creationTime": "2020-11-27T21:21:13.056Z",
+                "modifiedTime": "2020-11-27T21:21:14.056Z",
                 "givenName": "given name 2",
                 "familyName": "family name 2",
                 "streetAddress1": "string2",
@@ -1730,6 +1730,136 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
 
         result = self.send_get('researchHub/projectDirectory')
         self.assertEqual(len(result['data']), 2)
+
+    def test_hide_workspace_created_before_release_date_from_RH(self):
+        # create researchers
+        researchers_json = [
+            {
+                "userId": 0,
+                "creationTime": "2019-11-26T21:21:13.056Z",
+                "modifiedTime": "2019-11-26T21:21:13.056Z",
+                "givenName": "given name 1",
+                "familyName": "family name 1",
+                "streetAddress1": "string",
+                "streetAddress2": "string",
+                "city": "string",
+                "state": "string",
+                "zipCode": "string",
+                "country": "string",
+                "ethnicity": "HISPANIC",
+                "gender": ["MAN"],
+                "race": ["AIAN"],
+                "sexAtBirth": ["FEMALE"],
+                "degree": ["PHD", "MPH"],
+                "sexualOrientation": "BISEXUAL",
+                "affiliations": [
+                    {
+                        "institution": "institution1",
+                        "role": "institution role 1",
+                        "nonAcademicAffiliation": "INDUSTRY"
+                    }
+                ],
+                "verifiedInstitutionalAffiliation": {
+                    "institutionShortName": "verified institution",
+                    "institutionalRole": "verified institution role 1",
+                    "nonAcademicAffiliation": "INDUSTRY"
+                }
+            }
+        ]
+        self.send_post('workbench/directory/researchers', request_data=researchers_json)
+
+        # create workspace
+        request_json = [
+            {
+                "workspaceId": 0,
+                "name": "workspace name str",
+                "creationTime": "2020-04-25T17:43:41.085Z",
+                "modifiedTime": "2020-04-25T17:43:41.085Z",
+                "status": "ACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 0,
+                        "role": "OWNER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "excludeFromPublicDirectory": False,
+                "ethicalLegalSocialImplications": True,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "disease focused research name str",
+                "otherPurposeDetails": "other purpose details str",
+                "methodsDevelopment": True,
+                "controlSet": True,
+                "ancestry": True,
+                "socialBehavioral": True,
+                "populationHealth": True,
+                "drugDevelopment": True,
+                "commercialPurpose": True,
+                "educational": True,
+                "otherPurpose": True,
+                "scientificApproaches": 'reasonForInvestigation string',
+                "intendToStudy": 'intendToStudy string',
+                "findingsFromStudy": 'findingsFromStudy string',
+                "focusOnUnderrepresentedPopulations": True,
+                "workspaceDemographic": {
+                    "raceEthnicity": ['AIAN', 'MENA'],
+                    "age": ['AGE_0_11', 'AGE_65_74'],
+                    "sexAtBirth": "UNSET",
+                    "genderIdentity": "OTHER_THAN_MAN_WOMAN",
+                    "sexualOrientation": "OTHER_THAN_STRAIGHT",
+                    "geography": "RURAL",
+                    "disabilityStatus": "DISABILITY",
+                    "accessToCare": "NOT_EASILY_ACCESS_CARE",
+                    "educationLevel": "LESS_THAN_HIGH_SCHOOL",
+                    "incomeLevel": "BELOW_FEDERAL_POVERTY_LEVEL_200_PERCENT",
+                    "others": "string"
+                }
+            },
+            {
+                "workspaceId": 1,
+                "name": "workspace name str 2",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
+                "status": "INACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 0,
+                        "role": "OWNER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "creator": {
+                    "userId": 0,
+                    "givenName": "aaa",
+                    "familyName": "bbb"
+                },
+                "excludeFromPublicDirectory": False,
+                "ethicalLegalSocialImplications": False,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "disease focused research name str 2",
+                "otherPurposeDetails": "other purpose details str 2",
+                "methodsDevelopment": False,
+                "controlSet": False,
+                "ancestry": False,
+                "socialBehavioral": False,
+                "populationHealth": False,
+                "drugDevelopment": False,
+                "commercialPurpose": False,
+                "educational": False,
+                "otherPurpose": False,
+                "scientificApproaches": 'reasonForInvestigation string2',
+                "intendToStudy": 'intendToStudy string2',
+                "findingsFromStudy": 'findingsFromStudy string2'
+            }
+        ]
+        now = clock.CLOCK.now()
+        sequest_hours_ago = now - timedelta(hours=24)
+        with FakeClock(sequest_hours_ago):
+            self.send_post('workbench/directory/workspaces', request_data=request_json)
+
+        # check that only the workspace created after May of 2020 is returned
+        result = self.send_get('researchHub/projectDirectory')
+        self.assertEqual([1], [workspace_json['workspaceId'] for workspace_json in result['data']])
 
     def test_get_audit_researchers_with_params(self):
         researchers_json = [


### PR DESCRIPTION
## Resolves *[DA-2474](https://precisionmedicineinitiative.atlassian.net/browse/DA-2474)*
The workspaces sent to Research Directory needs an additional filter to make sure we don't send any workspaces that were created before May 20th, 2020. Workspaces created before this date appear to be from testing.


## Tests
- [x] unit tests


