### PR TITLE
[PDR-805] 'Prefer not to answer' should not be RBR.

### DIFF
--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -57,10 +57,9 @@ class ParticipantUBRCalculator:
         if answer in [None, 'PMI_Skip', 'PMI_PreferNotToAnswer']:
             return UBRValueEnum.NotAnswer_Skip
 
-        if answer not in ['SexualOrientation_Straight', 'PMI_PreferNotToAnswer']:
-            return UBRValueEnum.UBR
-
-        return UBRValueEnum.RBR
+        if answer == 'SexualOrientation_Straight':
+            return UBRValueEnum.RBR
+        return UBRValueEnum.UBR
 
     @staticmethod
     def ubr_gender_identity(birth_sex, gender_ident, gender_ident_closer):

--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -18,7 +18,8 @@ class UBRValueEnum(IntEnum):
 
     RBR = 0
     UBR = 1
-    NotAnswer_Skip = 2  # PMI_PreferNotToAnswer or PMI_Skip value.
+    # NotAnswer_Skip: Answer is Null (only if a TheBasics has been submitted), PMI_PreferNotToAnswer or PMI_Skip value.
+    NotAnswer_Skip = 2
 
 
 class ParticipantUBRCalculator:
@@ -34,7 +35,7 @@ class ParticipantUBRCalculator:
         :param answer: Answer code to BiologicalSexAtBirth_SexAtBirth question in "TheBasics" survey.
         :return: UBRValueEnum
         """
-        if answer is None or answer == 'PMI_Skip':
+        if answer in [None, 'PMI_Skip', 'PMI_PreferNotToAnswer']:
             return UBRValueEnum.NotAnswer_Skip
         if answer in ('SexAtBirth_SexAtBirthNoneOfThese', 'SexAtBirth_Intersex'):
             return UBRValueEnum.UBR
@@ -53,8 +54,7 @@ class ParticipantUBRCalculator:
         # they did not answer the expected SexualOrientation_None response to the parent TheBasics_SexualOrientation
         # question first.  This is not  consistent with the documented survey branching logic.  Therefore, UBR/RBR
         # calculations are still based only on the response to the TheBasics_SexualOrientation question alone
-
-        if answer is None or answer == 'PMI_Skip':
+        if answer in [None, 'PMI_Skip', 'PMI_PreferNotToAnswer']:
             return UBRValueEnum.NotAnswer_Skip
 
         if answer not in ['SexualOrientation_Straight', 'PMI_PreferNotToAnswer']:
@@ -93,14 +93,13 @@ class ParticipantUBRCalculator:
 
         # Note: assume ubr by default and check for exclusion criteria.
         if len(answers) == 1:
-            answer = answers[0]
-            if answer is None or answer == 'PMI_Skip':
+            answer = answers[0]  # Get the one answer in the list object.
+            if answer in [None, 'PMI_Skip', 'PMI_PreferNotToAnswer', 'GenderIdentity_PreferNotToAnswer']:
                 return UBRValueEnum.NotAnswer_Skip
-            if (answer == 'PMI_PreferNotToAnswer' or answer == 'GenderIdentity_PreferNotToAnswer') or \
-                    (answer == 'GenderIdentity_Man' and birth_sex in ['SexAtBirth_Male', 'PMI_Skip',
-                                                                      'GenderIdentity_PreferNotToAnswer', None]) or \
-                    (answer == 'GenderIdentity_Woman' and birth_sex in ['SexAtBirth_Female', 'PMI_Skip',
-                                                                        'GenderIdentity_PreferNotToAnswer', None]):
+            if (answer == 'GenderIdentity_Man' and
+                        birth_sex in ['SexAtBirth_Male', 'PMI_Skip', 'PMI_PreferNotToAnswer', None]) or \
+                    (answer == 'GenderIdentity_Woman' and
+                        birth_sex in ['SexAtBirth_Female', 'PMI_Skip', 'PMI_PreferNotToAnswer', None]):
                 return UBRValueEnum.RBR
         return UBRValueEnum.UBR
 
@@ -132,13 +131,14 @@ class ParticipantUBRCalculator:
         """
         if answers is None:
             return UBRValueEnum.NotAnswer_Skip
+
         # Note: assume UBR by default and check for exclusion criteria.
         answers = answers.split(',')
         if len(answers) == 1:
             answer = answers[0]
-            if answer == 'PMI_Skip':
+            if answer in [None, 'PMI_Skip', 'PMI_PreferNotToAnswer']:
                 return UBRValueEnum.NotAnswer_Skip
-            if answer in ('WhatRaceEthnicity_White', 'PMI_PreferNotToAnswer'):
+            if answer == 'WhatRaceEthnicity_White':
                 return UBRValueEnum.RBR
         return UBRValueEnum.UBR
 
