### PR TITLE
fix_rpm_time_compare_bug

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -579,7 +579,7 @@ class QuestionnaireResponseDao(BaseDao):
             )
 
         participant_id = questionnaire_response.participantId
-        authored = questionnaire_response.authored
+        authored = questionnaire_response.authored.replace(tzinfo=None)
         measurements = []
         pm_dao = PhysicalMeasurementsDao()
         exist_pm = pm_dao.get_exist_remote_pm(participant_id, authored)


### PR DESCRIPTION
## Resolves *[no ticket]*
Fix bug in `participant_summary_dao.calculate_max_core_sample_time`
Error: `TypeError("can't compare offset-naive and offset-aware datetimes")`

Add test case to cover this scenario

## Tests
- [x] unit tests


