### PR TITLE
[DA-2648] Have CircleCI check that the app is successfully deploy to the test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,6 @@ commands:
           name: Setup Python Environment
           command: ./ci/setup_python_env.sh
       - run:
-          name: Verify App Instance Running
-          command: source venv/bin/activate && python ./ci/verify_instance.py
-      - run:
           name: Code static analysis checks
           command: ci/full_static_analysis.sh
       - run:
@@ -74,6 +71,9 @@ commands:
           name: Deploy App To Test Environment
           command: ./ci/deploy_app.sh << parameters.project-id >> << parameters.git-target >>
           no_output_timeout: 60m
+      - run:
+          name: Verify App Instance Running
+          command: source venv/bin/activate && python ./ci/verify_instance.py << parameters.project-id >> << parameters.git-target >>
 
 jobs:
   job_run_unittests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ commands:
           name: Safety Check
           command: source venv/bin/activate && safety check
       - run:
+          name: Verify App Instance Running
+          command: source venv/bin/activate && python ./ci/verify_instance.py
+      - run:
           name: Check Licenses
           command : |
             export PYTHONPATH=$PYTHONPATH:`pwd`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,14 @@ commands:
           name: Setup Python Environment
           command: ./ci/setup_python_env.sh
       - run:
+          name: Verify App Instance Running
+          command: source venv/bin/activate && python ./ci/verify_instance.py
+      - run:
           name: Code static analysis checks
           command: ci/full_static_analysis.sh
       - run:
           name: Safety Check
           command: source venv/bin/activate && safety check
-      - run:
-          name: Verify App Instance Running
-          command: source venv/bin/activate && python ./ci/verify_instance.py
       - run:
           name: Check Licenses
           command : |

--- a/ci/verify_instance.py
+++ b/ci/verify_instance.py
@@ -1,0 +1,18 @@
+import logging
+import sys
+
+import requests
+
+
+logger = logging.getLogger()
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
+logger.setLevel(logging.INFO)
+
+response = requests.get('https://ks-check-instance-running-1-dot-all-of-us-rdr-sandbox.appspot.com/')
+
+if response.status_code != 200:
+    logger.error(f'ERROR: server responded with {response.status_code} status code')
+    exit(1)
+else:
+    logger.info('Instance successfully responded!')

--- a/ci/verify_instance.py
+++ b/ci/verify_instance.py
@@ -9,7 +9,12 @@ stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
 logger.setLevel(logging.INFO)
 
-response = requests.get('https://ks-check-instance-running-1-dot-all-of-us-rdr-sandbox.appspot.com/')
+project_id = sys.argv[1]
+version_id = sys.argv[2]
+app_engine_url = f'https://{version_id}-dot-{project_id}.appspot.com/'
+
+logger.info(f'Checking "{app_engine_url}" for a running instance')
+response = requests.get(app_engine_url)
 
 if response.status_code != 200:
     logger.error(f'ERROR: server responded with {response.status_code} status code')


### PR DESCRIPTION
## Resolves *[DA-2648](https://precisionmedicineinitiative.atlassian.net/browse/DA-2648)*
We've seen that everything can successfully run for the unit tests in CircleCI, but then when deployed to the Test environment the instance can fail to start. This adds a step to CircleCI that will check to be sure that the instance is running and responding to requests.

As of the current state of configuration, if an instance receives a GET request at the root url it will respond with the version number. This request fails if there is no instance running to process it.

## Tests
- [ ] unit tests


