### PR TITLE
More fixes for processing new layouts of CE consent PDFs

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -625,16 +625,15 @@ class CeFileWrapper:
 
     def get_signature_on_file(self):
         signature_offsets = [
-            (8, 10),
-            (73, 75)
+            (8, 15),
+            (73, 80)
         ]
 
         signature_label_strings = [
             "Participant's Name (printed)",
             "'s Name (printed)",
             "Name (printed)",
-            'Nombre del Participant',
-            'Nombre del'
+            'Nombre'
         ]
 
         for offset in signature_offsets:


### PR DESCRIPTION
## Resolves *no ticket*
This updates the validation of CE files to help the code find the signature and signing date in new layouts of the CE consent PDFs.


## Tests
- [ ] unit tests


