### PR TITLE
PDR generator fixes for remote PM, sensitive EHR

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -154,7 +154,7 @@ class BQPhysicalMeasurements(BQSchema):
     pm_origin = BQField('pm_origin', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     pm_origin_measurement_unit = BQField('pm_origin_measurement_unit', BQFieldTypeEnum.STRING,
                                          BQFieldModeEnum.NULLABLE)
-    pm_origin_measurement_unit_id = BQField('pm_origin_measurement_unit_id', BQFieldTypeEnum.STRING,
+    pm_origin_measurement_unit_id = BQField('pm_origin_measurement_unit_id', BQFieldTypeEnum.INTEGER,
                                             BQFieldModeEnum.NULLABLE)
 
 class BQBiobankSampleSchema(BQSchema):

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -29,6 +29,16 @@ class BQPDRPhysicalMeasurements(BQSchema):
                                          BQFieldModeEnum.NULLABLE)
     pm_final = BQField('pm_final', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     pm_restored = BQField('pm_restored', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    pm_questionnaire_response_id = BQField('pm_questionnaire_response_id',
+                                           BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    pm_collect_type = BQField('pm_collect_type', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    pm_collect_type_id = BQField('pm_collect_type_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    pm_origin = BQField('pm_origin', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
+    pm_origin_measurement_unit = BQField('pm_origin_measurement_unit', BQFieldTypeEnum.STRING,
+                                         BQFieldModeEnum.NULLABLE)
+    pm_origin_measurement_unit_id = BQField('pm_origin_measurement_unit_id', BQFieldTypeEnum.INTEGER,
+                                            BQFieldModeEnum.NULLABLE)
+
 
 
 # TODO:  Deprecate use of this class and add these fields to the BQBiobankOrderSchema

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1456,15 +1456,15 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 qnans = session.execute(_answers_sql, {'qr_id': row.questionnaire_response_id})
                 # Save answers into data dict.  Ignore duplicate answers to the same question from the same response
                 # (See: questionnaire_response_id 680418686 as an example)
-                last_question_id = None
+                last_question_code_id = None
                 last_answer = None
                 skipped_duplicates = 0
                 for qnan in qnans:
-                    if last_question_id == qnan.question_id and last_answer == qnan.answer:
+                    if last_question_code_id == qnan.code_id and last_answer == qnan.answer:
                         skipped_duplicates += 1
                         continue
                     else:
-                        last_question_id = qnan.question_id
+                        last_question_code_id = qnan.code_id
                         last_answer = qnan.answer
 
                     # For question codes with multiple distinct responses, created comma-separated list of answers

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -893,7 +893,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'collect_type_id': int(collection_type),
                 'origin': row.origin,
                 'origin_measurement_unit': str(origin_measurements_type),
-                'origin_measurement_unit_type': int(origin_measurements_type),
+                'origin_measurement_unit_id': int(origin_measurements_type),
                 # If status == UNSET in data, then the record has been cancelled and then restored. PM status is
                 # only set to UNSET in this scenario.
                 'restored': 1 if row.status == 0 else 0


### PR DESCRIPTION
## Resolves *No ticket*


## Description of changes/additions
Remote PM fixes:
- BigQuery sub-schema corrections
- Generator field name correction (to align with sub-schema definition updates)

Sensitive EHR testing w/PTSC exposed cases where PTSC was sending two different `question_id` (linkId) values for the `EHRConsentPII_ConsentPermission` question in the same QuestionnaireResponse payload.  Both `question_id` values mapped back to the same `code_id`.  The duplicate consent answers weren't filtered out by `get_module_answers()` because the filtering relied on finding duplicate  `question_id` values instead of `code_id`. 

`get_module_answers()` method returned a comma-separated string of duplicate consent answer code values (e.g., 'ConsentPermission_Yes,ConsentPermission_Yes'  instead of  'ConsentPermission_Yes'). Generator then failed to match that string to its list of consent answers that would signify SUBMITTED consent status.   Filtering logic is updated to look for duplicate question `code_id` values (and answer).

## Tests
- [x] unit tests
Existing unit tests include cases written to test the duplicate answer detection, confirmed they are passing


