### PR TITLE
Update genomics datagen output directory handling

### DIFF
--- a/rdr_service/tools/tool_libs/genomic_datagen.py
+++ b/rdr_service/tools/tool_libs/genomic_datagen.py
@@ -199,7 +199,8 @@ class ManifestGeneratorTool(ToolBase):
 
 def output_local_csv(filename, data):
     # Create output path if it doesn't exist
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    if os.path.dirname(filename):
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
 
     with open(filename, 'w') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=[k for k in data[0]])


### PR DESCRIPTION
## Resolves *[No ticket]*


## Description of changes/additions
Fixes saving the output csv when the filename doesn't include a path.

The participant generator doesn't include a path as part of the filename when generating the output csv but the manifest generator does. This updates the tool to only try to create an output directory when a path is part of the filename.

## Tests
- [] unit tests


