### PR TITLE
[DA-2630] Updating to match changes to WEAR consent "yes" answer value

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -119,6 +119,8 @@ CONSENT_GROR_NOT_SURE = "CheckDNA_NotSure"
 COHORT_1_REVIEW_CONSENT_YES_CODE = "ReviewConsentAgree_Yes"
 COHORT_1_REVIEW_CONSENT_NO_CODE = "ReviewConsentAgree_No"
 
+WEAR_YES_ANSWER_CODE = "wear_yes"
+
 # Cohort Group Code
 CONSENT_COHORT_GROUP_CODE = "ConsentPII_CohortGroup"
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -41,7 +41,6 @@ from rdr_service.code_constants import (
     GENDER_IDENTITY_QUESTION_CODE,
     LANGUAGE_OF_CONSENT,
     PMI_SKIP_CODE,
-    PMI_YES,
     PPI_EXTRA_SYSTEM,
     PPI_SYSTEM,
     RACE_QUESTION_CODE,
@@ -54,6 +53,7 @@ from rdr_service.code_constants import (
     CONSENT_COPE_DEFERRED_CODE,
     COPE_CONSENT_QUESTION_CODE,
     WEAR_CONSENT_QUESTION_CODE,
+    WEAR_YES_ANSWER_CODE,
     STREET_ADDRESS_QUESTION_CODE,
     STREET_ADDRESS2_QUESTION_CODE,
     EHR_CONSENT_EXPIRED_YES,
@@ -714,10 +714,8 @@ class QuestionnaireResponseDao(BaseDao):
                             logging.error(f'Invalid value given for cohort group: received "{answer.valueString}"')
                     elif code.value.lower() == WEAR_CONSENT_QUESTION_CODE:
                         answer_value = code_dao.get(answer.valueCodeId).value
-                        if answer_value.lower() == PMI_YES:
+                        if answer_value.lower() == WEAR_YES_ANSWER_CODE:
                             self.consents_provided.append(ConsentType.WEAR)
-
-
 
         # If the answer for line 2 of the street address was left out then it needs to be clear on summary.
         # So when it hasn't been submitted and there is something set for streetAddress2 we want to clear it out.


### PR DESCRIPTION
## Resolves *[DA-2630](https://precisionmedicineinitiative.atlassian.net/browse/DA-2630)*
Updates were made to the WEAR consent questionnaire that changed the code value used as an answer when the participant was supplying a "yes" response. This updates the RDR code so that we can detect when a participant gives consent and record that the PDF should be validated.


## Tests
- [ ] unit tests


