### PR TITLE
[PDR-861] Add wear_consent to PDR data

### DIFF
--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -33,6 +33,7 @@ BQ_TABLES = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRPostPMBFeedback'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPPIModuleFeedback'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRGROR'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRWearConsent'),
 
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummary'),
 
@@ -98,6 +99,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRPostPMBFeedbackView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRPPIModuleFeedbackView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRGRORView'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRWearConsentView'),
 
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherView'),
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherGenderView'),

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -1299,6 +1299,30 @@ class BQPDRPPIModuleFeedbackView(BQModuleView):
     __pk_id__ = ['participant_id', 'questionnaire_response_id']
     _show_created = True
 
+# PDR-861:  Add WEAR Consent module:
+class BQPDRWearConsentSchema(_BQModuleSchema):
+    """ WEAR Consent Module """
+    _module = 'wear_consent'
+    _force_boolean_fields = (
+        'timeofday',
+        'HelpMeWithConsent_Name'
+    )
+
+class BQPDRWearConsent(BQTable):
+    """ PDR wear_consent BigQuery Table """
+    __tablename__ = 'pdr_mod_wear_consent'
+    __schema__ = BQPDRWearConsentSchema
+
+
+class BQPDRWearConsentView(BQModuleView):
+    """ PDR Wear_Consent BigQuery View """
+    __viewname__ = 'v_pdr_mod_wear_consent'
+    __viewdescr__ = 'PDR wear_consent Module View'
+    __table__ = BQPDRWearConsent
+    __pk_id__ = ['participant_id', 'questionnaire_response_id']
+    _show_created = True
+
+
 #
 #
 #
@@ -1330,7 +1354,8 @@ PDR_MODULE_LIST = (
     BQPDRPersonalFamilyHistory,
     BQPDRGeneralFeedback,
     BQPDRPostPMBFeedback,
-    BQPDRPPIModuleFeedback
+    BQPDRPPIModuleFeedback,
+    BQPDRWearConsent
 )
 
 # Create a dictionary of module codes and table object references.

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -72,7 +72,8 @@ _consent_module_question_map = {
     'cope_dec': 'section_participation',
     'cope_feb': 'section_participation',
     'GeneticAncestry': 'GeneticAncestry_ConsentAncestryTraits',
-    'covid_19_serology_results': 'covid_19_serology_results_decision'
+    'covid_19_serology_results': 'covid_19_serology_results_decision',
+    'wear_consent': 'resultsconsent_wear'
 }
 
 # _consent_expired_question_map, for expired consents. { module: question code string }
@@ -106,6 +107,9 @@ _consent_answer_status_map = {
     # covid_19_serology_results_decision
     'Decision_Yes': BQModuleStatusEnum.SUBMITTED,
     'Decision_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    'WEAR_Yes': BQModuleStatusEnum.SUBMITTED,
+    'WEAR_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT
+
 }
 
 # PDR-252:  When RDR starts accepting QuestionnaireResponse payloads for withdrawal screens, AIAN participants


### PR DESCRIPTION
## Resolves *[PDR-861](https://precisionmedicineinitiative.atlassian.net/browse/PDR-861)*


## Description of changes/additions
Add support for the `wear_consent` module to the PDR data

## Tests
Built on RDR stable:
- `resource_data` record id 176984
- `bigquery_sync` record ids 472452, 472453


