### PR TITLE
[PDR-606] PDR support for remote physical measurements

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -147,7 +147,15 @@ class BQPhysicalMeasurements(BQSchema):
                                          BQFieldModeEnum.NULLABLE)
     pm_final = BQField('pm_final', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     pm_restored = BQField('pm_restored', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-
+    pm_questionnaire_response_id = BQField('pm_questionnaire_response_id',
+                                           BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    pm_collect_type = BQField('pm_collect_type', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    pm_collect_type_id = BQField('pm_collect_type_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    pm_origin = BQField('pm_origin', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    pm_origin_measurement_unit = BQField('pm_origin_measurement_unit', BQFieldTypeEnum.STRING,
+                                         BQFieldModeEnum.NULLABLE)
+    pm_origin_measurement_unit_id = BQField('pm_origin_measurement_unit_id', BQFieldTypeEnum.STRING,
+                                            BQFieldModeEnum.NULLABLE)
 
 class BQBiobankSampleSchema(BQSchema):
     """

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -10,7 +10,7 @@ from rdr_service.participant_enums import QuestionnaireStatus, ParticipantCohort
     PhysicalMeasurementsStatus, OrderStatus, EnrollmentStatusV2, EhrStatus, WithdrawalStatus, WithdrawalReason, \
     SuspensionStatus, QuestionnaireResponseStatus, QuestionnaireResponseClassificationType, \
     DeceasedStatus, ParticipantCohortPilotFlag, WithdrawalAIANCeremonyStatus, BiobankOrderStatus, \
-    SampleCollectionMethod
+    SampleCollectionMethod, PhysicalMeasurementsCollectType, OriginMeasurementUnit
 from rdr_service.resource import Schema, fields
 from rdr_service.resource.constants import SchemaID
 
@@ -171,6 +171,7 @@ class SexualOrientationSchema(Schema):
 class PhysicalMeasurementsSchema(Schema):
     """ Participant Physical Measurements """
     physical_measurements_id = fields.Int32()
+    questionnaire_response_id = fields.Int32()
     status = fields.EnumString(enum=PhysicalMeasurementsStatus)
     status_id = fields.EnumInteger(enum=PhysicalMeasurementsStatus)
     created = fields.DateTime()
@@ -181,6 +182,11 @@ class PhysicalMeasurementsSchema(Schema):
     finalized_site_id = fields.Int32()
     finalized = fields.DateTime()
     amended_measurements_id = fields.Int32()
+    collect_type = fields.EnumString(enum=PhysicalMeasurementsCollectType)
+    collect_type_id = fields.EnumInteger(enum=PhysicalMeasurementsCollectType)
+    origin = fields.String(validate=validate.Length(max=255))
+    origin_measurement_unit = fields.EnumString(enum=OriginMeasurementUnit)
+    origin_measurement_unit_id = fields.EnumInteger(enum=OriginMeasurementUnit)
     restored = fields.Boolean()
 
     class Meta:


### PR DESCRIPTION
## Resolves *[PDR-606](https://precisionmedicineinitiative.atlassian.net/browse/PDR-606)*


## Description of changes/additions
Update the participant physical measurements data generator to include the new columns added to RDR `physical_measurements` table in PR #3029

This updates the nested record consent in the PDR participant data generator, so the new columns will be "created" in BigQuery  when the `v_pdr_participant_pm` view is updated (don't need to be added ot the end).  

 The other changes (e.g., to `BQPhysicalMeasurements` sub-schema) were added for consistency, even though we aren't really using the sub-schemas or resource API for this data currently.

## Tests
- [x] unit tests

