### PR TITLE
[PDR-1059] Fix issues from genomic_set_member PDR data builds

### DIFF
--- a/rdr_service/model/bq_genomics.py
+++ b/rdr_service/model/bq_genomics.py
@@ -191,7 +191,7 @@ class BQGenomicSetMemberSchema(BQSchema):
     cvl_w5nf_pgx_manifest_job_run_id = BQField('cvl_w5nf_pgx_manifest_job_run_id', BQFieldTypeEnum.INTEGER,
                                                BQFieldModeEnum.NULLABLE)
     diversion_pouch_site_flag = BQField('diversion_pouch_site_flag', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-    gem_date_of_import = BQField('gem_date_of_import', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.REQUIRED)
+    gem_date_of_import = BQField('gem_date_of_import', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     gem_metrics_ancestry_loop_response = BQField('gem_metrics_ancestry_loop_response', BQFieldTypeEnum.STRING,
                                                  BQFieldModeEnum.NULLABLE)
     gem_metrics_available_results = BQField('gem_metrics_available_results', BQFieldTypeEnum.STRING,
@@ -201,7 +201,7 @@ class BQGenomicSetMemberSchema(BQSchema):
     ignore_flag = BQField('ignore_flag', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     informing_loop_ready_flag = BQField('informing_loop_ready_flag', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     informing_loop_ready_flag_modified = BQField('informing_loop_ready_flag_modified', BQFieldTypeEnum.DATETIME,
-                                                 BQFieldModeEnum.REQUIRED)
+                                                 BQFieldModeEnum.NULLABLE)
     participant_origin = BQField('participant_origin', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     replated_member_id = BQField('replated_member_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
@@ -348,7 +348,7 @@ class BQGenomicManifestFeedbackSchema(BQSchema):
     feedback_complete = BQField('feedback_complete', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
     feedback_complete_date = BQField('feedback_complete_date', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
     ignore_flag = BQField('ignore_flag', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
-    version = BQField('version', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+    version = BQField('version', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQGenomicManifestFeedback(BQTable):

--- a/rdr_service/resource/generators/genomics.py
+++ b/rdr_service/resource/generators/genomics.py
@@ -90,10 +90,17 @@ class GenomicSetMemberSchemaGenerator(generators.BaseGenerator):
             row = ro_session.execute(text('select * from genomic_set_member where id = :id'), {'id': _pk}).first()
             data = self.ro_dao.to_dict(row)
 
-            # Set biobank_id_str and delete biobank_id
+            # Convert biobank_id to integer value (if present and if it is a valid biobank_id )
             try:
-                data['biobank_id_str'] = data['biobank_id']
-                data['biobank_id'] = int(re.sub("[^0-9]", "", data['biobank_id']))
+                bb_id = data['biobank_id']
+                data['biobank_id_str'] = bb_id
+                # genomic_set_member table may contain pseudo-biobank_id values for control samples (e.g., HG-001)
+                # Only populate the PDR biobank_id integer field if there is a valid-looking AoU biobank ID
+                # (9 digits or one leading alpha char + 9 digits, where leading char will be stripped)
+                if bb_id and re.match("[A-Za-z]?\\d{9}", bb_id):
+                    data['biobank_id'] = int(re.sub("[^0-9]", "", bb_id))
+                else:
+                    data['biobank_id'] = None
             except KeyError:
                 pass
 

--- a/rdr_service/tools/tool_libs/resource_tool.py
+++ b/rdr_service/tools/tool_libs/resource_tool.py
@@ -86,7 +86,6 @@ class CleanPDRDataClass(object):
         else:
             self.pk_id_list = pk_id_list
 
-
     def delete_pk_ids_from_bigquery_sync(self, table_id):
         """
         Delete the requested records from the bigquery_sync table.  Note, that to restore an unintentional delete,


### PR DESCRIPTION
## Resolves *[PDR-1059](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1059)*


## Description of changes/additions
During the genomics (`genomic_set_member`) data rebuild for RDR 1.124.4 that incorporated new columns, issues were uncovered with BigQuery fields being defined as REQUIRED when they could be null in RDR data. Updating the schema definitions to specify NULLABLE columns.

Also, the `biobank_id` string values from the RDR `genomic_set_member` table were not being properly translated into integers when they appear to be valid AoU participant biobank ids.  That translation was partially implemented previously, but was encountering exceptions if the `biobank_id` field in RDR was (still) null.  Additionally, the cases where we will translate the string to an integer are restricted to valid-looking biobank_ids (vs. control sample pseudo-ids).

## Tests
- [x] unit tests


