### PR TITLE
Additional fixes for consent validation

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1587,6 +1587,7 @@ class QuestionnaireResponseDao(BaseDao):
             )
             .order_by(QuestionnaireResponse.authored.desc())
             .filter(QuestionnaireResponse.participantId == participant_id)
+            .limit(1)
         )
 
         return query.scalar()

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -291,8 +291,12 @@ class CeConsentFactory(ConsentFileAbstractFactory):
         pdf = blob_wrapper.get_parsed_pdf()
         return pdf.has_text([(
             'All of Us WEAR Study',
+            'All of Us WEAR\nStudy',
             'el Estudio WEAR de All of Us',
-            'All of Us Wearable Study'
+            'Estudio del uso desensores portátiles',
+            'Estudio\ndel uso de sensores portátiles',
+            'All of Us Wearable Study',
+            'All of Us Wearable\nStudy'
         )])
 
     def _build_primary_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'PrimaryConsentFile':


### PR DESCRIPTION
## Resolves *no ticket*
The consent validation nightly job has been failing to load some participant's answers to where they receive care. This happens when a participant has multiple answers to the question (even if they're the same answer). This PR updates the method to only process a single (latest) answer to the question.

We've also been seeing new layouts for the WEAR consent, this adds updated strings to detect those new versions.


## Tests
- [ ] unit tests


