### PR TITLE
Fixing bug in consent validation process

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -423,7 +423,7 @@ class ConsentValidationController:
                 output_strategy=output_strategy,
                 consent_responses=participant_id_consent_map[summary.participantId]
             )
-        session.commit()
+        output_strategy.process_results()
 
         # Use the legacy query for the day that the updated check is released (and in case any are missed)
         summaries_needing_validated = self.consent_dao.get_participants_with_unvalidated_files(session)

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -109,7 +109,7 @@ class ConsentControllerTest(BaseTestCase):
 
         # Confirm a call to the dispatcher to rebuild the consent metrics resource data, with the ConsentFile.id
         # values from the expected_updates list
-        self.assertDispatchRebuildConsentMetricsCalled([2, 5, 6, 4])
+        self.assertDispatchRebuildConsentMetricsCalled([2, 5, 6, 4], call_count=2)
 
     def test_validating_specific_consents(self):
         """Make sure only the provided consent types are validated when specified"""


### PR DESCRIPTION
## Resolves *no ticket*
The consent validation process primarily uses `ConsentResponse` records to know what consents need validation, but the previous algorithm is still in place to catch any that may have been missed. That is reporting some that haven't yet been processed, but I believe all of those are still queued in the output strategy and haven't yet been taken care of because the context hasn't closed.

This PR adds a line to have the last of the files queued in the output strategy get flushed to the database before checking to see if there are any others that need to be validated.


## Tests
- [ ] unit tests


