### PR TITLE
[DA-2558] Remove started event from IL reconciliation

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -3169,18 +3169,20 @@ class UserEventMetricsDao(BaseDao, GenomicDaoUtils):
             else:
                 return query.all()
 
-    def get_all_event_objects_for_pid_list(self, pid_list, module=None):
+    def get_all_event_objects_for_pid_list(self, pid_list, module=None, event_list=None):
         with self.session() as session:
             query = session.query(
                 UserEventMetrics
             ).filter(
                 UserEventMetrics.participant_id.in_(pid_list)
             )
+            if event_list:
+                query = query.filter(UserEventMetrics.event_name.in_(event_list))
 
             if module:
-                return query.filter(UserEventMetrics.event_name.like(f"{module}.informing%")).all()
-            else:
-                return query.all()
+                query = query.filter(UserEventMetrics.event_name.like(f"{module}.informing%"))
+
+            return query.all()
 
 
 class GenomicCVLSecondSampleDao(BaseDao):

--- a/rdr_service/genomic/genomic_mappings.py
+++ b/rdr_service/genomic/genomic_mappings.py
@@ -223,7 +223,6 @@ genome_centers_id_from_bucket_wgs = {
 }
 
 informing_loop_event_mappings = {
-    'gem.informing_loop_started': 'gem.informing_loop.started',
     'gem.informing_loop_decision.no': 'gem.informing_loop.screen8_no',
     'gem.informing_loop_decision.yes': 'gem.informing_loop.screen8_yes',
     'gem.informing_loop_decision.maybe_later': 'gem.informing_loop.screen8_maybe_later',

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -6399,14 +6399,22 @@ class GenomicPipelineTest(BaseTestCase):
 
         genomic_pipeline.reconcile_informing_loop_responses()
 
-        # Test data ingested correctly
-        incident = self.incident_dao.get(1)
-        self.assertEqual('RECONCILE_INFORMING_LOOP_RESPONSES: Informing Loop out of sync with User Events! PID: 5',
-                         incident.message)
-        self.assertEqual('5', incident.participant_id)
+        # Test no incident created for "started" event mismatch
+        incidents = self.incident_dao.get_all()
+        self.assertEqual(0, len(incidents))
 
+        # Test data ingested correctly
         pid_list = [1, 2, 3, 6, 7]
-        updated_events = event_dao.get_all_event_objects_for_pid_list(pid_list, module='gem')
+        event_list = ['gem.informing_loop.screen8_no',
+                      'gem.informing_loop.screen8_yes',
+                      'gem.informing_loop.screen8_maybe_later']
+
+        updated_events = event_dao.get_all_event_objects_for_pid_list(
+            pid_list,
+            module='gem',
+            event_list=event_list
+        )
+
         for event in updated_events:
             self.assertEqual(2, event.reconcile_job_run_id)
 


### PR DESCRIPTION
## Resolves *[DA-2558](https://precisionmedicineinitiative.atlassian.net/browse/DA-2558)*


## Description of changes/additions
Removing the "started" event from the informing loop reconciliation workflow. Updated query for unit tests.

## Tests
- [x] unit tests


