### PR TITLE
Fix consent metrics resource schema (for sensitive EHR new errors)

### DIFF
--- a/rdr_service/resource/schemas/consent_metrics.py
+++ b/rdr_service/resource/schemas/consent_metrics.py
@@ -41,6 +41,15 @@ class ConsentMetricSchema(Schema):
     va_consent_for_non_va = fields.Boolean(
         description='True if consent for participant not paired to VA is a VA consent form'
     )
+    sensitive_ehr_expected = fields.Boolean(
+        description='True if participant is from a sensitive EHR state but consent was not the sensitive EHR form'
+    )
+    non_sensitive_ehr_expected = fields.Boolean(
+        description='True if participant is not from a sensitive EHR state but consent was the sensitive EHR form'
+    )
+    sensitive_ehr_missing_initials = fields.Boolean(
+        description='True if a sensitive EHR form failed validation because expected fields were not initialed'
+    )
     test_participant = fields.Boolean(description='True if participant id is flagged as a test or ghost participant')
     ignore = fields.Boolean(
         description='True if record should be filtered out of metrics reporting'


### PR DESCRIPTION
## Resolves *No ticket*


## Description of changes/additions
The resource schema for the consent metric data needs the new error fields added in PR #3032.  Fields were added to the generator but not the resource schema.

## Tests
- [x] unit tests


