### PR TITLE
Reducing number of requests handled by offline instances

### DIFF
--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -2,7 +2,7 @@
 
 runtime: python37
 service: offline
-entrypoint: gunicorn -c rdr_service/services/gunicorn_offline_config.py --timeout 18000 rdr_service.offline.main:app
+entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 --max-requests 10 --max-requests-jitter 3 rdr_service.offline.main:app
 
 # Default AppEngine configuration (B1) has only 128 MB of RAM and 600 MhZ CPU, which makes
 # the metrics pipeline run very slowly. Bumping up to 1 GB of RAM and 2.4 GHz to speed things up.

--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -2,7 +2,8 @@
 
 runtime: python37
 service: offline
-entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 rdr_service.offline.main:app
+entrypoint: gunicorn -c rdr_service/services/gunicorn_offline_config.py --timeout 18000 rdr_service.offline.main:app
+
 # Default AppEngine configuration (B1) has only 128 MB of RAM and 600 MhZ CPU, which makes
 # the metrics pipeline run very slowly. Bumping up to 1 GB of RAM and 2.4 GHz to speed things up.
 # https://cloud.google.com/appengine/docs/standard/

--- a/rdr_service/services/gunicorn_offline_config.py
+++ b/rdr_service/services/gunicorn_offline_config.py
@@ -1,0 +1,4 @@
+from gunicorn_config import *  # pylint: disable=unused-import
+
+max_requests = 10
+max_requests_jitter = 3

--- a/rdr_service/services/gunicorn_offline_config.py
+++ b/rdr_service/services/gunicorn_offline_config.py
@@ -1,4 +1,0 @@
-from gunicorn_config import *  # pylint: disable=unused-import
-
-max_requests = 10
-max_requests_jitter = 3


### PR DESCRIPTION
## Resolves *no ticket*
The cron jobs have been seeing a number of memory issues come up. This reduces the number of requests each gunicorn worker on an instance would handle (bringing it down from 1000 requests to 10). Each cron job likely takes more memory than a typical request to the default service (that runs things like the ParticipantSummary API). So having each worker handle fewer requests will hopefully help reduce the number of jobs that are stopped because of the instance running out of memory.


## Tests
- [ ] unit tests


