### PR TITLE
Correct VA Reconsents Field Name

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1033,7 +1033,7 @@ class ParticipantSummaryDao(UpdatableDao):
             ConsentType.CABOR: 'consentForCABoR',
             ConsentType.EHR: 'consentForElectronicHealthRecords',
             ConsentType.GROR: 'consentForGenomicsROR',
-            ConsentType.PRIMARY_RECONSENT: 'reconsentForStudyEnrollement',
+            ConsentType.PRIMARY_RECONSENT: 'reconsentForStudyEnrollment',
             ConsentType.EHR_RECONSENT: 'reconsentForElectronicHealthRecords'
         }
         participant_id = result['participantId']
@@ -1045,6 +1045,11 @@ class ParticipantSummaryDao(UpdatableDao):
 
             if has_consent_path:
                 result[value_path_key] = has_consent_path[0].file_path
+
+        # DA-2895: Copy reconsentForStudyEnrollmentFilePath value to incorrect field name.
+        # This can be removed after HealthPro updates.
+        if 'reconsentForStudyEnrollmentFilePath' in result:
+            result['reconsentForStudyEnrollementFilePath'] = result['reconsentForStudyEnrollmentFilePath']
 
         return result
 

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -667,7 +667,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
             ConsentType.PRIMARY: 'consentForStudyEnrollment',
             ConsentType.CABOR: 'consentForCABoR',
             ConsentType.EHR: 'consentForElectronicHealthRecords',
-            ConsentType.GROR: 'consentForGenomicsROR'
+            ConsentType.GROR: 'consentForGenomicsROR',
+            ConsentType.PRIMARY_RECONSENT: 'reconsentForStudyEnrollment'
         }
 
         for num in range(num_summary):
@@ -709,6 +710,10 @@ class ParticipantSummaryApiTest(BaseTestCase):
             self.assertEqual(first_summary[file_path], first_path)
 
         self.assertEqual(first_count, len(consents_map.keys()))
+
+        # DA-2895: This assertion should be removed once the misspelled field name is no longer needed.
+        self.assertEqual(first_summary["reconsentForStudyEnrollmentFilePath"],
+                         first_summary["reconsentForStudyEnrollementFilePath"])
 
         self.overwrite_test_user_roles([PTC])
 


### PR DESCRIPTION
## Resolves *[DA-2895](https://precisionmedicineinitiative.atlassian.net/browse/DA-2895)*


## Description of changes/additions

Fixes the VA reconsent field name and copies the value from the correct field name (“reconsentForStudyEnrollmentFilePath”) to the misspelled field name so both are in the Participant Summary API output.

## Tests
- [x] unit tests


