### PR TITLE
[DA-2626] Checking for W1IL participants that have revoked and then re-submitted GROR consent

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -210,6 +210,7 @@ RDR_VALIDATION_WEBHOOK = "rdr_validation_webhook"
 DECEASED_REPORT_FILTER_EXCEPTIONS = "deceased_report_filter_exceptions"
 
 PTSC_SERVICE_DESK_EMAIL = "ptsc_service_desk_email"
+RDR_GENOMICS_NOTIFICATION_EMAIL = "rdr_genomics_notification_email"
 
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}

--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -84,6 +84,11 @@ cron:
   timezone: America/New_York
   schedule: every day 08:15
   target: offline
+- description: Check for Yes-No-Yes GROR W1IL participants
+  url: /offline/CheckForYesNoYesW1ilGrorParticipants
+  timezone: America/New_York
+  schedule: every monday 10:00
+  target: offline
 - description: Genomic Data PDR Reconcile
   url: /offline/GenomicDataPdrReconcile
   timezone: America/New_York

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -16,7 +16,7 @@ from sqlalchemy.sql.expression import literal, distinct, delete
 
 from werkzeug.exceptions import BadRequest, NotFound
 
-from rdr_service import clock, config
+from rdr_service import clock, code_constants, config
 from rdr_service.clock import CLOCK
 from rdr_service.config import GAE_PROJECT, GENOMIC_MEMBER_BLOCKLISTS
 from rdr_service.genomic_enums import GenomicJob, GenomicIncidentStatus, GenomicQcStatus, GenomicSubProcessStatus, \
@@ -44,6 +44,7 @@ from rdr_service.model.genomics import (
     GenomicCVLAnalysis, GenomicW3SCRaw, GenomicResultWorkflowState, GenomicW3NSRaw, GenomicW5NFRaw, GenomicW3SSRaw,
     GenomicCVLSecondSample, GenomicW2WRaw, GenomicW1ILRaw, GenomicCVLResultPastDue, GenomicSampleSwapMember,
     GenomicSampleSwap)
+from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireQuestion
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.participant_enums import (
     QuestionnaireStatus,
@@ -3583,6 +3584,93 @@ class GenomicQueriesDao(BaseDao):
                 )
 
             return query.all()
+
+    def _join_gror_answer(self, query, answer_code_str_list, start_datetime):
+        questionnaire_response = aliased(QuestionnaireResponse)
+        questionnaire_concept = aliased(QuestionnaireConcept)
+        answer = aliased(QuestionnaireResponseAnswer)
+        question = aliased(QuestionnaireQuestion)
+
+        survey_code = aliased(Code)
+        question_code = aliased(Code)
+        answer_code = aliased(Code)
+
+        new_query = query.join(
+            questionnaire_response,
+            and_(
+                questionnaire_response.participantId == ParticipantSummary.participantId,
+                questionnaire_response.authored > start_datetime
+            )
+        ).join(
+            questionnaire_concept,
+            and_(
+                questionnaire_concept.questionnaireId == questionnaire_response.questionnaireId,
+                questionnaire_concept.questionnaireVersion == questionnaire_response.questionnaireVersion
+            )
+        ).join(
+            survey_code,
+            and_(
+                survey_code.codeId == questionnaire_concept.codeId,
+                survey_code.value.ilike(code_constants.CONSENT_FOR_GENOMICS_ROR_MODULE)
+            )
+        ).join(
+            answer,
+            answer.questionnaireResponseId == questionnaire_response.questionnaireResponseId
+        ).join(
+            question,
+            question.questionnaireQuestionId == answer.questionId
+        ).join(
+            question_code,
+            and_(
+                question_code.codeId == question.codeId,
+                question_code.value.ilike(code_constants.GROR_CONSENT_QUESTION_CODE)
+            )
+        ).join(
+            answer_code,
+            and_(
+                answer_code.codeId == answer.valueCodeId,
+                answer_code.value.in_(answer_code_str_list)
+            )
+        )
+
+        return new_query
+
+    def get_w1il_yes_no_yes_participants(self, start_datetime):
+        # Find W1IL participants that have given a No response to GROR after being included in a W1IL,
+        # and that have recently switched back to a Yes to the GROR consent.
+        with self.session() as session:
+            query = session.query(
+                ParticipantSummary.participantId
+            ).join(
+                GenomicSetMember,
+                GenomicSetMember.participantId == ParticipantSummary.participantId
+            ).join(
+                GenomicJobRun,
+                GenomicJobRun.id.in_([
+                    GenomicSetMember.cvlW1ilHdrJobRunId,
+                    GenomicSetMember.cvlW1ilPgxJobRunId
+                ])
+            ).filter(
+                ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED
+            )
+            query = self._join_gror_answer(
+                query=query,
+                answer_code_str_list=[code_constants.CONSENT_GROR_YES_CODE],
+                start_datetime=func.greatest(GenomicJobRun.startTime, start_datetime)
+            )
+
+            # For each of the participants found, check to see if they have a No response to the GROR after the W1IL.
+            # (Just to filter out any strange double-Yes's we got)
+            query = self._join_gror_answer(
+                query=query,
+                answer_code_str_list=[
+                    code_constants.CONSENT_GROR_NO_CODE,
+                    code_constants.CONSENT_GROR_NOT_SURE
+                ],
+                start_datetime=GenomicJobRun.startTime
+            )
+
+            return query.distinct().all()
 
 
 class GenomicCVLResultPastDueDao(UpdatableDao):

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -3636,8 +3636,7 @@ class GenomicQueriesDao(BaseDao):
         return new_query
 
     def get_w1il_yes_no_yes_participants(self, start_datetime):
