### PR TITLE
CVL manifest testing tool updates

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -3367,7 +3367,6 @@ class GenomicQueriesDao(BaseDao):
             'hdr': GenomicSetMember.cvlW1ilHdrJobRunId
         }[module]
 
-
         informing_loop_decision_query = GenomicInformingLoopDao.build_latest_decision_query(
             module=module
         ).with_entities(
@@ -3386,6 +3385,7 @@ class GenomicQueriesDao(BaseDao):
                 GenomicGCValidationMetrics.hfVcfTbiPath.label('vcf_raw_index_path'),
                 GenomicGCValidationMetrics.hfVcfMd5Path.label('vcf_raw_md5_path'),
                 GenomicGCValidationMetrics.cramPath.label('cram_name'),
+                GenomicSetMember.sexAtBirth.label('sex_at_birth'),
                 func.IF(
                     GenomicSetMember.nyFlag == 1,
                     sqlalchemy.sql.expression.literal("Y"),
@@ -3445,7 +3445,7 @@ class GenomicQueriesDao(BaseDao):
 
             return query.all()
 
-    def get_data_ready_for_w2w_manifest(self, cvl_id: str):
+    def get_data_ready_for_w2w_manifest(self, cvl_id: str, sample_ids=None):
         gc_site_id = self.transform_cvl_site_id(cvl_id)
 
         with self.session() as session:
@@ -3473,4 +3473,10 @@ class GenomicQueriesDao(BaseDao):
                     GenomicSetMember.ignoreFlag != 1
                 )
             )
+
+            if sample_ids:
+                query = query.filter(
+                    GenomicSetMember.sampleId.in_(sample_ids)
+                )
+
             return query.all()

--- a/rdr_service/services/genomic_datagen.py
+++ b/rdr_service/services/genomic_datagen.py
@@ -400,6 +400,7 @@ class ManifestGenerator:
         sample_ids=None,
         update_samples=False,
         member_run_id_column=None,
+        cvl_site_id=None,
         logger=logging
     ):
         # Params
@@ -408,6 +409,7 @@ class ManifestGenerator:
         self.sample_ids = sample_ids
         self.update_samples = update_samples
         self.member_run_id_column = member_run_id_column  # only used for testing
+        self.cvl_site_id = cvl_site_id
         self.logger = logger
 
         # Job vars
@@ -466,8 +468,11 @@ class ManifestGenerator:
             manifest_query_result = self.execute_external_manifest_query()
 
         else:
+            # Get manifest defitions and set site
+            site = self.cvl_site_id if self.cvl_site_id else "rdr"
+            self.manifest_def_provider = ManifestDefinitionProvider(cvl_site_id=site, kwargs={})
+
             # check manifest defs
-            self.manifest_def_provider = ManifestDefinitionProvider(kwargs={})
             rdr_manifest_names = [a.name for a in self.manifest_def_provider.manifest_columns_config.keys()]
 
             if self.internal_manifest_type_name in rdr_manifest_names:

--- a/rdr_service/tools/tool_libs/genomic_datagen.py
+++ b/rdr_service/tools/tool_libs/genomic_datagen.py
@@ -117,6 +117,7 @@ class ManifestGeneratorTool(ToolBase):
         manifest_params = {
             "template_name": None,
             "sample_ids": None,
+            "cvl_site_id": None,
             "update_samples": self.args.update_samples,
             "logger": _logger,
         }
@@ -130,13 +131,16 @@ class ManifestGeneratorTool(ToolBase):
                 return 1
 
             with open(self.args.sample_id_file, encoding='utf-8-sig') as file:
-                csv_reader = csv.DictReader(file)
+                csv_reader = csv.reader(file)
                 sample_ids = []
 
                 for row in csv_reader:
-                    sample_ids.append(row)
+                    sample_ids.append(row[0])
 
                 manifest_params["sample_ids"] = sample_ids
+
+        if self.args.cvl_site_id:
+            manifest_params["cvl_site_id"] = self.args.cvl_site_id
 
         # Execute the manifest generator process or the job controller
         with ManifestGenerator(**manifest_params) as manifest_generator:
@@ -148,7 +152,7 @@ class ManifestGeneratorTool(ToolBase):
             if results['manifest_data']:
 
                 if self.args.output_manifest_directory:
-                    output_path = self.args.output_manifest_directory
+                    output_path = self.args.output_manifest_directory + "/"
                 else:
                     output_path = os.getcwd() + "/"
 
@@ -170,6 +174,9 @@ class ManifestGeneratorTool(ToolBase):
 
 
 def output_local_csv(filename, data):
+    # Create output path if it doesn't exist
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+
     with open(filename, 'w') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=[k for k in data[0]])
         writer.writeheader()
@@ -228,6 +235,8 @@ def run():
                                                        , default=None)  # noqa
     manifest.add_argument("--output-manifest-filename", help="what to name the output file",
                               default=None, required=False)  # noqa
+    manifest.add_argument("--cvl-site-id", help="cvl site to pass to manifest query",
+                          default=None, required=False)  # noqa
 
     args = parser.parse_args()
 

--- a/tests/genomics_tests/test_genomic_cvl_pipeline.py
+++ b/tests/genomics_tests/test_genomic_cvl_pipeline.py
@@ -1088,6 +1088,7 @@ class GenomicW1ilGenerationTest(ManifestGenerationTestMixin, BaseTestCase):
             validation_metrics.hfVcfTbiPath,
             validation_metrics.hfVcfMd5Path,
             validation_metrics.cramPath,
+            set_member.sexAtBirth,
             'Y' if set_member.nyFlag == 1 else 'N',
             set_member.gcSiteId.upper(),
             'Y' if summary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED else 'N',


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Needed some last-minute changes for the manifest generator to correctly lookup sample IDs. Also updated tool to pass cvl_site_id. The W1IL was missing sex_at_birth and the W2W was missing the sample_id filter. Both of these were updated.

## Tests
- [x] unit tests


