### PR TITLE
[ROC-1457] [ROC-1440] Fixes for curation ETL

### DIFF
--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -2,6 +2,7 @@
 #
 # Template for RDR tool python program.
 #
+from datetime import datetime
 import logging
 import pytz
 from sqlalchemy import and_, case, insert, or_, text, not_
@@ -25,7 +26,8 @@ from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireH
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer, \
     QuestionnaireResponseClassificationType
 from rdr_service.model.curation_etl import CdrExcludedCode
-from rdr_service.participant_enums import QuestionnaireResponseStatus, WithdrawalStatus, CdrEtlCodeType
+from rdr_service.participant_enums import QuestionnaireResponseStatus, WithdrawalStatus, CdrEtlCodeType,\
+    QuestionnaireStatus
 from rdr_service.services.gcp_utils import gcp_sql_export_csv
 from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
 from rdr_service.dao.curation_etl_dao import CdrEtlRunHistoryDao, CdrEtlSurveyHistoryDao, CdrExcludedCodeDao
@@ -67,6 +69,20 @@ class CurationExportClass(ToolBase):
 
     @classmethod
     def _render_export_select(cls, export_sql, column_name_list):
+        # We need to handle NULLs and convert them to empty strings as gcloud sql has a bug when putting them in a csv
+        # https://issuetracker.google.com/issues/64579566
+        # NULL characters (\0) can also corrupt the output file, so they're removed.
+        # And whitespace was trimmed before so that's moved into the SQL as well
+        # Newlines and double-quotes are also replaced with spaces and single-quotes, respectively
+        data_select_list = [
+            f"TRIM(REPLACE(REPLACE(REPLACE(COALESCE({name}, ''), '\\0', ''), '\n', ' '), '\\\"', '\\\''))"
+            for name in column_name_list
+        ]
+
+        # We have to add a row at the start for the CSV headers, Google hasn't implemented another way yet
+        # https://issuetracker.google.com/issues/111342008
+        # The below format forces the headers to the top of the file.
+        # Curation would like them in the file for schema validation (ROC-687)
         return f"""
             SELECT {', '.join(column_name_list)}
             FROM
@@ -78,9 +94,7 @@ class CurationExportClass(ToolBase):
                 )
                 UNION ALL
                 (
-                    SELECT
-                      2 as sort_col,
-                      data.*
+                    SELECT 2 as sort_col, {','.join(data_select_list)}
                     FROM ({export_sql}) as data
                 )
             ) a
@@ -109,45 +123,13 @@ class CurationExportClass(ToolBase):
         :param table: Table name
         :return:
         """
-        cloud_file = f'gs://{self.args.export_path}/{table}.csv'
-
-        # We have to add a row at the start for the CSV headers, Google hasn't implemented another way yet
-        # https://issuetracker.google.com/issues/111342008
-        column_names = self.get_field_names(table, ['id'])
-        header_string = ','.join([f"'{column_name}'" for column_name in column_names])
-
-        # We need to handle NULLs and convert them to empty strings as gcloud sql has a bug when putting them in a csv
-        # https://issuetracker.google.com/issues/64579566
-        # NULL characters (\0) can also corrupt the output file, so they're removed.
-        # And whitespace was trimmed before so that's moved into the SQL as well
-        # Newlines and double-quotes are also replaced with spaces and single-quotes, respectively
-        field_list = [f"TRIM(REPLACE(REPLACE(REPLACE(COALESCE({name}, ''), '\\0', ''), '\n', ' '), '\\\"', '\\\''))"
-                      for name in column_names]
-
-        # Unions are unordered, so the headers do not always end up at the top of the file.
-        # The below format forces the headers to the top of the file
-        # This is needed because gcloud export sql doesn't support column headers and
-        # Curation would like them in the file for schema validation (ROC-687)
-        sql_string = f"""
-            SELECT {','.join(column_names)}
-            FROM
-            (
-                (
-                    SELECT
-                      1 as sort_col,
-                      {header_string}
-                )
-                UNION ALL
-                (
-                    SELECT 2,
-                        {','.join(field_list)}
-                    FROM {table}
-                )
-            ) a
-            ORDER BY a.sort_col ASC
-        """
+        sql_string = self._render_export_select(
+            export_sql=f"SELECT * FROM {table}",
+            column_name_list=self.get_field_names(table, exclude=['id'])
+        )
 
         _logger.info(f'exporting {table}')
+        cloud_file = f'gs://{self.args.export_path}/{table}.csv'
         gcp_sql_export_csv(self.args.project, sql_string, cloud_file, database='cdm')
 
     def export_cope_map(self):
@@ -268,7 +250,7 @@ class CurationExportClass(ToolBase):
             ]
         )
         export_name = 'survey_conduct'
-        cloud_file = f'{self.args.export_path}/{export_name}.csv'
+        cloud_file = f'gs://{self.args.export_path}/{export_name}.csv'
 
         _logger.info(f'exporting {export_name}')
         gcp_sql_export_csv(self.args.project, export_sql, cloud_file, database='rdr')
@@ -479,7 +461,17 @@ class CurationExportClass(ToolBase):
             ParticipantSummary,
             ParticipantSummary.participantId == Participant.participantId
         ).filter(
-            Participant.isGhostId.isnot(True),
+            or_(
+                Participant.isGhostId.isnot(True),
+                and_(
+                    ParticipantSummary.participantId.isnot(None),
+                    Participant.dateAddedGhost > datetime(2022, 3, 18),
+                    or_(
+                        ParticipantSummary.consentForElectronicHealthRecords != QuestionnaireStatus.UNSET,
+                        ParticipantSummary.questionnaireOnTheBasics == QuestionnaireStatus.SUBMITTED
+                    )
+                )
+            ),
             Participant.isTestParticipant.isnot(True),
             Participant.participantOrigin != 'careevolution',
             HPO.name != 'TEST',


### PR DESCRIPTION
## Resolves *[ROC-1457](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1457)* and *[ROC-1440](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1440)*
Some tables of the curation ETL are passed through some SQL cleanup. When the survey conduct table was set up, it wasn't created in a way that uses those filters. So the curation team saw some strange data when column values were meant to be Null.

Data investigations are also finding that participants are being marked as ghosts when they shouldn't be.

## Description of changes/additions
This refactors the curation ETL script to pass the data through the cleanup for the survey conduct table (and any other tables that use the same approach).

This also fixes a file path error with the survey conduct table.

The ghost participant filter is being updated temporarily to be sure that participants that have been marked as ghosts are definitely ghosts (they're not if they've completed primary consent and atleast TheBasics or EHR).

## Tests
- [ ] unit tests


