### PR TITLE
Add site ID to external query; add other models.

### DIFF
--- a/rdr_service/services/genomic_datagen.py
+++ b/rdr_service/services/genomic_datagen.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-import
 import faker
 import os
 import logging
@@ -16,7 +17,13 @@ from rdr_service.genomic.genomic_job_components import ManifestDefinitionProvide
 from rdr_service.genomic_enums import GenomicJob, GenomicSubProcessStatus, GenomicSubProcessResult, \
     ResultsWorkflowState, GenomicManifestTypes
 from rdr_service.model.config_utils import get_biobank_id_prefix
-from rdr_service.model.genomics import GenomicSetMember, GenomicResultWorkflowState
+from rdr_service.model.genomics import (
+    GenomicSetMember,
+    GenomicResultWorkflowState,
+    GenomicGCValidationMetrics,
+    GenomicCVLAnalysis,
+    GenomicCVLSecondSample
+)
 from tests.helpers.data_generator import DataGenerator
 
 
@@ -499,8 +506,10 @@ class ManifestGenerator:
     def generate_manifest_data(self):
         manifest_query_result = None
         # Lookup in template table
-        self.template_fields = self.manifest_datagen_dao.get_template_by_name(self.project_name,
-                                                                  self.template_name)
+        self.template_fields = self.manifest_datagen_dao.get_template_by_name(
+            self.project_name,
+            self.template_name)
+
         if self.template_fields:
             self.logger.info("Manifest name found in template table. Running external manifest.")
 
@@ -575,7 +584,7 @@ class ManifestGenerator:
                 return
 
         # Run the manifest query for sample IDs.
-        return self.manifest_datagen_dao.execute_manifest_query(columns, self.sample_ids)
+        return self.manifest_datagen_dao.execute_manifest_query(columns, self.sample_ids, self.cvl_site_id)
 
     def execute_internal_manifest_query(self):
         self.manifest_compiler = ManifestCompiler()

--- a/tests/service_tests/test_genomic_datagen.py
+++ b/tests/service_tests/test_genomic_datagen.py
@@ -603,7 +603,7 @@ class GenomicDataGenManifestGeneratorTest(BaseTestCase):
     def test_execute_external_manifest_query(self):
         # create test genomic_set_members
         for i in range(1, 3):
-            self.build_default_genomic_set_member(i)
+            self.build_default_genomic_set_member(i, gcSiteId='bi')
 
         # run manifest
         dt = datetime.datetime(2022, 4, 6)
@@ -613,6 +613,7 @@ class GenomicDataGenManifestGeneratorTest(BaseTestCase):
                 template_name="W3NS",
                 sample_ids=['1001', '1002'],
                 update_samples=False,
+                cvl_site_id='co'
             ) as manifest_generator:
                 results = manifest_generator.generate_manifest_data()
 


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR modifies the CVL test manifest generator tool. This PR adds the gc_site_id filter and other possible CVL models to the external manifests query.

## Tests
- [x] unit tests


