### PR TITLE
[DA-2568] Refactoring enrollment status tests for 3.1

### DIFF
--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -69,7 +69,9 @@ WITHDRAWN_PARTICIPANT_FIELDS = [
     "consentForStudyEnrollmentAuthored",
     "consentForElectronicHealthRecords",
     "consentForElectronicHealthRecordsAuthored",
-    "enrollmentStatus"
+    "enrollmentStatus",
+    "enrollmentStatusV3_0",
+    "enrollmentStatusV3_1"
 ]
 
 # The period of time for which withdrawn participants will still be returned in results for


### PR DESCRIPTION
## Resolves *[DA-2568](https://precisionmedicineinitiative.atlassian.net/browse/DA-2568)*
This updates unit tests to use the 3.1 enrollment status value to help us be able to deprecate and potentially remove the old enrollment status field.

The tests also showed that the new enrollment status fields weren't being displayed for withdrawn participants (while the legacy enrollment status field is). This updates the code to also display the new enrollment status fields for withdrawn participants.

Note: Some redundant tests, or redundant lines within tests, were removed.


