### PR TITLE
Match manually validated wear consents to their questionnaire responses

### DIFF
--- a/rdr_service/tools/tool_libs/consent_response_matching.py
+++ b/rdr_service/tools/tool_libs/consent_response_matching.py
@@ -1,0 +1,40 @@
+import logging
+
+from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao
+from rdr_service.model.consent_file import ConsentFile, ConsentType
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
+
+tool_cmd = 'consent-match'
+tool_desc = 'find the response for consents that do not have a response set'
+
+
+class ConsentMatchScript(ToolBase):
+    def run(self):
+        super(ConsentMatchScript, self).run()
+
+        with self.get_session() as session:
+            unmatched_wear_consents = session.query(ConsentFile).filter(
+                ConsentFile.type == ConsentType.WEAR,
+                ConsentFile.consent_response_id.is_(None)
+            ).all()
+
+            wear_responses = QuestionnaireResponseDao.get_responses_to_surveys(
+                session=session,
+                survey_codes=['wear_consent'],
+                participant_ids=[file.participant_id for file in unmatched_wear_consents]
+            )
+
+            for file in unmatched_wear_consents:
+                if file.participant_id not in wear_responses:
+                    logging.error(f'response for {file.participant_id} not found')
+                else:
+                    response_list = wear_responses[file.participant_id].responses
+                    if len(response_list) != 1:
+                        logging.warning(f'{len(response_list)} responses found for {file.participant_id}')
+                    else:
+                        response = response_list[0]
+                        file.response = response
+
+
+def run():
+    return cli_run(tool_cmd, tool_desc, ConsentMatchScript)

--- a/rdr_service/tools/tool_libs/consent_response_matching.py
+++ b/rdr_service/tools/tool_libs/consent_response_matching.py
@@ -1,7 +1,9 @@
-import logging
+from collections import defaultdict
+from typing import List
 
-from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao
 from rdr_service.model.consent_file import ConsentFile, ConsentType
+from rdr_service.model.consent_response import ConsentResponse
+from rdr_service.model.questionnaire_response import QuestionnaireResponse
 from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
 
 tool_cmd = 'consent-match'
@@ -9,6 +11,8 @@ tool_desc = 'find the response for consents that do not have a response set'
 
 
 class ConsentMatchScript(ToolBase):
+    logger_name = None
+
     def run(self):
         super(ConsentMatchScript, self).run()
 
@@ -18,22 +22,68 @@ class ConsentMatchScript(ToolBase):
                 ConsentFile.consent_response_id.is_(None)
             ).all()
 
