### PR TITLE
[PDR-819] Fix handling of PMI_Skip answer to EmploymentWorkAddress_Zi…

### DIFF
--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from re import match as re_match
 
 from sqlalchemy import text
 
@@ -185,11 +186,13 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
                     elif field['type'] == BQFieldTypeEnum.INTEGER.name:
                         if fld_value != PMI_SKIP_CODE:
                             setattr(bqr, fld_name, 1)
-                    # Truncate zip codes to 3 digits.  Sanity check that the answer starts with a digit (consistent
-                    # with a 5-digit or Zip+4 format zipcode answer), and is not a code string like PMI_Skip
+                    # Truncate zip code fields to 3 chars (PDR fields are strings), provided the field
+                    # has a digit as its first non-whitespace char.  This does NOT try to discover all possible
+                    # invalid zipcode string conditions before truncating, but ensures coded values like PMI_Skip
+                    # don't get truncated
                     elif fld_name in ('StreetAddress_PIIZIP', 'EmploymentWorkAddress_ZipCode') and \
-                            len(fld_value) > 2 and fld_value[0].isdigit():
-                        setattr(bqr, fld_name, fld_value[:3])
+                           len(fld_value.lstrip()) > 2 and re_match(r'^\s*\d+', fld_value):
+                        setattr(bqr, fld_name, fld_value.lstrip()[:3])
                     else:
                         setattr(bqr, fld_name, str(fld_value))
 

--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -185,9 +185,10 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
                     elif field['type'] == BQFieldTypeEnum.INTEGER.name:
                         if fld_value != PMI_SKIP_CODE:
                             setattr(bqr, fld_name, 1)
-                    # Truncate zip codes to 3 digits
+                    # Truncate zip codes to 3 digits.  Sanity check that the answer starts with a digit (consistent
+                    # with a 5-digit or Zip+4 format zipcode answer), and is not a code string like PMI_Skip
                     elif fld_name in ('StreetAddress_PIIZIP', 'EmploymentWorkAddress_ZipCode') and \
-                            len(fld_value) > 2:
+                            len(fld_value) > 2 and fld_value[0].isdigit():
                         setattr(bqr, fld_name, fld_value[:3])
                     else:
                         setattr(bqr, fld_name, str(fld_value))
@@ -197,7 +198,6 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
                     break
 
         return table, bqrs
-
 
 def bq_questionnaire_update_task(p_id, qr_id):
     """


### PR DESCRIPTION
…pCode

## Resolves *[PDR-819](https://precisionmedicineinitiative.atlassian.net/browse/PDR-819)*


## Description of changes/additions
We have ~75K TheBasics responses where the answer to the EmploymentWorkAddress_ZipCode question was `PMI_Skip`
This was getting treated like a zipcode and truncated to three characters so it shows up as `PMI` in the PDR data.

Adds a sanity check to the generator so that it will only do the zipcode truncation if the answer starts with a digit.  This allows `PMI_Skip` responses to show up in PDR unaltered

## Tests
- [x] unit tests


