### PR TITLE
Event authored insert on POST

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -238,6 +238,7 @@ class GenomicOutreachApi(BaseApi):
         gem_result_record = self.member_dao.get_gem_results_for_report_state(m)
         if gem_result_record:
             report_dict = self.report_state_dao.process_gem_result_to_report(gem_result_record)
+            report_dict['event_authored_time'] = m.genomicWorkflowStateModifiedTime
             report_obj = self.report_state_dao.get_model_obj_from_items(report_dict.items())
             self.report_state_dao.insert(report_obj)
 

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -576,6 +576,7 @@ class GenomicOutreachApiTest(GenomicApiTestBase):
         self.assertEqual(report_state_member.genomic_report_state, GenomicReportState.GEM_RPT_PENDING_DELETE)
         self.assertEqual(report_state_member.module, 'gem')
         self.assertEqual(report_state_member.genomic_set_member_id, member.id)
+        self.assertEqual(report_state_member.event_authored_time, member.genomicWorkflowStateModifiedTime)
 
     def test_genomic_test_participant_not_found(self):
         # P2001 doesn't exist in participant


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
PTSC are creating test participants for results retrival from Outreach, need to make sure the event_authored_time gets populated for queries

## Tests
- [x] unit tests


