### PR TITLE
[DA-3006] Change IL ready flag job to tuesday.

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -212,7 +212,7 @@ cron:
 - description: Genomic Calculate Informing Loop Ready Status (Weekly)
   url: /offline/CalculateInformingLoopReadyStatusWeekly
   timezone: America/New_York
-  schedule: every monday 10:00
+  schedule: every tuesday 10:00
   target: offline
 - description: Genomic Calculate Informing Loop Ready Status (Daily)
   url: /offline/CalculateInformingLoopReadyStatusDaily


### PR DESCRIPTION
## Resolves *[DA-3006](https://precisionmedicineinitiative.atlassian.net/browse/DA-3006)*


## Description of changes/additions
This PR changes the weekly run of the `CalculateInformingLoopReadyStatusWeekly` job to Tuesday at 10 Eastern.

## Tests
- No tests


