### PR TITLE
[DA-2980] Curation ETL Fix for Questionnaire Responses After Cutoff Date

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -363,8 +363,7 @@ class GenomicJobController:
             except NoResultFound:
                 missing.append(member.id)
             else:
-                if raw_rec:
-                    update_recs.append((member, raw_rec))
+                update_recs.append((member, raw_rec))
 
         if update_recs:
             # Get unique file_paths

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -363,7 +363,8 @@ class GenomicJobController:
             except NoResultFound:
                 missing.append(member.id)
             else:
-                update_recs.append((member, raw_rec))
+                if raw_rec:
+                    update_recs.append((member, raw_rec))
 
         if update_recs:
             # Get unique file_paths

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -588,3 +588,65 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
                     ]
                 ]))
                 self.assertEqual(PMI_SKIP_CODE, answer.value_ppi_code)
+
+    def test_cutoff_date_questionnaire_response_used(self):
+        """The latest questionnaire response received before the cutoff date for a module should be used"""
+        # Note: this only applies to modules that shouldn't roll up answers (ConsentPII should be rolled up)
+
+        # Create a questionnaire response that would be used instead of the default for the test suite
+        self._setup_questionnaire_response(
+            self.participant,
+            self.questionnaire,
+            indexed_answers=[
+                (1, 'valueString', 'update'),
+                (3, 'valueString', 'intermediate answer')
+            ],
+            authored=datetime(2020, 5, 10),
+            created=datetime(2020, 5, 10)
+        )
+
+        self._setup_questionnaire_response(
+            self.participant,
+            self.questionnaire,
+            indexed_answers=[
+                (1, 'valueString', 'update2'),
+                (3, 'valueString', 'final answer')
+            ],
+            authored=datetime(2022, 5, 10),
+            created=datetime(2022, 5, 10)
+        )
+
+        # Check that we are only seeing the answers from the questionnaire response before cutoff date
+        self.run_cdm_data_generation(cutoff='2022-04-01')
+        for question_index, question in enumerate(self.questionnaire.questions):
+            expected_answer = None
+            if question_index == 1:
+                expected_answer = 'update'
+            elif question_index == 3:
+                expected_answer = 'intermediate answer'
+
+            src_clean_answer = self.session.query(SrcClean).filter(
+                SrcClean.question_code_id == question.codeId
+            ).one_or_none()
+            if expected_answer is None:
+                self.assertIsNone(src_clean_answer)
+            else:
+                self.assertEqual(expected_answer, src_clean_answer.value_string)
+        self.session.commit()
+
+        # Returns the newest answers without cutoff
+        self.run_cdm_data_generation()
+        for question_index, question in enumerate(self.questionnaire.questions):
+            expected_answer = None
+            if question_index == 1:
+                expected_answer = 'update2'
+            elif question_index == 3:
+                expected_answer = 'final answer'
+
+            src_clean_answer = self.session.query(SrcClean).filter(
+                SrcClean.question_code_id == question.codeId
+            ).one_or_none()
+            if expected_answer is None:
+                self.assertIsNone(src_clean_answer)
+            else:
+                self.assertEqual(expected_answer, src_clean_answer.value_string)


### PR DESCRIPTION
## Resolves *[DA-2980](https://precisionmedicineinitiative.atlassian.net/browse/DA-2980)*


## Description of changes/additions
Questionnaires with updates after the cutoff date were being dropped from the ETL. By excluding responses after the cutoff date the correct values are now populated.

## Tests
- [x] unit tests


