### PR TITLE
Fix for duplicate/simultaneous requests on Biobank Specimen API

### DIFF
--- a/rdr_service/api/biobank_specimen_api.py
+++ b/rdr_service/api/biobank_specimen_api.py
@@ -29,11 +29,11 @@ class BiobankSpecimenApi(BiobankApiBase):
         if rlims_id:
             self._check_required_specimen_fields(resource)
 
-            if self.dao.exists(rlims_id):
-                rlims_id = kwargs['rlims_id']
-                return super(BiobankSpecimenApi, self).put(rlims_id, skip_etag=True)
-            else:
-                with self.dao.get_mutually_exclusive_lock(rlims_id):
+            with self.dao.get_mutually_exclusive_lock(rlims_id):
+                if self.dao.exists(rlims_id):
+                    rlims_id = kwargs['rlims_id']
+                    return super(BiobankSpecimenApi, self).put(rlims_id, skip_etag=True)
+                else:
                     return super(BiobankSpecimenApi, self).post()
         else:
             success_count = 0
@@ -201,12 +201,12 @@ class BiobankAliquotApi(BiobankApiBase):
         self.aliquot_rlims_id = kwargs['rlims_id']
         self.parent_rlims_id = kwargs['parent_rlims_id']
 
-        aliquot_id = self.dao.get_id(BiobankAliquot(rlimsId=self.aliquot_rlims_id))
-        if aliquot_id is None:
-            with self.dao.get_mutually_exclusive_lock(self.aliquot_rlims_id):
+        with self.dao.get_mutually_exclusive_lock(self.aliquot_rlims_id):
+            aliquot_id = self.dao.get_id(BiobankAliquot(rlimsId=self.aliquot_rlims_id))
+            if aliquot_id is None:
                 super(BiobankAliquotApi, self).post()
-        else:
-            super(BiobankAliquotApi, self).put(aliquot_id, skip_etag=True)
+            else:
+                super(BiobankAliquotApi, self).put(aliquot_id, skip_etag=True)
 
     def _get_model_to_update(self, resource, id_, expected_version, participant_id=None):
         return self._parse_aliquot_json(resource)

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -1,0 +1,37 @@
+
+from rdr_service.dao import database_factory
+from rdr_service.dao.database_utils import NamedLock
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class DatabaseUtilsTest(BaseTestCase):
+    def test_named_locks(self):
+        database = database_factory.get_database()
+        with database.session() as first_connection, database.session() as another_connection:
+
+            # Should be able to take a named lock
+            with NamedLock(name='first_lock', session=first_connection) as first_lock:
+                self.assertTrue(first_lock.is_locked)
+
+                # Should be able to take another lock with a different name
+                with NamedLock(name='another_lock', session=first_connection) as another_lock:
+                    self.assertTrue(another_lock.is_locked)
+
+                # Should not be able to take a lock on something locked by another connection
+                with self.assertRaises(IOError):
+                    exception = IOError('error getting lock')
+                    with NamedLock(
+                        name='first_lock', session=another_connection, lock_failure_exception=exception,
+                        lock_timeout_seconds=1
+                    ):
+                        ...
+
+                # Should raise exception even if a type wasn't given
+                with self.assertRaises(Exception):
+                    with NamedLock(name='first_lock', session=another_connection, lock_timeout_seconds=1):
+                        ...
+
+            # Closing the context should release the lock, should be able to take the lock now
+            with NamedLock(name='first_lock', session=another_connection) as lock:
+                self.assertTrue(lock.is_locked)
+


### PR DESCRIPTION
## Resolves *no ticket*
The RDR occasionally receives duplicate requests from the Biobank to create a specimen or aliquot. Currently the API will  start processing both requests and then error out on one of them when attempting the `insert` (because of a unique constraint on the rlims id).

To avoid further errors with these duplicate requests, this PR sets up named locks around processing the requests. When we receive two simultaneous requests to insert the same data, the first request processed will take an exclusive lock on the database and prevent the second request from being processed in parallel. When the insert for the first request completes, the second request will then be able take the lock (as long as the 30 second timeout hasn't occurred). The second request will then perform an update instead of another insert.

The DeceasedReportDao already has functionality for named locks. That code was refactored into a reusable class.


## Tests
- [x] unit tests
Existing unit tests cover expected behavior (tests for named locks were moved in the refactor)