-        # Find W1IL participants that have given a No response to GROR after being included in a W1IL,
-        # and that have recently switched back to a Yes to the GROR consent.
+        # Find W1IL participants that have re-submitted a Yes response to GROR after being included in a W1IL.
         with self.session() as session:
             query = session.query(
                 ParticipantSummary.participantId
@@ -3660,7 +3659,8 @@ class GenomicQueriesDao(BaseDao):
             )
 
             # For each of the participants found, check to see if they have a No response to the GROR after the W1IL.
-            # (Just to filter out any strange double-Yes's we got)
+            # (Just to filter out any strange double-Yes's we got, ie. participants that had a Yes before the W1IL
+            #  and then submitted another Yes afterwards with no revocation in between)
             query = self._join_gror_answer(
                 query=query,
                 answer_code_str_list=[

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -51,7 +51,9 @@ from rdr_service.dao.genomics_dao import (
     GcDataFileStagingDao,
     GenomicSetDao,
     UserEventMetricsDao,
-    GenomicResultViewedDao)
+    GenomicResultViewedDao,
+    GenomicQueriesDao
+)
 from rdr_service.services.email_service import Email, EmailService
 from rdr_service.services.slack_utils import SlackMessageHandler
 
@@ -1519,6 +1521,31 @@ class GenomicJobController:
             file_attr = attributes_map[manifest_type]
 
         return file_attr
+
+    @staticmethod
+    def check_w1il_gror_resubmit(since_datetime):
+        dao = GenomicQueriesDao()
+        participant_list = dao.get_w1il_yes_no_yes_participants(start_datetime=since_datetime)
+
+        logging.warning(
+            f'The following {len(participant_list)} participants '
+            f'switched back to a Yes consent for GROR after being in W1IL: ' +
+            ','.join([f'{participant.participantId}' for participant in participant_list])
+        )
+
+        notification_email_address = config.getSettingJson(config.RDR_GENOMICS_NOTIFICATION_EMAIL, default=None)
+        if notification_email_address and participant_list:
+            message = 'The following participants recently provided GROR consent again ' \
+                      '(after having appeared in a W1IL manifest and then revoking their GROR consent):\n\n'
+            message += '\n'.join([f'P{participant.participantId}' for participant in participant_list])
+
+            EmailService.send_email(
+                Email(
+                    recipients=[notification_email_address],
+                    subject='GHR3 participants recently re-submitting GROR consent',
+                    plain_text_content=message
+                )
+            )
 
     @staticmethod
     def execute_cloud_task(payload, endpoint):

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -118,6 +118,7 @@ class GenomicJob(messages.Enum):
     RECONCILE_CVL_HDR_RESULTS = 61
     RECONCILE_CVL_ALERTS = 62
     RECONCILE_CVL_RESOLVE = 63
+    CHECK_FOR_W1IL_GROR_RESUBMIT = 64
 
     # Data Quality Pipeline Jobs
     # Naming matters for reports (timeframe_level_report_target)

--- a/rdr_service/offline/genomic_pipeline.py
+++ b/rdr_service/offline/genomic_pipeline.py
@@ -1,13 +1,12 @@
 import logging
 
 from rdr_service import clock, config
-from rdr_service.dao.genomics_dao import GenomicQueriesDao, GenomicAW1RawDao, GenomicAW2RawDao, GenomicAW3RawDao, \
+from rdr_service.dao.genomics_dao import GenomicAW1RawDao, GenomicAW2RawDao, GenomicAW3RawDao, \
     GenomicAW4RawDao, GenomicJobRunDao, GenomicW2SCRawDao, GenomicW3SRRawDao, GenomicW4WRRawDao, GenomicW3SCRawDao, \
     GenomicW3NSRawDao, GenomicW5NFRawDao, GenomicW3SSRawDao, GenomicW2WRawDao, GenomicW1ILRawDao
 from rdr_service.genomic.genomic_cvl_reconciliation import GenomicCVLReconcile
 from rdr_service.genomic.genomic_job_controller import GenomicJobController
 from rdr_service.genomic_enums import GenomicJob, GenomicSubProcessResult, GenomicManifestTypes
-from rdr_service.services.email_service import Email, EmailService
 from rdr_service.services.system_utils import JSONObject
 
 
@@ -606,26 +605,6 @@ def load_awn_manifest_into_raw_table(
         )
 
 
-def notify_email_group_of_yes_no_yes_w1il_participants(since_datetime):
-    dao = GenomicQueriesDao()
-    participant_list = dao.get_w1il_yes_no_yes_participants(start_datetime=since_datetime)
-
-    logging.warning(
-        f'The following {len(participant_list)} participants '
-        f'switched back to a Yes consent for GROR after being in W1IL: ' +
-        ','.join([f'{participant.participantId}' for participant in participant_list])
-    )
-
-    notification_email_address = config.getSettingJson(config.RDR_GENOMICS_NOTIFICATION_EMAIL, default=None)
-    if notification_email_address:
-        message = 'The following participants recently provided GROR consent again ' \
-                  '(after having appeared in a W1IL manifest and then revoking their GROR consent):\n\n'
-        message += '\n'.join([f'P{participant.participantId}' for participant in participant_list])
-
-        EmailService.send_email(
-            Email(
-                recipients=[notification_email_address],
-                subject='GHR3 participants recently re-submitting GROR consent',
-                plain_text_content=message
-            )
-        )
+def notify_email_group_of_w1il_gror_resubmit_participants(since_datetime):
+    with GenomicJobController(GenomicJob.CHECK_FOR_W1IL_GROR_RESUBMIT) as controller:
+        controller.check_w1il_gror_resubmit(since_datetime=since_datetime)

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -635,6 +635,13 @@ def reconcile_gc_data_file_to_table():
     genomic_pipeline.reconcile_gc_data_file_to_table()
     return '{"success": "true"}'
 
+
+@app_util.auth_required_cron
+def check_for_yes_no_yes_w1il_gror_participants():
+    a_week_ago = datetime.utcnow() - timedelta(weeks=1)
+    genomic_pipeline.notify_email_group_of_yes_no_yes_w1il_participants(since_datetime=a_week_ago)
+    return '{"success": "true"}'
+
 # Disabling job until further notice
 # @app_util.auth_required_cron
 # @run_genomic_cron_job('reconcile_raw_to_aw1_ingested_workflow')
@@ -1063,6 +1070,12 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "ReconcileGCDataFileToTable",
         endpoint="reconcile_gc_data_file_to_table",
         view_func=reconcile_gc_data_file_to_table,
+        methods=["GET"]
+    )
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "CheckForYesNoYesW1ilGrorParticipants",
+        endpoint="check_for_yes_no_yes_w1il_gror",
+        view_func=check_for_yes_no_yes_w1il_gror_participants,
         methods=["GET"]
     )
     # Disabling job until further notice

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -637,9 +637,9 @@ def reconcile_gc_data_file_to_table():
 
 
 @app_util.auth_required_cron
