### PR TITLE
Fix for CI verification step when releasing to test environments

### DIFF
--- a/ci/verify_instance.py
+++ b/ci/verify_instance.py
@@ -1,18 +1,29 @@
 import logging
+import re
 import sys
 
 import requests
 
 
+# Configure logger to print out to CircleCI interface
 logger = logging.getLogger()
 stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
 logger.setLevel(logging.INFO)
 
+# Get GAE project and version number from CLI input
 project_id = sys.argv[1]
 version_id = sys.argv[2]
-app_engine_url = f'https://{version_id}-dot-{project_id}.appspot.com/'
 
+# Convert the version number if needed
+# (our deploy replaces periods with hyphens during a release)
+release_version_pattern = re.compile('^\d+\.\d+\.\d+$')
+if release_version_pattern.match(version_id):
+    # Version is 3 numbers separated by periods, so is a release version and would be deploy to GAE with hyphens
+    version_id = version_id.replace('.', '-')
+
+# Check to see if an instance responds
+app_engine_url = f'https://{version_id}-dot-{project_id}.appspot.com/'
 logger.info(f'Checking "{app_engine_url}" for a running instance')
 response = requests.get(app_engine_url)
 


### PR DESCRIPTION
## Resolves *no ticket*
CI fails to verify a running instance when deploying to the test environments since the version number uses hyphens in GAE and we have periods in the tags. This updates the verification step to use the version number as it appears in GAE (not necessarily that it would need to be checked when releasing, since it's already been checked to be able to run in GAE when merged to devel, but mostly to keep the CI jobs from failing).

## Tests
- [ ] unit tests


