### PR TITLE
[PDR-833] PDR schema changes for new GROR codebook

### DIFF
--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -483,7 +483,9 @@ class BQPDRGRORSchema(_BQModuleSchema):
     )
     _force_boolean_fields = (
         'ResultsConsent_Signature',
-        'HelpMeWithConsent_Name'
+        'HelpMeWithConsent_Name',
+        'other_concerns',
+        'other_reasons'
     )
 
 class BQPDRGROR(BQTable):


### PR DESCRIPTION
## Partially resolves *[PDR-833](https://precisionmedicineinitiative.atlassian.net/browse/PDR-833)*


## Description of changes/additions
Updates the schema generation for the BQPDRGRORSchema.  The new GROR codebook includes "exit" questions for participants who decline or answer "not sure" to consent for GROR results.    New codes include some free text codes (`other_concerns`, `other_reasons`) that will be mapped to boolean.     Complete list of new fields to be added to `pdr_mod_gror` table schema in PDR when migration is applied:

        pdr_mod_gror column CheckDNA_NONOTsure_notuseful ('STRING', 'NULLABLE') added
        pdr_mod_gror column CheckDNA_NONOTsure_personal_concerns ('STRING', 'NULLABLE') added
        pdr_mod_gror column other_concerns ('INTEGER', 'NULLABLE') added
        pdr_mod_gror column other_reasons ('INTEGER', 'NULLABLE') added
        pdr_mod_gror column resultsconsent_checkdna_nonotsure ('STRING', 'NULLABLE') added
        pdr_mod_gror column resultsconsent_checkdna_nonotsure_insurance ('STRING', 'NULLABLE') added
        pdr_mod_gror column resultsconsent_checkdna_nonotsure_security ('STRING', 'NULLABLE') added


## Tests
Dry run of `migrate-bq` migration tool


