### PR TITLE
Consent validation changes for CE sensitive EHR files

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -265,10 +265,14 @@ class CeConsentFactory(ConsentFileAbstractFactory):
 
     def _is_ehr_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         pdf = blob_wrapper.get_parsed_pdf()
-        return pdf.has_text([(
-            'HIPAA Authorization for Research EHR',
-            'Autorización para Investigación de HIPAA'
-        )])
+        return pdf.has_text([
+            (
+                'HIPAA Authorization for Research EHR',
+                'Autorización para Investigación de HIPAA',
+                'Authorization to Share My EHRs for Research',
+                'Autorización para compartir mis EHR para propósitos de investigación'
+            )
+        ])
 
     def _is_gror_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         pdf = blob_wrapper.get_parsed_pdf()

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -683,6 +683,9 @@ class ConsentValidator:
     def _additional_ehr_checks(self, consent: files.EhrConsentFile, result: ParsingResult):
         self._validate_is_va_file(consent, result)
 
+        if self.participant_summary.participantOrigin == 'careevolution':
+            return
+
         sensitive_form_release_date_str = config.getSettingJson(config.SENSITIVE_EHR_RELEASE_DATE)
         sensitive_form_release_date = parse(sensitive_form_release_date_str).date()
 


### PR DESCRIPTION
## Resolves *no ticket*
This updates the consent validation to recognize sensitive EHR PDFs from CareEvolution as EHR documents. It also skips validating that the initials exist on the PDFs (since CareEvolution doesn't have the initials on the PDF).

## Tests
- [ ] unit tests


