### PR TITLE
[DA-2822] Validating re-consent files

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -172,7 +172,6 @@ PERSONAL_MEDICAL_HISTORY_MODULE = "PersonalMedicalHistory"
 MEDICATIONS_MODULE = "MedicationsPPI"
 REMOTE_PM_MODULE = 'pm_height_weight'
 REMOTE_PM_UNIT = 'measurement_unit'
-# TODO: UPDATE THIS TO REAL CODEBOOK VALUES WHEN PRESENT
 HEALTHCARE_ACCESS_MODULE = "HealthcareAccess"
 # COVID Experience surveys:
 # The COPE module covers the May/June/July (2020) COPE Survey questionnaires
@@ -182,6 +181,11 @@ COPE_NOV_MODULE = 'cope_nov'
 COPE_DEC_MODULE = "cope_dec"
 COPE_FEB_MODULE = "cope_feb"
 GENETIC_ANCESTRY_MODULE = 'GeneticAncestry'
+
+VA_PRIMARY_RECONSENT_C1_C2 = 'vaprimaryreconsent_c1_2'
+VA_PRIMARY_RECONSENT_C3 = 'vaprimaryreconsent_c3'
+VA_EHR_RECONSENT = 'vaehrreconsent'
+NON_VA_PRIMARY_RECONSENT = 'nonvaprimaryreconsent'
 
 # ConsentPII Questions
 RECEIVE_CARE_STATE = "ReceiveCare_PIIState"

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -75,7 +75,11 @@ from rdr_service.code_constants import (
     BASICS_PROFILE_UPDATE_QUESTION_CODES,
     REMOTE_PM_MODULE,
     REMOTE_PM_UNIT,
-    MEASUREMENT_SYS
+    MEASUREMENT_SYS,
+    VA_PRIMARY_RECONSENT_C1_C2,
+    VA_PRIMARY_RECONSENT_C3,
+    VA_EHR_RECONSENT,
+    NON_VA_PRIMARY_RECONSENT
 )
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.code_dao import CodeDao
@@ -1000,6 +1004,13 @@ class QuestionnaireResponseDao(BaseDao):
                         setattr(participant_summary, mod_submitted, QuestionnaireStatus.SUBMITTED)
                         setattr(participant_summary, mod_authored, authored)
                         module_changed = True
+                elif self._code_in_list(
+                    code.value,
+                    [VA_PRIMARY_RECONSENT_C1_C2, VA_PRIMARY_RECONSENT_C3, NON_VA_PRIMARY_RECONSENT]
+                ):
+                    self.consents_provided.append(ConsentType.PRIMARY_RECONSENT)
+                elif self._code_in_list(code.value, [VA_EHR_RECONSENT]):
+                    self.consents_provided.append(ConsentType.EHR_RECONSENT)
 
         if module_changed:
             participant_summary.numCompletedBaselinePPIModules = count_completed_baseline_ppi_modules(
@@ -1577,6 +1588,10 @@ class QuestionnaireResponseDao(BaseDao):
         )
 
         return query.scalar()
+
+    @classmethod
+    def _code_in_list(cls, code_value: str, code_list: List[str]):
+        return code_value.lower in [list_value.lower for list_value in code_list]
 
 
 def _validate_consent_pdfs(resource):

--- a/rdr_service/model/consent_file.py
+++ b/rdr_service/model/consent_file.py
@@ -26,6 +26,8 @@ class ConsentType(messages.Enum):
     UNKNOWN = 5
     PRIMARY_UPDATE = 6
     WEAR = 7
+    PRIMARY_RECONSENT = 8
+    EHR_RECONSENT = 9
 
 
 class ConsentSyncStatus(messages.Enum):


### PR DESCRIPTION
## Resolves *[DA-2822](https://precisionmedicineinitiative.atlassian.net/browse/DA-2822)*
Adding code for detecting and validating Primary and EHR re-consents for participants that have received the wrong version of either of the files and need to sign a new one.


## Tests
- [ ] unit tests


