### PR TITLE
[DA-2573] Updating validation of GROR PDF

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -231,10 +231,13 @@ class CeConsentFactory(ConsentFileAbstractFactory):
 
     def _is_gror_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         pdf = blob_wrapper.get_parsed_pdf()
-        return pdf.has_text([(
-            'Consent to Receive DNA Results',
-            'Consentimiento para Recibir Resultados de ADN'
-        )])
+        return pdf.has_text([
+            (
+                'Consent to Receive DNA Results',
+                'Consentimiento para Recibir Resultados de ADN'
+            ),
+            ('Consent to Get DNA Results',)
+        ])
 
     def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date: datetime) -> bool:
         return False  # CE doesn't have cohort 1 participants to have needed re-consents

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -234,9 +234,9 @@ class CeConsentFactory(ConsentFileAbstractFactory):
         return pdf.has_text([
             (
                 'Consent to Receive DNA Results',
-                'Consentimiento para Recibir Resultados de ADN'
-            ),
-            ('Consent to Get DNA Results',)
+                'Consentimiento para Recibir Resultados de ADN',
+                'Consent to Get DNA Results'
+            )
         ])
 
     def _is_primary_update_consent(self, blob_wrapper: '_ConsentBlobWrapper', consent_date: datetime) -> bool:


### PR DESCRIPTION
## Resolves *[DA-2573](https://precisionmedicineinitiative.atlassian.net/browse/DA-2573)*
The GROR consent process is being updated. This PR is to update the validation process to be sure it continues to function after the changes take affect. The only change that will affect the validation is that the wording of title of the file is changing from "Consent to Receive DNA Results" to "Consent to Get DNA Results". We use file names when detecting consent types for Vibrent, but the CE code needs to use the title to determine what the consent type is (the Spanish translation hasn't changed).

## Tests
- [ ] unit tests


