### PR TITLE
[PDR-757] Add pipeline_id field to PDR genomic_gc_validation_metrics …

### DIFF
--- a/rdr_service/model/bq_genomics.py
+++ b/rdr_service/model/bq_genomics.py
@@ -422,6 +422,7 @@ class BQGenomicGCValidationMetricsSchema(BQSchema):
     gvcf_md5_received = BQField('gvcf_md5_received', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     gvcf_md5_deleted = BQField('gvcf_md5_deleted', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     drc_call_rate = BQField('drc_call_rate', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    pipeline_id = BQField('pipeline_id', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
 
 
 class BQGenomicGCValidationMetrics(BQTable):

--- a/rdr_service/resource/schemas/genomics.py
+++ b/rdr_service/resource/schemas/genomics.py
@@ -291,6 +291,7 @@ class GenomicGCValidationMetricsSchema(Schema):
     gvcf_md5_received = fields.Int16()
     gvcf_md5_deleted = fields.Int16()
     drc_call_rate = fields.String(validate=validate.Length(max=128))
+    pipeline_id = fields.String(validate=validate.Length(max=128))
 
     class Meta:
         schema_id = SchemaID.genomic_gc_validation_metrics


### PR DESCRIPTION
…schemas

## Resolves *[PDR-757](https://precisionmedicineinitiative.atlassian.net/browse/PDR-757)*


## Description of changes/additions
The `pipeline_id` field was missing from the PDR `genomic_gc_validation_metrics` table/view schemas.  

Next steps will be to update/migrate the PDR PostgresQL and BigQuery tables/views to add the new column, and use the `resource` tool to rebuild the records in the `genomic_gc_validation_metrics` table that have a `pipeline_id` value populated.  

## Tests
- [x] unit tests


