### PR TITLE
[DA-2710] Disabling the data glossary 3 fields by default

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -148,6 +148,9 @@ CE_HEALTH_DATA_BUCKET_NAME = "ce_health_data_bucket_name"
 VA_WORKQUEUE_BUCKET_NAME = 'va_workqueue_bucket_name'
 VA_WORKQUEUE_SUBFOLDER = 'va_workqueue_subfolder'
 
+ENABLE_ENROLLMENT_STATUS_3 = 'enable_enrollment_status_3'
+ENABLE_HEALTH_SHARING_STATUS_3 = 'enable_health_sharing_status_3'
+
 # Buckets to listen for Pub/Sub notifications
 PUBSUB_NOTIFICATION_BUCKETS_PROD = [
     "prod-genomics-baylor",

--- a/rdr_service/config/config_dev.json
+++ b/rdr_service/config/config_dev.json
@@ -176,6 +176,8 @@
   "va_workqueue_subfolder": [
     "DailyParticipants"
   ],
-  "sensitive_ehr_release_date": "2100-01-01"
+  "sensitive_ehr_release_date": "2100-01-01",
+  "enable_enrollment_status_3": true,
+  "enable_health_sharing_status_3": true
 }
 

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1224,6 +1224,32 @@ class ParticipantSummaryDao(UpdatableDao):
             result["physicalMeasurementsFinalizedSite"] = "UNSET"
             result["physicalMeasurementsCollectType"] = str(PhysicalMeasurementsCollectType.SELF_REPORTED)
 
+        # Check to see if we should hide 3.0 and 3.1 fields
+        if not config.getSettingJson(config.ENABLE_ENROLLMENT_STATUS_3, default=False):
+            del result['enrollmentStatusV3_0']
+            del result['enrollmentStatusV3_1']
+            for field_name in [
+                'enrollmentStatusParticipantV3_0Time'
+                'enrollmentStatusParticipantPlusEhrV3_0Time'
+                'enrollmentStatusPmbEligibleV3_0Time'
+                'enrollmentStatusCoreMinusPmV3_0Time'
+                'enrollmentStatusCoreV3_0Time'
+                'enrollmentStatusParticipantV3_1Time'
+                'enrollmentStatusParticipantPlusEhrV3_1Time'
+                'enrollmentStatusParticipantPlusBasicsV3_1Time'
+                'enrollmentStatusCoreMinusPmV3_1Time'
+                'enrollmentStatusCoreV3_1Time'
+                'enrollmentStatusParticipantPlusBaselineV3_1Time'
+            ]:
+                if field_name in result:
+                    del result[field_name]
+
+        # Check to see if we should hide digital health sharing fields
+        if not config.getSettingJson(config.ENABLE_HEALTH_SHARING_STATUS_3, default=False):
+            del result['healthDataStreamSharingStatusV3_1']
+            if 'healthDataStreamSharingStatusV3_1Time' in result:
+                del result['healthDataStreamSharingStatusV3_1Time']
+
         # Strip None values.
         if strip_none_values is True:
             result = {k: v for k, v in list(result.items()) if v is not None}

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -3750,6 +3750,20 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual(sharing_summary.participantId, participant_id_list[1])
         self.assertEqual(later_shared_summary.participantId, participant_id_list[2])
 
+    def test_disabling_data_glossary_3_fields(self):
+        """Check that the 3.x enrollment statuses and digital health sharing fields are disabled by default"""
+        summary = self.data_generator.create_database_participant_summary()
+
+        # Override the default config, disabling the fields on the API
+        self.temporarily_override_config_setting(config.ENABLE_ENROLLMENT_STATUS_3, False)
+        self.temporarily_override_config_setting(config.ENABLE_HEALTH_SHARING_STATUS_3, False)
+
+        # Check that the new fields are hidden
+        api_response = self.send_get(f'Participant/P{summary.participantId}/Summary')
+        self.assertNotIn('enrollmentStatusV3_0', api_response)
+        self.assertNotIn('enrollmentStatusV3_1', api_response)
+        self.assertNotIn('healthDataStreamSharingStatusV3_1', api_response)
+
     def test_blank_demographics_data_mapped_to_skip(self):
         # Create a participant summary that doesn't use skip codes for the demographics questions that weren't answered.
         # Some early summaries show this, we should map to displaying skip to have a more consistent output.


### PR DESCRIPTION
## Resolves *[DA-2710](https://precisionmedicineinitiative.atlassian.net/browse/DA-2710)*
By default RDR is supposed to hide the new data glossary fields from the API output. This sets code to remove them unless a flag is set in the config to enable them.


## Tests
- [x] unit tests


