### PR TITLE
Allow for Null Values in ID Verification

### DIFF
--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -486,12 +486,14 @@ class MetricsCronJobStage(messages.Enum):
 
 class OnSiteVerificationType(messages.Enum):
     """Types of on site verification"""
+    UNSET = 0
     PHOTO_AND_ONE_OF_PII = 1
     TWO_OF_PII = 2
 
 
 class OnSiteVerificationVisitType(messages.Enum):
     """Types of on site visit"""
+    UNSET = 0
     PMB_INITIAL_VISIT = 1
     PHYSICAL_MEASUREMENTS_ONLY = 2
     BIOSPECIMEN_COLLECTION_ONLY = 3

--- a/tests/api_tests/test_onsite_verification_api.py
+++ b/tests/api_tests/test_onsite_verification_api.py
@@ -11,6 +11,7 @@ class OnsiteVerificationApiTest(BaseTestCase):
                                                              googleGroup='test-group')
         self.p = self.data_generator.create_database_participant(hpoId=self.hpo.hpoId)
         self.p2 = self.data_generator.create_database_participant(hpoId=self.hpo.hpoId)
+        self.p3 = self.data_generator.create_database_participant(hpoId=self.hpo.hpoId)
         self.ps = self.data_generator.create_database_participant_summary(participant=self.p)
 
     def test_onsite_verification(self):
@@ -39,10 +40,15 @@ class OnsiteVerificationApiTest(BaseTestCase):
             "verificationType": "TWO_OF_PII",
             "visitType": "BIOSPECIMEN_COLLECTION_ONLY"
         }
+        payload_4 = {
+            "participantId": 'P' + str(self.p3.participantId),
+            "verifiedTime": "2022-02-03T04:05:06Z",
+        }
 
         response1 = self.send_post(path, payload_1)
         response2 = self.send_post(path, payload_2)
         response3 = self.send_post(path, payload_3)
+        response4 = self.send_post(path, payload_4)
         self.assertEqual(response1,
                          {'participantId': 'P' + str(self.p.participantId),
                           'verifiedTime': '2022-03-22T06:07:08',
@@ -69,6 +75,15 @@ class OnsiteVerificationApiTest(BaseTestCase):
                           'siteName': self.site.siteName,
                           'verificationType': 'TWO_OF_PII',
                           'visitType': 'BIOSPECIMEN_COLLECTION_ONLY'}
+                         )
+        self.assertEqual(response4,
+                         {'participantId': 'P' + str(self.p3.participantId),
+                          'verifiedTime': '2022-02-03T04:05:06',
+                          'userEmail': None,
+                          'siteGoogleGroup': None,
+                          'siteName': None,
+                          'verificationType': 'UNSET',
+                          'visitType': 'UNSET'}
                          )
 
         get_path = 'Onsite/Id/Verification/P' + str(self.p.participantId)
@@ -102,3 +117,16 @@ class OnsiteVerificationApiTest(BaseTestCase):
                               'verificationType': 'TWO_OF_PII',
                               'visitType': 'BIOSPECIMEN_COLLECTION_ONLY'}
                          ]})
+        get_path = 'Onsite/Id/Verification/P' + str(self.p3.participantId)
+        result = self.send_get(get_path)
+        self.assertEqual(result,
+                         {'entry': [
+                             {'participantId': 'P' + str(self.p3.participantId),
+                              'verifiedTime': '2022-02-03T04:05:06',
+                              'userEmail': None,
+                              'siteGoogleGroup': None,
+                              'siteName': None,
+                              'verificationType': 'UNSET',
+                              'visitType': 'UNSET'}
+                         ]})
+


### PR DESCRIPTION
## Resolves *[DA-2634](https://precisionmedicineinitiative.atlassian.net/browse/DA-2634)*


## Description of changes/additions
Modifies onsite verification api to allow verification type, and visit type fields to be omitted or set to to null. In these cases the value will be saved as UNSET.

## Tests
- [x] unit tests


