### PR TITLE
[DA-2834] Update blocklist job to mitigate memory fails

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -17,7 +17,7 @@ from rdr_service.config import (
     GENOME_TYPE_ARRAY,
     MissingConfigException,
     RDR_SLACK_WEBHOOKS,
-    GENOME_TYPE_WGS)
+    GENOME_TYPE_WGS, GENOMIC_MEMBER_BLOCKLISTS)
 from rdr_service.dao.message_broker_dao import MessageBrokenEventDataDao
 from rdr_service.genomic.genomic_data_quality_components import ReportingComponent
 from rdr_service.genomic.genomic_mappings import raw_aw1_to_genomic_set_member_fields, \
@@ -1571,17 +1571,71 @@ class GenomicJobController:
         logging.warning(message)
 
     def update_members_blocklists(self):
-        members = self.member_dao.get_members_from_date()
+        member_blocklists_config = config.getSettingJson(GENOMIC_MEMBER_BLOCKLISTS, {})
+        if not member_blocklists_config:
+            return
 
+        members = self.member_dao.get_members_from_date()
         if not members:
             return
 
         logging.info(f'Checking {len(members)} newly added/modified genomic member(s) for updating blocklists')
 
-        for member in members:
-            self.member_dao.update_member_blocklists(member)
+        blocklists_map = {
+            'block_research': {
+                'block_attributes': [
+                    {
+                        'key': 'blockResearch',
+                        'value': 1
+                    },
+                    {
+                        'key': 'blockResearchReason',
+                        'value': None
+                    }
+                ],
+            },
+            'block_results': {
+                'block_attributes': [
+                    {
+                        'key': 'blockResults',
+                        'value': 1
+                    },
+                    {
+                        'key': 'blockResultsReason',
+                        'value': None
+                    }
+                ]
+            }
+        }
+        try:
+            for member in members:
+                for block_map_type, block_map_type_config in blocklists_map.items():
+                    blocklist_config_items = member_blocklists_config.get(block_map_type, None)
 
-        self.job_result = GenomicSubProcessResult.SUCCESS
+                    for item in blocklist_config_items:
+                        if not hasattr(member, item.get('attribute')):
+                            continue
+
+                        current_attr_value, evaluate_value = getattr(member, item.get('attribute')), item.get('value')
+
+                        if (isinstance(item.get('value'), list) and
+                            current_attr_value in evaluate_value) or \
+                                current_attr_value == evaluate_value:
+
+                            for attr in block_map_type_config.get('block_attributes'):
+                                value = item.get('reason_string') if not attr['value'] else attr['value']
+
+                                if getattr(member, attr['key']) is None or getattr(member, attr['key']) == 0:
+                                    setattr(member, attr['key'], value)
+
+                            self.member_dao.update(member)
+
+            self.job_result = GenomicSubProcessResult.SUCCESS
+
+        # pylint: disable=broad-except
+        except Exception as e:
+            logging.error(e)
+            self.job_result = GenomicSubProcessResult.ERROR
 
     @staticmethod
     def update_member_file_record(manifest_type):

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1626,7 +1626,7 @@ class GenomicJobController:
         )
 
         if not members:
-            self.job_result = GenomicSubProcessResult.NO_FILES
+            self.job_result = GenomicSubProcessResult.NO_RESULTS
             return
 
         logging.info(f'Checking {len(members)} newly added/modified genomic member(s) for updating blocklists')

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -275,6 +275,8 @@ class GenomicSubProcessResult(messages.Enum):
     INVALID_FILE_NAME = 3
     INVALID_FILE_STRUCTURE = 4
     ERROR = 5
+    MISSING_CONFIG = 6
+    NO_RESULTS = 7
 
 
 class GenomicManifestTypes(messages.Enum):

--- a/tests/dao_tests/test_genomic_dao.py
+++ b/tests/dao_tests/test_genomic_dao.py
@@ -265,54 +265,6 @@ class GenomicDaoTest(BaseTestCase):
         self.assertEqual(len(resolved_incidents), len(self.incident_dao.get_all()))
         self.assertTrue(all(obj.status == GenomicIncidentStatus.RESOLVED.name for obj in resolved_incidents))
 
-    def test_update_member_blocklist(self):
-
-        non_aian_member = self.data_generator.create_database_genomic_set_member(
-            genomicSetId=self.gen_set.id,
-            biobankId="11111111",
-            sampleId="222222222222",
-            genomeType="aou_wgs",
-        )
-
-        self.member_dao.update_member_blocklists(non_aian_member)
-        updated_non_ai_an = self.member_dao.get(non_aian_member.id)
-
-        self.assertEqual(updated_non_ai_an.blockResearch, 0)
-        self.assertIsNone(updated_non_ai_an.blockResearchReason)
-
-        aian_member = self.data_generator.create_database_genomic_set_member(
-            genomicSetId=self.gen_set.id,
-            biobankId="11111111",
-            sampleId="222222222222",
-            genomeType="aou_wgs",
-            ai_an="Y"
-        )
-
-        self.member_dao.update_member_blocklists(aian_member)
-        updated_ai_an = self.member_dao.get(aian_member.id)
-
-        self.assertEqual(updated_ai_an.blockResearch, 1)
-        self.assertIsNotNone(updated_ai_an.blockResearchReason)
-        self.assertEqual(updated_ai_an.blockResearchReason, 'aian')
-
-        blocked_aian_member = self.data_generator.create_database_genomic_set_member(
-            genomicSetId=self.gen_set.id,
-            biobankId="11111111",
-            sampleId="222222222222",
-            genomeType="aou_wgs",
-            ai_an="Y",
-            blockResearch=1,
-            blockResearchReason='sample_swap'
-        )
-
-        self.member_dao.update_member_blocklists(blocked_aian_member)
-        updated_blocked_aian_member = self.member_dao.get(blocked_aian_member.id)
-
-        # should not change if already blocked
-        self.assertEqual(updated_blocked_aian_member.blockResearch, 1)
-        self.assertIsNotNone(updated_blocked_aian_member.blockResearchReason)
-        self.assertEqual(updated_blocked_aian_member.blockResearchReason, 'sample_swap')
-
     def test_genomic_set_member_job_id(self):
         self.assertFalse(GenomicSetMemberDao._is_valid_set_member_job_field(None))
         self.assertFalse(GenomicSetMemberDao._is_valid_set_member_job_field('notARealField'))


### PR DESCRIPTION
## Resolves *[ticket DA-2834]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2815

## Description of changes/additions
Refactor member blocklists job to only query for attributes needed in blocklist config dictionaries, instead of bulk calling thousands of complete GenomicSetMember objects, which will greatly decrease memory load. Also moved logic out of `dao` that should be in the controller and added a bulk update method for updating set members

## Tests
- [] unit tests
** current unit tests should still pass, since this is a refactor only to stop Google from having memory issues

