### PR TITLE
[DA-2762] Update Investigation genome type to populate sex_at_birth

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -537,6 +537,7 @@ class GenomicFileIngester:
             participantId=participant.participantId,
             reconcileGCManifestJobRunId=self.job_run_id,
             genomeType=aw1_data['genometype'],
+            sexAtBirth=aw1_data['sexatbirth'],
             blockResearch=1,
             blockResearchReason="Created from AW1 with investigation genome type.",
             blockResults=1,

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -2720,6 +2720,7 @@ class GenomicPipelineTest(BaseTestCase):
             self.assertEqual("Created from AW1 with investigation genome type.", member.blockResearchReason)
             self.assertEqual(1, member.blockResults)
             self.assertEqual("Created from AW1 with investigation genome type.", member.blockResultsReason)
+            self.assertEqual("F", member.sexAtBirth)
 
         # Test the end result code is recorded
         self.assertEqual(GenomicSubProcessResult.SUCCESS, self.job_run_dao.get(2).runResult)


### PR DESCRIPTION
## Resolves *[DA-2762](https://precisionmedicineinitiative.atlassian.net/browse/DA-2762)*


## Description of changes/additions
Sets sex_at_birth for genomic_set_member when an investigation AW1 is ingested.

## Tests
- [x] unit tests


