### PR TITLE
Updates to survey response validation

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -39,6 +39,7 @@ from rdr_service.dao.site_dao import SiteDao
 from rdr_service.model.config_utils import from_client_biobank_id, to_client_biobank_id
 from rdr_service.model.consent_file import ConsentType
 from rdr_service.model.retention_eligible_metrics import RetentionEligibleMetrics
+from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import (
     ParticipantGenderAnswers,
     ParticipantRaceAnswers,
@@ -1118,7 +1119,14 @@ class ParticipantSummaryDao(UpdatableDao):
 
     @classmethod
     def get_all_consented_participant_ids(cls, session):
-        db_results = session.query(ParticipantSummary.participantId).all()
+        db_results = session.query(
+            ParticipantSummary.participantId
+        ).join(
+            Participant,
+            Participant.participantId == ParticipantSummary.participantId
+        ).filter(
+            Participant.isTestParticipant.is_(False)
+        ).all()
         return [obj.participantId for obj in db_results]
 
     def get_participant_ids_with_ehr_data_available(self):

--- a/rdr_service/services/response_validation/validation.py
+++ b/rdr_service/services/response_validation/validation.py
@@ -625,7 +625,7 @@ class ResponseValidator:
     def get_errors_in_responses(self, participant_responses: response_domain_model.ParticipantResponses):
         errors_by_question = defaultdict(list)
         for response in participant_responses.in_authored_order:
-            # self._check_for_definition_errors(response, errors_by_question)
+            self._check_for_definition_errors(response, errors_by_question)
 
             branching_errors = self._branching_logic.check_for_errors(response)
             for error in branching_errors:
@@ -746,7 +746,7 @@ class ResponseValidator:
                                     f'Unexpected validation string for question, got "{question.validation}"'
                                 )
 
-                            if min_value and answer_value < min_value:
+                            if min_value is not None and answer_value < min_value:
                                 errors_by_question[question_code_str].append(
                                     ValidationError(
                                         question_code_str,
@@ -754,7 +754,7 @@ class ResponseValidator:
                                         reason='Answer lower than minimum value'
                                     )
                                 )
-                            if max_value and answer_value > max_value:
+                            if max_value is not None and answer_value > max_value:
                                 errors_by_question[question_code_str].append(
                                     ValidationError(
                                         question_code_str,


### PR DESCRIPTION
## Resolves *[DA-2595](https://precisionmedicineinitiative.atlassian.net/browse/DA-2595)*
Making some adjustments to the response validation script:
- Ignoring data for test participants
- Enabling check for requirements specified in recap (previously just the branching logic was checked, now things like min/max of the answer and the data type are checked)
- Using logger set up for the scripts so the log lines get printed to the console
- Fixing how the rebuild tasks were sent

## Tests
- [ ] unit tests


