### PR TITLE
Edit blocklist check

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1738,18 +1738,16 @@ class GenomicJobController:
 
         try:
             updated_members = []
+
             for member in members:
                 member_dict = {'id': member.id}
-
                 for block_map_type, block_map_type_config in blocklists_map.items():
                     blocklist_config_items = member_blocklists_config.get(block_map_type, None)
 
                     for item in blocklist_config_items:
                         if not hasattr(member, item.get('attribute')):
                             continue
-
                         current_attr_value, evaluate_value = getattr(member, item.get('attribute')), item.get('value')
-
                         if (isinstance(item.get('value'), list) and
                             current_attr_value in evaluate_value) or \
                                 current_attr_value == evaluate_value:
@@ -1760,7 +1758,7 @@ class GenomicJobController:
                                 if getattr(member, attr['key']) is None or getattr(member, attr['key']) == 0:
                                     member_dict[attr['key']] = value
 
-                if member_dict:
+                if len(member_dict) > 1:
                     updated_members.append(member_dict)
 
             if not updated_members:

--- a/tests/genomics_tests/test_genomic_job_controller.py
+++ b/tests/genomics_tests/test_genomic_job_controller.py
@@ -258,15 +258,18 @@ class GenomicJobControllerTest(BaseTestCase):
             genomicSetVersion=1
         )
 
+        ids_should_be_updated = []
         # for just created and wf state query and MATCHES criteria
         for i in range(4):
-            self.data_generator.create_database_genomic_set_member(
-                genomicSetId=gen_set.id,
-                biobankId="100153482",
-                sampleId="21042005280",
-                genomeType='test_investigation_one' if i & 2 != 0 else 'aou_wgs',
-                genomicWorkflowState=GenomicWorkflowState.AW0,
-                ai_an='Y' if i & 2 == 0 else 'N'
+            ids_should_be_updated.append(
+                self.data_generator.create_database_genomic_set_member(
+                    genomicSetId=gen_set.id,
+                    biobankId="100153482",
+                    sampleId="21042005280",
+                    genomeType='test_investigation_one' if i & 2 != 0 else 'aou_wgs',
+                    genomicWorkflowState=GenomicWorkflowState.AW0,
+                    ai_an='Y' if i & 2 == 0 else 'N'
+                ).id
             )
 
         # for just created and wf state query and DOES NOT MATCH criteria
@@ -285,6 +288,9 @@ class GenomicJobControllerTest(BaseTestCase):
 
         # current config json in base_config.json
         created_members = self.member_dao.get_all()
+
+        blocklisted = list(filter(lambda x: x.blockResults == 1 or x.blockResearch == 1, created_members))
+        self.assertTrue(ids_should_be_updated.sort() == [obj.id for obj in blocklisted].sort())
 
         # should be RESEARCH blocked
         self.assertTrue(all(


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
In checking logs noticed that bloklist refactor was sending all obj to save method and showing x number was updated in log message. The data and logic for this is still correct but added a better check for dict keys so as to not send all members to update method. 


## Tests
- [x] unit tests


