### PR TITLE
[PDR-863] Filter pending duplicate responses from PDR data

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -745,7 +745,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 # consent_added == True means we already know it wasn't a replayed response
                 if consent_added or not self.is_replay(last_mod_processed, last_answer_hash,
                                                        module_data, row.answerHash,
-                                                       ignore_keys=['module_created', 'questionnaire_response_id']):
+                                                       ignore_keys=['module_created', 'questionnaire_response_id',
+                                                                    'classification_type', 'classification_type_id',
+                                                                    'semantic_version']):
                     modules.append(module_data)
                     # Find module in ParticipantActivity Enum via a case-insensitive way.
                     mod_found = False


### PR DESCRIPTION
## Resolves *[PDR-863](https://precisionmedicineinitiative.atlassian.net/browse/PDR-863)*


## Description of changes/additions

Currently,  the PDR participant generator for the  `participant_module` survey response summary history has an `is_replay()` method (existed before `answer_hash` values were added to RDR `questionnaire_response` records) to recognize and exclude replays/duplicate responses.

The PDR module data generator had no corresponding filtering.  This adds the logic to look for duplicate responses which may not have been flagged yet in RDR, and proactively exclude them from PDR module data builds.

Also fixed:

- corrected placement of the `order by` clause when retrieving participant module responses in participant generator
- Made the participant generator `is_replay()` logic more consistent with the RDR `ResponseDuplicationDetector ` class logic so that potential duplicates are not missed.

## Tests
- [x] unit tests
- Manual testing of participants with unflagged duplicates to make sure PDR participant data and module data included the same `questionnaire_response_id` records


