### PR TITLE
[DA-2758] core_minus_pm_time_bug

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -868,6 +868,8 @@ class ParticipantSummaryDao(UpdatableDao):
                 return participant_summary.enrollmentStatusCoreStoredSampleTime
             else:
                 return max_core_sample_time
+        elif participant_summary.enrollmentStatusCoreMinusPMTime is not None:
+            return participant_summary.enrollmentStatusCoreMinusPMTime
         else:
             return None
 

--- a/tests/dao_tests/test_participant_summary_dao.py
+++ b/tests/dao_tests/test_participant_summary_dao.py
@@ -523,6 +523,14 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         self.assertEqual(EnrollmentStatus.CORE_MINUS_PM, summary.enrollmentStatus)
         self.assertEqual(sample_time, summary.enrollmentStatusCoreMinusPMTime)
 
+        summary.physicalMeasurementsStatus = PhysicalMeasurementsStatus.COMPLETED
+        self.dao.update_enrollment_status(summary)
+        self.assertEqual(EnrollmentStatus.FULL_PARTICIPANT, summary.enrollmentStatus)
+        self.assertEqual(sample_time, summary.enrollmentStatusCoreMinusPMTime)
+        # calculate again, enrollmentStatusCoreMinusPMTime should still there
+        self.dao.update_enrollment_status(summary)
+        self.assertEqual(sample_time, summary.enrollmentStatusCoreMinusPMTime)
+
     def testDowngradeCoreMinusPm(self):
         ehr_consent_authored_time = datetime.datetime(2018, 3, 1)
         sample_time = datetime.datetime(2019, 3, 1)


### PR DESCRIPTION
## Resolves *[DA-2758](https://precisionmedicineinitiative.atlassian.net/browse/DA-2758)*
fix core_minus_pm_time set to NONE bug

## Description of changes/additions
Once have a core_minus_pm_time, it will never set to NONE

## Tests
- [x] unit tests


