### PR TITLE
Update to consent validation trigger

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -47,13 +47,22 @@ class ConsentDao(BaseDao):
         """
         consent_batch_limit = 500
 
-        # A ConsentResponse hasn't been validated yet if there aren't any ConsentFiles that link to the response
-        consent_responses = session.query(ConsentResponse).outerjoin(
-            ConsentFile
-        ).filter(
-            ConsentFile.id.is_(None)
-        ).options(
-            joinedload(ConsentResponse.response)
+        # A ConsentResponse will need to be validated if there are not yet any ConsentFile objects
+        # that are of the same type and for the same participant.
+        consent_responses = (
+            session.query(ConsentResponse)
+            .join(QuestionnaireResponse)
+            .outerjoin(
+                ConsentFile,
+                and_(
+                    ConsentFile.type == ConsentResponse.type,
+                    ConsentFile.participant_id == QuestionnaireResponse.participantId
+                )
+            ).filter(
+                ConsentFile.id.is_(None)
+            ).options(
+                joinedload(ConsentResponse.response)
+            )
         ).limit(consent_batch_limit).all()
 
         grouped_results = defaultdict(list)

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -97,13 +97,14 @@ class ConsentFileDaoTest(BaseTestCase):
     def test_finding_validations_needed_by_response(self):
         # Set up a pair of QuestionnaireResponses, one of which needs to be validated
         response_to_validate = self.data_generator.create_database_questionnaire_response()
-        self.session.add(ConsentResponse(response=response_to_validate))
+        self.session.add(ConsentResponse(response=response_to_validate, type=ConsentType.EHR))
 
         ignored_response = self.data_generator.create_database_questionnaire_response()
-        consent_response = ConsentResponse(response=ignored_response)
+        consent_response = ConsentResponse(response=ignored_response, type=ConsentType.PRIMARY)
         self.data_generator.create_database_consent_file(
             consent_response=consent_response,
-            participant_id=ignored_response.participantId
+            participant_id=ignored_response.participantId,
+            type=ConsentType.PRIMARY
         )
 
         self.session.commit()


### PR DESCRIPTION
## Resolves *no ticket*
We're seeing that some responses are being sent for consents we already have validated consents for. The consent process is currently only looking for one valid response to a given consent type. So this updates the check for what needs to be validated. With these changes we'll only validate consent response types that haven't yet been validated.

Currently we're seeing a growing number of ConsentResponses that are being validated each day, but no ConsentFiles are being stored for them since we already have ConsentFiles of the same type for these participants.

## Tests
- [x] unit tests


