### PR TITLE
[PDR-979] Update PDR BQ model for new sensitive EHR consent

### DIFF
--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -422,7 +422,14 @@ class BQPDREHRConsentPIISchema(_BQModuleSchema):
         'EHRConsentPII_ILHIPPAWitnessSignature',
         'EHRConsentPII_HelpWithConsentSignature',
         '12MoEHRConsentPII_EmailCopy',
-        '30MoEHRConsentPII_EmailCopy'
+        '30MoEHRConsentPII_EmailCopy',
+        'sensitivetype2_mentalhealth',
+        'sensitivetype2_hivaids',
+        'sensitivetype2_substanceuse',
+        'sensitivetype2_genetictesting',
+        'sensitivetype2_domesticviolence',
+        'signature_type',
+        'signature_draw'
     )
 
 


### PR DESCRIPTION
## Resolves *[PDR-979](https://precisionmedicineinitiative.atlassian.net/browse/PDR-979)*


## Description of changes/additions
An updated EHRConsentPII module codebook has been imported that adds new question/answer codes.   This expands the forced boolean fields in the PDR BQEHRConsentPIISchema model so that new TEXT question types will have their answers mapped to 0 (no answer present) or 1.

A separate PR will be submitted to update business logic in the PDR generators to look for the appropriate question/answer codes to determine if participant granted consent.

Note:  The definition/hierarchy of the question codes for selecting how they want to sign the consent  (typing vs. drawing on a mobile screen) has changed,  and the `EHRConsentPII_Signature` question code appears to have changed from TEXT to a RADIO selection in this codebook. For backwards compatibility, the new coded answers to the `EHRConsentPII_Signature` question are still forced to boolean.  This mapping shouldn't impact analytics.

## Tests
- [x] unit tests


