### PR TITLE
moving safety check back down in ci process list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,6 @@ commands:
           name: Code static analysis checks
           command: ci/full_static_analysis.sh
       - run:
-          name: Safety Check
-          command: source venv/bin/activate && safety check
-      - run:
           name: Check Licenses
           command : |
             export PYTHONPATH=$PYTHONPATH:`pwd`
@@ -50,6 +47,9 @@ commands:
       - run:
           name: Upload Coverage Report
           command: ./ci/run_upload_coverage_report.sh
+      - run:
+          name: Safety Check
+          command: source venv/bin/activate && safety check
 
   deploy-app-steps:
     parameters:


### PR DESCRIPTION
## Resolves *no ticket*
We have less control over the results of the Safety check than we do our own unit tests. So we may occasionally need to temporarily ignore a package flagged by the Safety check (such as version 39 of cryptography). If that happens, it would still be beneficial to see the unit test results in CI.

## Description of changes/additions
This moves the Safety check step in CI back down to after the unit tests so that we can still get the unit test results even if the Safety check fails.


