### PR TITLE
Validating EHR form based on latest ReceiveCare_PIIState answer

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -689,16 +689,11 @@ class ConsentValidator:
         if result.expected_sign_date < sensitive_form_release_date or consent.get_is_va_consent():
             return  # Skip the following checks for sensitive release fields
 
-        # get latest response to consentpii
-        consentpii_response_collection = QuestionnaireResponseDao.get_responses_to_surveys(
+        state_of_care_answer_str = QuestionnaireResponseDao.get_latest_answer_for_state_receiving_care(
             session=self._session,
-            survey_codes=[code_constants.CONSENT_FOR_STUDY_ENROLLMENT_MODULE],
-            participant_ids=[self.participant_summary.participantId]
-        )[self.participant_summary.participantId]
-        latest_consentpii_response = consentpii_response_collection.in_authored_order[0]
-
-        state_of_care_answer = latest_consentpii_response.get_single_answer_for(code_constants.RECEIVE_CARE_STATE)
-        if state_of_care_answer.value in code_constants.SENSITIVE_EHR_STATES:
+            participant_id=self.participant_summary.participantId
+        )
+        if state_of_care_answer_str in code_constants.SENSITIVE_EHR_STATES:
             if not consent.is_sensitive_form():
                 self._append_other_error(ConsentOtherErrors.SENSITIVE_EHR_EXPECTED, result)
                 result.sync_status = ConsentSyncStatus.NEEDS_CORRECTING


### PR DESCRIPTION
## Resolves *no ticket*
Responses to the ConsentPII module can be received multiple times (when participants update their address for example). So the current code for validating EHR forms may miss if the state the participant receives care hasn't been updated (so wouldn't be sent in a new payload).

## Description of changes/additions
This updates the validation code to use the latest answer for where a participant receives care, even if that answer isn't in the latest ConsentPII response received.

## Tests
- [ ] unit tests


