### PR TITLE
[DA-2505] Add cc: list to consent error emails

### DIFF
--- a/rdr_service/tools/tool_libs/consent_error_report.py
+++ b/rdr_service/tools/tool_libs/consent_error_report.py
@@ -6,6 +6,7 @@ import argparse
 
 # pylint: disable=superfluous-parens
 # pylint: disable=broad-except
+import os
 import logging
 import sys
 
@@ -29,7 +30,7 @@ class ConsentErrorReportTool(object):
         The ConsentReport class will contain attributes and methods common to both the daily consent validation report
         and the weekly consent validation status report.
     """
-    def __init__(self, args, gcp_env: GCPEnvConfigObject):
+    def __init__(self, args, gcp_env: GCPEnvConfigObject, id_list=None):
         """
         :param args: command line arguments.
         :param gcp_env: gcp environment information, see: gcp_initialize().
@@ -37,6 +38,23 @@ class ConsentErrorReportTool(object):
         self.args = args
         self.gcp_env = gcp_env
         self.db_conn = None
+        self.id_list = id_list
+        self.recipients, self.cc_recipients = self._get_email_addresses(self.args.to, self.args.cc)
+
+    @staticmethod
+    def _get_email_addresses(to_list: str or None, cc_list: str or None):
+        """
+        Transform comma-separated strings passed as tool params into lists
+        :param to_list:  A comma-separated list of emails from the args.to param
+        :param cc_list: A comma-separated list of emails from the args.cc_list param
+        :returns:  recipients, cc_list list objects
+        """
+        recipients, cc_recipients = None, None
+        if to_list:
+            recipients = list(to_list.split(','))
+        if cc_list:
+            cc_recipients = list(cc_list.split(','))
+        return recipients, cc_recipients
 
     def _connect_to_rdr_replica(self):
         """ Establish a connection to the replica RDR database for reading consent validation data """
@@ -61,13 +79,37 @@ class ConsentErrorReportTool(object):
                 raise (config.MissingConfigException, 'No API key configured for sendgrid')
             # This enables use of SendGrid email service when running this tool from a dev server vs. app instance
             config.override_setting(config.SENDGRID_KEY, project_config[config.SENDGRID_KEY])
-            config.override_setting(config.PTSC_SERVICE_DESK_EMAIL, project_config[config.PTSC_SERVICE_DESK_EMAIL])
 
+        errors_since = self.args.errors_since
         report = ConsentErrorReportGenerator()
-        report.create_error_reports(errors_created_since=self.args.errors_since,
+        # Specific ids will override any date filter
+        if self.id_list:
+            errors_since = None
+        report.create_error_reports(errors_created_since=errors_since,
+                                    id_list=self.id_list,
+                                    recipients=self.recipients,
+                                    cc_list=self.cc_recipients,
                                     participant_origin=self.args.origin,
                                     to_file=self.args.to_file)
         return 0
+
+def get_id_list(fname):
+    """
+    Shared helper routine for tool classes that allow input from a file of integer ids (participant ids or
+    id values from a specific table).
+    :param fname:  The filename passed with the --from-file argument
+    :return: A list of integers, or None on missing/empty fname
+    """
+    filename = os.path.expanduser(fname)
+    if not os.path.exists(filename):
+        _logger.error(f"File '{fname}' not found.")
+        return None
+
+    # read ids from file.
+    ids = open(os.path.expanduser(fname)).readlines()
+    # convert ids from a list of strings to a list of integers.
+    ids = [int(i) for i in ids if i.strip()]
+    return ids if len(ids) else None
 
 def run():
     # Set global debug value and setup application logging.
@@ -86,12 +128,26 @@ def run():
                         default=f'configurator@{RdrEnvironment.PROD.value}.iam.gserviceaccount.com') #noqa
     parser.add_argument("--errors-since", type=lambda s: datetime.strptime(s, '%Y-%m-%d'),
                         help="Date (YYYY-MM-DD string) filter to apply when finding validation errors for report")
+    parser.add_argument("--id", type=int, help="Specific consent_file primary key id to create an error report for, " +\
+                                               "takes precedence over --errors-since")
+    parser.add_argument("--from-file", type=str, help="File with list of consent_file primary_key ids to create " + \
+                                                      "error reports for")
     parser.add_argument("--to-file", help="Output error report content to this file",
                         default=False, type=str, dest="to_file")
     parser.add_argument("--origin", default='vibrent', help="participant_origin value to filter on")
+    parser.add_argument("--to", default=None,
+                        help="Comma-separated list of email addresses for To: list.  Overrides app config setting")
+    parser.add_argument("--cc", default=None,
+                        help="Comma-separated list of email address for the Cc: list. Overrides app config setting")
     args = parser.parse_args()
 
     with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
-        process = ConsentErrorReportTool(args, gcp_env)
+        ids = None
+        if hasattr(args, 'from_file') and args.from_file:
+            ids = get_id_list(args.from_file)
+        elif hasattr(args, 'id') and args.id:
+            ids = [args.id, ]
+
+        process = ConsentErrorReportTool(args, gcp_env, ids)
         exit_code = process.execute()
         return exit_code

--- a/tests/resource_tests/generator_tests/test_consent_metrics.py
+++ b/tests/resource_tests/generator_tests/test_consent_metrics.py
@@ -577,9 +577,12 @@ class ConsentMetricGeneratorTest(BaseTestCase):
     def test_consent_error_report_email_generation(self, email_mock):
         # Override config settings for test purposes
         test_key = 'test_key'
-        test_recipients = ['test_recipient@unittest.com',]
+        test_email_config = {
+            "recipients": ["test_error_report_recipient@test.com", ],
+            "cc_recipients": ["test_error_report_cc_recipient1@test.com", "test_error_report_cc_recipient2@test.com"]
+        }
         config.override_setting(config.SENDGRID_KEY, [test_key])
-        config.override_setting(config.PTSC_SERVICE_DESK_EMAIL, test_recipients)
+        config.override_setting(config.PTSC_SERVICE_DESK_EMAIL, test_email_config)
 
         participant = self._create_participant_with_all_consents_authored(
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
@@ -617,7 +620,8 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             subject_lines.append(call_arg.args[0].subject)
             # Verify the to/from email addresses
             self.assertEqual('no-reply@pmi-ops.org', call_arg.args[0].from_email)
-            self.assertEqual(test_recipients, call_arg.args[0].recipients)
+            self.assertEqual(test_email_config.get('recipients'), call_arg.args[0].recipients)
+            self.assertEqual(test_email_config.get('cc_recipients'), call_arg.args[0].cc_recipients)
             self.assertIn('DRC Consent Validation Issue', call_arg.args[0].subject)
 
         # Verify the expected subject lines were generated


### PR DESCRIPTION
## Resolves *[DA-2505](https://precisionmedicineinitiative.atlassian.net/browse/DA-2505)*


## Description of changes/additions
Changes the PTSC_SERVICE_DESK_EMAIL config item from just a `recipient` key/list value to a JSON struct with key/list value pairs for `recipients` and `cc_recipients` (modeled after genomics emails).

Tool updates to the `consent-error-report` tool will take `--to` and `--cc` command line arguments to override the config settings, and will also allow a specific list of `consent_file` ids to be passed as the records needing error report generation.

Also fix the logging message when error reports are generated to de-duplicate the participant ID list for which errors were generated.

## Tests
- [x] unit tests (updated)


