### PR TITLE
[DA-2489] Sending notification if date of birth validation fails

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -5,7 +5,7 @@ from flask_restful import Resource
 from werkzeug.exceptions import NotFound
 
 from rdr_service.api.data_gen_api import generate_samples_task
-from rdr_service.api_util import returns_success, parse_date
+from rdr_service.api_util import parse_date, returns_success
 from rdr_service.app_util import task_auth_required
 from rdr_service.dao.bq_code_dao import rebuild_bq_codebook_task
 from rdr_service.dao.bq_participant_summary_dao import bq_participant_summary_update_task

--- a/rdr_service/api_util.py
+++ b/rdr_service/api_util.py
@@ -253,7 +253,7 @@ def returns_success(func):
 def dispatch_task(endpoint: str, payload: dict, in_seconds=30, quiet=True, project_id=config.GAE_PROJECT):
     """Queue a task in GAE that will execute with the specified task with the provided json"""
 
-    if project_id == 'localhost' and False:
+    if project_id == 'localhost':
         logging.warning(f'Skipping {endpoint} task targeting localhost')
     else:
         task = GCPCloudTask()

--- a/rdr_service/api_util.py
+++ b/rdr_service/api_util.py
@@ -234,3 +234,13 @@ def download_cloud_file(source_path, destination_path):
 def is_cloud_file_exits(path):
     provider = get_storage_provider()
     return provider.exists(path)
+
+
+def returns_success(func):
+    """A decorator for cron or task api that simply returns a json structure with success set to true"""
+
+    def wrapper(*args, **kwargs):
+        func(*args, **kwargs)
+        return '{"success": "true"}'
+
+    return wrapper

--- a/rdr_service/api_util.py
+++ b/rdr_service/api_util.py
@@ -253,8 +253,8 @@ def returns_success(func):
 def dispatch_task(endpoint: str, payload: dict, in_seconds=30, quiet=True, project_id=config.GAE_PROJECT):
     """Queue a task in GAE that will execute with the specified task with the provided json"""
 
