### PR TITLE
[DA-2611] Refactor consent error reporting automation to not rely on validation job timestamps

### DIFF
--- a/rdr_service/model/consent_file.py
+++ b/rdr_service/model/consent_file.py
@@ -76,7 +76,7 @@ class ConsentErrorReport(Base):
     modified = Column(UTCDateTime)
     consent_file_id = Column(Integer, ForeignKey(ConsentFile.id), nullable=False)
     notes = Column(String(2048))
-    """ May contain additional details about the error report, such as a corresponding PTSC SD ticket number """
+    """ Additional details about the report, e.g. the error description and/or corresponding PTSC SD ticket number """
 
 
 event.listen(ConsentFile, "before_insert", model_insert_listener)

--- a/rdr_service/resource/generators/consent_metrics.py
+++ b/rdr_service/resource/generators/consent_metrics.py
@@ -462,12 +462,9 @@ class ConsentErrorReportGenerator(ConsentMetricGenerator):
         :param subject:  A string in the expected format (agreed upon w/PTSC) summarizing the error condition
         :param body: Text/string (multi-line/multi-paragraph format agreed upon w/PTSC ) with details of each instance
                      of the detected error condition
-        :param recipients: Destination email address list, if overriding the default config item
-        :param cc_list: List of cc email addresses, if overriding the default config item
+        :param recipients: Destination email address list
+        :param cc_list: List of cc email addresses
         """
-        email_config = config.getSettingJson(config.PTSC_SERVICE_DESK_EMAIL, {})
-        recipients = recipients if isinstance(recipients, list) else email_config.get('recipients')
-        cc_list = cc_list if isinstance(cc_list, list) else email_config.get('cc_recipients')
         if recipients is None:
             logging.error('No recipient address list available for consent error email generation')
         elif not isinstance(recipients, list):

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -110,7 +110,7 @@ def check_consent_errors_task(payload):
     origin = payload.get('participant_origin', 'vibrent')
     # DA-2611: Generate a list of all previously unreported errors, based on ConsentErrorReport table content
     gen = ConsentErrorReportGenerator()
-    id_list = gen.get_unreported_error_ids(origin=origin)
+    id_list = gen.get_unreported_error_ids()
     if len(id_list):
         gen.create_error_reports(participant_origin=origin, id_list=id_list)
     else:

--- a/rdr_service/resource/tasks.py
+++ b/rdr_service/resource/tasks.py
@@ -111,7 +111,7 @@ def check_consent_errors_task(payload):
     # DA-2611: Generate a list of all previously unreported errors, based on ConsentErrorReport table content
     gen = ConsentErrorReportGenerator()
     id_list = gen.get_unreported_error_ids()
-    if len(id_list):
+    if id_list and len(id_list):
         gen.create_error_reports(participant_origin=origin, id_list=id_list)
     else:
         logging.info(f'No unreported consent errors found for participants with origin {origin}')

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -410,8 +410,6 @@ class ConsentValidationController:
         """
         Find all the expected consents (filtering by dates if provided) and check the files that have been uploaded
         """
-        validation_start_time = datetime.utcnow().replace(microsecond=0)
-
         # Retrieve consent response objects that need to be validated
         participant_id_consent_map = self.consent_dao.get_consent_responses_to_validate(session=session)
         participant_summaries = self.participant_summary_dao.get_by_ids_with_session(
@@ -437,8 +435,10 @@ class ConsentValidationController:
                 max_authored_date=max_consent_date
             )
 
-        # Queue a task to check for new errors to report to PTSC
-        dispatch_check_consent_errors_task(validation_start_time)
+        # Queue a task to check for new errors to report.  Reporting mechanisms differ for PTSC and CE, so perform
+        # origin-specific tasks to look for errors that have not yet been reported and generate a report
+        dispatch_check_consent_errors_task(participant_origin='vibrent')
+        dispatch_check_consent_errors_task(participant_origin='careevolution')
 
     def validate_all_for_participant(self, participant_id: int, output_strategy: ValidationOutputStrategy):
         summary: ParticipantSummary = self.participant_summary_dao.get(participant_id)

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -437,8 +437,8 @@ class ConsentValidationController:
 
         # Reporting mechanisms differ for PTSC and CE, so perform separate origin-specific tasks to process
         # errors that have not been reported yet
-        dispatch_check_consent_errors_task(participant_origin='vibrent')
-        dispatch_check_consent_errors_task(participant_origin='careevolution')
+        dispatch_check_consent_errors_task(origin='vibrent')
+        dispatch_check_consent_errors_task(origin='careevolution')
 
     def validate_all_for_participant(self, participant_id: int, output_strategy: ValidationOutputStrategy):
         summary: ParticipantSummary = self.participant_summary_dao.get(participant_id)

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -435,8 +435,8 @@ class ConsentValidationController:
                 max_authored_date=max_consent_date
             )
 
-        # Queue a task to check for new errors to report.  Reporting mechanisms differ for PTSC and CE, so perform
-        # origin-specific tasks to look for errors that have not yet been reported and generate a report
+        # Reporting mechanisms differ for PTSC and CE, so perform separate origin-specific tasks to process
+        # errors that have not been reported yet
         dispatch_check_consent_errors_task(participant_origin='vibrent')
         dispatch_check_consent_errors_task(participant_origin='careevolution')
 

--- a/rdr_service/tools/tool_libs/consent_error_report.py
+++ b/rdr_service/tools/tool_libs/consent_error_report.py
@@ -78,10 +78,12 @@ class ConsentErrorReportTool(object):
 
         if not self.args.to_file:
             project_config = self.gcp_env.get_app_config()
-            if not project_config[config.SENDGRID_KEY]:
-                raise (config.MissingConfigException, 'No API key configured for sendgrid')
+            if not project_config[config.SENDGRID_KEY] or not project_config[config.PTSC_SERVICE_DESK_EMAIL]:
+                raise (config.MissingConfigException,
+                       'Missing configuration for sendgrid key or default email addresses')
             # This enables use of SendGrid email service when running this tool from a dev server vs. app instance
             config.override_setting(config.SENDGRID_KEY, project_config[config.SENDGRID_KEY])
+            config.override_setting(config.PTSC_SERVICE_DESK_EMAIL, project_config[config.PTSC_SERVICE_DESK_EMAIL])
 
         report = ConsentErrorReportGenerator()
         # If no user-provided ids were specified (--id or --from-file), default to all unreported errors

--- a/rdr_service/tools/tool_libs/consent_error_report.py
+++ b/rdr_service/tools/tool_libs/consent_error_report.py
@@ -59,7 +59,7 @@ class ConsentErrorReportTool(object):
     def _connect_to_rdr_replica(self):
         """ Establish a connection to the replica RDR database for reading consent validation data """
         replica = True if self.gcp_env.project == 'all-of-us-rdr-prod' else False
-        self.gcp_env.activate_sql_proxy(replica=replica, project=self.gpc_env.project)
+        self.gcp_env.activate_sql_proxy(replica=replica, project=self.gcp_env.project)
         if self.gcp_env.project != 'localhost':
             self.db_conn = self.gcp_env.make_mysqldb_connection()
 

--- a/rdr_service/tools/tool_libs/consent_error_report.py
+++ b/rdr_service/tools/tool_libs/consent_error_report.py
@@ -80,17 +80,19 @@ class ConsentErrorReportTool(object):
             # This enables use of SendGrid email service when running this tool from a dev server vs. app instance
             config.override_setting(config.SENDGRID_KEY, project_config[config.SENDGRID_KEY])
 
-        errors_since = self.args.errors_since
         report = ConsentErrorReportGenerator()
+        id_list = self.id_list
         # Specific ids will override any date filter
-        if self.id_list:
-            errors_since = None
-        report.create_error_reports(errors_created_since=errors_since,
+        if not id_list:
+            report.get_unreported_error_ids()
+
+        report.create_error_reports(
                                     id_list=self.id_list,
                                     recipients=self.recipients,
                                     cc_list=self.cc_recipients,
                                     participant_origin=self.args.origin,
-                                    to_file=self.args.to_file)
+                                    to_file=self.args.to_file
+        )
         return 0
 
 def get_id_list(fname):

--- a/rdr_service/tools/tool_libs/consent_error_report.py
+++ b/rdr_service/tools/tool_libs/consent_error_report.py
@@ -89,7 +89,7 @@ class ConsentErrorReportTool(object):
 
         if id_list and len(id_list):
             report.create_error_reports(
-                                        id_list=self.id_list,
+                                        id_list=id_list,
                                         recipients=self.recipients,
                                         cc_list=self.cc_recipients,
                                         participant_origin=self.args.origin,

--- a/tests/resource_tests/generator_tests/test_consent_metrics.py
+++ b/tests/resource_tests/generator_tests/test_consent_metrics.py
@@ -23,8 +23,7 @@ class ConsentMetricGeneratorTest(BaseTestCase):
 
     def _create_participant_with_all_consents_authored(self, **kwargs):
         """ Populate a participant_summary record with provided data """
-        # Tests using this setup method may need participants with specific origin or paired hpo_id values and specify
-        # those in the kwargs
+        # Tests using this setup method may create participants with specific origin or paired hpo_id values
         participant = self.data_generator.create_database_participant(
             participantOrigin=kwargs.get('participantOrigin','vibrent'),
             hpoId=kwargs.get('hpoId', 0)
@@ -37,7 +36,7 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             'consentForElectronicHealthRecordsFirstYesAuthored': \
                 datetime.strptime('2020-01-01 03:00:00', "%Y-%m-%d %H:%M:%S"),
             'consentForGenomicsRORAuthored': datetime.strptime('2020-01-01 04:00:00', "%Y-%m-%d %H:%M:%S"),
-            'participantOrigin': 'vibrent',
+            'participantOrigin': participant.participantOrigin,
             'participant': participant
         }
 

--- a/tests/resource_tests/generator_tests/test_consent_metrics.py
+++ b/tests/resource_tests/generator_tests/test_consent_metrics.py
@@ -16,13 +16,17 @@ class ConsentMetricGeneratorTest(BaseTestCase):
 
     def setUp(self, *args, **kwargs) -> None:
         super(ConsentMetricGeneratorTest, self).setUp(*args, **kwargs)
-        self.resource_data_dao = ResourceDataDao()
+        self.dao = ResourceDataDao()
         self._participant = self.data_generator.create_database_participant(participantOrigin='vibrent')
         self.consent_metric_resource_generator = rdr_service.resource.generators.ConsentMetricGenerator()
         self.consent_error_report_generator = rdr_service.resource.generators.ConsentErrorReportGenerator()
 
     def _create_participant_with_all_consents_authored(self, **kwargs):
         """ Populate a participant_summary record with provided data """
+        participant = self.data_generator.create_database_participant(
+            participantOrigin=kwargs.get('participantOrigin','vibrent'),
+            hpoId=kwargs.get('hpoId', 0)
+        )
         defaults = {
             'consentForStudyEnrollmentAuthored': datetime.strptime('2020-01-01 01:00:00', "%Y-%m-%d %H:%M:%S"),
             'consentForStudyEnrollmentFirstYesAuthored': datetime.strptime('2020-01-01 01:00:00', "%Y-%m-%d %H:%M:%S"),
@@ -31,13 +35,15 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             'consentForElectronicHealthRecordsFirstYesAuthored': \
                 datetime.strptime('2020-01-01 03:00:00', "%Y-%m-%d %H:%M:%S"),
             'consentForGenomicsRORAuthored': datetime.strptime('2020-01-01 04:00:00', "%Y-%m-%d %H:%M:%S"),
-            'participant': self._participant
+            'participantOrigin': 'vibrent',
+            'participant': participant
         }
 
         # Merge the kwargs and defaults dicts; kwargs values take precedence over default values
         for key in defaults.keys():
             if key not in kwargs.keys():
                 kwargs = dict(**{key: defaults[key]}, **kwargs)
+
 
         participant = self.data_generator.create_database_participant_summary(**kwargs)
         return participant
@@ -79,7 +85,7 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         return expected_values_dict
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_no_errors(self, send_error_report_mock):
+    def test_consent_metrics_generator_no_errors(self, send_error_email_mock):
         """ Test the consent_metrics generator with no error conditions """
 
         # Use a valid datOfBirth for participant summary data
@@ -87,7 +93,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
         )
         # Create consent_file record with no error conditions
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.READY_FOR_SYNC,
@@ -101,7 +106,9 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         self.assertIsNotNone(consent_file_rec.id)
 
         resource_data = self.consent_metric_resource_generator.make_resource(consent_file_rec.id).get_data()
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.assertIsNone(unreported_errors)
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
 
         # No expected_errors provided, all error conditions default to False
         expected = self._create_expected_metrics_dict(participant, expected_errors=[])
@@ -113,10 +120,10 @@ class ConsentMetricGeneratorTest(BaseTestCase):
                          datetime.date(participant.consentForElectronicHealthRecordsFirstYesAuthored))
 
         # No error emails to send
-        self.assertEqual(0, send_error_report_mock.call_count)
+        self.assertEqual(0, send_error_email_mock.call_count)
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_dob_invalid(self, send_error_report_mock):
+    def test_consent_metrics_generator_dob_invalid(self, send_error_email_mock):
         """
         invalid_dob error calculated from participant_summary data, sync_status can still be READY_TO_SYNC
         """
@@ -128,7 +135,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         p1_consents = self._create_participant_with_all_consents_authored(participant=p1, dateOfBirth=None)
         p2_consents = self._create_participant_with_all_consents_authored(participant=p2, dateOfBirth=invalid_dob)
         # Create consent_file records for each participant's primary consent with no other error conditions
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec_1 = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.READY_FOR_SYNC,
@@ -164,16 +170,14 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         generated = {k: v for k, v in resource_data.items() if k in expected}
         self.assertDictEqual(generated, expected)
 
-        # Email generated for one error type (invalid DOB), with two instances described in the email body text
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
-        self.assertEqual(1, send_error_report_mock.call_count)
-        subject = send_error_report_mock.call_args[0][0]
-        body = send_error_report_mock.call_args[0][1]
-        self.assertIn('Invalid date of birth', subject)
-        self.assertEqual(2, body.count('Error Detected'))
+        # DA-2611: READY_FOR_SYNC files with DOB/age_at_consent issues no longer trigger automated error reports
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.assertEqual(unreported_errors, None)
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
+        self.assertEqual(0, send_error_email_mock.call_count)
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_invalid_age_at_consent(self, send_error_report_mock):
+    def test_consent_metrics_generator_invalid_age_at_consent(self, send_error_email_mock):
         """
          invalid_age_at_consent errors come from participant_summary data, sync_status can still be READY_TO_SYNC
          """
@@ -182,7 +186,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('2014-01-01', '%Y-%m-%d')),
         )
         # Create consent_file record with no other error conditions
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.READY_FOR_SYNC,
@@ -201,17 +204,14 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         generated = {k: v for k, v in resource_data.items() if k in expected}
         self.assertDictEqual(generated, expected)
 
-        # Email generated for one error type (invalid age at consent), with one instance described in the email
-        # body text
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
-        self.assertEqual(1, send_error_report_mock.call_count)
-        subject = send_error_report_mock.call_args[0][0]
-        body = send_error_report_mock.call_args[0][1]
-        self.assertIn('Invalid age at consent', subject)
-        self.assertEqual(1, body.count('Error Detected'))
+        # DA-2611: READY_FOR_SYNC files with DOB/age at consent errors no longer trigger automated reports
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.assertEqual(unreported_errors, None)
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
+        self.assertEqual(0, send_error_email_mock.call_count)
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_missing_file(self, send_error_report_mock):
+    def test_consent_metrics_generator_missing_file(self, send_error_email_mock):
         """
         Consent metrics missing_file error based on consent_file having file_exists = 0
         """
@@ -220,7 +220,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
         )
         # Create consent_file record with file_exists set to false, status NEEDS_CORRECTING
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -242,17 +241,19 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         generated = {k: v for k, v in resource_data.items() if k in expected}
         self.assertDictEqual(generated, expected)
 
-        # Email generated for one error type (invalid age at consent), with one instance described in the email
-        # body text
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
-        self.assertEqual(1, send_error_report_mock.call_count)
-        subject = send_error_report_mock.call_args[0][0]
-        body = send_error_report_mock.call_args[0][1]
+        # Email generated for missing file
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
+        self.assertEqual(1, send_error_email_mock.call_count)
+        subject = send_error_email_mock.call_args[0][0]
+        body = send_error_email_mock.call_args[0][1]
         self.assertIn('Missing file', subject)
         self.assertEqual(1, body.count('Error Detected'))
+        # Confirm after report generation that there are no unreported ids
+        self.assertIsNone(self.consent_error_report_generator.get_unreported_error_ids())
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_dob_and_file_errors(self, send_error_report_mock):
+    def test_consent_metrics_generator_dob_and_file_errors(self, send_error_email_mock):
         """
          Consent metrics signature_missing error + invalid_age_at_consent error from primary consent
          """
@@ -261,7 +262,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('2004-01-01', '%Y-%m-%d'))
         )
         # Create consent_file record with file_exists set to false, status NEEDS_CORRECTING
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -275,7 +275,7 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         )
         self.assertIsNotNone(consent_file_rec.id)
 
-        # Expected: invalid_age_at_consent and signature_missing errors
+        # Expected: invalid_age_at_consent and signature missing errors
         resource_data = self.consent_metric_resource_generator.make_resource(consent_file_rec.id).get_data()
         expected = self._create_expected_metrics_dict(participant,
                                                       consent_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -283,12 +283,14 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         generated = {k: v for k, v in resource_data.items() if k in expected}
         self.assertDictEqual(generated, expected)
 
-        # Emails generated for two error types (invalid age at consent, missing signature), in indeterminate order
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
-        self.assertEqual(2, send_error_report_mock.call_count)
+        # DA-2611: NEEDS_CORRECTING primary consent files in the unreported_errors consent_file ids list can also
+        # trigger DOB/age at consent error reports associated with the same ConsentPII payload
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
+        self.assertEqual(2, send_error_email_mock.call_count)
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_other_errors(self, send_error_report_mock):
+    def test_consent_metrics_generator_other_errors(self, send_error_email_mock):
         """
         Consent metrics errors that are extracted from the consent_file other_errors string field
         """
@@ -297,7 +299,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
         )
         # Create consent_file record with missing check error,  status NEEDS_CORRECTING
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec_1 = self.data_generator.create_database_consent_file(
             type=ConsentType.GROR,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -310,7 +311,7 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             other_errors=ConsentOtherErrors.MISSING_CONSENT_CHECK_MARK
         )
 
-        # Create consent_file record with non-veteran consent for veteran participant error
+        # Create consent_file record with veteran consent for non-veteran participant error
         consent_file_rec_2 = self.data_generator.create_database_consent_file(
             type=ConsentType.EHR,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -383,9 +384,10 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         self.assertEqual(resource_data.get('consent_authored_date', None),
                          datetime.date(participant.consentForElectronicHealthRecordsFirstYesAuthored))
 
-        # Expected:  Three email reports (in indeterminate order), for each distinct error type
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
-        self.assertEqual(3, send_error_report_mock.call_count)
+        # Expected:  Three email reports for each of the three distinct error conditions
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
+        self.assertEqual(3, send_error_email_mock.call_count)
 
     def test_consent_metrics_generator_resolved_date(self):
         """
