### PR TITLE
Fix for retrieving date of birth validation task json

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -257,7 +257,7 @@ class ValidateDateOfBirthApi(Resource):
     @task_auth_required
     @returns_success
     def post(self):
-        task_data = request.json
+        task_data = request.get_json(force=True)
         date_of_birth = parse_date(task_data['date_of_birth'])
 
         ParticipantDataValidation.analyze_date_of_birth(


### PR DESCRIPTION
## Resolves *no ticket*
The JSON for the date of birth validation is showing as Null and that's causing an error when attempting to validate. This updates the task to ignore the mime-type when retrieving the json.


## Tests
- [ ] unit tests


