### PR TITLE
GHR3 Broker payload captures, remove GEM constraint

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -428,8 +428,7 @@ class GenomicJobController:
 
         def _set_module_type(records):
             mod_type = [obj for obj in records if obj.fieldName in ['module_type', 'result_type'] and obj.valueString]
-            mod_type = mod_type[0].valueString
-            return mod_type
+            return mod_type[0].valueString if mod_type else None
 
         if 'informing_loop' in event_type:
             loop_type = event_type
@@ -440,10 +439,9 @@ class GenomicJobController:
 
             if informing_records:
                 module_type = _set_module_type(informing_records)
-
-                if module_type.lower() != 'gem':
-                    logging.info(f'Cannot insert Message broker data for module {module_type}, only accepting gem '
-                                 f'modules at this time')
+                if not module_type:
+                    logging.warning(f'Cannot find module type in message record id: '
+                                    f'{informing_records[0].messageRecordId}')
                     return
 
                 first_record = informing_records[0]
@@ -470,10 +468,9 @@ class GenomicJobController:
             )
             if result_records:
                 module_type = _set_module_type(result_records)
-
-                if module_type.lower() != 'gem':
-                    logging.info(f'Cannot insert Message broker data for module {module_type}, only accepting gem '
-                                 f'modules at this time')
+                if not module_type:
+                    logging.warning(f'Cannot find module type in message record id: '
+                                    f'{result_records[0].messageRecordId}')
                     return
 
                 first_record = result_records[0]


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
For GHR3 the new payloads from the MessageBroker will contain new modules codes for health/CVL flows, removing the GEM constraint that I added in the GEM to GP migration

** Codacy issues are failing for Python Standard Lib random method, which is only utilized in tests, so would prefer not to correct it.

## Tests
- [x] unit tests


