### PR TITLE
[DA-2899] Clearing EHR consent status on rejected VA reconsent

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -40,6 +40,7 @@ GROR_CONSENT_QUESTION_CODE = "ResultsConsent_CheckDNA"
 COPE_CONSENT_QUESTION_CODE = "section_participation"
 WEAR_CONSENT_QUESTION_CODE = "resultsconsent_wear"
 PRIMARY_CONSENT_UPDATE_QUESTION_CODE = "Reconsent_ReviewConsentAgree"
+VA_EHR_RECONSENT_QUESTION_CODE = "vaehrreconsent_agree"
 
 DATE_OF_BIRTH_QUESTION_CODE = "PIIBirthInformation_BirthDate"
 
@@ -214,6 +215,10 @@ APPLE_HEALTH_KIT_SHARING_MODULE = "participantintendstoshareapplehealthkit"
 APPLE_HEALTH_KIT_STOP_SHARING_MODULE = "participantintendstostopsharingapplehealthkit"
 FITBIT_SHARING_MODULE = "participantintendstosharefitbit"
 FITBIT_STOP_SHARING_MODULE = "participantintendstostopsharingfitbit"
+
+# General response answer codes
+AGREE_YES = "agree_yes"
+AGREE_NO = "agree_no"
 
 BIOBANK_TESTS = [
     "1ED10",


### PR DESCRIPTION
## Resolves *[DA-2899](https://precisionmedicineinitiative.atlassian.net/browse/DA-2899)*
If a participant responds with No to the reconsent process, we should set their EHR status to No.

Edit: The DAO code is a bit messy, and this doesn't help it. I'll be working on more extensive changes to get the logic into separate classes, but for now this is what I'll be able to have ready for the release.

## Tests
- [ ] unit tests


