### PR TITLE
[PDR-1222] Bring original foreign key values over to PDR.

### DIFF
--- a/rdr_service/dao/bq_workbench_dao.py
+++ b/rdr_service/dao/bq_workbench_dao.py
@@ -35,6 +35,10 @@ class BQRWBWorkspaceGenerator(BigQueryGenerator):
                     {'id': src_pk_id}).first()
             data = ro_dao.to_dict(row)
 
+            data['orig_id'] = row.id
+            data['orig_created'] = row.created
+            data['orig_modified'] = row.modified
+
             data['status'] = str(WorkbenchWorkspaceStatus(row.status))
             data['status_id'] = int(WorkbenchWorkspaceStatus(row.status))
 
@@ -133,6 +137,9 @@ class BQRWBWorkspaceUsersGenerator(BigQueryGenerator):
                     text('select * from rdr.workbench_workspace_user where id = :id order by modified desc'),
                         {'id': pk_id}).first()
             data = ro_dao.to_dict(row)
+            data['orig_id'] = row.id
+            data['orig_created'] = row.created
+            data['orig_modified'] = row.modified
 
             if row.role:
                 data['role'] = str(WorkbenchWorkspaceUserRole(row.role))
@@ -189,6 +196,9 @@ class BQRWBResearcherGenerator(BigQueryGenerator):
         """
         res = WBResearcherGenerator().make_resource(src_pk_id)
         data = res.get_data()
+        data['orig_id'] = data['id']
+        data['orig_created'] = data['created']
+        data['orig_modified'] = data['modified']
 
         return BQRecord(schema=BQRWBResearcherSchema, data=data, convert_to_enum=convert_to_enum)
 
@@ -242,6 +252,9 @@ class BQRWBInstitutionalAffiliationsGenerator(BigQueryGenerator):
                 text('select * from rdr.workbench_institutional_affiliations_history where id = :id'),
                         {'id': pk_id}).first()
             data = ro_dao.to_dict(row)
+            data['orig_id'] = row.id
+            data['orig_created'] = row.created
+            data['orig_modified'] = row.modified
 
             data['modified_time'] = row.modified
             data['non_academic_affiliation'] = str(WorkbenchInstitutionNonAcademic(row.non_academic_affiliation))
@@ -298,6 +311,9 @@ class BQRWBAuditGenerator(BigQueryGenerator):
             row = ro_session.execute(
                 text('select * from rdr.workbench_audit where id = :id'), {'id': pk_id}).first()
             data = ro_dao.to_dict(row)
+            data['orig_id'] = row.id
+            data['orig_created'] = row.created
+            data['orig_modified'] = row.modified
 
             data['auditor_pmi_email'] = 1 if data['auditor_pmi_email'] else 0
             data['audit_notes'] = 1 if data['audit_notes'] else 0

--- a/rdr_service/model/bq_workbench_researcher.py
+++ b/rdr_service/model/bq_workbench_researcher.py
@@ -133,6 +133,10 @@ class BQRWBResearcherSchema(BQSchema):
                                          BQFieldModeEnum.NULLABLE)
     dsv2_survey_comments = BQField('dsv2_survey_comments', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
 
 class BQRWBResearcher(BQTable):
     """ Code BigQuery Table """
@@ -175,7 +179,8 @@ class BQRWBResearcherGenderView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -191,7 +196,8 @@ class BQRWBResearcherRaceView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -207,7 +213,8 @@ class BQRWBResearcherSexAtBirthView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -223,7 +230,8 @@ class BQRWBResearcherDegreeView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -238,7 +246,8 @@ class BQAccessTierShortNameView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -255,7 +264,8 @@ class BQDSV2EthnicCategoryView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -272,7 +282,8 @@ class BQDSV2GenderIdentityView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -289,7 +300,8 @@ class BQDSV2SexualOrientationView(BQView):
     __pk_id__ = 'id'
     __table__ = BQRWBResearcher
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.user_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.user_source_id, t.modified_time, nt.*
           FROM (
             SELECT *,
                 ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified desc) AS rn
@@ -312,6 +324,10 @@ class BQRWBInstitutionalAffiliationsSchema(BQSchema):
                                           BQFieldModeEnum.NULLABLE)
     is_verified = BQField('is_verified', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     modified_time = BQField('modified_time', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
 
 class BQRWBInstitutionalAffiliations(BQTable):

--- a/rdr_service/model/bq_workbench_workspace.py
+++ b/rdr_service/model/bq_workbench_workspace.py
@@ -83,6 +83,10 @@ class BQRWBWorkspaceSchema(BQSchema):
     access_tier = BQField('access_tier', BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     access_tier_id = BQField('access_tier_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+
 
 class BQRWBWorkspace(BQTable):
     """ Research Workbench Workspace BigQuery Table """
@@ -119,7 +123,8 @@ class BQRWBWorkspaceRaceEthnicityView(BQView):
     __pk_id__ = 'workspace_source_id'
     __table__ = BQRWBWorkspace
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.workspace_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.workspace_source_id, t.modified_time, nt.*
           FROM (
             SELECT *, 
                    ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified) AS rn
@@ -135,7 +140,8 @@ class BQRWBWorkspaceAgeView(BQView):
     __pk_id__ = 'workspace_source_id'
     __table__ = BQRWBWorkspace
     __sql__ = """
