### PR TITLE
[DA-2887] Reset W3SR after W3SC ingestion

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1370,6 +1370,9 @@ class GenomicFileIngester:
                     continue
 
                 member.cvlSecondaryConfFailure = row_copy['cvlsecondaryconffailure']
+                # allows for sample to be resent in subsequent W3SR
+                # https://docs.google.com/presentation/d/1QqXCzwz6MGLMhNwuXlV6ieoMLaJYuYai8csxagF_2-E/edit#slide=id.g10f369a487f_0_0
+                member.cvlW3srManifestJobRunID = None
                 self.member_dao.update(member)
 
             return GenomicSubProcessResult.SUCCESS


### PR DESCRIPTION
## Resolves *[ticket DA-2887]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-2887

## Description of changes/additions
Need to reset the W3SR run ids if W3SC is sent back so the subsequent W3SR will pick up the same sample.

## Tests
- [x] unit tests


