### PR TITLE
Biobank_ID as param for RHP

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1763,10 +1763,10 @@ class GenomicPiiDao(BaseDao):
 
         return {self.camel_to_snake(k): v for k, v in participant_dict.items()}
 
-    def get_pii(self, mode, participant_id, biobank_id):
+    def get_pii(self, mode, participant_id=None, biobank_id=None):
         """
-        :param participant_id:
         :param mode:
+        :param participant_id:
         :param biobank_id:
         :return: query results for PID
         """

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1763,11 +1763,11 @@ class GenomicPiiDao(BaseDao):
 
         return {self.camel_to_snake(k): v for k, v in participant_dict.items()}
 
-    def get_by_pid(self, pid, mode):
+    def get_pii(self, mode, participant_id, biobank_id):
         """
-        Returns Biobank ID, First Name, and Last Name for requested PID
-        :param pid:
+        :param participant_id:
         :param mode:
+        :param biobank_id:
         :return: query results for PID
         """
         mode = mode.lower()
@@ -1777,7 +1777,7 @@ class GenomicPiiDao(BaseDao):
         ).subquery()
 
         with self.session() as session:
-            if mode == 'gp':
+            if mode == 'gp' and participant_id:
                 record = session.query(
                     GenomicSetMember.biobankId,
                     ParticipantSummary.firstName,
@@ -1797,8 +1797,10 @@ class GenomicPiiDao(BaseDao):
                 ).outerjoin(
                     informing_loop_ready,
                     informing_loop_ready.c.participant_id == GenomicSetMember.participantId
+                ).filter(
+                    GenomicSetMember.participantId == participant_id
                 )
-            elif mode == 'rhp':
+            elif mode == 'rhp' and biobank_id:
                 record = session.query(
                     GenomicSetMember.participantId,
                     ParticipantSummary.firstName,
@@ -1817,11 +1819,11 @@ class GenomicPiiDao(BaseDao):
                     or_(
                         GenomicSetMember.cvlW4wrHdrManifestJobRunID.isnot(None),
                         GenomicSetMember.cvlW4wrPgxManifestJobRunID.isnot(None)
-                    )
+                    ),
+                    GenomicSetMember.biobankId == biobank_id
                 )
 
             record = record.filter(
-                GenomicSetMember.participantId == pid,
                 ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
                 ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
                 GenomicSetMember.genomicWorkflowState != GenomicWorkflowState.IGNORE

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -304,7 +304,7 @@ api.add_resource(RedcapResearcherAuditApi,
                  methods=['GET'])
 
 api.add_resource(GenomicPiiApi,
-                 API_PREFIX + "GenomicPII/<string:mode>/<participant_id:p_id>",
+                 API_PREFIX + "GenomicPII/<string:mode>/<string:pii_id>",
                  endpoint='genomic.pii',
                  methods=['GET'])
 

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -233,6 +233,7 @@ class RhpGenomicPIIApiTest(GenomicApiTestBase):
         self._make_summary(participant)
         self._make_set_member(
             participant=participant,
+            biobankId=participant.biobankId,
             collectionTubeId=11111,
             cvlW4wrHdrManifestJobRunID=1,
             gcManifestSampleSource='Whole Blood'
@@ -243,8 +244,9 @@ class RhpGenomicPIIApiTest(GenomicApiTestBase):
             biobankStoredSampleId=11111,
             confirmed=clock.CLOCK.now()
         )
-        response = self.send_get(f"GenomicPII/RHP/P{participant.participantId}")
+        response = self.send_get(f"GenomicPII/RHP/A{participant.biobankId}")
         self.assertIsNotNone(response)
+
         needed_keys = ['participant_id', 'first_name', 'last_name', 'date_of_birth', 'sample_source', 'collection_date']
         all_keys_values = all(not len(response.keys() - needed_keys) and
                               response.values())
@@ -255,7 +257,7 @@ class RhpGenomicPIIApiTest(GenomicApiTestBase):
         self._make_summary(p, withdrawalStatus=WithdrawalStatus.NO_USE
                            )
         self._make_set_member(p)
-        self.send_get("GenomicPII/RHP/P2", expected_status=404)
+        self.send_get("GenomicPII/RHP/A2", expected_status=404)
 
     def test_get_pii_no_gror_consent(self):
         participant = self._make_participant()
@@ -265,6 +267,7 @@ class RhpGenomicPIIApiTest(GenomicApiTestBase):
         )
         self._make_set_member(
             participant=participant,
+            biobankId=participant.biobankId,
             collectionTubeId=11111,
             cvlW4wrHdrManifestJobRunID=1,
             gcManifestSampleSource='Whole Blood'
@@ -275,7 +278,7 @@ class RhpGenomicPIIApiTest(GenomicApiTestBase):
             biobankStoredSampleId=11111,
             confirmed=clock.CLOCK.now()
         )
-        p2_pii = self.send_get("GenomicPII/RHP/P2")
+        p2_pii = self.send_get(f"GenomicPII/RHP/A{participant.biobankId}")
         self.assertEqual(p2_pii['message'], "No RoR consent.")
 
     def test_get_pii_bad_request(self):


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Missed the `GET` example in the tech design that RHP would be using biobank_ids as the parameter instead of participant_ids

## Tests
- [x] unit tests


