### PR TITLE
Adding new text for wear consent header

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -291,7 +291,8 @@ class CeConsentFactory(ConsentFileAbstractFactory):
         pdf = blob_wrapper.get_parsed_pdf()
         return pdf.has_text([(
             'All of Us WEAR Study',
-            'el Estudio WEAR de All of Us'
+            'el Estudio WEAR de All of Us',
+            'All of Us Wearable Study'
         )])
 
     def _build_primary_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'PrimaryConsentFile':


### PR DESCRIPTION
## Resolves *no ticket*
We've received a different version of the WEAR consent than expected. This PR adds the text of the different version so we're able to detect them as WEAR files.


## Tests
- [x] unit tests


