### PR TITLE
[ROC-1344] add_more_filters_to_etl

### DIFF
--- a/rdr_service/etl/raw_sql/finalize_cdm_data.sql
+++ b/rdr_service/etl/raw_sql/finalize_cdm_data.sql
@@ -1525,7 +1525,9 @@ CREATE TABLE cdm.pid_rid_mapping (
     research_id                 bigint,
     external_id                 bigint
 );
-INSERT INTO cdm.pid_rid_mapping SELECT DISTINCT participant_id, research_id, external_id FROM cdm.src_clean;
+INSERT INTO cdm.pid_rid_mapping
+SELECT DISTINCT sc.participant_id, sc.research_id, sc.external_id
+FROM cdm.src_clean sc join cdm.person p on sc.participant_id=p.person_id;
 
 
 -- ---------------------------------------------------------------------

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -10,7 +10,6 @@ from sqlalchemy.sql.expression import literal_column
 from sqlalchemy.sql.functions import coalesce, concat
 from typing import Type
 
-from rdr_service.clock import CLOCK
 from rdr_service import config
 from rdr_service.code_constants import PPI_SYSTEM, CONSENT_FOR_STUDY_ENROLLMENT_MODULE, PMI_SKIP_CODE, \
     EMPLOYMENT_ZIPCODE_QUESTION_CODE, STREET_ADDRESS_QUESTION_CODE, STREET_ADDRESS2_QUESTION_CODE, ZIPCODE_QUESTION_CODE
@@ -396,7 +395,9 @@ class CurationExportClass(ToolBase):
             QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE,
             and_(
                 ParticipantSummary.dateOfBirth.isnot(None),
-                func.timestampdiff(text('YEAR'), ParticipantSummary.dateOfBirth, CLOCK.now()) >= 18
+                ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored.isnot(None),
+                func.timestampdiff(text('YEAR'), ParticipantSummary.dateOfBirth,
+                                   ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored) >= 18
             )
         )
 


### PR DESCRIPTION
## Resolves *[ROC-1344](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1344)*
1. populate `pid_rid_mapping` table with participants only in `person` table.
2. exclude participants who would have been <18 years of age at the time of consent.


## Tests
- [x] unit tests

Manually compared with last ETL result, there is only one participant excluded.


