### PR TITLE
lowering idle timeout significantly as recommended by Google to test …

### DIFF
--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -11,5 +11,5 @@ instance_class: B4
 # We need to specify basic scaling in order to use a backend instance class.
 basic_scaling:
   max_instances: 10
-  idle_timeout: 60m
+  idle_timeout: 1m
 


### PR DESCRIPTION
…cause of latency issue.

## Resolves *No Ticket*


## Description of changes/additions
Lowers idle timeout to 1 minute from 1 hour on recommendation from Google support specialist. This is to test the hypothesis that the idle timeout is causing throttling which is interfering with the jobs during the affected period.

```
I’ve heard back from the specialist. It looks like you have an idle timeout set 3600 seconds (1 hour). They suggest changing that because it might be causing throttling on your server due to having long running idle instances. I would significantly lower or remove that idle timeout and then see if the issue reoccurs.
```

## Tests
No tests


