### PR TITLE
Fix VA Workqueue Export Timestamp Parsing Error

### DIFF
--- a/rdr_service/offline/export_va_workqueue.py
+++ b/rdr_service/offline/export_va_workqueue.py
@@ -182,7 +182,7 @@ def _get_json_fields(participant):
 
 def _export_datetime(api_datetime):
     if api_datetime:
-        return datetime.datetime.fromisoformat(api_datetime).strftime("%m/%d/%Y %H:%M:%S")
+        return datetime.datetime.fromisoformat(api_datetime.replace("Z", "")).strftime("%m/%d/%Y %H:%M:%S")
     else:
         return ""
 

--- a/tests/cron_job_tests/test_export_va_workqueue.py
+++ b/tests/cron_job_tests/test_export_va_workqueue.py
@@ -48,7 +48,7 @@ class ExportVaWorkQueueTest(BaseTestCase, PDRGeneratorTestMixin):
                 ps.dateOfBirth = datetime.date(1979, 3, 11)
                 ps.questionnaireOnCopeDec = 1
                 ps.questionnaireOnCopeDecAuthored = datetime.datetime(2022, 1, 3, 13, 23)
-                ps.digitalHealthSharingStatus = {'fitbit':{'status':'YES', 'authoredTime': '2022-04-03T17:12:34'}}
+                ps.digitalHealthSharingStatus = {'fitbit':{'status':'YES', 'authoredTime': '2022-04-03T17:12:34Z'}}
                 ps.patientStatus = [{'status': 'YES', 'organization': 'VA_BOSTON_VAMC'}]
                 ps.consentCohort = 2
                 ps.cohort2PilotFlag = 1
@@ -74,6 +74,7 @@ class ExportVaWorkQueueTest(BaseTestCase, PDRGeneratorTestMixin):
                     self.assertEqual(item["COPE Dec PPI Survey Complete"], "1")
                     self.assertEqual(item["COPE Dec PPI Survey Completion Date"], "01/03/2022 13:23:00")
                     self.assertEqual(item["Fitbit Consent"], "1")
+                    self.assertEqual(item["Fitbit Consent Date"], "04/03/2022 17:12:34")
                     self.assertEqual(item["Patient Status: Yes"], "VA_BOSTON_VAMC")
                     self.assertEqual(item["Consent Cohort"], "Cohort 2.1")
                     self.assertEqual(item["EHR Expiration Status"], "1")


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
The VA workqueue export is unable to run because of a timestamp parsing error in digitalHealthSharingStatus. Updates datetime parsing to handle timestamps with 'Z' at the end.

## Tests
- [x] unit tests


