### PR TITLE
[DA-2712] Validating consents in batches

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -417,7 +417,21 @@ class ConsentValidationController:
         dispatch_check_consent_errors_task(origin='careevolution', in_seconds=28800)
 
         # Retrieve consent response objects that need to be validated
-        participant_id_consent_map = self.consent_dao.get_consent_responses_to_validate(session=session)
+        is_last_batch = False
+        while not is_last_batch:
+            participant_id_consent_map, is_last_batch = self.consent_dao.get_consent_responses_to_validate(
+                session=session
+            )
+            self._process_id_consent_map(
+                participant_id_consent_map=participant_id_consent_map,
+                output_strategy=output_strategy,
+                session=session,
+                min_consent_date=min_consent_date,
+                max_consent_date=max_consent_date
+            )
+
+    def _process_id_consent_map(self, participant_id_consent_map, output_strategy,
+                                session, min_consent_date=None, max_consent_date=None):
         participant_summaries = self.participant_summary_dao.get_by_ids_with_session(
             session=session,
             obj_ids=participant_id_consent_map.keys()

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -109,7 +109,7 @@ class ConsentFileDaoTest(BaseTestCase):
         self.session.commit()
 
         # Make sure we get the correct response from the DAO
-        pid_consent_response_map = self.consent_dao.get_consent_responses_to_validate(session=self.session)
+        pid_consent_response_map, _ = self.consent_dao.get_consent_responses_to_validate(session=self.session)
         self.assertNotIn(ignored_response.participantId, pid_consent_response_map)
 
         consent_response = pid_consent_response_map[response_to_validate.participantId][0]

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -54,24 +54,27 @@ class ConsentControllerTest(BaseTestCase):
         """The controller should find all recent participant summary consents authored and validate files for them"""
         primary_and_ehr_participant_id = 123
         cabor_participant_id = 456
-        self.consent_dao_mock.get_consent_responses_to_validate.return_value = {
-            primary_and_ehr_participant_id: [
-                ConsentResponse(
-                    response=QuestionnaireResponse(participantId=primary_and_ehr_participant_id),
-                    type=ConsentType.PRIMARY
-                ),
-                ConsentResponse(
-                    response=QuestionnaireResponse(participantId=primary_and_ehr_participant_id),
-                    type=ConsentType.EHR
-                )
-            ],
-            cabor_participant_id: [
-                ConsentResponse(
-                    response=QuestionnaireResponse(participantId=cabor_participant_id),
-                    type=ConsentType.CABOR
-                ),
-            ]
-        }
+        self.consent_dao_mock.get_consent_responses_to_validate.return_value = (
+            {
+                primary_and_ehr_participant_id: [
+                    ConsentResponse(
+                        response=QuestionnaireResponse(participantId=primary_and_ehr_participant_id),
+                        type=ConsentType.PRIMARY
+                    ),
+                    ConsentResponse(
+                        response=QuestionnaireResponse(participantId=primary_and_ehr_participant_id),
+                        type=ConsentType.EHR
+                    )
+                ],
+                cabor_participant_id: [
+                    ConsentResponse(
+                        response=QuestionnaireResponse(participantId=cabor_participant_id),
+                        type=ConsentType.CABOR
+                    ),
+                ]
+            },
+            True  # is last batch
+        )
 
         self.consent_validator_mock.get_primary_validation_results.return_value = [
             ConsentFile(id=1, sync_status=ConsentSyncStatus.NEEDS_CORRECTING, file_path='/invalid_primary_1'),


### PR DESCRIPTION
## Resolves *[DA-2712](https://precisionmedicineinitiative.atlassian.net/browse/DA-2712)*
Loading the consent validations needed all at once is causing memory issues. This loads them in batches of 500 to reduce the memory footprint.

## Tests
- [ ] unit tests


