### PR TITLE
Skip problem test pid in PDR data rebuilds

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -3,6 +3,7 @@ import json
 import re
 
 from rdr_service import config
+from rdr_service.resource.constants import SKIP_TEST_PIDS_FOR_PDR
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_participant_summary import BQParticipantSummarySchema, BQParticipantSummary
@@ -156,4 +157,6 @@ def bq_participant_summary_update_task(p_id):
     Cloud task to update the Participant Summary record for the given participant.
     :param p_id: Participant ID
     """
-    rebuild_bq_participant(p_id)
+
+    if p_id not in SKIP_TEST_PIDS_FOR_PDR:
+        rebuild_bq_participant(p_id)

--- a/rdr_service/resource/constants.py
+++ b/rdr_service/resource/constants.py
@@ -70,6 +70,11 @@ class SchemaID(IntEnum):
 COHORT_1_CUTOFF = datetime(2018, 4, 24, 0, 0, 0)
 COHORT_2_CUTOFF = datetime(2020, 4, 21, 4, 0, 0)
 
+# Workaround:  Allow PDR data rebuild tasks to skip building certain test pids that have so much data associated
+# with them (e.g., high numbers of questionnaire responses) that the PDR generator tasks can exceed time or memory
+# limits and be terminated abnormally.   For now, there is one pid known to cause such task failures
+SKIP_TEST_PIDS_FOR_PDR = [838981439, ]
+
 class ConsentCohortEnum(IntEnum):
     """
     Which cohort does a participant belong too, based on consent date.

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 
 import rdr_service.config as config
+from rdr_service.resource.constants import SKIP_TEST_PIDS_FOR_PDR
 
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao
 from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGenerator, rebuild_bq_participant
@@ -54,6 +55,10 @@ def batch_rebuild_participants_task(payload, project_id=None):
         p_id = item['pid']
         patch_data = item.get('patch', None)
         count += 1
+
+        if int(p_id) in SKIP_TEST_PIDS_FOR_PDR:
+            logging.warning(f'Skipping rebuild of test pid {p_id} data')
+            continue
 
         if build_participant_summary:
             rebuild_participant_summary_resource(p_id, res_gen=res_gen, patch_data=patch_data)


### PR DESCRIPTION
## Resolves *No ticket*


## Description of changes/additions
Investigation determined that a specific test pid 838981439 is associated with over 2300 `questionnaire_response` records, and whichever PDR rebuild task has that pid in its batch is consistently failing during full rebuilds (presumably due to maxing out execution time or memory limits for tasks)

This is a workaround to allow us to skip these kinds of pids during rebuilds.  Ultimately, we may want to consider paring down what gets sent to PDR for test pids (e.g., just create a skeleton `pdr_participant` record but don't assemble the other associated data)
## Tests
- [x] unit tests


