### PR TITLE
Bug fix when interacting with google sheets

### DIFF
--- a/rdr_service/services/google_sheets_client.py
+++ b/rdr_service/services/google_sheets_client.py
@@ -250,13 +250,14 @@ class GoogleSheetsClient:
 
     @backoff.on_exception(backoff.constant, HttpError, max_tries=4, jitter=None, interval=30)
     def _process_batch_update_requests(self, service):
-        request = service.spreadsheets().batchUpdate(
-            spreadsheetId=self._spreadsheet_id,
-            body={
-                'requests': self._spreadsheets_batch_update_requests
-            }
-        )
-        request.execute()
+        if self._spreadsheets_batch_update_requests:
+            request = service.spreadsheets().batchUpdate(
+                spreadsheetId=self._spreadsheet_id,
+                body={
+                    'requests': self._spreadsheets_batch_update_requests
+                }
+            )
+            request.execute()
 
     @backoff.on_exception(backoff.constant, HttpError, max_tries=4, jitter=None, interval=30)
     def _upload_sheet_values(self, service):


### PR DESCRIPTION
## Resolves *no ticket*
The biobank API comparison needs to set up a 'batch request' to create a new tab, but updating the data dictionary doesn't need to do that. Google gives an error if you try to send a batchUpdate call with no requests, so this checks to see if anything would be sent first.


## Tests
- [ ] unit tests


