### PR TITLE
[DA-2993] Sensitive EHR validation: using state of residence as backup

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1455,7 +1455,7 @@ class QuestionnaireResponseDao(BaseDao):
         return [result_row.participantId for result_row in query.all()]
 
     @classmethod
-    def get_latest_answer_for_state_receiving_care(cls, session: Session, participant_id) -> str:
+    def get_latest_answer_to_question(cls, session: Session, participant_id, question_code) -> str:
         answer_code = aliased(Code)
         question_code = aliased(Code)
         query = (
@@ -1467,10 +1467,9 @@ class QuestionnaireResponseDao(BaseDao):
                 question_code,
                 and_(
                     question_code.codeId == QuestionnaireQuestion.codeId,
-                    question_code.value == code_constants.RECEIVE_CARE_STATE
+                    question_code.value == question_code
                 )
-            )
-            .join(
+            ).join(
                 answer_code,
                 answer_code.codeId == QuestionnaireResponseAnswer.valueCodeId
             )
@@ -1480,6 +1479,22 @@ class QuestionnaireResponseDao(BaseDao):
         )
 
         return query.scalar()
+
+    @classmethod
+    def get_latest_answer_for_state_of_residence(cls, session: Session, participant_id) -> str:
+        return cls.get_latest_answer_to_question(
+            session=session,
+            participant_id=participant_id,
+            question_code=code_constants.STATE_QUESTION_CODE
+        )
+
+    @classmethod
+    def get_latest_answer_for_state_receiving_care(cls, session: Session, participant_id) -> str:
+        return cls.get_latest_answer_to_question(
+            session=session,
+            participant_id=participant_id,
+            question_code=code_constants.RECEIVE_CARE_STATE
+        )
 
     @classmethod
     def _code_in_list(cls, code_value: str, code_list: List[str]):

--- a/tests/service_tests/consent_tests/test_consent_validation.py
+++ b/tests/service_tests/consent_tests/test_consent_validation.py
@@ -3,6 +3,8 @@ import json
 import mock
 from typing import List, Type
 
+from rdr_service import config
+from rdr_service.code_constants import SENSITIVE_EHR_STATES
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType, ConsentOtherErrors
 from rdr_service.model.hpo import HPO
 from rdr_service.model.participant_summary import ParticipantSummary
@@ -20,11 +22,11 @@ class ConsentValidationTesting(BaseTestCase):
         self.another_hpo = HPO(hpoId=8)
 
         self._default_signature = 'Test'
-        default_consent_timestamp = datetime(2019, 8, 27, 17, 9)
-        self._default_signing_date = default_consent_timestamp.date()
+        self._default_consent_timestamp = datetime(2019, 8, 27, 17, 9)
+        self._default_signing_date = self._default_consent_timestamp.date()
 
         self.participant_summary = ParticipantSummary(
-            consentForStudyEnrollmentFirstYesAuthored=default_consent_timestamp
+            consentForStudyEnrollmentFirstYesAuthored=self._default_consent_timestamp
         )
         self.consent_factory_mock = mock.MagicMock(spec=files.ConsentFileAbstractFactory)
 
@@ -379,6 +381,58 @@ class ConsentValidationTesting(BaseTestCase):
                 }
             ],
             self.validator.get_primary_update_validation_results()
+        )
+
+    @mock.patch('rdr_service.services.consent.validation.QuestionnaireResponseDao')
+    def test_sensitive_state_of_residence(self, response_dao_mock):
+        """Check that state of residence is used to determine if a PDF should be the sensitive version"""
+        self.temporarily_override_config_setting(config.SENSITIVE_EHR_RELEASE_DATE, '1990-1-1')
+        response_dao_mock.get_latest_answer_for_state_receiving_care.return_value = None
+        response_dao_mock.get_latest_answer_for_state_of_residence.return_value = SENSITIVE_EHR_STATES[0]
+
+        self.participant_summary.consentForElectronicHealthRecordsAuthored = self._default_consent_timestamp
+        self.consent_factory_mock.get_ehr_consents.return_value = [
+            self._mock_consent(
+                consent_class=files.EhrConsentFile,
+                is_sensitive_form=False
+            )
+        ]
+        self.assertMatchesExpectedResults(
+            [
+                {
+                    'participant_id': self.participant_summary.participantId,
+                    'type': ConsentType.EHR,
+                    'other_errors': ConsentOtherErrors.SENSITIVE_EHR_EXPECTED,
+                    'sync_status': ConsentSyncStatus.NEEDS_CORRECTING
+                }
+            ],
+            self.validator.get_ehr_validation_results()
+        )
+
+    @mock.patch('rdr_service.services.consent.validation.QuestionnaireResponseDao')
+    def test_sensitive_state_of_care(self, response_dao_mock):
+        """Check that state of care is used over state of residence when it is available"""
+        self.temporarily_override_config_setting(config.SENSITIVE_EHR_RELEASE_DATE, '1990-1-1')
+        response_dao_mock.get_latest_answer_for_state_receiving_care.return_value = SENSITIVE_EHR_STATES[0]
+        response_dao_mock.get_latest_answer_for_state_of_residence.return_value = 'otherstate'
+
+        self.participant_summary.consentForElectronicHealthRecordsAuthored = self._default_consent_timestamp
+        self.consent_factory_mock.get_ehr_consents.return_value = [
+            self._mock_consent(
+                consent_class=files.EhrConsentFile,
+                is_sensitive_form=False
+            )
+        ]
+        self.assertMatchesExpectedResults(
+            [
+                {
+                    'participant_id': self.participant_summary.participantId,
+                    'type': ConsentType.EHR,
+                    'other_errors': ConsentOtherErrors.SENSITIVE_EHR_EXPECTED,
+                    'sync_status': ConsentSyncStatus.NEEDS_CORRECTING
+                }
+            ],
+            self.validator.get_ehr_validation_results()
         )
 
     def test_long_signature_gets_truncated(self):


### PR DESCRIPTION
## Resolves *[DA-2993](https://precisionmedicineinitiative.atlassian.net/browse/DA-2993)*
Some participants haven't yet responded to TheBasics, so we don't know what state they receive care in. But we've seen that Vibrent will occasionally still give them the sensitive EHR anyway. After investigation it's been established that we need to use the state of residence as a back up when we don't have the state of care.

## Description of changes/additions
If the state of care isn't found, state of residence is used instead.

## Tests
- [x] unit tests


