### PR TITLE
[PDR] Revise handling of new sensitive EHR consent codes

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -66,10 +66,7 @@ _consent_module_question_map = {
     # { module: question code string }
     'ConsentPII': None,
     'DVEHRSharing': 'DVEHRSharing_AreYouInterested',
-    # PDR-979: The sensitive EHR shares the same EHRConsentPII module code but has a different consent question
-    # TODO:  Determine if we also need to check for the "opt out" questions/no consent  answers
-    #  (ehrconsentpii_proceedtoform, ehrconsentpii_sensitivetype1, decisionoptions).
-    'EHRConsentPII': ['EHRConsentPII_ConsentPermission', 'ehrconsentpii_sensitivetype2'],
+    'EHRConsentPII': 'EHRConsentPII_ConsentPermission',
     'GROR': 'ResultsConsent_CheckDNA',
     'PrimaryConsentUpdate': 'Reconsent_ReviewConsentAgree',
     'ProgramUpdate': None,
@@ -115,10 +112,6 @@ _consent_answer_status_map = {
     'Decision_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'WEAR_Yes': BQModuleStatusEnum.SUBMITTED,
     'WEAR_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
-    # TODO:  May need to add "opt out" question sensitive EHR answers that will map to SUBMITTED_NO_CONSENT (e.g.,
-    # removeauthorization answer code for decisionchangeoptions question code)
-    'sensitivetype2__agree': BQModuleStatusEnum.SUBMITTED,
-    'sensitivetype2__donotagree': BQModuleStatusEnum.SUBMITTED_NO_CONSENT
 }
 
 # PDR-252:  When RDR starts accepting QuestionnaireResponse payloads for withdrawal screens, AIAN participants


### PR DESCRIPTION
## Resolves *no ticket*


## Description of changes/additions
PDR generators were previously changed when it was expected we would need to look for a new consent question for sensitive EHR.  Instead, it has been determined during end-to-end testing that PTSC is still using the existing `EHRConsentPII_ConsentPermission` code and `ConsentPermission_Yes` / `ConsentPermission_No` answer codes.

This reverts the relevant changes to the code lists used in the generator, and removes the unit tests that were added specifically for cases involving the new codes  we now know PTSC is not sending.

## Tests
- [x] unit tests


