### PR TITLE
[DA-2886] Update to Participant Summary API/Ops Data API for Physical Measurements Fields

### DIFF
--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -1386,6 +1386,14 @@ class ParticipantSummary(Base):
     lastModified = Column("last_modified", UTCDateTime6)
     """UTC timestamp of the last time the participant summary was modified"""
 
+    #Placeholder fields for deprecated columns
+    physicalMeasurementsStatus = None
+    physicalMeasurementsTime = None
+    physicalMeasurementsFinalizedTime = None
+    physicalMeasurementsCreatedSite = None
+    physicalMeasurementsFinalizedSite = None
+    physicalMeasurementsCollectType = None
+
 
 Index("participant_summary_biobank_id", ParticipantSummary.biobankId)
 Index("participant_summary_ln_dob", ParticipantSummary.lastName, ParticipantSummary.dateOfBirth)

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -1386,14 +1386,6 @@ class ParticipantSummary(Base):
     lastModified = Column("last_modified", UTCDateTime6)
     """UTC timestamp of the last time the participant summary was modified"""
 
-    #Placeholder fields for deprecated columns
-    physicalMeasurementsStatus = None
-    physicalMeasurementsTime = None
-    physicalMeasurementsFinalizedTime = None
-    physicalMeasurementsCreatedSite = None
-    physicalMeasurementsFinalizedSite = None
-    physicalMeasurementsCollectType = None
-
 
 Index("participant_summary_biobank_id", ParticipantSummary.biobankId)
 Index("participant_summary_ln_dob", ParticipantSummary.lastName, ParticipantSummary.dateOfBirth)

--- a/tests/dao_tests/test_participant_summary_dao.py
+++ b/tests/dao_tests/test_participant_summary_dao.py
@@ -1163,6 +1163,68 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         self.assertIsNotNone(participant_summary)
         self.assertEqual(pid, participant_summary.participantId)
 
+    def test_create_synthetic_pm_fields(self):
+        summary_1 = ParticipantSummary(
+            participantId=1
+        )
+        results = self.dao.to_client_json(summary_1)
+        self.assertEqual(results["physicalMeasurementsStatus"], "UNSET")
+        self.assertEqual(results["clinicPhysicalMeasurementsStatus"], "UNSET")
+        self.assertEqual(results["selfReportedPhysicalMeasurementsStatus"], "UNSET")
+        self.assertEqual(results["physicalMeasurementsCollectType"], "UNSET")
+
+        summary_2 = ParticipantSummary(
+            participantId=2,
+            clinicPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.COMPLETED,
+            clinicPhysicalMeasurementsFinalizedTime=TIME_1
+        )
+        results = self.dao.to_client_json(summary_2)
+        self.assertEqual(results["physicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["clinicPhysicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["selfReportedPhysicalMeasurementsStatus"], "UNSET")
+        self.assertEqual(results["physicalMeasurementsFinalizedTime"], TIME_1.isoformat())
+        self.assertEqual(results["physicalMeasurementsCollectType"], "SITE")
+
+        summary_3 = ParticipantSummary(
+            participantId=3,
+            selfReportedPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.COMPLETED,
+            selfReportedPhysicalMeasurementsAuthored=TIME_2
+        )
+        results = self.dao.to_client_json(summary_3)
+        self.assertEqual(results["physicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["clinicPhysicalMeasurementsStatus"], "UNSET")
+        self.assertEqual(results["selfReportedPhysicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["physicalMeasurementsFinalizedTime"], TIME_2.isoformat())
+        self.assertEqual(results["physicalMeasurementsCollectType"], "SELF_REPORTED")
+
+        summary_4 = ParticipantSummary(
+            participantId=4,
+            selfReportedPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.COMPLETED,
+            selfReportedPhysicalMeasurementsAuthored=TIME_2,
+            clinicPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.COMPLETED,
+            clinicPhysicalMeasurementsFinalizedTime=TIME_1
+        )
+        results = self.dao.to_client_json(summary_4)
+        self.assertEqual(results["physicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["clinicPhysicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["selfReportedPhysicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["physicalMeasurementsFinalizedTime"], TIME_2.isoformat())
+        self.assertEqual(results["physicalMeasurementsCollectType"], "SELF_REPORTED")
+
+        summary_5 = ParticipantSummary(
+            participantId=5,
+            selfReportedPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.COMPLETED,
+            selfReportedPhysicalMeasurementsAuthored=TIME_4,
+            clinicPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.COMPLETED,
+            clinicPhysicalMeasurementsFinalizedTime=TIME_3
+        )
+        results = self.dao.to_client_json(summary_5)
+        self.assertEqual(results["physicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["clinicPhysicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["selfReportedPhysicalMeasurementsStatus"], "COMPLETED")
+        self.assertEqual(results["physicalMeasurementsFinalizedTime"], TIME_3.isoformat())
+        self.assertEqual(results["physicalMeasurementsCollectType"], "SITE")
+
     def test_parse_enums_from_resource(self):
         resource = {
             "withdrawalStatus": "NO_USE",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -78,6 +78,16 @@ def load_measurement_json_amendment(participant_id, amended_id, now=None):
     return measurement
 
 
+def load_remote_measurement_json(template_file_name, questionnaire_id, participant_id_str):
+    with open(data_path(template_file_name)) as fd:
+        resource = json.load(fd)
+
+    resource["subject"]["reference"] = f'Patient/{participant_id_str}'
+    resource["questionnaire"]["reference"] = f'Questionnaire/{questionnaire_id}'
+
+    return resource
+
+
 def load_biobank_order_json(participant_id, filename="biobank_order_1.json"):
     with open(data_path(filename)) as f:
         return json.loads(


### PR DESCRIPTION
## Resolves *[DA-2886](https://precisionmedicineinitiative.atlassian.net/browse/DA-2886)*


## Description of changes/additions
Creates physicalMeasurementsStatus, physicalMeasurementsTime, physicalMeasurementsFinalizedTime, physicalMeasurementsCreatedSite, physicalMeasurementsFinalizedSite, physicalMeasurementsCollectType as API fields from the clinic and self reported physical measurements columns in ParticipantSummary

## Tests
- [x] unit tests


