### PR TITLE
Fix CoreMinusPMTime calculation

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -815,7 +815,7 @@ class ParticipantSummaryDao(UpdatableDao):
         )
         summary.enrollmentStatusCoreOrderedSampleTime = self.calculate_core_ordered_sample_time(consent, summary)
         summary.enrollmentStatusCoreStoredSampleTime = self.calculate_core_stored_sample_time(consent, summary)
-        summary.enrollmentStatusCoreMinusPMTime = self.calculate_core_minus_pm_time(consent, summary)
+        summary.enrollmentStatusCoreMinusPMTime = self.calculate_core_minus_pm_time(consent, summary, enrollment_status)
 
         # [DA-1623] Participants that have 'Core' status should never lose it
         # CORE_MINUS_PM status can not downgrade, but can upgrade to FULL_PARTICIPANT
@@ -879,7 +879,7 @@ class ParticipantSummaryDao(UpdatableDao):
         else:
             return None
 
-    def calculate_core_minus_pm_time(self, consent, participant_summary):
+    def calculate_core_minus_pm_time(self, consent, participant_summary, enrollment_status):
         if (
             consent
             and participant_summary.numCompletedBaselinePPIModules == self._get_num_baseline_ppi_modules()
@@ -889,7 +889,7 @@ class ParticipantSummaryDao(UpdatableDao):
             and participant_summary.samplesToIsolateDNA == SampleStatus.RECEIVED
             and (participant_summary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED
                  or participant_summary.consentCohort != ParticipantCohort.COHORT_3)
-        ) or participant_summary.enrollmentStatus == EnrollmentStatus.CORE_MINUS_PM:
+        ) or enrollment_status == EnrollmentStatus.CORE_MINUS_PM:
 
             max_core_sample_time = self.calculate_max_core_sample_time(
                 participant_summary, field_name_prefix="sampleStatus"

--- a/tests/dao_tests/test_participant_summary_dao.py
+++ b/tests/dao_tests/test_participant_summary_dao.py
@@ -567,6 +567,7 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         self.assertEqual(sample_time, summary.enrollmentStatusCoreMinusPMTime)
 
         summary.clinicPhysicalMeasurementsStatus = PhysicalMeasurementsStatus.COMPLETED
+        summary.clinicPhysicalMeasurementsFinalizedTime = datetime.datetime(2022, 7, 12)
         self.dao.update_enrollment_status(summary)
         self.assertEqual(EnrollmentStatus.FULL_PARTICIPANT, summary.enrollmentStatus)
         self.assertEqual(sample_time, summary.enrollmentStatusCoreMinusPMTime)
@@ -607,6 +608,7 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         self.assertEqual(sample_time, summary.enrollmentStatusCoreMinusPMTime)
 
         summary.selfReportedPhysicalMeasurementsStatus = SelfReportedPhysicalMeasurementsStatus.COMPLETED
+        summary.selfReportedPhysicalMeasurementsAuthored = datetime.datetime(2022, 7, 12)
         self.dao.update_enrollment_status(summary)
         self.assertEqual(EnrollmentStatus.FULL_PARTICIPANT, summary.enrollmentStatus)
         self.assertEqual(sample_time, summary.enrollmentStatusCoreMinusPMTime)
@@ -643,7 +645,8 @@ class ParticipantSummaryDaoTest(BaseTestCase):
             samplesToIsolateDNA=SampleStatus.RECEIVED,
             clinicPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.UNSET,
             enrollmentStatus=EnrollmentStatus.CORE_MINUS_PM,
-            sampleStatus2ED10Time=sample_time
+            sampleStatus2ED10Time=sample_time,
+            enrollmentStatusCoreMinusPMTime=sample_time
         )
         self.dao.update_enrollment_status(summary)
         self.assertEqual(EnrollmentStatus.CORE_MINUS_PM, summary.enrollmentStatus)


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Investigation into [ROC-1446](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1446) revealed that there is a bug in the way Core Minus PM Time is calculated. If the enrollment status changes from CORE_MINUS_PM to FULL_PARTICIPANT because physical measurements have been received then Core Minus PM Time is changed to the timestamp of the physical measurements because the calculation is relying on a stale value for enrollment status.

Updates ParticipantSummaryDao.update_enrollment_status and ParticipantSummaryDao.calculate_core_minus_pm_time to use the calculated enrollment status instead of the stale value from participant summary.

## Tests
- [x] unit tests


