### PR TITLE
Fix pylintrc in Python 3.8

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -8,13 +8,13 @@
 init-hook="from pylint.config import find_pylintrc; \
     import os; \
     import sys; \
-    sys.path = [x for x in sys.path if 'python3.7' in x]; \
+    sys.path = [x for x in sys.path if 'python3.' in x]; "
 #    sdk_bin_dir = [p for p in set(os.environ['PATH'].split(os.pathsep)) if os.path.exists(os.path.join(p, 'gcloud'))][0]; \
 #    ae_dir = os.path.join(sdk_bin_dir, '..', 'platform', 'google_appengine'); \
 #    sys.path.insert(0, ae_dir); \
 #    lib_dir = os.path.join(ae_dir, 'lib'); \
 #    sys.path.extend([os.path.join(lib_dir, x) for x in os.listdir(lib_dir)]) if os.path.exists(lib_dir) else None; \
-    "
+
 
 # Profiled execution.
 profile=no


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions

Pylintrc was unable to run in a Python 3.8 environment because of a problem with line continuation.
This shortens the string to exclude the comments and changes the sys.path list to work with multiple versions of Python 3.

## Tests
- [] unit tests


