### PR TITLE
[DA-2571] Manifest generator tool for CVL pipeline test

### DIFF
--- a/rdr_service/dao/genomic_datagen_dao.py
+++ b/rdr_service/dao/genomic_datagen_dao.py
@@ -5,9 +5,9 @@ from sqlalchemy.orm import Query, aliased
 from sqlalchemy.sql import functions
 
 from rdr_service.dao.base_dao import BaseDao
-from rdr_service.model.genomic_datagen import GenomicDataGenCaseTemplate, GenomicDataGenRun, GenomicDatagenMemberRun,\
-    GenomicDataGenOutputTemplate
 from rdr_service.model.genomics import GenomicInformingLoop, GenomicSetMember
+from rdr_service.model.genomic_datagen import GenomicDataGenCaseTemplate, GenomicDataGenRun, \
+    GenomicDatagenMemberRun, GenomicDataGenOutputTemplate, GenomicDataGenManifestSchema
 from rdr_service.model.participant_summary import ParticipantSummary
 
 
@@ -169,3 +169,31 @@ class GenomicDataGenOutputTemplateDao(BaseDao):
                 GenomicDataGenOutputTemplate.field_index
             ).all()
 
+
+class GenomicDataGenManifestSchemaDao(BaseDao):
+    def __init__(self):
+        super(GenomicDataGenManifestSchemaDao, self).__init__(
+            GenomicDataGenManifestSchema, order_by_ending=['id'])
+
+    def get_id(self, obj):
+        pass
+
+    def from_client_json(self):
+        pass
+
+    def get_template_by_name(self, project_name, template_name):
+        with self.session() as session:
+            return session.query(GenomicDataGenManifestSchema).filter(
+                GenomicDataGenManifestSchema.project_name == project_name,
+                GenomicDataGenManifestSchema.template_name == template_name,
+                GenomicDataGenManifestSchema.ignore_flag == 0
+            ).order_by(GenomicDataGenManifestSchema.field_index).all()
+
+    def execute_manifest_query(self, columns, sample_ids):
+        with self.session() as session:
+            return session.query(
+                *columns
+            ).join(
+                ParticipantSummary,
+                ParticipantSummary.participantId == GenomicSetMember.participantId
+            ).filter(GenomicSetMember.sampleId.in_(sample_ids)).all()

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -458,6 +458,25 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoUtils):
                 )
             return member.first()
 
+    def get_members_from_sample_ids(self, sample_ids, genome_type=None):
+        """
+        Returns genomicSetMember objects for list of sample IDs.
+        :param sample_ids:
+        :param genome_type:
+        :return:
+        """
+        with self.session() as session:
+            members = session.query(GenomicSetMember).filter(
+                GenomicSetMember.sampleId.in_(sample_ids),
+                GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE,
+            )
+
+            if genome_type:
+                members = members.filter(
+                    GenomicSetMember.genomeType == genome_type
+                )
+            return members.all()
+
     def get_members_from_member_ids(self, member_ids):
         with self.session() as session:
             return session.query(GenomicSetMember).filter(
@@ -3286,6 +3305,7 @@ class GenomicQueriesDao(BaseDao):
 
     def get_w3sr_records(self, **kwargs):
         site_id = self.transform_cvl_site_id(kwargs.get('site_id'))
+        sample_ids = kwargs.get('sample_ids')
 
         with self.session() as session:
             records = session.query(
@@ -3329,9 +3349,14 @@ class GenomicQueriesDao(BaseDao):
                     GenomicSetMember.gcSiteId == site_id.lower()
                 )
 
+            if sample_ids:
+                records = records.filter(
+                    GenomicSetMember.sampleId.in_(sample_ids)
+                )
+
             return records.distinct().all()
 
-    def get_data_ready_for_w1il_manifest(self, module: str, cvl_id: str):
+    def get_data_ready_for_w1il_manifest(self, module: str, cvl_id: str, sample_ids=None):
         """
         Returns the genomic set member and other data needed for a W1IL manifest.
         :param module: Module to retrieve genomic set members for, either 'pgx' or 'hdr'
@@ -3437,6 +3462,11 @@ class GenomicQueriesDao(BaseDao):
                 GenomicSetMember.genomicWorkflowState == GenomicWorkflowState.CVL_READY,
                 previous_w1il_job_field.is_(None)
             )
+
+            if sample_ids:
+                query = query.filter(
+                    GenomicSetMember.sampleId.in_(sample_ids)
+                )
 
             return query.all()
 

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -3279,7 +3279,7 @@ class ManifestDefinitionProvider:
         job_run_id=None,
         bucket_name=None,
         genome_type=None,
-        cvl_site_id=None,
+        cvl_site_id='rdr',
         **kwargs
     ):
         # Attributes
@@ -3578,7 +3578,7 @@ class ManifestCompiler:
     """
     def __init__(
         self,
-        run_id,
+        run_id=None,
         bucket_name=None,
         max_num=None,
         controller=None
@@ -3613,7 +3613,7 @@ class ManifestCompiler:
         )
 
         self.manifest_def = self.def_provider.get_def(manifest_type)
-        source_data = self._pull_source_data()
+        source_data = self.pull_source_data()
 
         if not source_data:
             logging.info(f'No records found for manifest type: {manifest_type}.')
@@ -3733,7 +3733,7 @@ class ManifestCompiler:
             "code": GenomicSubProcessResult.SUCCESS,
         }
 
