### PR TITLE
[DA-2761] Adding W5NF pub sub changes 

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -169,7 +169,8 @@ PUBSUB_NOTIFICATION_BUCKETS_STABLE = [
     "genomics-baylor-dryrun",
     "genomics-color-dryrun",
     "genomics-northwest-dryrun",
-    "genomics-broad-dryrun"
+    "genomics-broad-dryrun",
+    "color-rhp-stable"
 ]
 
 PUBSUB_NOTIFICATION_BUCKETS_SANDBOX = [

--- a/rdr_service/config/pub_sub_config_prod.json
+++ b/rdr_service/config/pub_sub_config_prod.json
@@ -1,752 +1,752 @@
 {
-  "notifications": [
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "43",
-      "object_name_prefix": "AW1_genotyping_sample_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "44",
-      "object_name_prefix": "AW1_wgs_sample_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "45",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "46",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "47",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "48",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "49",
-      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "56",
-      "object_name_prefix": "W3SS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "57",
-      "object_name_prefix": "W3NS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "30",
-      "object_name_prefix": "W3NS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "31",
-      "object_name_prefix": "W3SS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "38",
-      "object_name_prefix": "AW1_genotyping_sample_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "39",
-      "object_name_prefix": "AW1_wgs_sample_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "40",
-      "object_name_prefix": "wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "41",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "42",
-      "object_name_prefix": "wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "43",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "53",
-      "object_name_prefix": "AW1_genotyping_sample_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "54",
-      "object_name_prefix": "AW1_wgs_sample_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "55",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "56",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "57",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "58",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "59",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "60",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "61",
-      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "62",
-      "object_name_prefix": "AW1F_genotyping_accessioning_results/AW1F_pre_results/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "65",
-      "object_name_prefix": "W3SS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "66",
-      "object_name_prefix": "W3NS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "32",
-      "object_name_prefix": "AW2_genotyping_data_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "33",
-      "object_name_prefix": "AW2_wgs_data_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "39",
-      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "40",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "41",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "42",
-      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "54",
-      "object_name_prefix": "W2SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "56",
-      "object_name_prefix": "W3SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "57",
-      "object_name_prefix": "W4WR_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "58",
-      "object_name_prefix": "W4WR_manifests_pgx/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "59",
-      "object_name_prefix": "W5NF_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "37",
-      "object_name_prefix": "AW2_genotyping_data_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "38",
-      "object_name_prefix": "aw2_wgs_data_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "46",
-      "object_name_prefix": "wgs_sample_raw_data/ss_vcf_research/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "47",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "48",
-      "object_name_prefix": "wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "4",
-      "object_name_prefix": "W2SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "6",
-      "object_name_prefix": "W3SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "7",
-      "object_name_prefix": "W4WR_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "8",
-      "object_name_prefix": "W4WR_manifests_pgx/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "9",
-      "object_name_prefix": "W5NF_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "37",
-      "object_name_prefix": "AW2_genotyping_data_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "38",
-      "object_name_prefix": "AW2_wgs_data_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "44",
-      "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "45",
-      "object_name_prefix": "Genotyping_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "48",
-      "object_name_prefix": "Wgs_sample_raw_data/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_data_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "49",
-      "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "50",
-      "object_name_prefix": "AW1F_genotyping_accessioning_results/AW1F_pre_results/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "63",
-      "object_name_prefix": "W5NF_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "64",
-      "object_name_prefix": "W4WR_manifests_pgx/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "65",
-      "object_name_prefix": "W4WR_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "66",
-      "object_name_prefix": "W3SC_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-genomics-data-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "67",
-      "object_name_prefix": "W2SC_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "9",
-      "object_name_prefix": "AW3_genotyping_data_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "prod-drc-broad",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "14",
-      "object_name_prefix": "AW4_array_manifest/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "15",
-      "object_name_prefix": "AW4_wgs_manifest/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "16",
-      "object_name_prefix": "AW5_array_manifest/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-drc-broad",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "17",
-      "object_name_prefix": "AW5_wgs_manifest/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    },
-    {
-      "bucket": "prod-color-rhp",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "17",
-      "object_name_prefix": "user_events/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_metric_files_upload",
-      "topic_project": "all-of-us-rdr-prod"
-    }
-  ]
+   "notifications": [
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "43",
+         "object_name_prefix": "AW1_genotyping_sample_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "44",
+         "object_name_prefix": "AW1_wgs_sample_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "45",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "46",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "47",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "48",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "49",
+         "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "56",
+         "object_name_prefix": "W3SS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "57",
+         "object_name_prefix": "W3NS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "30",
+         "object_name_prefix": "W3NS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "31",
+         "object_name_prefix": "W3SS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "38",
+         "object_name_prefix": "AW1_genotyping_sample_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "39",
+         "object_name_prefix": "AW1_wgs_sample_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "40",
+         "object_name_prefix": "wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "41",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "42",
+         "object_name_prefix": "wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "43",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "53",
+         "object_name_prefix": "AW1_genotyping_sample_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "54",
+         "object_name_prefix": "AW1_wgs_sample_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "55",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "56",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "57",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "58",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "59",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "60",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "61",
+         "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "62",
+         "object_name_prefix": "AW1F_genotyping_accessioning_results/AW1F_pre_results/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "65",
+         "object_name_prefix": "W3SS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "66",
+         "object_name_prefix": "W3NS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "32",
+         "object_name_prefix": "AW2_genotyping_data_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "33",
+         "object_name_prefix": "AW2_wgs_data_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "39",
+         "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "40",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "41",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "42",
+         "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "54",
+         "object_name_prefix": "W2SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "56",
+         "object_name_prefix": "W3SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "57",
+         "object_name_prefix": "W4WR_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "58",
+         "object_name_prefix": "W4WR_manifests_pgx/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "37",
+         "object_name_prefix": "AW2_genotyping_data_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "38",
+         "object_name_prefix": "aw2_wgs_data_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "46",
+         "object_name_prefix": "wgs_sample_raw_data/ss_vcf_research/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "47",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "48",
+         "object_name_prefix": "wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "4",
+         "object_name_prefix": "W2SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "6",
+         "object_name_prefix": "W3SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "7",
+         "object_name_prefix": "W4WR_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "8",
+         "object_name_prefix": "W4WR_manifests_pgx/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "37",
+         "object_name_prefix": "AW2_genotyping_data_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "38",
+         "object_name_prefix": "AW2_wgs_data_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "44",
+         "object_name_prefix": "Wgs_sample_raw_data/SS_VCF_research/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "45",
+         "object_name_prefix": "Genotyping_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "48",
+         "object_name_prefix": "Wgs_sample_raw_data/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_data_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "49",
+         "object_name_prefix": "AW1F_wgs_accessioning_results/AW1F_pre_results/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "50",
+         "object_name_prefix": "AW1F_genotyping_accessioning_results/AW1F_pre_results/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "64",
+         "object_name_prefix": "W4WR_manifests_pgx/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "65",
+         "object_name_prefix": "W4WR_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "66",
+         "object_name_prefix": "W3SC_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-genomics-data-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "67",
+         "object_name_prefix": "W2SC_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-drc-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "9",
+         "object_name_prefix": "AW3_genotyping_data_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "prod-drc-broad",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-drc-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "14",
+         "object_name_prefix": "AW4_array_manifest/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-drc-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "15",
+         "object_name_prefix": "AW4_wgs_manifest/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-drc-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "16",
+         "object_name_prefix": "AW5_array_manifest/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-drc-broad",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "17",
+         "object_name_prefix": "AW5_wgs_manifest/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-color-rhp",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "17",
+         "object_name_prefix": "user_events/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_metric_files_upload",
+         "topic_project": "all-of-us-rdr-prod"
+      },
+      {
+         "bucket": "prod-color-rhp",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "21",
+         "object_name_prefix": "UW_W5NF_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "prod-color-rhp",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "22",
+         "object_name_prefix": "CO_W5NF_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "prod-color-rhp",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "23",
+         "object_name_prefix": "BCM_W5NF_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      }
+   ]
 }

--- a/rdr_service/config/pub_sub_config_stable.json
+++ b/rdr_service/config/pub_sub_config_stable.json
@@ -1,235 +1,246 @@
 {
-  "notifications": [
-    {
-      "bucket": "genomics-raw-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "32",
-      "object_name_prefix": "W5NF_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "33",
-      "object_name_prefix": "W4WR_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "34",
-      "object_name_prefix": "W4WR_manifests_pgx/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "35",
-      "object_name_prefix": "W3SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-baylor",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "36",
-      "object_name_prefix": "W2SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "14",
-      "object_name_prefix": "W2SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "15",
-      "object_name_prefix": "W3SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "16",
-      "object_name_prefix": "W4WR_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "17",
-      "object_name_prefix": "W4WR_manifests_pgx/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-color",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "18",
-      "object_name_prefix": "W5NF_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "33",
-      "object_name_prefix": "W5NF_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "34",
-      "object_name_prefix": "W4WR_manifests_hdr/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "35",
-      "object_name_prefix": "W4WR_manifests_pgx/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "36",
-      "object_name_prefix": "W2SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-raw-northwest",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "37",
-      "object_name_prefix": "W3SC_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-baylor-dryrun",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "32",
-      "object_name_prefix": "W3NS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-baylor-dryrun",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "33",
-      "object_name_prefix": "W3SS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-color-dryrun",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "23",
-      "object_name_prefix": "W3SS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-color-dryrun",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "24",
-      "object_name_prefix": "W3NS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-northwest-dryrun",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "26",
-      "object_name_prefix": "W3NS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    },
-    {
-      "bucket": "genomics-northwest-dryrun",
-      "event_types": [
-        "OBJECT_FINALIZE"
-      ],
-      "id": "27",
-      "object_name_prefix": "W3SS_manifests/",
-      "payload_format": "JSON_API_V1",
-      "topic_name": "genomic_manifest_upload",
-      "topic_project": "all-of-us-rdr-stable"
-    }
-  ]
+   "notifications": [
+      {
+         "bucket": "genomics-raw-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "33",
+         "object_name_prefix": "W4WR_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "34",
+         "object_name_prefix": "W4WR_manifests_pgx/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "35",
+         "object_name_prefix": "W3SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-baylor",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "36",
+         "object_name_prefix": "W2SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "14",
+         "object_name_prefix": "W2SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "15",
+         "object_name_prefix": "W3SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "16",
+         "object_name_prefix": "W4WR_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-color",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "17",
+         "object_name_prefix": "W4WR_manifests_pgx/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "34",
+         "object_name_prefix": "W4WR_manifests_hdr/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "35",
+         "object_name_prefix": "W4WR_manifests_pgx/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "36",
+         "object_name_prefix": "W2SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-raw-northwest",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "37",
+         "object_name_prefix": "W3SC_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-baylor-dryrun",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "32",
+         "object_name_prefix": "W3NS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-baylor-dryrun",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "33",
+         "object_name_prefix": "W3SS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-color-dryrun",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "23",
+         "object_name_prefix": "W3SS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-color-dryrun",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "24",
+         "object_name_prefix": "W3NS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-northwest-dryrun",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "26",
+         "object_name_prefix": "W3NS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "genomics-northwest-dryrun",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "27",
+         "object_name_prefix": "W3SS_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "color-rhp-stable",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "12",
+         "object_name_prefix": "user_events/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_metric_files_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "color-rhp-stable",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "16",
+         "object_name_prefix": "BCM_W5NF_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "color-rhp-stable",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "17",
+         "object_name_prefix": "CO_W5NF_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      },
+      {
+         "bucket": "color-rhp-stable",
+         "event_types": [
+            "OBJECT_FINALIZE"
+         ],
+         "id": "18",
+         "object_name_prefix": "UW_W5NF_manifests/",
+         "payload_format": "JSON_API_V1",
+         "topic_name": "genomic_manifest_upload",
+         "topic_project": "all-of-us-rdr-stable"
+      }
+   ]
 }

--- a/rdr_service/tools/__main__.py
+++ b/rdr_service/tools/__main__.py
@@ -25,6 +25,7 @@ def _grep_prop(filename, prop_name):
         return obj.group(1)
     return None
 
+
 def _run_tool(lib_paths, import_path):
     """
     Run the tools from the given path.


### PR DESCRIPTION
## Resolves *[ticket DA-27561]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2761

## Description of changes/additions
Instead of RHP having access to all CVL buckets, the decision was made to allow CVLs to have read-only to the RHP bucket for W5NFs to be dropped when there is an issue with the W4WR. Now that this process has changed, some of the RDR processes need to be updated.

## Tests
- [] unit tests

<img width="956" alt="rhp_prod" src="https://user-images.githubusercontent.com/5114837/176242462-53f1809a-f6c3-4829-ab62-4c43d68bdf19.png">
<img width="1046" alt="rhp_stable" src="https://user-images.githubusercontent.com/5114837/176242486-c8cdd30c-8ced-4802-ba94-650935399e1e.png">