-        SELECT t.id, t.created, t.modified, t.workspace_source_id, t.modified_time, nt.*
+        SELECT t.id, t.created, t.modified, t.orig_id, t.orig_created, t.orig_modified, 
+            t.workspace_source_id, t.modified_time, nt.*
           FROM (
             SELECT *, 
                    ROW_NUMBER() OVER (PARTITION BY id ORDER BY modified) AS rn
@@ -159,6 +165,10 @@ class BQRWBWorkspaceUsersSchema(BQSchema):
     status_id = BQField('status_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     researcher_id = BQField('researcher_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     is_creator = BQField('is_creator', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
 
 class BQRWBWorkspaceUsers(BQTable):
@@ -187,6 +197,10 @@ class BQRWBAuditSchema(BQSchema):
     audit_workspace_access_decision = BQField('audit_workspace_access_decision', BQFieldTypeEnum.INTEGER,
                                               BQFieldModeEnum.REQUIRED)
     audit_notes = BQField('audit_notes', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.REQUIRED)
+
+    orig_id = BQField('orig_id', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    orig_created = BQField('orig_created', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    orig_modified = BQField('orig_modified', BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
 
 class BQRWBAudit(BQTable):

--- a/rdr_service/resource/schemas/workbench_researcher.py
+++ b/rdr_service/resource/schemas/workbench_researcher.py
@@ -199,6 +199,10 @@ class WorkbenchResearcherSchema(Schema):
     dsv2_ethnicity_white_other = fields.Boolean()
     dsv2_survey_comments = fields.Boolean()
 
+    orig_id = fields.Int32()
+    orig_created = fields.DateTime()
+    orig_modified = fields.DateTime()
+
     class Meta:
         schema_id = SchemaID.workbench_researcher
         resource_uri = 'WorkbenchResearcher'
@@ -217,6 +221,10 @@ class WorkbenchInstitutionalAffiliationsSchema(Schema):
     non_academic_affiliation_id = fields.EnumInteger(enum=WorkbenchInstitutionNonAcademic, required=True)
     is_verified = fields.Boolean()
     modified_time = fields.DateTime()
+
+    orig_id = fields.Int32()
+    orig_created = fields.DateTime()
+    orig_modified = fields.DateTime()
 
     class Meta:
         schema_id = SchemaID.workbench_institutional_affiliation

--- a/rdr_service/resource/schemas/workbench_workspace.py
+++ b/rdr_service/resource/schemas/workbench_workspace.py
@@ -98,6 +98,10 @@ class WorkbenchWorkspaceSchema(Schema):
     access_tier = fields.EnumString(enum=WorkbenchWorkspaceAccessTier)
     access_tier_id = fields.EnumInteger(enum=WorkbenchWorkspaceAccessTier)
 
+    orig_id = fields.Int32()
+    orig_created = fields.DateTime()
+    orig_modified = fields.DateTime()
+
     class Meta:
         schema_id = SchemaID.workbench_workspace
         resource_uri = 'WorkbenchWorkspace'
@@ -118,6 +122,10 @@ class WorkbenchWorkspaceUsersSchema(Schema):
     status_id = fields.EnumInteger(enum=WorkbenchWorkspaceStatus, required=True)
 
     is_creator = fields.Boolean()
+
+    orig_id = fields.Int32()
+    orig_created = fields.DateTime()
+    orig_modified = fields.DateTime()
 
     class Meta:
         schema_id = SchemaID.workbench_workspace_users


### PR DESCRIPTION
## Resolves *[PDR-1222](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1222)*


## Description of changes/additions
The old BigQuery sync process replaces any table source field named 'id', 'created' and 'modified' with new values during the sync process.  The research workbench tables depend on the 'id' field values for foreign key relationships.  This PR adds new 'orig_*' fields for those three fields to keep the original values for them.

## Tests
- [x] unit tests


