### PR TITLE
[DA-2566] Using new enrollment status calculation when updating from biobank samples pipeline

### DIFF
--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -25,6 +25,7 @@ from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.site_dao import SiteDao
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import CodeType
+from rdr_service.model.config_utils import from_client_biobank_id
 from rdr_service.model.consent_file import ConsentType
 from rdr_service.model.enrollment_status_history import EnrollmentStatusHistory
 from rdr_service.model.hpo import HPO
@@ -2252,7 +2253,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._store_biobank_sample(participant_1, "1SAL", time=TIME_4)
         self._store_biobank_sample(participant_1, "2ED10", time=TIME_5)
         # Update participant summaries based on these changes.
-        self.ps_dao.update_from_biobank_stored_samples()
+        self.ps_dao.update_from_biobank_stored_samples(biobank_ids=[from_client_biobank_id(participant_1['biobankId'])])
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual(TIME_6.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
@@ -2348,7 +2349,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._store_biobank_sample(participant_1, "1SAL", time=TIME_4)
         self._store_biobank_sample(participant_1, "2ED10", time=TIME_5)
         # Update participant summaries based on these changes.
-        self.ps_dao.update_from_biobank_stored_samples()
+        self.ps_dao.update_from_biobank_stored_samples(biobank_ids=[from_client_biobank_id(participant_1['biobankId'])])
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual(TIME_6.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
@@ -2439,7 +2440,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._store_biobank_sample(participant_1, "1SAL", time=TIME_4)
         self._store_biobank_sample(participant_1, "2ED10", time=TIME_5)
         # Update participant summaries based on these changes.
-        self.ps_dao.update_from_biobank_stored_samples()
+        self.ps_dao.update_from_biobank_stored_samples(biobank_ids=[from_client_biobank_id(participant_1['biobankId'])])
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual(TIME_6.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
@@ -2478,7 +2479,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual("COMPLETED", ps_1.get("clinicPhysicalMeasurementsStatus"))
 
-        self.ps_dao.update_from_biobank_stored_samples()
+        self.ps_dao.update_from_biobank_stored_samples(biobank_ids=[from_client_biobank_id(participant_1['biobankId'])])
 
         # cancel a physical measurement
         path = "Participant/%s/PhysicalMeasurements" % participant_id_1
@@ -2724,7 +2725,10 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._store_biobank_sample(participant_3, "1SAL")
         self._store_biobank_sample(participant_3, "2ED10")
         # Update participant summaries based on these changes.
-        self.ps_dao.update_from_biobank_stored_samples()
+        self.ps_dao.update_from_biobank_stored_samples(biobank_ids=[
+            from_client_biobank_id(participant_json['biobankId'])
+            for participant_json in [participant_1, participant_3]
+        ])
         # Update version for participant 3, which has changed.
         participant_3 = self.send_get("Participant/%s" % participant_id_3)
 
@@ -3135,7 +3139,10 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._store_biobank_sample(participant_3, "1SAL")
         self._store_biobank_sample(participant_3, "2ED10")
         # Update participant summaries based on these changes.
-        self.ps_dao.update_from_biobank_stored_samples()
+        self.ps_dao.update_from_biobank_stored_samples(biobank_ids=[
+            from_client_biobank_id(participant_json['biobankId'])
+            for participant_json in [participant_1, participant_3]
+        ])
 
         ps_2 = self.send_get("Participant/%s/Summary" % participant_id_2)
         self.assertEqual("SUBMITTED", ps_2["consentForDvElectronicHealthRecordsSharing"])

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -15,6 +15,7 @@ from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_summary_dao import ParticipantGenderAnswersDao, ParticipantRaceAnswersDao, \
     ParticipantSummaryDao
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
+from rdr_service.model.config_utils import from_client_biobank_id
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.questionnaire_dao import QuestionnaireDao
 from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseAnswerDao, QuestionnaireResponseDao
@@ -208,7 +209,7 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
         # clinicPhysicalMeasurementsFinalizedTime with other times to cover the bug scenario:
         # TypeError("can't compare offset-naive and offset-aware datetimes")
         ps_dao = ParticipantSummaryDao()
-        ps_dao.update_from_biobank_stored_samples()
+        ps_dao.update_from_biobank_stored_samples(biobank_ids=[from_client_biobank_id(participant_1['biobankId'])])
 
         summary = self.send_get("Participant/{0}/Summary".format(participant_id))
         self.assertEqual(summary["selfReportedPhysicalMeasurementsStatus"], 'UNSET')

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -27,6 +27,7 @@ from rdr_service.offline import biobank_samples_pipeline
 from rdr_service.offline.sql_exporter import SqlExporter
 from rdr_service.participant_enums import EnrollmentStatus, SampleStatus, get_sample_status_enum_value,\
     SampleCollectionMethod
+from rdr_service.services.system_utils import DateRange
 from tests import test_data
 from tests.helpers.unittest_base import BaseTestCase, PDRGeneratorTestMixin
 
@@ -141,8 +142,13 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
         ps = self.summary_dao.get(participant.participantId)
         self.assertEqual(EnrollmentStatus.FULL_PARTICIPANT, ps.enrollmentStatus)
 
+    @mock.patch('rdr_service.dao.participant_summary_dao.QuestionnaireResponseRepository')
     @mock.patch('rdr_service.offline.biobank_samples_pipeline.dispatch_participant_rebuild_tasks')
-    def test_end_to_end(self, mock_dispatch_rebuild):
+    def test_end_to_end(self, mock_dispatch_rebuild, response_repository):
+        response_repository.get_interest_in_sharing_ehr_ranges.return_value = [
+            DateRange(start=datetime(2016, 11, 29, 12, 16))
+        ]
+
         config.override_setting(BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN, 'cloud')
 
         self.clear_default_storage()
@@ -200,9 +206,9 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
         core_minus_pm_summary.consentForStudyEnrollment = 1
         core_minus_pm_summary.consentForElectronicHealthRecords = 1
         core_minus_pm_summary.enrollmentStatusMemberTime = '2016-11-29 12:16:00'
-        core_minus_pm_summary.questionnaireOnTheBasicsTime = '2016-11-29 12:16:00'
-        core_minus_pm_summary.questionnaireOnOverallHealthTime = '2016-11-29 12:16:00'
-        core_minus_pm_summary.questionnaireOnLifestyleTime = '2016-11-29 12:16:00'
+        core_minus_pm_summary.questionnaireOnTheBasicsAuthored = '2016-11-29 12:16:00'
+        core_minus_pm_summary.questionnaireOnOverallHealthAuthored = '2016-11-29 12:16:00'
+        core_minus_pm_summary.questionnaireOnLifestyleAuthored = '2016-11-29 12:16:00'
         participant_summary_dao.update(core_minus_pm_summary)
 
         core_summary = participant_summary_dao.get(core_participant_id)
@@ -211,9 +217,9 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
         core_summary.consentForStudyEnrollment = 1
         core_summary.consentForElectronicHealthRecords = 1
         core_summary.enrollmentStatusMemberTime = '2016-11-29 12:16:00'
-        core_summary.questionnaireOnTheBasicsTime = '2016-11-29 12:16:00'
-        core_summary.questionnaireOnOverallHealthTime = '2016-11-29 12:16:00'
-        core_summary.questionnaireOnLifestyleTime = '2016-11-29 12:16:00'
+        core_summary.questionnaireOnTheBasicsAuthored = '2016-11-29 12:16:00'
+        core_summary.questionnaireOnOverallHealthAuthored = '2016-11-29 12:16:00'
+        core_summary.questionnaireOnLifestyleAuthored = '2016-11-29 12:16:00'
         core_summary.clinicPhysicalMeasurementsStatus = 1
         core_summary.clinicPhysicalMeasurementsFinalizedTime = '2016-11-29 12:16:00'
         participant_summary_dao.update(core_summary)

--- a/tests/dao_tests/test_participant_dao.py
+++ b/tests/dao_tests/test_participant_dao.py
@@ -3,6 +3,7 @@ import mock
 from sqlalchemy.exc import OperationalError
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound, PreconditionFailed, ServiceUnavailable
 
+from rdr_service import participant_enums
 from rdr_service.clock import FakeClock
 from rdr_service.dao.base_dao import MAX_INSERT_ATTEMPTS
 from rdr_service.dao.hpo_dao import HPODao
@@ -184,6 +185,9 @@ class ParticipantDaoTest(BaseTestCase):
             self.dao.update(p)
 
         summary = self.participant_summary(p)
+        summary.enrollmentStatus = participant_enums.EnrollmentStatus.INTERESTED
+        summary.enrollmentStatusV3_0 = participant_enums.EnrollmentStatusV30.PARTICIPANT
+        summary.enrollmentStatusV3_1 = participant_enums.EnrollmentStatusV31.PARTICIPANT
         self.participant_summary_dao.insert(summary)
 
         # lastModified, hpoId, version is updated on p after being passed in

--- a/tests/dao_tests/test_participant_summary_dao.py
+++ b/tests/dao_tests/test_participant_summary_dao.py
@@ -79,6 +79,7 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         )
         response_dao_mock = response_dao_patch.start()
         self.mock_ehr_interest_ranges = response_dao_mock.get_interest_in_sharing_ehr_ranges
+        self.mock_ehr_interest_ranges.return_value = []
         self.addCleanup(response_dao_patch.stop)
 
     def assert_no_results(self, query):
@@ -117,6 +118,9 @@ class ParticipantSummaryDaoTest(BaseTestCase):
     def _insert(self, participant, first_name=None, last_name=None):
         self.participant_dao.insert(participant)
         summary = self.participant_summary(participant)
+        summary.enrollmentStatus = EnrollmentStatus.INTERESTED
+        summary.enrollmentStatusV3_0 = EnrollmentStatusV30.PARTICIPANT
+        summary.enrollmentStatusV3_1 = EnrollmentStatusV31.PARTICIPANT
         if first_name:
             summary.firstName = first_name
         if last_name:
@@ -727,7 +731,10 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         reset_summary()
 
         # Update and reload summary record
-        self.dao.update_from_biobank_stored_samples(participant_id=participant.participantId)
+        self.dao.update_from_biobank_stored_samples(
+            participant_id=participant.participantId,
+            biobank_ids=[participant.biobankId]
+        )
         summary = self.dao.get(participant.participantId)
 
         # Test that status has changed and lastModified is also different
@@ -770,7 +777,10 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         reset_summary()
 
         # Update and reload summary record
-        self.dao.update_from_biobank_stored_samples(participant_id=participant.participantId)
+        self.dao.update_from_biobank_stored_samples(
+            participant_id=participant.participantId,
+            biobank_ids=[participant.biobankId]
+        )
         summary = self.dao.get(participant.participantId)
 
         # Test that status has changed and lastModified is also different

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -21,9 +21,7 @@ from tempfile import mkdtemp
 
 import faker
 
-from rdr_service import api_util
-from rdr_service import config
-from rdr_service import main
+from rdr_service import api_util, config, main, participant_enums
 from rdr_service.clock import FakeClock
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.concepts import Concept
@@ -613,6 +611,10 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         summary.firstName = self.fake.first_name()
         summary.lastName = self.fake.last_name()
         summary.email = self.fake.email()
+        summary.enrollmentStatus = participant_enums.EnrollmentStatus.MEMBER
+        summary.enrollmentStatusV3_0 = participant_enums.EnrollmentStatusV30.PARTICIPANT_PLUS_EHR
+        summary.enrollmentStatusV3_1 = participant_enums.EnrollmentStatusV31.PARTICIPANT_PLUS_EHR
+
         return summary
 
     def create_participant(self, provider_link=None):


### PR DESCRIPTION
## Resolves *[DA-2566](https://precisionmedicineinitiative.atlassian.net/browse/DA-2566)*
This updates the biobank samples pipeline to use the new enrollment status calculation module (rather than raw sql).


## Tests
- [X] unit tests
Existing tests have been updated.


