### PR TITLE
[DA-2676] Creating release tickets as "Release" issue type

### DIFF
--- a/rdr_service/services/jira_utils.py
+++ b/rdr_service/services/jira_utils.py
@@ -114,7 +114,7 @@ class JiraTicketHandler:
             raise ValueError('Invalid JIRA ticket ID value.')
         return self._jira_connection.issue(ticket_id)
 
-    def create_ticket(self, summary, descr, issue_type="Task", board_id=_JIRA_BOARD_ID, components=None):
+    def create_ticket(self, summary, descr, issue_type=None, board_id=_JIRA_BOARD_ID, components=None):
         """
         Create a new ticket in a Jira project.
         :param summary: Ticket summary to search for.
@@ -125,6 +125,8 @@ class JiraTicketHandler:
         """
         if components is None:
             components = []
+        if issue_type is None:
+            issue_type = 'Task'
 
         if not summary:
             raise ValueError('Jira ticket summary may not be empty')

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -205,7 +205,7 @@ class DeployAppClass(ToolBase):
             if os.path.exists(c):
                 os.remove(c)
 
-    def create_jira_ticket(self, summary, descr=None, board_id=None, components=None):
+    def create_jira_ticket(self, summary, descr=None, board_id=None, components=None, issue_type=None):
         """
         Create a Jira ticket.
         """
@@ -252,7 +252,13 @@ class DeployAppClass(ToolBase):
         if not board_id:
             board_id = self.jira_board
 
-        ticket = self._jira_handler.create_ticket(summary, descr, board_id=board_id, components=components)
+        ticket = self._jira_handler.create_ticket(
+            summary,
+            descr,
+            board_id=board_id,
+            components=components,
+            issue_type=issue_type
+        )
         return ticket
 
     def add_jira_comment(self, comment):
@@ -279,6 +285,7 @@ class DeployAppClass(ToolBase):
             if self.gcp_env.project == 'all-of-us-rdr-staging':
                 ticket = self.create_jira_ticket(
                     summary,
+                    issue_type='Release',
                     components=[{'id': '10074'}]  # "Change Management" component
                 )
                 if not ticket:


### PR DESCRIPTION
## Resolves *[DA-2676](https://precisionmedicineinitiative.atlassian.net/browse/DA-2676)*
We got a request to have the release tickets created as "Release" issue types rather than "Task" types. This update the deploy script to create the release ticket as a "Release" type.


## Tests
- [ ] unit tests


