### PR TITLE
Backfill script fix

### DIFF
--- a/rdr_service/tools/tool_libs/backfill_enrollment.py
+++ b/rdr_service/tools/tool_libs/backfill_enrollment.py
@@ -1,3 +1,5 @@
+import logging
+from datetime import datetime
 
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.participant_summary import ParticipantSummary
@@ -9,18 +11,37 @@ tool_desc = 'Backfill enrollement status fields for version 3 of data glossary'
 
 
 class BackfillEnrollment(ToolBase):
+    logger_name = None
+
     def run(self):
+        super(BackfillEnrollment, self).run()
+
         with self.get_session() as session:
             summary_dao = ParticipantSummaryDao()
-            summary_list = session.query(ParticipantSummary).all()
+            participant_id_list = session.query(
+                ParticipantSummary.participantId
+            ).order_by(ParticipantSummary.participantId).all()
+            count = 0
+            last_id = None
 
             chunk_size = 50
-            for summary_list_subset in list_chunks(lst=summary_list, chunk_size=chunk_size):
-                for summary in summary_list_subset:
+            for id_list_subset in list_chunks(lst=participant_id_list, chunk_size=chunk_size):
+                logging.info(f'{datetime.now()}: {count} of {len(participant_id_list)} (last id: {last_id})')
+                count += chunk_size
+
+                summary_list = session.query(
+                    ParticipantSummary
+                ).filter(
+                    ParticipantSummary.participantId.in_([id_list_subset])
+                ).with_for_update().all()
+
+                for summary in summary_list:
                     summary_dao.update_enrollment_status(
                         summary=summary,
                         session=session
                     )
+                    last_id = summary.participantId
+
                 session.commit()
 
 

--- a/rdr_service/tools/tool_libs/backfill_enrollment.py
+++ b/rdr_service/tools/tool_libs/backfill_enrollment.py
@@ -32,7 +32,7 @@ class BackfillEnrollment(ToolBase):
                 summary_list = session.query(
                     ParticipantSummary
                 ).filter(
-                    ParticipantSummary.participantId.in_([id_list_subset])
+                    ParticipantSummary.participantId.in_(id_list_subset)
                 ).with_for_update().all()
 
                 for summary in summary_list:


### PR DESCRIPTION
## Resolves *no ticket*
The original way that the backfill was set up allows for strange data bugs to crop up. If changes were made to a participant summary while the script was running, they could potentially be overwritten when the script gets to the modified summary.

## Description of changes/additions
This modifies the script to load the summaries being changed and lock them at the same time, preventing anything else from making modifications to them until after the change is complete.

## Tests
- [ ] unit tests