-    def _pull_source_data(self):
+    def pull_source_data(self):
         """
         Runs the source data query
         :return: result set

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -153,6 +153,9 @@ class GenomicJob(messages.Enum):
     AW4_ARRAY_INVESTIGATION_WORKFLOW = 2003
     AW4_WGS_INVESTIGATION_WORKFLOW = 2004
 
+    # Datagen Manifest Workflows
+    DATAGEN_MANIFEST_GENERATION = 3001
+
 
 class GenomicWorkflowState(messages.Enum):
     """Genomic State Definitions. States are not in any order. """

--- a/rdr_service/services/genomic_datagen.py
+++ b/rdr_service/services/genomic_datagen.py
@@ -12,10 +12,7 @@ from rdr_service.dao.genomics_dao import GenomicSetMemberDao, GenomicJobRunDao, 
 from rdr_service.genomic.genomic_job_components import ManifestDefinitionProvider, ManifestCompiler
 from rdr_service.genomic_enums import GenomicJob, GenomicSubProcessStatus, GenomicSubProcessResult, \
     ResultsWorkflowState, GenomicManifestTypes
-from rdr_service.model.genomics import GenomicSetMember, GenomicGCValidationMetrics, GenomicInformingLoop, \
-    GenomicResultWorkflowState
-from rdr_service.model.participant import Participant
-from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.genomics import GenomicSetMember, GenomicResultWorkflowState
 from tests.helpers.data_generator import DataGenerator
 
 
@@ -433,24 +430,6 @@ class ManifestGenerator:
             "manifest_data": []
         }
 
-        self.default_table_map = {
-            'participant': {
-                'model': Participant,
-            },
-            'participant_summary': {
-                'model': ParticipantSummary,
-            },
-            'genomic_set_member': {
-                'model': GenomicSetMember
-            },
-            'genomic_gc_validation_metrics': {
-                'model': GenomicGCValidationMetrics
-            },
-            'genomic_informing_loop': {
-                'model': GenomicInformingLoop
-            }
-        }
-
     def __enter__(self):
         if self.update_samples:
             # Create job run ID like controller
@@ -542,10 +521,6 @@ class ManifestGenerator:
         return self.manifest_datagen_dao.execute_manifest_query(columns, self.sample_ids)
 
     def execute_internal_manifest_query(self):
-        # If sample IDs, use sample ID injection
-        if self.sample_ids:
-            pass
-
         self.manifest_compiler = ManifestCompiler()
         manifest_type = GenomicManifestTypes.lookup_by_name(self.internal_manifest_type_name)
 

--- a/rdr_service/services/genomic_datagen.py
+++ b/rdr_service/services/genomic_datagen.py
@@ -12,6 +12,7 @@ from rdr_service.dao.genomics_dao import GenomicSetMemberDao, GenomicJobRunDao, 
 from rdr_service.genomic.genomic_job_components import ManifestDefinitionProvider, ManifestCompiler
 from rdr_service.genomic_enums import GenomicJob, GenomicSubProcessStatus, GenomicSubProcessResult, \
     ResultsWorkflowState, GenomicManifestTypes
+from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.model.genomics import GenomicSetMember, GenomicResultWorkflowState
 from tests.helpers.data_generator import DataGenerator
 
@@ -481,6 +482,13 @@ class ManifestGenerator:
             self.run_results['manifest_data'] = [self.manifest_datagen_dao.to_dict(result)
                                                  if not isinstance(result, dict) else result
                                                  for result in manifest_query_result]
+            # Add biobank_id prefix
+            for result in self.run_results['manifest_data']:
+                bid_field = "biobank_id"
+                if "biobankid" in result.keys():
+                    bid_field = "biobankid"
+                if result[bid_field][0] not in [get_biobank_id_prefix(), 'T']:
+                    result[bid_field] = f"{get_biobank_id_prefix()}{result[bid_field]}"
 
             self.run_results['message'] = f"Completed {self.template_name} Manifest Generation. "
             self.run_results['message'] += f"{self.template_name} Manifest Included" \

--- a/rdr_service/tools/tool_libs/genomic_datagen.py
+++ b/rdr_service/tools/tool_libs/genomic_datagen.py
@@ -10,7 +10,7 @@ import sys
 
 from rdr_service import clock
 from rdr_service.dao.genomic_datagen_dao import GenomicDataGenRunDao
-from rdr_service.services.genomic_datagen import ParticipantGenerator, GeneratorOutputTemplate
+from rdr_service.services.genomic_datagen import ParticipantGenerator, GeneratorOutputTemplate, ManifestGenerator
 from rdr_service.services.system_utils import setup_logging, setup_i18n
 
 from rdr_service.tools.tool_libs import GCPProcessContext
@@ -105,18 +105,82 @@ class ParticipantGeneratorTool(ToolBase):
             return 0
 
 
-def output_local_csv(*, filename, data):
+class ManifestGeneratorTool(ToolBase):
+
+    def run(self):
+        if self.args.project == 'all-of-us-rdr-prod':
+            _logger.error(f'Manifest generator cannot be used on project: {self.args.project}')
+            return 1
+
+        self.gcp_env.activate_sql_proxy()
+        _ = self.get_server_config()
+
+        manifest_params = {
+            "template_name": None,
+            "sample_ids": None,
+            "update_samples": self.args.update_samples,
+            "logger": _logger,
+        }
+
+        if self.args.manifest_template:
+            manifest_params["template_name"] = self.args.manifest_template
+
+        if self.args.sample_id_file:
+            if not os.path.exists(self.args.sample_id_file):
+                _logger.error(f'File {self.args.sample_id_file} was not found.')
+                return 1
+
+            with open(self.args.sample_id_file, encoding='utf-8-sig') as file:
+                csv_reader = csv.DictReader(file)
+                sample_ids = []
+
+                for row in csv_reader:
+                    sample_ids.append(row)
+
+                manifest_params["sample_ids"] = sample_ids
+
+        # Execute the manifest generator process or the job controller
+        with ManifestGenerator(**manifest_params) as manifest_generator:
+            _logger.info("running...")
+            results = manifest_generator.generate_manifest_data()
+            _logger.info(results['status'])
+            _logger.info(results['message'])
+
+            if results['manifest_data']:
+
+                if self.args.output_manifest_directory:
+                    output_path = self.args.output_manifest_directory
+                else:
+                    output_path = os.getcwd() + "/"
+
+                if self.args.output_manifest_filename:
+                    output_path += self.args.output_manifest_filename
+                else:
+                    output_path += results['output_filename']
+
+                _logger.info("output path: " + output_path)
+
+                # write file
+                output_local_csv(output_path, results['manifest_data'])
+
+                _logger.info("File Created: " + output_path)
+
+                return 0
+
+            return 1
+
+
+def output_local_csv(filename, data):
     with open(filename, 'w') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=[k for k in data[0]])
         writer.writeheader()
         writer.writerows(data)
 
-    _logger.info(f'Generated output template csv: {os.getcwd()}/{filename}')
-
 
 def get_datagen_process_for_run(args, gcp_env):
     datagen_map = {
         'participant_generator': ParticipantGeneratorTool(args, gcp_env),
+        'manifest_generator': ManifestGeneratorTool(args, gcp_env),
     }
     return datagen_map.get(args.process)
 
@@ -150,6 +214,22 @@ def run():
     participants.add_argument("--output-template-name", help="template name for output type, "
                                                              "specified in datagen_output_template",
                               default='default', required=True)  # noqa
+
+    manifest = subparser.add_parser("manifest_generator")
+    manifest.add_argument("--manifest-template", help="which manifest to generate",
+                          default=None,
+                          required=True)  # noqa
+    manifest.add_argument("--sample-id-file", help="path to the list of sample_ids to include in manifest. "
+                                                   "Leave blank for End-to-End manifest (pulls all eligible samples)",
+                              default=None)  # noqa
+    manifest.add_argument("--update-samples",
+                          help="update the result state and manifest job run id field on completion",
+                          default=False, required=False, action="store_true")  # noqa
+    manifest.add_argument("--output-manifest-directory", help="local output directory for the generated manifest"
+                                                       , default=None)  # noqa
+    manifest.add_argument("--output-manifest-filename", help="what to name the output file",
+                              default=None, required=False)  # noqa
+
     args = parser.parse_args()
 
     with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
@@ -158,7 +238,7 @@ def run():
             exit_code = datagen_process.run()
         # pylint: disable=broad-except
         except Exception as e:
-            _logger.info(f'Error has occured, {e}. For help use "genomic --help".')
+            _logger.info(f'Error has occured, {e}. For help use "genomic_datagen --help".')
             exit_code = 1
 
         return exit_code

--- a/rdr_service/tools/tool_libs/genomic_datagen.py
+++ b/rdr_service/tools/tool_libs/genomic_datagen.py
@@ -113,7 +113,6 @@ class ManifestGeneratorTool(ToolBase):
             return 1
 
         self.gcp_env.activate_sql_proxy()
-        _ = self.get_server_config()
 
         manifest_params = {
             "template_name": None,

--- a/tests/helpers/data_generator.py
+++ b/tests/helpers/data_generator.py
@@ -9,7 +9,8 @@ from rdr_service.model.code import Code, CodeType
 from rdr_service.model.consent_file import ConsentFile
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.ehr import ParticipantEhrReceipt
-from rdr_service.model.genomic_datagen import GenomicDataGenCaseTemplate, GenomicDataGenOutputTemplate
+from rdr_service.model.genomic_datagen import GenomicDataGenCaseTemplate, GenomicDataGenOutputTemplate, \
+    GenomicDataGenManifestSchema
 from rdr_service.model.genomics import (
     GenomicManifestFile,
     GenomicJobRun,
@@ -793,6 +794,15 @@ class DataGenerator:
 
     def create_database_datagen_template(self, **kwargs):
         m = self._genomic_datagen_template(**kwargs)
+        self._commit_to_database(m)
+        return m
+
+    @staticmethod
+    def _genomic_datagen_manifest_schema(**kwargs):
+        return GenomicDataGenManifestSchema(**kwargs)
+
+    def create_database_genomic_datagen_manifest_schema(self, **kwargs):
+        m = self._genomic_datagen_manifest_schema(**kwargs)
         self._commit_to_database(m)
         return m
 

--- a/tests/service_tests/test_genomic_datagen.py
+++ b/tests/service_tests/test_genomic_datagen.py
@@ -7,6 +7,7 @@ from rdr_service.dao.genomic_datagen_dao import GenomicDateGenCaseTemplateDao, G
 from rdr_service.dao.genomics_dao import GenomicSetMemberDao, GenomicGCValidationMetricsDao, \
     GenomicCVLSecondSampleDao, GenomicInformingLoopDao, GenomicResultWorkflowStateDao
 from rdr_service.dao.participant_dao import ParticipantDao
+from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.genomic_datagen_dao import GenomicDataGenRunDao, GenomicDataGenMemberRunDao
 from rdr_service.participant_enums import QuestionnaireStatus, WithdrawalStatus
@@ -618,6 +619,7 @@ class GenomicDataGenManifestGeneratorTest(BaseTestCase):
         self.assertEqual("SUCCESS", results['status'].name)
         self.assertEqual("Completed W3NS Manifest Generation. W3NS Manifest Included 2 records.",
                          results['message'])
+        self.assertEqual(f"{get_biobank_id_prefix()}500000000", results['manifest_data'][0].get('biobank_id'))
         self.assertEqual('1001', results['manifest_data'][0].get('sample_id'))
         self.assertEqual('test unavailable reason',
                          results['manifest_data'][0].get('unavailable_reason'))
@@ -690,6 +692,7 @@ class GenomicDataGenManifestGeneratorTest(BaseTestCase):
                 results = manifest_generator.generate_manifest_data()
 
         # Test Manifest Data
+        self.assertEqual(f"{get_biobank_id_prefix()}500000000", results['manifest_data'][0].get('biobank_id'))
         self.assertEqual('1001', results['manifest_data'][0].get('sample_id'))
         self.assertEqual('101', results['manifest_data'][0].get('collection_tubeid'))
         self.assertEqual('1002', results['manifest_data'][1].get('sample_id'))


### PR DESCRIPTION
## Resolves *[DA-2571](https://precisionmedicineinitiative.atlassian.net/browse/DA-2571)*


## Description of changes/additions
This PR creates the manifest generator tool. The basis of the tool is this [tech design]( https://docs.google.com/document/d/15FR_9Hk3XE8d-1TdXKOz-kZL4sarWPv0ALSwy-vucHk/edit#heading=h.x4i1clg9c5l2).

The tool can generate RDR-generated and non-RDR-generated manifests. If `--update-samples` is `True`, the tool will write the associated manifest job run ID and insert a `genomic_result_workflow_state` record.

## Tests
- [x] unit tests


