### PR TITLE
[PDR-1054] Update publish_pdr_pubsub to support pubsub schema changes

### DIFF
--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -583,7 +583,7 @@ class RebuildGenomicTableRecordsApi(BaseGenomicTaskApi):
             logging.info('Rebuild complete.')
 
             # Publish PDR data-pipeline pub-sub event.
-            publish_pdr_pubsub(table, action='upsert', pk_column='id', ids=batch)
+            publish_pdr_pubsub(table, action='upsert', pk_columns=['id'], pk_values=batch)
             logging.info('PubSub notification sent.')
 
             self.create_cloud_record()

--- a/rdr_service/cloud_utils/gcp_google_pubsub.py
+++ b/rdr_service/cloud_utils/gcp_google_pubsub.py
@@ -6,6 +6,7 @@
 # https://cloud.google.com/pubsub/docs/reference/rest
 #
 from datetime import datetime
+from typing import List
 import base64
 import json
 import logging
@@ -14,7 +15,7 @@ from apiclient import errors
 from googleapiclient import discovery
 
 from rdr_service.config import GAE_PROJECT
-from rdr_service.services.system_utils import retry_func
+from rdr_service.services.system_utils import retry_func, list_chunks
 
 
 _INSTANCE_MAPPING = {
@@ -55,7 +56,7 @@ class GCPGooglePubSubTopic:
         payload = json.dumps(message).encode('utf-8')
         body = {
             "messages": [
-                { 'data': base64.b64encode(payload).decode('utf-8') }
+                {'data': base64.b64encode(payload).decode('utf-8')}
             ]
         }
 
@@ -63,51 +64,95 @@ class GCPGooglePubSubTopic:
         resp = req.execute()
         return resp
 
+def _validate_pk_values(values_list: list, expected_len=1) -> List[List[str]] or None:
+    """
+    Helper function to verify/convert the pk_values into expected nested list of strings for the pubsub event
+    :param values_list:  An object containing the primary key values
+    :param expected_len: The number of RDR table columns that make up a valid primary key value.
+    :return: The resulting nested list object, or None if data could not be validated and converted
+    """
+    if not len(values_list):
+        return None
 
-def publish_pdr_pubsub(table: str, action: str, pk_column: str, ids: (list, tuple)):
+    # Examples of the pk_values (and pk_columns) content expected by the pubsub schema.  Uses all string values
+    # 1. RDR participant table has a single column primary key, sample pubsub data specifying two records:
+    #   pk_columns = ['participant_id']
+    #   pk_values = [['012345678'], ['456789012']]
+    # 2. RDR participant_history has a compound (2-column) primary key, sample pubsub data specifying three records:
+    #   pk_columns = ['participant_id', 'version']
+    #   pk_values = [['012345678', '1'], ['012345678', '2'] , ['456789012', '1']]
+
+    converted_list = []
+    # Convert a single-dimensional list of ints or strings to make it a nested list, per the required pubsub data schema
+    if all(isinstance(v, (int, str)) for v in values_list):
+        converted_list = [[str(val)] for val in values_list]
+    # Received a list of lists/tuples, but confirm all elements of the sublists are ints or strings; convert to all str
+    elif all(isinstance(v, list) or isinstance(v, tuple) for v in values_list):
+        for sub_list in values_list:
+            if all(isinstance(v, (int, str)) for v in sub_list):
+                converted_list.append([str(val) for val in sub_list])
+            else:
+                return None
+    else:
+        # Couldn't apply conversions due to unexpected/mixed data types
+        return None
+
+    # Confirm each nested list element of primary key data has the expected number of items.  The expected_len should
+    # be the number of table columns comprising the primary key (1 in most cases)
+    for sub_list in converted_list:
+        if len(sub_list) != expected_len:
+            return None
+
+    return converted_list
+
+def publish_pdr_pubsub(table: str, action: str, pk_columns : List[str] = [],
+                       pk_values: List = [],
+                       project=GAE_PROJECT):
     """
     Publish database table updates to the 'data-pipeline' pub-sub topic.
     :param table: Table name
     :param action: must be one of 'insert', 'update', 'delete' or 'upsert'.
-    :param pk_column: Name of primary key column in table
-    :param ids: List of primary key ids
+    :param pk_columns: List of names of primary key columns in table
+    :param pk_values: A list object containing the primary key values, which may represent compound primary keys.
+                      If the caller did not provide the expected nested list, this method will attempt to convert
+                      the pk_values data into its expected format for the pubsub data schema
     """
-    if GAE_PROJECT not in _ALLOWED_PROJECTS:
+    last_response = None
+    if project not in _ALLOWED_PROJECTS:
         return None
 
     if action not in ['insert', 'update', 'delete', 'upsert']:
         logging.error('Invalid database action value')
         return None
 
-    if not ids or not isinstance(ids, (list, tuple)):
-        logging.error('Ids argument is invalid or empty')
+    if not len(pk_columns) or not all(isinstance(col, str) for col in pk_columns):
+        logging.error(f'pk_columns list {pk_columns} is invalid or empty, only string values of column names expected')
         return None
 
-    # Both "int_ids" and "str_ids" must be list objects even if there are no values.
-    int_ids = list()
-    str_ids = list()
-    if isinstance(ids[0], int):
-        int_ids = ids
-    else:
-        str_ids = [str(i) for i in ids]
+    validated_pk_values = _validate_pk_values(pk_values, expected_len=len(pk_columns)) or []
+    if not len(validated_pk_values):
+        logging.error(f'pk_values argument {pk_values} contains invalid data types or is empty')
+        return None
 
     # Publish PubSub event for new RDR to PDR pipeline
-    topic = GCPGooglePubSubTopic(GAE_PROJECT, 'data-pipeline')
+    topic = GCPGooglePubSubTopic(project, 'data-pipeline')
     # Payload data will be validated by the pub-sub topic schema.
-    data = {
-        "instance": _INSTANCE_MAPPING[GAE_PROJECT],
-        "database": "rdr",
-        "table": table,
-        "timestamp": datetime.utcnow().isoformat(),
-        "action": action,
-        "pk_column": pk_column,
-        "int_ids": int_ids,
-        "str_ids": str_ids
-    }
-    try:
-        resp = retry_func(topic.publish, backoff_amount=0.1, message=data)
-        return resp
-    except errors.HttpError as e:
-        logging.error(e)
+    # list_chunks will yield smaller batches of pk_values (limit of 500) so each pubsub event covers no more than
+    # 500 corresponding RDR table record ids
+    for pk_values_batch in list_chunks(validated_pk_values, 500):
+        data = {
+            "instance": _INSTANCE_MAPPING[project],
+            "database": "rdr",
+            "table": table,
+            "timestamp": datetime.utcnow().isoformat(),
+            "action": action,
+            "pk_columns": pk_columns,
+            "pk_values": pk_values_batch
+        }
+        try:
+            last_response = retry_func(topic.publish, backoff_amount=0.1, message=data)
+            logging.info(f'Published pubsub event.  Response: {last_response}')
+        except errors.HttpError as e:
+            logging.error(e)
 
-    return None
+    return last_response


### PR DESCRIPTION
## Resolves *[PDR-1054](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1054)*


## Description of changes/additions
The prototype RDR-PDR pipeline pubsub events have had their schemas revised (see: https://github.com/all-of-us/program-data-repository/pull/74)

This updates the RDR-side function which generates the pubsub events.  For convenience, it allows the caller to pass in the values for the RDR table primary keys in the most intuitive fashion and makes the appropriate conversions.  E.g., caller can pass in a flat list of integer primary key values and it will automatically be converted into a nested list of strings as required by the pubsub topic AVRO schema.

Note:  pubsub events are currently blocked from being generated in all environments except RDR sandbox/test/stable


## Tests
- [x] unit tests (existing)  + manual tests in the `pmi-drc-api-test` environment to generate the events via the `resource` tool and confirm the PDR app engine instance received/processed them



