### PR TITLE
[DA-2620] Add div pouch lookup to AW1 ingestion

### DIFF
--- a/rdr_service/dao/biobank_stored_sample_dao.py
+++ b/rdr_service/dao/biobank_stored_sample_dao.py
@@ -2,7 +2,9 @@ import logging
 
 from rdr_service.code_constants import BIOBANK_TESTS_SET
 from rdr_service.dao.base_dao import BaseDao
+from rdr_service.model.biobank_order import BiobankOrderIdentifier, BiobankOrder
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
+from rdr_service.model.site import Site
 
 
 class BiobankStoredSampleDao(BaseDao):
@@ -34,3 +36,27 @@ class BiobankStoredSampleDao(BaseDao):
             return written
 
         return self._database.autoretry(upsert)
+
+    def get_diversion_pouch_site_id(self, biobank_stored_sample_id):
+        with self.session() as session:
+            results = session.query(
+                BiobankStoredSample.biobankStoredSampleId,
+                Site.siteId
+            ).join(
+                BiobankOrderIdentifier,
+                BiobankOrderIdentifier.value == BiobankStoredSample.biobankOrderIdentifier
+            ).join(
+                BiobankOrder,
+                BiobankOrder.biobankOrderId == BiobankOrderIdentifier.biobankOrderId
+            ).join(
+                Site,
+                Site.siteId == BiobankOrder.collectedSiteId
+            ).filter(
+                Site.siteType == "Diversion Pouch",
+                BiobankStoredSample.biobankStoredSampleId == biobank_stored_sample_id
+            ).distinct().one_or_none()
+
+            if results:
+                return getattr(results, 'siteId')
+            else:
+                return

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -496,6 +496,12 @@ class GenomicFileIngester:
                                                     )
                     # Skip rest of iteration and continue processing file
                     continue
+
+            # Check for diversion pouch site
+            div_pouch_site_id = self.sample_dao.get_diversion_pouch_site_id(row_copy['collectiontubeid'])
+            if div_pouch_site_id:
+                member.diversionPouchSiteFlag = 1
+
             # Process the attribute data
             member_changed, member = self._process_aw1_attribute_data(row_copy, member)
             if member_changed:


### PR DESCRIPTION
## Resolves *[DA-2620](https://precisionmedicineinitiative.atlassian.net/browse/DA-2620)*


## Description of changes/additions
The `diversionPouchSiteFlag` attribute was recently added to the `GenomicSetMember` model. This PR updates the AW1 ingestion to set the `diversionPouchSiteFlag` after the collection tube is validated. The method `get_diversion_pouch_site_id` was added to the `BiobankStoredSampleDao` class to perform this lookup. Unit tests were updated to check the flag is updated after ingestion.

## Tests
- [x] unit tests


