### PR TITLE
updates to EHR pdf parsing

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -530,20 +530,21 @@ class VibrentEhrConsentFile(EhrConsentFile):
     def _get_printed_name_elements(self):
         signature_page_number = self._get_signature_page_number()
         return self.pdf.get_elements_intersecting_box(
-            Rect.from_edges(left=350, right=500, bottom=45, top=50),
+            Rect.from_edges(left=350, right=500, bottom=45, top=55),
             page=signature_page_number
         )
 
     def is_sensitive_form(self):
-        return self.pdf.get_page_number_of_text([
-            ('I agree to release sensitive information from my EHRs', )
-        ]) is not None
+        return self.pdf.get_page_number_of_text([(
+            'I agree to release sensitive information from my EHRs',
+            'Acepto compartir información confidencial de mis EHR'
+        )]) is not None
 
     def _get_signature_page_number(self):
-        if self.is_sensitive_form():
-            return 9
-        else:
-            return 6
+        return self.pdf.get_page_number_of_text([(
+            'You will have access to a signed copy of this form',
+            'Usted tendrá acceso a una copia firmada de este documento'
+        )])
 
     def has_valid_sensitive_form_initials(self):
         initial_location_list = [
@@ -568,13 +569,7 @@ class VibrentEhrConsentFile(EhrConsentFile):
                         # Move to the next element to check if nothing was found here
                         continue
 
-                    if initial_text_found is None:
-                        # If no initials were parsed yet, set the first initial string found as the expected value
-                        initial_text_found = initial_from_element
-                    elif initial_text_found.lower() != initial_from_element.lower():
-                        # If the initials don't all match with each other, report that they weren't valid
-                        return False
-
+                    initial_text_found = initial_from_element
                     initial_text_at_location = initial_from_element
                     break
 

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -417,6 +417,10 @@ class ConsentFileParsingTest(BaseTestCase):
         basic_ehr_pdf = self._build_pdf(pages=[
             *six_empty_pages,
             [
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='You will have access to a signed copy of this form',
+                ),
                 self._build_form_element(text='Test ehr', bbox=(125, 150, 450, 180)),
                 self._build_form_element(text='Dec 21, 2019', bbox=(125, 100, 450, 130))
             ]
@@ -430,6 +434,10 @@ class ConsentFileParsingTest(BaseTestCase):
         va_ehr_pdf = self._build_pdf(pages=[
             *six_empty_pages,
             [
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='You will have access to a signed copy of this form',
+                ),
                 self._build_pdf_element(
                     cls=LTTextLineHorizontal,
                     text='We may ask you to go to a local clinic to be measured'


### PR DESCRIPTION
## Resolves *no ticket*
Along with updates to the sensitive EHR, there were also updates to the layout of the standard EHR PDF. As a result, validation started failing to find the participant's signature.

## Description of changes/additions
This makes a couple of updates to get the EHR validation working again:
- Sometimes the printed name will be skewed up a bit, so the search box for that is increased vertically
- For sensitive EHR I had missed the Spanish translation for detecting that it was a sensitive version
- I had also missed the page number for the signature on the sensitive version of the form, the page number for the standard version also shifted. So I updated the code to find the page based on specific text.
- Need to remove the check to make sure the same initial is used in each field.

## Tests
- [ ] unit tests