-def check_for_yes_no_yes_w1il_gror_participants():
+def check_for_w1il_gror_resubmit_participants():
     a_week_ago = datetime.utcnow() - timedelta(weeks=1)
-    genomic_pipeline.notify_email_group_of_yes_no_yes_w1il_participants(since_datetime=a_week_ago)
+    genomic_pipeline.notify_email_group_of_w1il_gror_resubmit_participants(since_datetime=a_week_ago)
     return '{"success": "true"}'
 
 # Disabling job until further notice
@@ -1073,9 +1073,9 @@ def _build_pipeline_app():
         methods=["GET"]
     )
     offline_app.add_url_rule(
-        OFFLINE_PREFIX + "CheckForYesNoYesW1ilGrorParticipants",
-        endpoint="check_for_yes_no_yes_w1il_gror",
-        view_func=check_for_yes_no_yes_w1il_gror_participants,
+        OFFLINE_PREFIX + "CheckForW1ilGrorResubmitParticipants",
+        endpoint="check_for_w1il_gror_resubmit",
+        view_func=check_for_w1il_gror_resubmit_participants,
         methods=["GET"]
     )
     # Disabling job until further notice


### PR DESCRIPTION
## Resolves *[DA-2626](https://precisionmedicineinitiative.atlassian.net/browse/DA-2626)*
When a participant has appeared in the W1IL and then later revokes their GROR consent their results are hidden from them. But if they go back and give GROR consent again (respond with a Yes) they should be able to view their results again.

## Description of changes/additions
This adds a cron job that runs weekly that detects participants that fall into that category and sends an email to notify that they should be able to view their results again.

## Tests
- [x] unit tests


