### PR TITLE
[ROC-1440] Fixing remote pm filter in curation etl and adding cutoff date for pm

### DIFF
--- a/rdr_service/etl/raw_sql/finalize_cdm_data.sql
+++ b/rdr_service/etl/raw_sql/finalize_cdm_data.sql
@@ -597,8 +597,8 @@ FROM rdr.measurement meas
 INNER JOIN rdr.physical_measurements pm
     ON meas.physical_measurements_id = pm.physical_measurements_id
     AND pm.final = 1
-    AND pm.collect_type <> 2
-    AND (pm.status <> 2 OR pm.status IS NULL)
+    AND (pm.collect_type <> 2 OR pm.collect_type IS NULL)
+    AND (pm.status <> 2 OR pm.status IS NULL) -- %SED_PM_CUTOFF_FILTER%
 INNER JOIN cdm.person pe
     ON pe.person_id = pm.participant_id
 ;

--- a/rdr_service/etl/run_cloud_etl.sh
+++ b/rdr_service/etl/run_cloud_etl.sh
@@ -65,9 +65,10 @@ mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT}
 if [ -z "${CUTOFF}" ]
 then
   python -m tools curation --project ${PROJECT} cdm-data --vocabulary ${VOCABULARY}
+  mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT} < etl/raw_sql/finalize_cdm_data.sql
 else
   python -m tools curation --project ${PROJECT} cdm-data --cutoff ${CUTOFF} --vocabulary ${VOCABULARY}
+  sed 's/-- %SED_PM_CUTOFF_FILTER%/AND pm.finalized < "'"${CUTOFF}"'"/g' etl/raw_sql/finalize_cdm_data.sql | mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT}
 fi
-mysql -v -v -v -h 127.0.0.1 -u "${ALEMBIC_DB_USER}" -p${PASSWORD} --port ${PORT} < etl/raw_sql/finalize_cdm_data.sql
 
 echo "Done with ETL. Please manually run export."


### PR DESCRIPTION
## Resolves *[ROC-1440](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1440)*
The curation team found a pair of issues around the physical measurement data they received in the most recent ETL exports:
1. A significant number of measurements disappeared from the exported data
2. Measurements that occurred after the cutoff date were appearing in the exported data

## Description of changes/additions
The first issue was caused by trying to filter out the self-reported physical measurements. The collectType value of every physical measurement before that column was added is NULL. So `pm.collect_type <> 2` was also excluding those measurements with a NULL collectType.

The physical measurements are read from the RDR database using a raw SQL script, so it's difficult to use the CLI arguments in a way that would exclude measurements recorded after the cutoff. Ideally the measurements would be processed as part of a script (so we could dynamically use the cutoff date in the same way we use it on questionnaire responses). But that is a larger project and would require more time to move the needed SQL into a script. As a work around (one that I know isn't sustainable) I've set the run_cloud_etl.sh script up to replace a string token with additional filtering by date.

## Tests
- [ ] unit tests


