### PR TITLE
Removing empty components field from Jira API call for ROC ticket

### DIFF
--- a/rdr_service/services/jira_utils.py
+++ b/rdr_service/services/jira_utils.py
@@ -131,9 +131,15 @@ class JiraTicketHandler:
         if not descr:
             raise ValueError('Jira ticket description may not be empty')
 
-        ticket = self._jira_connection.create_issue(
-            project=board_id, summary=summary, description=descr, issuetype={"name": issue_type}, components=components
-        )
+        ticket_parameters = {
+            'project': board_id,
+            'summary': summary,
+            'description': descr,
+            'issuetype': {'name': issue_type}
+        }
+        if components:
+            ticket_parameters['components'] = components
+        ticket = self._jira_connection.create_issue(**ticket_parameters)
 
         # pylint: disable=W0511
         #NOTE: the drc api jira account does not have permissions to add watchers. This is a no-op.


### PR DESCRIPTION
## Resolves *no ticket*
When calling to the Jira API for creating the release ticket, we tag it with the "Change Management" component. We don't have a component to set for the ROC board, so I left the field in but with a blank value. It looks like the the Jira API throws an error when trying to create a ticket for the ROC board because components isn't set up there.

## Description of changes/additions
This PR updates the code to only send the `components` field if there is a component to send, otherwise it leaves the field out.

## Tests
- [ ] unit tests


