### PR TITLE
add distinct to IL ready query.

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1073,7 +1073,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
                 BiobankOrder.finalizedTime
             )
             if limit:
-                return records.limit(limit).all()
+                return records.distinct().limit(limit).all()
 
             return records.all()
 

--- a/tests/genomics_tests/test_genomic_job_controller.py
+++ b/tests/genomics_tests/test_genomic_job_controller.py
@@ -736,7 +736,13 @@ class GenomicJobControllerTest(BaseTestCase):
                 )
                 self.data_generator.create_database_biobank_order_identifier(
                     value=stored_sample.biobankOrderIdentifier,
-                    biobankOrderId=order.biobankOrderId
+                    biobankOrderId=order.biobankOrderId,
+                    system="1",
+                )
+                self.data_generator.create_database_biobank_order_identifier(
+                    value=stored_sample.biobankOrderIdentifier,
+                    biobankOrderId=order.biobankOrderId,
+                    system="2",
                 )
                 member = self.data_generator.create_database_genomic_set_member(
                     genomicSetId=gen_set.id,


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR removes duplicate records from the set of samples returned from the IL ready query. Multiple biobank_order_identifier records per biospecimen were causing duplicate sample_ids to be returned. The duplicate sample_ids were taking the place of unique IDs and therefore causing the job to update less genomic_set_member records than expected.

## Tests
- [x] unit tests


