### PR TITLE
[DA-2709] Remove references to GCP cloud debugger due to sunsetting

### DIFF
--- a/rdr_service/activate_debugger.py
+++ b/rdr_service/activate_debugger.py
@@ -1,7 +1,0 @@
-import os
-if os.getenv('GAE_ENV', '').startswith('standard'):
-    try:
-        import googleclouddebugger
-        googleclouddebugger.enable()
-    except ImportError:
-        pass

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -2,15 +2,13 @@
 
 This defines the APIs and the handlers for the APIs. All responses are JSON.
 """
-# pylint: disable=unused-import
-import rdr_service.activate_debugger
 
 import logging
 
-from flask import got_request_exception, Response
+from flask import got_request_exception
 from flask_restful import Api
 from sqlalchemy.exc import DBAPIError
-from werkzeug.exceptions import HTTPException, InternalServerError
+from werkzeug.exceptions import HTTPException
 
 from rdr_service import app_util, config_api, version_api
 from rdr_service.api import metrics_ehr_api

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -1,5 +1,4 @@
 """The main API definition file for endpoints that trigger MapReduces and batch tasks."""
-import rdr_service.activate_debugger  # pylint: disable=unused-import
 
 from rdr_service.genomic_enums import GenomicJob
 

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -1,7 +1,5 @@
 """The main API definition file for endpoints that trigger MapReduces and batch tasks."""
 
-import rdr_service.activate_debugger  # pylint: disable=unused-import
-
 from flask import Flask, got_request_exception
 from flask_restful import Api
 from sqlalchemy.exc import DBAPIError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 -r requirements_base.txt
 
 mysqlclient==1.4.6        # via -r requirements.in
-google-python-cloud-debugger


### PR DESCRIPTION
## Resolves *[DA-2709](https://precisionmedicineinitiative.atlassian.net/browse/DA-2709)*


## Description of changes/additions
Removes `googleclouddebugger` and related dependencies from RDR codebase.
Note:  imports from` flask` and `werkzeug.exceptions `were modified due to pylint errors for unused imports


## Tests
These changes are currently deployed in the sandbox project, for reviewing/testing how the GAE instances are impacted.  This is what appears in the Debugger page/UI now:

<img width="393" alt="image" src="https://user-images.githubusercontent.com/65624611/176499108-df8c692b-2a0c-4fe4-9226-a21da5a1ea94.png">