-    if project_id == 'localhost':
-        logging.warning(f'Skipping {endpoint} task targeting at localhost')
+    if project_id == 'localhost' and False:
+        logging.warning(f'Skipping {endpoint} task targeting localhost')
     else:
         task = GCPCloudTask()
         task.execute(

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -144,7 +144,6 @@ class ParticipantSummary(Base):
     language = None  # placeholder for docs, API sets on model using corresponding ID field
     '*Deprecated*'
 
-
     dateOfBirth = Column("date_of_birth", Date)
     """The day the participant was born."""
 

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -159,6 +159,11 @@ def _build_resource_app():
     #
     # End primary Resource API endpoint
     #
+
+    _api.add_resource(cloud_tasks_api.ValidateDateOfBirthApi,
+                      TASK_PREFIX + 'ValidateDateOfBirth',
+                      endpoint='check_date_of_birth', methods=['POST'])
+
     _app.add_url_rule('/_ah/start', endpoint='start', view_func=flask_start, methods=["GET"])
     _app.add_url_rule('/_ah/stop', endpoint='stop', view_func=flask_stop, methods=["GET"])
 

--- a/rdr_service/services/participant_data_validation.py
+++ b/rdr_service/services/participant_data_validation.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+import logging
+
+from dateutil.relativedelta import relativedelta
+
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.services.slack_utils import SlackMessageHandler
+
+
+class ParticipantDataValidation:
+    @classmethod
+    def analyze_date_of_birth(
+        cls,
+        participant_id: int,
+        date_of_birth: datetime
+    ):
+        is_age_at_consent_valid = cls._is_age_at_consent_valid(
+            date_of_birth=date_of_birth,
+            participant_id=participant_id
+        )
+        is_current_age_valid = cls._is_current_age_valid(
+            date_of_birth=date_of_birth,
+            participant_id=participant_id
+        )
+
+        if not (is_age_at_consent_valid and is_current_age_valid):
+            cls._send_notification()
+
+    @classmethod
+    def _is_current_age_valid(cls, date_of_birth: datetime, participant_id: int):
+        current_age_years = relativedelta(datetime.utcnow(), date_of_birth).years
+        if cls._is_outside_expected_bounds(current_age_years):
+            logging.warning(
+                f'Unexpected date of birth for P{participant_id}: '
+                f'date of birth means current age is invalid for program'
+            )
+            return False
+
+        return True
+
+    @classmethod
+    def _is_age_at_consent_valid(cls, date_of_birth: datetime, participant_id: int):
+        summary_dao = ParticipantSummaryDao()
+        participant_summary: ParticipantSummary = summary_dao.get_by_participant_id(participant_id)
+
+        if not participant_summary:
+            logging.error(f'Unable to find participant summary for {participant_id}')
+            return True
+
+        age_at_consent_years = relativedelta(
+            participant_summary.consentForStudyEnrollmentFirstYesAuthored,
+            date_of_birth
+        ).years
+        if cls._is_outside_expected_bounds(age_at_consent_years):
+            logging.warning(
+                f'Unexpected date of birth for P{participant_id}: '
+                f'date of birth means age at consent was invalid for program'
+            )
+            return False
+
+        return True
+
+    @classmethod
+    def _is_outside_expected_bounds(cls, age_years: int):
+        return age_years < 18 or age_years > 125
+
+    @classmethod
+    def _send_notification(cls):
+        handler = SlackMessageHandler(webhook_url='aoeu')
+        handler.send_message_to_webhook(message_data={
+            'text': 'Invalid date of birth detected'
+        })
+
+
+

--- a/rdr_service/services/participant_data_validation.py
+++ b/rdr_service/services/participant_data_validation.py
@@ -3,6 +3,7 @@ import logging
 
 from dateutil.relativedelta import relativedelta
 
+from rdr_service import config
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.services.slack_utils import SlackMessageHandler
@@ -67,10 +68,19 @@ class ParticipantDataValidation:
 
     @classmethod
     def _send_notification(cls):
-        handler = SlackMessageHandler(webhook_url='aoeu')
+        validation_webhook = cls._get_slack_webhook_url()
+        if validation_webhook is None:
+            logging.warning('Webhook not found. Skipping slack notification for validation error.')
+
+        handler = SlackMessageHandler(webhook_url=validation_webhook)
         handler.send_message_to_webhook(message_data={
             'text': 'Invalid date of birth detected'
         })
 
+    @classmethod
+    def _get_slack_webhook_url(cls):
+        webhook_config = config.getSettingJson(config.RDR_SLACK_WEBHOOKS, None)
+        if webhook_config is None:
+            return None
 
-
+        return webhook_config.get('rdr_validation_webhook')

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -900,6 +900,13 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         """
         return textwrap.dedent(multiline_str).strip()
 
+    def mock(self, namespace_to_patch):
+        patcher = mock.patch(namespace_to_patch)
+        mock_instance = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        return mock_instance
+
 
 class InMemorySqlExporter(sql_exporter.SqlExporter):
     """Store rows that would be written to GCS CSV in a StringIO instead.

--- a/tests/service_tests/test_participant_data_validation.py
+++ b/tests/service_tests/test_participant_data_validation.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import mock
 
+from rdr_service import config
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.services.participant_data_validation import ParticipantDataValidation
 from tests.helpers.unittest_base import BaseTestCase
@@ -21,6 +22,10 @@ class ParticipantDataValidationTest(BaseTestCase):
         self.slack_client_instance = mock_slack_client_class.return_value
 
         self.logging_mock = self.mock('rdr_service.services.participant_data_validation.logging')
+
+        self.temporarily_override_config_setting(config.RDR_SLACK_WEBHOOKS, {
+            'rdr_validation_webhook': 'aoeu1234'
+        })
 
     def test_valid_date_of_birth_gives_no_errors(self):
         self._set_consent_datetime(datetime.utcnow())

--- a/tests/service_tests/test_participant_data_validation.py
+++ b/tests/service_tests/test_participant_data_validation.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta
+import mock
+
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.services.participant_data_validation import ParticipantDataValidation
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ParticipantDataValidationTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs):
+        super(ParticipantDataValidationTest, self).setUp(*args, **kwargs)
+
+        mock_summary_dao_class = self.mock('rdr_service.services.participant_data_validation.ParticipantSummaryDao')
+        self.summary_dao_instance = mock_summary_dao_class.return_value
+
+        mock_slack_client_class = self.mock('rdr_service.services.participant_data_validation.SlackMessageHandler')
+        self.slack_client_instance = mock_slack_client_class.return_value
+
+        self.logging_mock = self.mock('rdr_service.services.participant_data_validation.logging')
+
+    def test_valid_date_of_birth_gives_no_errors(self):
+        self._set_consent_datetime(datetime.utcnow())
+        date_of_birth = datetime.utcnow() - timedelta(weeks=52 * 23)  # about 23 years ago
+
+        ParticipantDataValidation.analyze_date_of_birth(
+            date_of_birth=date_of_birth,
+            participant_id=1234
+        )
+
+        self.slack_client_instance.send_message_to_webhook.assert_not_called()
+        self.logging_mock.warning.assert_not_called()
+
+    def test_invalid_date_of_birth_gives_errors(self):
+        self._set_consent_datetime(datetime.utcnow())
+        date_of_birth = datetime.utcnow() - timedelta(days=10)
+
+        ParticipantDataValidation.analyze_date_of_birth(
+            date_of_birth=date_of_birth,
+            participant_id=1234
+        )
+
+        self.slack_client_instance.send_message_to_webhook.assert_called_with(
+            message_data={'text': 'Invalid date of birth detected'}
+        )
+        self.assertEqual(2, self.logging_mock.warning.call_count)
+        self.logging_mock.warning.assert_has_calls(
+            calls=[
+                mock.call(
+                    'Unexpected date of birth for P1234: date of birth means age at consent was invalid for program'
+                ),
+                mock.call(
+                    'Unexpected date of birth for P1234: date of birth means current age is invalid for program'
+                )
+            ],
+            any_order=True
+        )
+
+    def test_invalid_dob_found_with_strange_authored_date(self):
+        """If the authored date is at a strange time, make sure invalid dob is still detected"""
+        self._set_consent_datetime(datetime(1940, 1, 1))
+        ParticipantDataValidation.analyze_date_of_birth(
+            date_of_birth=datetime(1870, 1, 1),
+            participant_id=1234
+        )
+
+        self.slack_client_instance.send_message_to_webhook.assert_called_with(
+            message_data={'text': 'Invalid date of birth detected'}
+        )
+        self.assertEqual(1, self.logging_mock.warning.call_count)
+        self.logging_mock.warning.assert_has_calls(
+            calls=[
+                mock.call(
+                    'Unexpected date of birth for P1234: date of birth means current age is invalid for program'
+                )
+            ],
+            any_order=True
+        )
+
+    def _set_consent_datetime(self, consent_datetime: datetime):
+        self.summary_dao_instance.get_by_participant_id.return_value = ParticipantSummary(
+            consentForStudyEnrollmentFirstYesAuthored=consent_datetime
+        )
+

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+import mock
+
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class TaskApiTest(BaseTestCase):
+    def setUp(self, *args, **kwargs):
+        super(TaskApiTest, self).setUp(*args, **kwargs)
+
+        from rdr_service.resource.main import app
+        self.test_client = app.test_client()
+
+    @mock.patch('rdr_service.api.cloud_tasks_api.ParticipantDataValidation')
+    def test_date_of_birth_check(self, validation_mock):
+        self._call_task_endpoint(
+            task_path='ValidateDateOfBirth',
+            json={
+                'participant_id': 1234,
+                'date_of_birth': '2000-3-19'
+            }
+        )
+
+        validation_mock.analyze_date_of_birth.assert_called_with(
+            participant_id=1234,
+            date_of_birth=datetime(2000, 3, 19)
+        )
+
+    def _call_task_endpoint(self, task_path, json):
+        response = self.send_post(
+            f'/resource/task/{task_path}',
+            json,
+            test_client=self.test_client,
+            prefix=''
+        )
+        self.assertEqual('{"success": "true"}', response)


### PR DESCRIPTION
## Resolves *[DA-2489](https://precisionmedicineinitiative.atlassian.net/browse/DA-2489)*
We need the RDR to flag any dates of birth that would mean a participant is currently, or at the time of their consent, less than 18 or more than 125 years old.

## Description of changes/additions
This adds code to have dates of birth checked when we receive them. When the QuestionnaireResponseDao detects a response to the date of birth question, it will send the date and participant id to a task to have it checked in 30 seconds. If the date of birth is outside the expected range, then a slack notification will be sent to notify us that a validation error occurred and needs to be investigated.

## Tests
- [x] unit tests


