### PR TITLE
[DA-2773] update_remote_pm_weight_format

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -614,9 +614,12 @@ class QuestionnaireResponseDao(BaseDao):
                         else:
                             raise BadRequest(f'unknown measurement unit {answer_code_value} for participant '
                                              f'{participant_id}')
-                    elif question_code.value in self_reported_int_value_map:
-                        if answer.valueInteger:
-                            self_reported_int_value_map[question_code.value] = round(answer.valueInteger, 1)
+                    elif question_code.value in ['self_reported_height_ft', 'self_reported_height_in',
+                                                 'self_reported_height_cm'] and answer.valueInteger:
+                        self_reported_int_value_map[question_code.value] = round(answer.valueInteger, 1)
+                    elif question_code.value in ['self_reported_weight_pounds',
+                                                 'self_reported_weight_kg'] and answer.valueString:
+                        self_reported_int_value_map[question_code.value] = round(float(answer.valueString), 1)
 
         if origin_measurement_unit == OriginMeasurementUnit.IMPERIAL:
             # validation

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -193,7 +193,7 @@ class QuestionnaireResponseApiTest(BaseTestCase, PDRGeneratorTestMixin):
                          {
                              "code": "kg",
                              "unit": "kg",
-                             "value": 72.6,
+                             "value": 72.8,
                              "system": "http://unitsofmeasure.org"
                          }
                          )
@@ -244,7 +244,7 @@ class QuestionnaireResponseApiTest(BaseTestCase, PDRGeneratorTestMixin):
                          {
                              "code": "kg",
                              "unit": "kg",
-                             "value": 60,
+                             "value": 60.6,
                              "system": "http://unitsofmeasure.org"
                          }
                          )

--- a/tests/test-data/remote_pm_response_imperial.json
+++ b/tests/test-data/remote_pm_response_imperial.json
@@ -75,7 +75,7 @@
         "text": "QUESTION LABEL WAS NOT DEFINED, PLEASE CONTACT ADMINISTRATOR",
         "answer": [
           {
-            "valueInteger": 160
+            "valueString": "160.6"
           }
         ]
       }

--- a/tests/test-data/remote_pm_response_metric.json
+++ b/tests/test-data/remote_pm_response_metric.json
@@ -66,7 +66,7 @@
         "text": "QUESTION LABEL WAS NOT DEFINED, PLEASE CONTACT ADMINISTRATOR",
         "answer": [
           {
-            "valueInteger": 60
+            "valueString": "60.6"
           }
         ]
       }


### PR DESCRIPTION
## Resolves *[DA-2773]*
Following up a change that PTSC made recently, use `valueString` instead of `valueInteger` for code `self_reported_weight_pounds` and `self_reported_weight_kg`


## Tests
- [x] unit tests




[DA-2773]: https://precisionmedicineinitiative.atlassian.net/browse/DA-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