@@ -169,7 +169,7 @@ class ParticipantUBRCalculator:
         :param answer: Answer code to EducationLevel_HighestGrade question in "TheBasics" survey.
         :return: UBRValueEnum
         """
-        if answer is None or answer == 'PMI_Skip':
+        if answer in [None, 'PMI_Skip', 'PMI_PreferNotToAnswer']:
             return UBRValueEnum.NotAnswer_Skip
         if answer in (
                 'HighestGrade_NeverAttended',
@@ -186,7 +186,7 @@ class ParticipantUBRCalculator:
         :param answer: Answer code to Income_AnnualIncome question in "TheBasics" survey.
         :return: UBRValueEnum
         """
-        if answer is None or answer == 'PMI_Skip':
+        if answer in [None, 'PMI_Skip', 'PMI_PreferNotToAnswer']:
             return UBRValueEnum.NotAnswer_Skip
         if answer in (
                 'AnnualIncome_less10k',
@@ -201,6 +201,9 @@ class ParticipantUBRCalculator:
         :param answers: Dict with keys and answer codes for 'Disability_Blind',
                         'Disability_WalkingClimbing', 'Disability_DressingBathing', 'Disability_ErrandsAlone',
                         'Disability_Deaf' and 'Disability_DifficultyConcentrating' from "TheBasics" survey.
+        # List of "Prefer Not To Answer" answer values for each question:
+         'Blind_PreferNotToAnswer', 'WalkingClimbing_PreferNotToAnswer', 'DressingBathing_PreferNotToAnswer',
+         'ErrandsAlone_PreferNotToAnswer', 'Deaf_PreferNotToAnswer', 'DifficultyConcentrating_PreferNotToAnswer'
         :return: UBRValueEnum
         """
         if answers:
@@ -213,11 +216,14 @@ class ParticipantUBRCalculator:
                     answers.get('Disability_Deaf', None) == 'Deaf_Yes' or \
                     answers.get('Disability_DifficultyConcentrating', None) == 'DifficultyConcentrating_Yes':
                 return UBRValueEnum.UBR
-        # Check and see if all question answers are either Null or PMI_Skip.
+        # Check and see if all question answers are either Null, 'Prefer Not To Answer' or PMI_Skip.
         null_skip = True
-        for k in [ 'Disability_Blind', 'Disability_WalkingClimbing', 'Disability_DressingBathing',
+        for k in ['Disability_Blind', 'Disability_WalkingClimbing', 'Disability_DressingBathing',
                    'Disability_ErrandsAlone', 'Disability_Deaf' and 'Disability_DifficultyConcentrating']:
-            if answers.get(k, None) not in (None, 'PMI_Skip'):
+            if answers.get(k, None) not in \
+                    [None, 'PMI_Skip', 'Blind_PreferNotToAnswer', 'WalkingClimbing_PreferNotToAnswer',
+                     'DressingBathing_PreferNotToAnswer', 'ErrandsAlone_PreferNotToAnswer',
+                     'Deaf_PreferNotToAnswer', 'DifficultyConcentrating_PreferNotToAnswer']:
                 null_skip = False
                 break
         if null_skip is True:
@@ -232,14 +238,15 @@ class ParticipantUBRCalculator:
         :param answer: Answer to the PIIBirthInformation_BirthDate question in the ConsentPII survey.
         :return: UBRValueEnum
         """
-        if answer is None or answer == 'PMI_Skip':
+        if answer in [None, 'PMI_Skip']:
             return UBRValueEnum.NotAnswer_Skip
         if not consent_time:
             return UBRValueEnum.RBR
         # Convert date string to date object if needed.
         if isinstance(answer, str):
             answer = parse(answer)
-
+        # When calculating 'Age At Consent', ensure that leap years are accounted for. A date subtraction
+        # function that is "leap year" aware must be used.
         rd = relativedelta(consent_time, answer)
         if not 18 <= rd.years < 65:
             return UBRValueEnum.UBR

--- a/tests/resource_tests/calculator_tests/test_ubr_calculator.py
+++ b/tests/resource_tests/calculator_tests/test_ubr_calculator.py
@@ -42,7 +42,7 @@ class UBRCalculatorTest(BaseTestCase):
         # Test RBR value
         self.assertEqual(self.ubr.ubr_sex('SexAtBirth_Male'), UBRValueEnum.RBR)
         self.assertEqual(self.ubr.ubr_sex('SexAtBirth_Female'), UBRValueEnum.RBR)
-        self.assertEqual(self.ubr.ubr_sex('PMI_PreferNotToAnswer'), UBRValueEnum.RBR)
+        self.assertEqual(self.ubr.ubr_sex('PMI_PreferNotToAnswer'), UBRValueEnum.NotAnswer_Skip)
 
         # Bad or unknown value will default to RBR
         self.assertEqual(self.ubr.ubr_sex('BadValueTest'), UBRValueEnum.RBR)
@@ -67,7 +67,7 @@ class UBRCalculatorTest(BaseTestCase):
 
         # Test RBR value
         self.assertEqual(self.ubr.ubr_sexual_orientation('SexualOrientation_Straight'), UBRValueEnum.RBR)
-        self.assertEqual(self.ubr.ubr_sexual_orientation('PMI_PreferNotToAnswer'), UBRValueEnum.RBR)
+        self.assertEqual(self.ubr.ubr_sexual_orientation('PMI_PreferNotToAnswer'), UBRValueEnum.NotAnswer_Skip)
 
         # Bad or unknown value will default to UBR.
         self.assertEqual(self.ubr.ubr_sexual_orientation('BadValueTest'), UBRValueEnum.UBR)
@@ -114,9 +114,9 @@ class UBRCalculatorTest(BaseTestCase):
 
         # Test RBR values
         self.assertEqual(self.ubr.ubr_gender_identity(
-                'SexAtBirth_Intersex', 'PMI_PreferNotToAnswer', None), UBRValueEnum.RBR)
+                'SexAtBirth_Intersex', 'PMI_PreferNotToAnswer', None), UBRValueEnum.NotAnswer_Skip)
         self.assertEqual(self.ubr.ubr_gender_identity(
-            'SexAtBirth_Male', 'GenderIdentity_PreferNotToAnswer', None), UBRValueEnum.RBR)
+            'SexAtBirth_Male', 'GenderIdentity_PreferNotToAnswer', None), UBRValueEnum.NotAnswer_Skip)
         self.assertEqual(self.ubr.ubr_gender_identity(
                 'SexAtBirth_Female', 'GenderIdentity_Woman', 'PMI_Skip'), UBRValueEnum.RBR)
         self.assertEqual(self.ubr.ubr_gender_identity(
@@ -181,7 +181,7 @@ class UBRCalculatorTest(BaseTestCase):
 
         # Test RBR value
         self.assertEqual(self.ubr.ubr_ethnicity('WhatRaceEthnicity_White'), UBRValueEnum.RBR)
-        self.assertEqual(self.ubr.ubr_ethnicity('PMI_PreferNotToAnswer'), UBRValueEnum.RBR)
+        self.assertEqual(self.ubr.ubr_ethnicity('PMI_PreferNotToAnswer'), UBRValueEnum.NotAnswer_Skip)
 
         # Bad or unknown value will default to UBR
         self.assertEqual(self.ubr.ubr_ethnicity('ABC-123'), UBRValueEnum.UBR)
@@ -268,7 +268,7 @@ class UBRCalculatorTest(BaseTestCase):
         self.assertEqual(self.ubr.ubr_income('AnnualIncome_100k150k'), UBRValueEnum.RBR)
         self.assertEqual(self.ubr.ubr_income('AnnualIncome_150k200k'), UBRValueEnum.RBR)
         self.assertEqual(self.ubr.ubr_income('AnnualIncome_more200k'), UBRValueEnum.RBR)
-        self.assertEqual(self.ubr.ubr_income('PMI_PreferNotToAnswer'), UBRValueEnum.RBR)
+        self.assertEqual(self.ubr.ubr_income('PMI_PreferNotToAnswer'), UBRValueEnum.NotAnswer_Skip)
 
         # Bad or unknown value will default to RBR
         self.assertEqual(self.ubr.ubr_income('BadValueTest'), UBRValueEnum.RBR)
@@ -285,6 +285,13 @@ class UBRCalculatorTest(BaseTestCase):
         for k in self.disability_answers.keys():
             values[k] = 'PMI_Skip'
         self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NotAnswer_Skip)
+
+        # Test with "Prefer Not To Answer" values.
+        values = self.disability_answers
+        values['Disability_Deaf'] = 'Deaf_PreferNotToAnswer'
+        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.NotAnswer_Skip)
+        values['Disability_ErrandsAlone'] = 'ErrandsAlone_Yes'
+        self.assertEqual(self.ubr.ubr_disability(values), UBRValueEnum.UBR)
 
         # Test UBR value
         values = self.disability_answers


### PR DESCRIPTION
## Resolves *[PDR-805](https://precisionmedicineinitiative.atlassian.net/browse/PDR-805)*


## Description of changes/additions
Due to changes in the Program Data Glossary, when a participant answers with 'PMI_PreferNotToAnswer', these should not be counted as RBR.

## Tests
- [x] unit tests