-            wear_responses = QuestionnaireResponseDao.get_responses_to_surveys(
-                session=session,
-                survey_codes=['wear_consent'],
-                participant_ids=[file.participant_id for file in unmatched_wear_consents]
+            consent_response_list = session.query(ConsentResponse).join(
+                QuestionnaireResponse
+            ).filter(
+                ConsentResponse.type == ConsentType.WEAR,
+                QuestionnaireResponse.participantId.in_([file.participant_id for file in unmatched_wear_consents])
+            ).all()
+
+            self.find_matches(
+                file_list=unmatched_wear_consents,
+                consent_response_list=consent_response_list
             )
 
-            for file in unmatched_wear_consents:
-                if file.participant_id not in wear_responses:
-                    logging.error(f'response for {file.participant_id} not found')
-                else:
-                    response_list = wear_responses[file.participant_id].responses
-                    if len(response_list) != 1:
-                        logging.warning(f'{len(response_list)} responses found for {file.participant_id}')
-                    else:
-                        response = response_list[0]
-                        file.response = response
+    def find_matches(self, file_list: List[ConsentFile], consent_response_list: List[ConsentResponse]):
+        consent_response_list_by_pid = defaultdict(list)
+        for consent_response in consent_response_list:
+            consent_response_list_by_pid[consent_response.response.participantId].append(consent_response)
+
+        file_list_by_participant = defaultdict(list)
+        for file in file_list:
+            file_list_by_participant[file.participant_id].append(file)
+
+        for participant_id, file_list in file_list_by_participant.items():
+            consent_response_list_for_participant = consent_response_list_by_pid[participant_id]
+
+            self.match_files_to_responses(
+                file_list=file_list,
+                consent_response_list=consent_response_list_for_participant
+            )
+
+    @classmethod
+    def match_files_to_responses(cls, file_list: List[ConsentFile], consent_response_list: List[ConsentResponse]):
+        # Match up all the validation results to a corresponding consent_response
+
+        if len(file_list) == 1 and len(consent_response_list) == 1:
+            file_list[0].consent_response = consent_response_list[0]
+            return
+
+        previously_matched_consent_response_list = []
+
+        for file in file_list:
+            unmatched_consent_response_list = [
+                consent_response for consent_response in consent_response_list
+                if consent_response not in previously_matched_consent_response_list
+            ]
+            match_found = False
+            for consent_response in unmatched_consent_response_list:
+                if file.file_path[30:] in consent_response.response.resource:
+                    file.consent_response = consent_response
+                    previously_matched_consent_response_list.append(consent_response)
+                    match_found = True
+                    break
+
+            if not match_found:
+                for consent_response in unmatched_consent_response_list:
+                    if file.expected_sign_date == consent_response.response.authored.date():
+                        file.consent_response = consent_response
+                        previously_matched_consent_response_list.append(consent_response)
+                        match_found = True
+                        break
+
+            if not match_found:
+                raise Exception(f'File id {file.id} was unable to match')
 
 
 def run():

--- a/tests/tool_tests/test_consent_response_matching.py
+++ b/tests/tool_tests/test_consent_response_matching.py
@@ -1,0 +1,101 @@
+from datetime import date, datetime
+
+from rdr_service.model.consent_file import ConsentFile
+from rdr_service.model.consent_response import ConsentResponse
+from rdr_service.model.questionnaire_response import QuestionnaireResponse
+from rdr_service.tools.tool_libs.consent_response_matching import ConsentMatchScript
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ConsentResponseMatchingTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def test_one_to_one_matching(self):
+        """If there's only one in each list, they're matched with each other"""
+        consent_response = ConsentResponse()
+        file = ConsentFile()
+
+        ConsentMatchScript.match_files_to_responses(
+            file_list=[file],
+            consent_response_list=[consent_response]
+        )
+        self.assertEqual(consent_response, file.consent_response)
+
+    def test_match_by_file_path(self):
+        """A file can be matched up if it's file path is in the response payload"""
+        response_file_paths = [
+            'test_one.pdf',
+            'aeouaoeu.pdf',
+            'match.pdf',
+            'other_file.pdf',
+        ]
+        consent_response_list = [
+            ConsentResponse(
+                response=QuestionnaireResponse(
+                    resource=f"aoeuaoeu': '{file_path}'"
+                )
+            ) for file_path in response_file_paths
+        ]
+        file = ConsentFile(file_path='test_bucket_name/Participants/match.pdf')
+
+        ConsentMatchScript.match_files_to_responses(
+            file_list=[file],
+            consent_response_list=consent_response_list
+        )
+        self.assertEqual(consent_response_list[2], file.consent_response)
+
+    def test_match_by_authored_date(self):
+        """If the file path isn't found, then the match should be based on the authored date"""
+        response_authored_date_list = [
+            datetime(2022, 1, 17),
+            datetime(2022, 2, 14),
+            datetime(2022, 5, 22),
+            datetime(2022, 8, 19),
+        ]
+        consent_response_list = [
+            ConsentResponse(
+                response=QuestionnaireResponse(
+                    authored=authored_date,
+                    resource='necessary fluff'
+                )
+            ) for authored_date in response_authored_date_list
+        ]
+        file = ConsentFile(expected_sign_date=date(2022, 2, 14), file_path='test_bucket_name/Participants/test.pdf')
+
+        ConsentMatchScript.match_files_to_responses(
+            file_list=[file],
+            consent_response_list=consent_response_list
+        )
+        self.assertEqual(consent_response_list[1], file.consent_response)
+
+    def test_multiple_match_to_different_responses(self):
+        """The matching algorithm should try to match one validation record to one consent_response"""
+        response_authored_date_list = [
+            datetime(2022, 2, 14),
+            datetime(2022, 2, 14)
+        ]
+        consent_response_list = [
+            ConsentResponse(
+                response=QuestionnaireResponse(
+                    authored=authored_date,
+                    resource='necessary fluff'
+                )
+            ) for authored_date in response_authored_date_list
+        ]
+        first_file = ConsentFile(
+            expected_sign_date=date(2022, 2, 14),
+            file_path='test_bucket_name/Participants/test.pdf'
+        )
+        second_file = ConsentFile(
+            expected_sign_date=date(2022, 2, 14),
+            file_path='test_bucket_name/Participants/other.pdf'
+        )
+
+        ConsentMatchScript.match_files_to_responses(
+            file_list=[first_file, second_file],
+            consent_response_list=consent_response_list
+        )
+        self.assertEqual(consent_response_list[0], first_file.consent_response)
+        self.assertEqual(consent_response_list[1], second_file.consent_response)


### PR DESCRIPTION
## Partially Resolves *[DA-2889](https://precisionmedicineinitiative.atlassian.net/browse/DA-2889)*
Manually validating consents doesn't currently set the matching consent_response record for the validation result. This PR creates a script for matching up the consent validation records to a questionnaire response. At the moment, all the WEAR validation results that are missing a link to a questionnaire response only have one response that they could link to.

If, in the future, this script needs to be applied to other consent types or needs to handle a case where multiple responses are found, then the functionality will be expanded at that time.


## Tests
- [ ] unit tests


