### PR TITLE
[DA-2842] Sorting on 'State' Field in the Ops Data API

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -68,6 +68,7 @@ from rdr_service.participant_enums import (
     WithdrawalStatus,
     get_bucketed_age
 )
+from rdr_service.model.code import Code
 from rdr_service.query import FieldFilter, FieldJsonContainsFilter, Operator, OrderBy, PropertyType
 
 # By default / secondarily order by last name, first name, DOB, and participant ID
@@ -606,7 +607,17 @@ class ParticipantSummaryDao(UpdatableDao):
             return super(ParticipantSummaryDao, self)._add_order_by(
                 query, OrderBy(order_by.field_name + "Id", order_by.ascending), field_names, fields
             )
+        elif order_by.field_name == 'state':
+            return self._add_order_by_state(order_by, query)
         return super(ParticipantSummaryDao, self)._add_order_by(query, order_by, field_names, fields)
+
+    @staticmethod
+    def _add_order_by_state(order_by, query):
+        query = query.outerjoin(Code, ParticipantSummary.stateId == Code.codeId)
+        if order_by.ascending:
+            return query.order_by(Code.display)
+        else:
+            return query.order_by(Code.display.desc())
 
     def _make_query(self, session, query_def):
         query, order_by_field_names = super(ParticipantSummaryDao, self)._make_query(session, query_def)

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -3749,7 +3749,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
         ma_participant_id = generate_participant_with_state("Massachusetts")
         mt_participant_id = generate_participant_with_state("Montana")
         ms_participant_id = generate_participant_with_state("Mississippi")
-        null_state_participant_id = to_client_participant_id(self.data_generator.create_database_participant_summary())
+        null_state_participant_id = to_client_participant_id(
+            self.data_generator.create_database_participant_summary().participantId)
 
         response = self.send_get('ParticipantSummary?_sort=state')
         response_ids = [entry['resource']['participantId'] for entry in response['entry']]

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -55,7 +55,7 @@ class CodebookTestMixin:
     def setup_codes(values, code_type):
         code_dao = CodeDao()
         for value in values:
-            code_dao.insert(Code(system=PPI_SYSTEM, value=value, codeType=code_type, mapped=True))
+            code_dao.insert(Code(system=PPI_SYSTEM, value=value, display=value, codeType=code_type, mapped=True))
 
 
 class QuestionnaireTestMixin:


### PR DESCRIPTION
## Resolves *[DA-2842](https://precisionmedicineinitiative.atlassian.net/browse/DA-2842)*


## Description of changes/additions
Updates ParticipantSummaryDao to allow the API to sort on the state field.

## Tests
- [x] unit tests