@@ -426,7 +428,7 @@ class ConsentMetricGeneratorTest(BaseTestCase):
                          datetime.date(consent_file_rec.modified))
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_signature_missing_error_filtered(self, send_error_report_mock):
+    def test_consent_metrics_generator_signature_missing_error_filtered(self, send_error_email_mock):
         """
         Ignore known potential false positives for missing signatures, for consents authored before 2018-07-13
         """
@@ -436,7 +438,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
         )
         # Create consent_file record with signature missing/signing date missing, status NEEDS_CORRECTING
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -447,16 +448,17 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             is_signing_date_valid=0
         )
         self.assertIsNotNone(consent_file_rec.id)
-        resource_data =  self.consent_metric_resource_generator.make_resource(consent_file_rec.id).get_data()
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
+        resource_data = self.consent_metric_resource_generator.make_resource(consent_file_rec.id).get_data()
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
 
         # Confirm this record's ignore flag was set due to filtering the false positive case for missing signature
         # and that no email report was generated
         self.assertEqual(resource_data['ignore'], True)
-        self.assertEqual(0, send_error_report_mock.call_count)
+        self.assertEqual(0, send_error_email_mock.call_count)
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_invalid_signing_date_error_filtered(self, send_error_report_mock):
+    def test_consent_metrics_generator_invalid_signing_date_error_filtered(self, send_error_email_mock):
         """
         Ignore known potential false positives for valid signature but missing signing dates
         for consents authored before 2018-07-13
@@ -467,7 +469,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
         )
         # Create consent_file record with the missing signing date condition
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -479,15 +480,16 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         )
         self.assertIsNotNone(consent_file_rec.id)
         resource_data = self.consent_metric_resource_generator.make_resource(consent_file_rec.id).get_data()
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
 
         # Confirm this record's ignore flag was set due to filtering the invalid_signing_date error, and that
         # no email report was generated
         self.assertEqual(resource_data['ignore'], True)
-        self.assertEqual(0, send_error_report_mock.call_count)
+        self.assertEqual(0, send_error_email_mock.call_count)
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_special_sync_status_filtered(self, send_error_report_mock):
+    def test_consent_metrics_generator_special_sync_status_filtered(self, send_error_email_mock):
         """
         Ignore consent records whose current sync_status is a special case status such as UNKNOWN or DELAYING_SYNC
         """
@@ -497,7 +499,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d'))
         )
         # Create consent_file record with a "non-standard" sync_status
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.DELAYING_SYNC,
@@ -509,15 +510,16 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         )
         self.assertIsNotNone(consent_file_rec.id)
         resource_data = self.consent_metric_resource_generator.make_resource(consent_file_rec.id).get_data()
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
 
         # Confirm this record's ignore flag was set due to filtering on the special sync_status and that
         # no email report was generated
         self.assertEqual(resource_data['ignore'], True)
-        self.assertEqual(0, send_error_report_mock.call_count)
+        self.assertEqual(0, send_error_email_mock.call_count)
 
     @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
-    def test_consent_metrics_generator_va_consent_for_non_va_filtered(self, send_error_report_mock):
+    def test_consent_metrics_generator_va_consent_for_non_va_filtered(self, send_error_email_mock):
         """
         Ignore va_consent_for_non_va errors if that's the only error and participant's current pairing is to the VA HPO
         """
@@ -529,7 +531,6 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             hpoId=va_hpo.hpoId
         )
         # Create consent_file record with file_exists set to false, status NEEDS_CORRECTING
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         consent_file_rec = self.data_generator.create_database_consent_file(
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -542,12 +543,13 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         )
         self.assertIsNotNone(consent_file_rec.id)
         resource_data = self.consent_metric_resource_generator.make_resource(consent_file_rec.id).get_data()
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(unreported_errors)
 
         # Confirm this record's ignore flag was set due to filtering the va_consent_for_non_va error and no
         # error report email was sent
         self.assertEqual(resource_data['ignore'], True)
-        self.assertEqual(0, send_error_report_mock.call_count)
+        self.assertEqual(0, send_error_email_mock.call_count)
 
     def test_consent_metrics_generator_test_participant(self):
         """ Confirm test_participant flag is set by generator if participant is paired to TEST hpo """
@@ -586,9 +588,9 @@ class ConsentMetricGeneratorTest(BaseTestCase):
 
         participant = self._create_participant_with_all_consents_authored(
             dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
+            participantOrigin='vibrent'
         )
         # Create consent_file record with missing check error,  status NEEDS_CORRECTING
-        rec_create_time = datetime.utcnow().replace(microsecond=0)
         self.data_generator.create_database_consent_file(
             type=ConsentType.GROR,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
@@ -611,7 +613,9 @@ class ConsentMetricGeneratorTest(BaseTestCase):
             is_signing_date_valid=1,
             other_errors=ConsentOtherErrors.VETERAN_CONSENT_FOR_NON_VETERAN
         )
-        self.consent_error_report_generator.create_error_reports(errors_created_since=rec_create_time)
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(id_list=unreported_errors,
+                                                                 participant_origin='vibrent')
         # Two email reports should be sent, one for each error type (order of emails indeterminate)
         self.assertEqual(email_mock.call_count, 2)
         call_args = email_mock.call_args_list
@@ -628,4 +632,104 @@ class ConsentMetricGeneratorTest(BaseTestCase):
         self.assertIn('DRC Consent Validation Issue | GROR | Checkbox not checked', subject_lines)
         self.assertIn('DRC Consent Validation Issue | PRIMARY | VA consent version for non-VA participant',
                       subject_lines)
+
+    @mock.patch('rdr_service.resource.generators.consent_metrics.ConsentErrorReportGenerator.send_consent_error_email')
+    def test_get_unreported_errors(self, send_error_email_mock):
+        participant = self._create_participant_with_all_consents_authored(
+            dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
+            participantOrigin='vibrent'
+        )
+        # Create consent_file record with missing check error,  status NEEDS_CORRECTING
+        gror_consent = self.data_generator.create_database_consent_file(
+            type=ConsentType.GROR,
+            sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
+            participant_id=participant.participantId,
+            signing_date=participant.consentForStudyEnrollmentFirstYesAuthored.date(),
+            expected_sign_date=date(year=2020, month=1, day=1),
+            file_exists=1,
+            is_signature_valid=1,
+            is_signing_date_valid=1,
+            other_errors=ConsentOtherErrors.MISSING_CONSENT_CHECK_MARK
+        )
+        # Create consent_file record with consent version error,  status NEEDS_CORRECTING
+        primary_consent = self.data_generator.create_database_consent_file(
+            type=ConsentType.PRIMARY,
+            sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
+            participant_id=participant.participantId,
+            expected_sign_date=date(year=2018, month=1, day=1),
+            file_exists=1,
+            is_signature_valid=1,
+            is_signing_date_valid=1,
+            other_errors=ConsentOtherErrors.VETERAN_CONSENT_FOR_NON_VETERAN
+        )
+        # Report the NEEDS_CORRECTING records created so far (two distinct error types / two email reports)
+        first_unreported_ids_list = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(id_list=first_unreported_ids_list,
+                                                                 participant_origin='vibrent')
+        self.assertEqual(2, send_error_email_mock.call_count)
+
+        # Add checkbox error for an additional consent
+        ehr_consent = self.data_generator.create_database_consent_file(
+            type=ConsentType.EHR,
+            sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
+            participant_id=participant.participantId,
+            expected_sign_date=date(year=2018, month=1, day=31),
+            file_exists=1,
+            is_signature_valid=1,
+            is_signing_date_valid=1,
+            other_errors=ConsentOtherErrors.MISSING_CONSENT_CHECK_MARK
+        )
+        second_unreported_ids_list = self.consent_error_report_generator.get_unreported_error_ids()
+        # The second check of get_unreported_error_ids() should only find the new/not yet reported error
+        self.assertEqual(first_unreported_ids_list, [gror_consent.id, primary_consent.id])
+        self.assertEqual(second_unreported_ids_list, [ehr_consent.id])
+
+    @mock.patch('rdr_service.services.email_service.EmailService.send_email')
+    def test_ce_error_email(self, email_mock):
+        """ For consent errors originating from CE, email report (temporarily) goes to DRC "to" list """
+        # Override config settings for test purposes
+        test_key = 'test_key'
+        test_email_config = {
+            "recipients": ["test_error_report_recipient@test.com", ],
+            "cc_recipients": ["test_error_report_cc_recipient1@test.com", "test_error_report_cc_recipient2@test.com"]
+        }
+        config.override_setting(config.SENDGRID_KEY, [test_key])
+        config.override_setting(config.PTSC_SERVICE_DESK_EMAIL, test_email_config)
+
+        participant = self._create_participant_with_all_consents_authored(
+            dateOfBirth=datetime.date(datetime.strptime('1999-01-01', '%Y-%m-%d')),
+            participantOrigin='careevolution'
+        )
+        # Create NEEDS_CORRECTING consent_file record with missing check error
+        self.data_generator.create_database_consent_file(
+            type=ConsentType.GROR,
+            sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
+            participant_id=participant.participantId,
+            signing_date=participant.consentForStudyEnrollmentFirstYesAuthored.date(),
+            expected_sign_date=date(year=2020, month=1, day=1),
+            file_exists=1,
+            is_signature_valid=1,
+            is_signing_date_valid=1,
+            other_errors=ConsentOtherErrors.MISSING_CONSENT_CHECK_MARK
+        )
+        # Generate the report for the CE consent error
+        unreported_errors = self.consent_error_report_generator.get_unreported_error_ids()
+        self.consent_error_report_generator.create_error_reports(id_list=unreported_errors,
+                                                                 participant_origin='careevolution')
+        self.assertEqual(email_mock.call_count, 1)
+        call_args = email_mock.call_args_list
+        subject_lines = []
+        for call_arg in call_args:
+            subject_lines.append(call_arg.args[0].subject)
+            # For CE reports, the 'cc_recipients' (DRC / RDR team) config item is currently used for the "to" list.
+            # The email should have no cc: list
+            self.assertEqual('no-reply@pmi-ops.org', call_arg.args[0].from_email)
+            self.assertEqual(test_email_config.get('cc_recipients'), call_arg.args[0].recipients)
+            self.assertEmpty(call_arg.args[0].cc_recipients)
+            # CE notation prepended to subject line text
+            self.assertIn('(CE)', call_arg.args[0].subject)
+
+        # Verify the expected subject line was generated
+        self.assertIn('(CE) DRC Consent Validation Issue | GROR | Checkbox not checked', subject_lines)
+
 

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -104,8 +104,9 @@ class ConsentControllerTest(BaseTestCase):
                 ConsentFile(id=4, file_path='/valid_cabor_1', sync_status=ConsentSyncStatus.READY_FOR_SYNC),
             ]
         )
-        # Confirm call to dispatcher for task that checks for newly detected validation errors
-        self.assertEqual(1, self.dispatch_check_consent_errors_mock.call_count)
+        # Confirm calls to dispatcher for task that checks for newly detected validation errors.   A separate task
+        # is dispatched for each participant origin.
+        self.assertEqual(2, self.dispatch_check_consent_errors_mock.call_count)
 
         # Confirm a call to the dispatcher to rebuild the consent metrics resource data, with the ConsentFile.id
         # values from the expected_updates list


### PR DESCRIPTION
## Resolves *[DA-2611](https://precisionmedicineinitiative.atlassian.net/browse/DA-2611)*


## Description of changes/additions
The consent error report automation tasks are triggered at the end of each nightly consent validation job.  They were passed a timestamp from the start of that nightly validation job, used to  filter for `consent_file` records created since that timestamp.  Because the validation job has been regularly failing (OOM killer) before triggering the task,  that's no longer sufficient since there may be error records from previous partial/failed validation runs that are still  not processed.

This refactors the `check_consent_errors` task  to use the ConsentErrorReport table added in PR #2943, for tracking error reports and filtering to find unreported errors from the `consent_file` table.

Main changes:

- Deprecate `created_since` timestamp filters and logic
- Add a `get_unreported_error_ids()` method to find unreported NEEDS_CORRECTING `consent_file` records
- Add records to the ConsentErrorReport tracking table based on the new email reports that get sent
-  Add regeneration of the primary consent metrics records to the PDR  participant data rebuild, since those metrics records can be impacted by the receipt of new ConsentPII `questionnaire_response` payloads (unrelated to PDF validation)
- Enable reports for CareEvolution consent errors; they will only be sent to DRC/RDR recipients and do not have a Jira target email 

Side effect of these changes is the invalid DOB or invalid age at consent errors cannot be reliably discovered/reported every day since they don't have tracking in the `consent_file` table and may not be associated with a NEEDS_CORRECTING record.  DOB/age errors that were associated with the same ConsentPII payload that had a failed primary consent PDF validation may still be discovered when the related PDF error record is processed.

## Tests
- [x] unit tests (updated)


