### PR TITLE
[DA-2844] block_remote_pm_from_cdr

### DIFF
--- a/rdr_service/etl/raw_sql/finalize_cdm_data.sql
+++ b/rdr_service/etl/raw_sql/finalize_cdm_data.sql
@@ -597,6 +597,7 @@ FROM rdr.measurement meas
 INNER JOIN rdr.physical_measurements pm
     ON meas.physical_measurements_id = pm.physical_measurements_id
     AND pm.final = 1
+    AND pm.collect_type <> 2
     AND (pm.status <> 2 OR pm.status IS NULL)
 INNER JOIN cdm.person pe
     ON pe.person_id = pm.participant_id


### PR DESCRIPTION
## Resolves *[DA-2844](https://precisionmedicineinitiative.atlassian.net/browse/DA-2844)*
Block remote physical measurement data from Curation ETL


