### PR TITLE
[PDR-842] Allow participant research_id to populate in PDR.

### DIFF
--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -201,6 +201,7 @@ class BQPDRParticipantSummarySchema(BQSchema):
     enrl_status = BQField('enrl_status', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     enrl_status_id = BQField('enrl_status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     age_at_consent = BQField('age_at_consent', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    research_id = BQField('research_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQPDRParticipantSummary(BQTable):

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -433,7 +433,7 @@ class ParticipantSchema(Schema):
         # Exclude fields and/or functions to strip PII information from fields.
         pii_fields = ('phone_number', 'login_phone_number', 'email',
                       'distinct_visits', 'first_name', 'middle_name', 'last_name',
-                      'sexual_orientation', 'sexual_orientation_id', 'research_id', 'last_modified'
+                      'sexual_orientation', 'sexual_orientation_id', 'last_modified'
                       ) # List fields that contain PII data
 
         pii_filter = {}  # dict(field: lambda function).


### PR DESCRIPTION
## Resolves *[PDR-842](https://precisionmedicineinitiative.atlassian.net/browse/PDR-842)*


## Description of changes/additions
Allow the participant's 'research_id' value to be in PDR now.

## Tests
- [x] unit tests


