### PR TITLE
[DA-2558] Update GP event reconciliation query

### DIFF
--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -98,7 +98,6 @@
     "reconcile_gc_data_file_to_table_workflow": 1,
     "reconcile_pdr_data": 1,
     "retry_manifest_ingestion_failures": 1,
-    "genomic_delete_old_gp_user_events": 0,
     "reconcile_raw_to_aw1_ingested_workflow": 1,
     "reconcile_raw_to_aw2_ingested_workflow": 1,
     "members_state_resolved_workflow": 1,

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -98,7 +98,7 @@
     "reconcile_gc_data_file_to_table_workflow": 1,
     "reconcile_pdr_data": 1,
     "retry_manifest_ingestion_failures": 1,
-    "genomic_delete_old_gp_user_events": 1,
+    "genomic_delete_old_gp_user_events": 0,
     "reconcile_raw_to_aw1_ingested_workflow": 1,
     "reconcile_raw_to_aw2_ingested_workflow": 1,
     "members_state_resolved_workflow": 1,

--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -84,9 +84,4 @@ cron:
   timezone: America/New_York
   schedule: every 6 hours
   target: offline
-- description: Genomic Delete Old GP User Events
-  url: /offline/GenomicDeleteOldGPUserEvents
-  timezone: America/New_York
-  schedule: every day 13:30
-  target: offline
 

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -330,11 +330,6 @@ def reconcile_informing_loop_responses():
         controller.reconcile_informing_loop_responses()
 
 
-def delete_old_gp_user_events(days=7):
-    with GenomicJobController(GenomicJob.DELETE_OLD_GP_USER_EVENT_METRICS) as controller:
-        controller.delete_old_gp_user_event_metrics(days=days)
-
-
 def reconcile_gc_data_file_to_table():
     with GenomicJobController(GenomicJob.RECONCILE_GC_DATA_FILE_TO_TABLE) as controller:
         controller.reconcile_gc_data_file_to_table()

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -636,13 +636,6 @@ def genomic_reconcile_pdr_data():
 
 
 @app_util.auth_required_cron
-@run_genomic_cron_job('genomic_delete_old_gp_user_events')
-def genomic_delete_old_gp_user_events():
-    genomic_pipeline.delete_old_gp_user_events(days=7)
-    return '{"success": "true"}'
-
-
-@app_util.auth_required_cron
 @run_genomic_cron_job('daily_ingestion_summary')
 def genomic_data_quality_daily_ingestion_summary():
     genomic_data_quality_pipeline.data_quality_workflow(GenomicJob.DAILY_SUMMARY_REPORT_INGESTIONS)
@@ -974,11 +967,6 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "GenomicDataPdrReconcile",
         endpoint="genomic_data_pdr_reconcile",
         view_func=genomic_reconcile_pdr_data, methods=["GET"]
-    )
-    offline_app.add_url_rule(
-        OFFLINE_PREFIX + "GenomicDeleteOldGPUserEvents",
-        endpoint="genomic_delete_old_gp_user_events",
-        view_func=genomic_delete_old_gp_user_events, methods=["GET"]
     )
     offline_app.add_url_rule(
         OFFLINE_PREFIX + "GenomicRetryManifestIngestions",

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -6318,9 +6318,9 @@ class GenomicPipelineTest(BaseTestCase):
                   'gem.informing_loop.screen8_no',
                   'gem.informing_loop.screen8_yes',
                   'hdr.informing_loop.started',
-                  'gem.informing_loop.screen8_maybe_later']
+                  'gem.informing_loop.screen3']
         for p in range(4):
-            for i in range(4):
+            for i in range(len(events)):
                 self.data_generator.create_database_genomic_user_event_metrics(
                     created=clock.CLOCK.now(),
                     modified=clock.CLOCK.now(),
@@ -6415,11 +6415,6 @@ class GenomicPipelineTest(BaseTestCase):
         old_event.created = old_event.created - datetime.timedelta(days=8)
         with event_dao.session() as session:
             session.merge(old_event)
-
-        genomic_pipeline.delete_old_gp_user_events()
-
-        all_events = event_dao.get_all()
-        self.assertEqual(18, len(all_events))
 
     def test_investigation_aw2_ingestion(self):
         self._create_fake_datasets_for_gc_tests(3,


### PR DESCRIPTION
## Resolves *[DA-2558](https://precisionmedicineinitiative.atlassian.net/browse/DA-2558)*


## Description of changes/additions
The RDR receives a superset of the events that require reconciliation against the genomic_informing_loop table. This PR updates the GP user events reconciliation query to only compare against events found in `informing_loop_event_mapping`. Additionally, the process to remove GP user events after 8 days was removed. This was an artifact from when the user events file was cumulative instead of incremental.

## Tests
- [x] unit tests


