### PR TITLE
[DA-2612] Add PDR data rebuild tasks to ghost check cron job

### DIFF
--- a/rdr_service/offline/bigquery_sync.py
+++ b/rdr_service/offline/bigquery_sync.py
@@ -44,8 +44,8 @@ def dispatch_participant_rebuild_tasks(pid_list, batch_size=100, project_id=GAE_
     :param batch_size:  Size of the batch of participant IDs to include in the rebuild task payload
     :param project_id: String identifier for the GAE project
     :param build_locally: Boolean value indicating whether to build participant summaries in this process.
-        If False is given, GCP tasks are created for rebuilding participants. Defaults to True if config.GAE_PROJECT
-        is localhost.
+        If False is given, GCP tasks are created for rebuilding participants. Defaults to True if the project_id value
+        is localhost
     :param build_participant_summary:  Boolean value indicating whether PDR participant summary data should be rebuilt
     :param build_modules: Boolean value indicating whether PDR module data for the participant should be rebuilt
     """
@@ -60,7 +60,7 @@ def dispatch_participant_rebuild_tasks(pid_list, batch_size=100, project_id=GAE_
     task = GCPCloudTask()
 
     if build_locally is None:
-        build_locally = config.GAE_PROJECT == 'localhost'
+        build_locally = project_id == 'localhost'
 
     # queue up a batch of participant ids and send them to be rebuilt.
     for pid_data in pid_list:

--- a/rdr_service/services/ghost_check_service.py
+++ b/rdr_service/services/ghost_check_service.py
@@ -3,6 +3,7 @@ from logging import Logger
 
 from sqlalchemy.orm import Session
 
+from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.ghost_check_dao import GhostCheckDao, GhostFlagModification
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.participant import Participant
@@ -17,7 +18,7 @@ class GhostCheckService:
         self._config = ptsc_config
         self._participant_dao = ParticipantDao()
 
-    def run_ghost_check(self, start_date: date, end_date: date = None):
+    def run_ghost_check(self, start_date: date, end_date: date = None, project=GAE_PROJECT):
         """
         Finds all the participants that need to be checked to see if they're ghosts and calls out to Vibrent's API
         to check them, recording the result.
@@ -72,7 +73,7 @@ class GhostCheckService:
 
         if len(pdr_rebuild_list):
             # PDR BQ module views select the test/ghost flag from participant data; don't need to rebuild module data
-            dispatch_participant_rebuild_tasks(pdr_rebuild_list, build_modules=False)
+            dispatch_participant_rebuild_tasks(pdr_rebuild_list, project=project, build_modules=False)
 
     def _record_ghost_result(self, is_ghost_response: bool, participant: Participant) -> bool:
         """ Update the participant isGhostId status if needed.  Returns true if update was performed """

--- a/rdr_service/tools/tool_libs/ghost_check_script.py
+++ b/rdr_service/tools/tool_libs/ghost_check_script.py
@@ -25,7 +25,8 @@ class GhostCheckScript(ToolBase):
                 logger=logger,
                 ptsc_config=server_config
             )
-            service.run_ghost_check(start_date=start_date, end_date=end_date)
+            service.run_ghost_check(start_date=start_date, end_date=end_date,
+                                    project=self.gcp_env.project)
 
 
 def add_additional_arguments(parser: argparse.ArgumentParser):

--- a/tests/service_tests/test_ghost_check_service.py
+++ b/tests/service_tests/test_ghost_check_service.py
@@ -58,6 +58,7 @@ class GhostCheckServiceTest(BaseTestCase):
         ])
 
         self.participant_dao_mock.update_ghost_participant.assert_not_called()
+        self.assertEqual(self.pdr_rebuild_mock.call_count, 0)
 
     def test_logging_for_vibrent_server_anomalies(self):
         """Vibrent could have ids we don't know about, or participants with missing DRC ids"""

--- a/tests/service_tests/test_ghost_check_service.py
+++ b/tests/service_tests/test_ghost_check_service.py
@@ -28,7 +28,7 @@ class GhostCheckServiceTest(BaseTestCase):
         self.ghost_dao_mock = dao_patch.start()
         self.addCleanup(dao_patch.stop)
 
-        pdr_rebuild_patch = mock.patch('rdr_service.services.ghost_check_service.batch_rebuild_participants_task')
+        pdr_rebuild_patch = mock.patch('rdr_service.services.ghost_check_service.dispatch_participant_rebuild_tasks')
         self.pdr_rebuild_mock = pdr_rebuild_patch.start()
         self.addCleanup(pdr_rebuild_patch.stop)
 
@@ -120,6 +120,5 @@ class GhostCheckServiceTest(BaseTestCase):
         ])
         # Assert the PDR data rebuild was invoked with both pids in the batch list
         self.assertEqual(1, self.pdr_rebuild_mock.call_count)
-        pdr_rebuild_payload = self.pdr_rebuild_mock.call_args[0][0]
-        self.assertEqual(pdr_rebuild_payload.get('batch'),
-                         [{'pid': 1123}, {'pid': 4567}])
+        self.assertListEqual(self.pdr_rebuild_mock.call_args[0][0], [1123, 4567])
+

--- a/tests/service_tests/test_ghost_check_service.py
+++ b/tests/service_tests/test_ghost_check_service.py
@@ -28,6 +28,10 @@ class GhostCheckServiceTest(BaseTestCase):
         self.ghost_dao_mock = dao_patch.start()
         self.addCleanup(dao_patch.stop)
 
+        pdr_rebuild_patch = mock.patch('rdr_service.services.ghost_check_service.batch_rebuild_participants_task')
+        self.pdr_rebuild_mock = pdr_rebuild_patch.start()
+        self.addCleanup(pdr_rebuild_patch.stop)
+
         self.service = GhostCheckService(
             session=mock.MagicMock(),
             ptsc_config=mock.MagicMock(),
@@ -113,3 +117,8 @@ class GhostCheckServiceTest(BaseTestCase):
                 session=mock.ANY
             )
         ])
+        # Assert the PDR data rebuild was invoked with both pids in the batch list
+        self.assertEqual(1, self.pdr_rebuild_mock.call_count)
+        pdr_rebuild_payload = self.pdr_rebuild_mock.call_args[0][0]
+        self.assertEqual(pdr_rebuild_payload.get('batch'),
+                         [{'pid': 1123}, {'pid': 4567}])


### PR DESCRIPTION
## Resolves *[DA-2612](https://precisionmedicineinitiative.atlassian.net/browse/DA-2612)*


## Description of changes/additions
The Ghost API check cron job has been running for a few months and can make updates to the RDR participant records, but the PDR participant data is not being rebuilt with the RDR data changes.  In between full PDR rebuilds, this causes the PDR participant data/ghost id counts to become increasingly out of sync with RDR.

Add logic to fire off PDR data rebuild tasks from the cron job

## Tests
- [x] unit tests


