### PR TITLE
[DA-2770] Skipping update to participant summary if receiving responses out of order

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -742,7 +742,7 @@ class QuestionnaireResponseDao(BaseDao):
                 )
                 if survey_name in QUESTIONNAIRE_MODULE_CODE_TO_FIELD:
                     summary_field_name = QUESTIONNAIRE_MODULE_CODE_TO_FIELD.get(survey_name) + 'Authored'
-                    existing_authored_datetime = getattr(participant_summary, summary_field_name)
+                    existing_authored_datetime = getattr(participant_summary, summary_field_name, None)
                     if existing_authored_datetime and authored < existing_authored_datetime:
                         logging.warning(
                             f'Skipping summary update for {module_code.value} response authored on {authored} '

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -735,18 +735,19 @@ class QuestionnaireResponseDao(BaseDao):
         if questionnaire_history.concepts:
             concept = questionnaire_history.concepts[0]
             module_code = code_map.get(concept.codeId)
-            summary_field_name = QUESTIONNAIRE_MODULE_CODE_TO_FIELD.get(
-                module_code.value.lower()
-                if self._is_digital_health_share_code(module_code.value)
-                else module_code.value
-            ) + 'Authored'
-            existing_authored_datetime = getattr(participant_summary, summary_field_name)
-            if existing_authored_datetime and authored < existing_authored_datetime:
-                logging.warning(
-                    f'Skipping summary update for {module_code.value} response authored on {authored} '
-                    f'(previous response recorded was authored {existing_authored_datetime})'
-                )
-                return
+            if module_code:
+                summary_field_name = QUESTIONNAIRE_MODULE_CODE_TO_FIELD.get(
+                    module_code.value.lower()
+                    if self._is_digital_health_share_code(module_code.value)
+                    else module_code.value
+                ) + 'Authored'
+                existing_authored_datetime = getattr(participant_summary, summary_field_name)
+                if existing_authored_datetime and authored < existing_authored_datetime:
+                    logging.warning(
+                        f'Skipping summary update for {module_code.value} response authored on {authored} '
+                        f'(previous response recorded was authored {existing_authored_datetime})'
+                    )
+                    return
 
         # Set summary fields for answers that have questions with codes found in QUESTION_CODE_TO_FIELD
         for answer in questionnaire_response.answers:

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -480,7 +480,6 @@ class QuestionnaireResponseDao(BaseDao):
         elif questionnaire_response.status == QuestionnaireResponseStatus.IN_PROGRESS:
             questionnaire_response.classificationType = QuestionnaireResponseClassificationType.PARTIAL
 
-
         # IMPORTANT: update the participant summary first to grab an exclusive lock on the participant
         # row. If you instead do this after the insert of the questionnaire response, MySQL will get a
         # shared lock on the participant row due the foreign key, and potentially deadlock later trying
@@ -730,6 +729,23 @@ class QuestionnaireResponseDao(BaseDao):
         dvehr_consent = QuestionnaireStatus.SUBMITTED_NO_CONSENT
         street_address_submitted = False
         street_address2_submitted = False
+
+        # Skip updating the summary if the response being stored has an authored
+        # date earlier than one that's already been recorded
+        if questionnaire_history.concepts:
+            concept = questionnaire_history.concepts[0]
+            module_code = code_map.get(concept.codeId)
+            summary_field_name = QUESTIONNAIRE_MODULE_CODE_TO_FIELD.get(
+                module_code.value.lower()
+                if self._is_digital_health_share_code(module_code.value)
+                else module_code.value
+            ) + 'Authored'
+            existing_authored_datetime = getattr(participant_summary, summary_field_name)
+            if existing_authored_datetime and authored < existing_authored_datetime:
+                logging.warning(
+                    f'Skipping summary update for {module_code.value} response authored on {authored} '
+                    f'(previous response recorded was authored {existing_authored_datetime})'
+                )
 
         # Set summary fields for answers that have questions with codes found in QUESTION_CODE_TO_FIELD
         for answer in questionnaire_response.answers:

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -878,10 +878,11 @@ class QuestionnaireResponseDao(BaseDao):
         for concept in questionnaire_history.concepts:
             code = code_map.get(concept.codeId)
             if code:
+                current_authored = self._check_for_current_module_authored(participant_summary, code.value)
                 # the digital health code in code table is in lowercase, but in questionnaire payload is in CamelCased
                 summary_field = QUESTIONNAIRE_MODULE_CODE_TO_FIELD.get(
                     code.value.lower() if self._is_digital_health_share_code(code.value) else code.value)
-                if summary_field:
+                if summary_field and (current_authored is None or authored > current_authored):
                     new_status = QuestionnaireStatus.SUBMITTED
                     if code.value == CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE and not ehr_consent:
                         new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT
@@ -1061,6 +1062,21 @@ class QuestionnaireResponseDao(BaseDao):
 
             if is_new_consent:
                 session.add(ConsentResponse(response=questionnaire_response, type=consent_type))
+
+    def _check_for_current_module_authored(self, ps_rec, module):
+        """ Checks if a participant_summary record already has an authored time for a given field """
+        current_authored = None
+        module_to_authored_field = {
+            'ConsentPII': 'consentForStudyEnrollmentAuthored',
+            'EHRConsentPII': 'consentForElectronicHealthRecordsAuthored',
+            'DVEHRSharing': 'consentForDvElectronicHealthRecordsSharingAuthored',
+            'GROR': 'consentForGenomicsRORAuthored'
+        }
+        if module in module_to_authored_field.keys():
+            current_authored = getattr(ps_rec, module_to_authored_field[module])
+
+        return current_authored
+
 
     @classmethod
     def _authored_times_match(cls, new_authored_time: datetime, current_authored_item: datetime):

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -736,18 +736,19 @@ class QuestionnaireResponseDao(BaseDao):
             concept = questionnaire_history.concepts[0]
             module_code = code_map.get(concept.codeId)
             if module_code:
-                summary_field_name = QUESTIONNAIRE_MODULE_CODE_TO_FIELD.get(
-                    module_code.value.lower()
-                    if self._is_digital_health_share_code(module_code.value)
+                survey_name = (
+                    module_code.value.lower() if self._is_digital_health_share_code(module_code.value)
                     else module_code.value
-                ) + 'Authored'
-                existing_authored_datetime = getattr(participant_summary, summary_field_name)
-                if existing_authored_datetime and authored < existing_authored_datetime:
-                    logging.warning(
-                        f'Skipping summary update for {module_code.value} response authored on {authored} '
-                        f'(previous response recorded was authored {existing_authored_datetime})'
-                    )
-                    return
+                )
+                if survey_name in QUESTIONNAIRE_MODULE_CODE_TO_FIELD:
+                    summary_field_name = QUESTIONNAIRE_MODULE_CODE_TO_FIELD.get(survey_name) + 'Authored'
+                    existing_authored_datetime = getattr(participant_summary, summary_field_name)
+                    if existing_authored_datetime and authored < existing_authored_datetime:
+                        logging.warning(
+                            f'Skipping summary update for {module_code.value} response authored on {authored} '
+                            f'(previous response recorded was authored {existing_authored_datetime})'
+                        )
+                        return
 
         # Set summary fields for answers that have questions with codes found in QUESTION_CODE_TO_FIELD
         for answer in questionnaire_response.answers:

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1822,10 +1822,13 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual("SUBMITTED_NO_CONSENT", ps_1["consentForElectronicHealthRecords"])
         self.assertEqual(None, ps_1.get("enrollmentStatusMemberTime"))
 
-        self._submit_consent_questionnaire_response(participant_id_1, questionnaire_id, CONSENT_PERMISSION_YES_CODE)
+        # DA-2732:  Make sure the test assigns a more recent timestamp for the YES response.  An identical authored
+        # time for both YES/NO responses will not guarantee the consent status changes
+        self._submit_consent_questionnaire_response(participant_id_1, questionnaire_id, CONSENT_PERMISSION_YES_CODE,
+                                                    time=TIME_2)
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual("SUBMITTED", ps_1["consentForElectronicHealthRecords"])
-        self.assertEqual(TIME_1.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
+        self.assertEqual(TIME_2.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
 
     def _submit_dvehr_consent_questionnaire_response(
         self, participant_id, questionnaire_id, dvehr_consent_answer, time=TIME_1
@@ -1845,25 +1848,25 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual("UNSET", ps_1["consentForDvElectronicHealthRecordsSharing"])
 
         self._submit_dvehr_consent_questionnaire_response(
-            participant_id_1, questionnaire_id, DVEHRSHARING_CONSENT_CODE_NO
+            participant_id_1, questionnaire_id, DVEHRSHARING_CONSENT_CODE_NO, time=TIME_1
         )
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual("SUBMITTED_NO_CONSENT", ps_1["consentForDvElectronicHealthRecordsSharing"])
 
         self._submit_dvehr_consent_questionnaire_response(
-            participant_id_1, questionnaire_id, DVEHRSHARING_CONSENT_CODE_YES
+            participant_id_1, questionnaire_id, DVEHRSHARING_CONSENT_CODE_YES, time=TIME_2
         )
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual("SUBMITTED", ps_1["consentForDvElectronicHealthRecordsSharing"])
 
         self._submit_dvehr_consent_questionnaire_response(
-            participant_id_1, questionnaire_id, DVEHRSHARING_CONSENT_CODE_NOT_SURE
+            participant_id_1, questionnaire_id, DVEHRSHARING_CONSENT_CODE_NOT_SURE, time=TIME_3
         )
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual("SUBMITTED_NOT_SURE", ps_1["consentForDvElectronicHealthRecordsSharing"])
 
-        self._submit_dvehr_consent_questionnaire_response(participant_id_1, questionnaire_id, "")
+        self._submit_dvehr_consent_questionnaire_response(participant_id_1, questionnaire_id, "", time=TIME_4)
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual("SUBMITTED_NO_CONSENT", ps_1["consentForDvElectronicHealthRecordsSharing"])

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -4,6 +4,7 @@ import http.client
 import json
 import mock
 import pytz
+import unittest
 from sqlalchemy import or_
 from sqlalchemy.orm.session import make_transient
 
@@ -148,6 +149,7 @@ class QuestionnaireResponseApiTest(BaseTestCase, PDRGeneratorTestMixin):
 
         summary = self.send_get("Participant/{0}/Summary".format(participant_id))
         self.assertEqual(summary.get('baselineQuestionnairesFirstCompleteAuthored'), TIME_3.isoformat())
+
 
     def test_remote_pm_imperial_response(self):
         participant_id = self.create_participant()
@@ -370,6 +372,45 @@ class QuestionnaireResponseApiTest(BaseTestCase, PDRGeneratorTestMixin):
                                  "&consentForElectronicHealthRecords=SUBMITTED&ehrConsentExpireStatus=UNSET"
                                  "&_includeTotal=true")
         self.assertEqual(len(summary2.get('entry')), 1)
+
+    @unittest.skip('Test should be skipped until fix for DA-2732 is implemented')
+    def test_ehr_conflicting_responses_received_out_of_order(self):
+        """
+        DA-2732: multiple EHR with conflicting consent responses received in inverse order of authored
+        """
+        participant_id = self.create_participant()
+        authored_1 = datetime.datetime(2022, 1, 1, 0, 0, 0, tzinfo=pytz.utc)
+        created = datetime.datetime(2022, 1, 1, 0, 0, 0)
+        with FakeClock(created):
+            self.send_consent(participant_id, authored=authored_1)
+        summary = self.send_get("Participant/{0}/Summary".format(participant_id))
+        self.assertEqual(parse(summary["consentForStudyEnrollmentTime"]), created.replace(tzinfo=None))
+        self.assertEqual(parse(summary["consentForStudyEnrollmentAuthored"]), authored_1.replace(tzinfo=None))
+
+        self.assertEqual(summary.get('consentForElectronicHealthRecordsAuthored'), None)
+        self.assertEqual(summary.get('enrollmentStatusMemberTime'), None)
+        self.assertEqual(summary.get('enrollmentStatus'), 'INTERESTED')
+
+        self._ehr_questionnaire_id = self.create_questionnaire("ehr_consent_questionnaire.json")
+
+        # send ConsentPermission_No questionnaire response first (but later authored than next Yes payload)
+        with FakeClock(datetime.datetime(2022, 3, 12)):
+            self.submit_ehr_questionnaire(participant_id, CONSENT_PERMISSION_NO_CODE, None,
+                                          datetime.datetime(2022, 2, 12))
+
+        # send ConsentPermission_Yes questionnaire response last (but earlier authored than previous No payload)
+        with FakeClock(datetime.datetime(2022, 3, 12, 5)):
+            self.submit_ehr_questionnaire(participant_id, CONSENT_PERMISSION_YES_CODE, None,
+                                          datetime.datetime(2022, 2, 11))
+
+        # Expect the later authored "No" payload to be reflected in participant summary current EHR status fields
+        # (but have a "first yes" matching the earlier authored "yes" payload)
+        summary = self.send_get("Participant/{0}/Summary".format(participant_id))
+        self.assertEqual(summary.get('consentForElectronicHealthRecordsFirstYesAuthored'), '2022-02-11T00:00:00')
+        self.assertEqual(summary.get('consentForElectronicHealthRecordsAuthored'), '2022-02-12T00:00:00')
+        self.assertEqual(summary.get('consentForElectronicHealthRecords'), 'SUBMITTED_NO_CONSENT')
+
+
 
     def submit_ehr_questionnaire(self, participant_id, ehr_response_code, string_answers, authored):
         if not self._ehr_questionnaire_id:

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -1599,11 +1599,11 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
         self.assertEqual({
             't_1': [Answer(id=mock.ANY, value='one', data_type=DataType.STRING)],
             't_2': [Answer(id=mock.ANY, value='two', data_type=DataType.STRING)]
-        }, responses.latest_response_per_survey_in_authored_order[0].answered_codes)
+        }, responses.in_authored_order[0].answered_codes)
         self.assertEqual({
             'x_1': [Answer(id=mock.ANY, value='nine', data_type=DataType.STRING)],
             'x_2': [Answer(id=mock.ANY, value='ten', data_type=DataType.STRING)]
-        }, responses.latest_response_per_survey_in_authored_order[1].answered_codes)
+        }, responses.in_authored_order[1].answered_codes)
 
     def _generate_response(self, questionnaire, answers, participant_id=None, authored_date=None, created_date=None):
         response = self.data_generator.create_database_questionnaire_response(

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -1599,11 +1599,11 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
         self.assertEqual({
             't_1': [Answer(id=mock.ANY, value='one', data_type=DataType.STRING)],
             't_2': [Answer(id=mock.ANY, value='two', data_type=DataType.STRING)]
-        }, responses.in_authored_order[0].answered_codes)
+        }, responses.latest_response_per_survey_in_authored_order[0].answered_codes)
         self.assertEqual({
             'x_1': [Answer(id=mock.ANY, value='nine', data_type=DataType.STRING)],
             'x_2': [Answer(id=mock.ANY, value='ten', data_type=DataType.STRING)]
-        }, responses.in_authored_order[1].answered_codes)
+        }, responses.latest_response_per_survey_in_authored_order[1].answered_codes)
 
     def _generate_response(self, questionnaire, answers, participant_id=None, authored_date=None, created_date=None):
         response = self.data_generator.create_database_questionnaire_response(


### PR DESCRIPTION
## Resolves *[DA-2770](https://precisionmedicineinitiative.atlassian.net/browse/DA-2770)*
We've seen cases where we'll get a series of survey responses, and then receive one or more responses again but not get the latest response. In this scenario the RDR would record the latest we've seen as the most recent response, even if the authored date received is earlier than one already received.

Here's an example:
A participant provides the following EHR consent responses:
- On March 4th they submit a Yes response (let's call this Response1).
- Then on March 27th they submit a No response (let's call this Response2).

If the RDR receives both of those payloads when they were authored, then we correctly end with the participant summary showing that the participant does not provide EHR consent. But if then, on April 1st, we get a replay of Response1 and don't see a replay of Response2. The RDR would record that they have provided a Yes response for EHR consent, even though the latest response they've authored was No.

## Description of changes/additions
This adds a check to make sure we only update the participant summary if the questionnaire response was authored later than what we've seen previously.

## Tests
- [x] unit tests


