### PR TITLE
Adding GEM role to outreach V1

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -47,7 +47,7 @@ class GenomicOutreachApi(BaseApi):
         super(GenomicOutreachApi, self).__init__(GenomicOutreachDao())
         self.member_dao = GenomicSetMemberDao()
 
-    @auth_required(RDR_AND_PTC)
+    @auth_required([GEM] + RDR_AND_PTC)
     def get(self, mode=None):
         self._check_mode(mode)
 


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
In meetings with Color and discussions about the GHR3 testing plan, they need to be able to see GEM report status for certain participants, so instead of adding onto the GenomicPII route
we are giving them access to the GET request to the Outreach V1 route. 

## Tests
- [x] unit tests


