### PR TITLE
[DA-3039] Add genome_type to SPoT rdr_ods.sample_data_element.

### DIFF
--- a/rdr_service/spot/data/data_element_registry.json
+++ b/rdr_service/spot/data/data_element_registry.json
@@ -174,7 +174,7 @@
   "normalization_rule": ["boolean_to_upper_string"]
 }, {
   "data_element_id": "c07d2c98e67148d8aad694c745a7261b",
-  "active_flag": "true",
+  "active_flag": "false",
   "target_table": "sample_data_element"
 }, {
   "data_element_id": "7c4c49b41d974fcf826e9b6183d912b8",

--- a/rdr_service/spot/data/export_schema_data_element_full.json
+++ b/rdr_service/spot/data/export_schema_data_element_full.json
@@ -97,12 +97,12 @@
   "schema_name": "genomic_research_wgs",
   "data_element_id": "c07d2c98e67148d8aad694c745a7261b",
   "display_name": "sex_at_birth",
-  "active_flag": "true"
+  "active_flag": "false"
 }, {
   "schema_name": "genomic_research_wgs",
   "data_element_id": "7c4c49b41d974fcf826e9b6183d912b8",
   "display_name": "genome_type",
-  "active_flag": "true"
+  "active_flag": "false"
 }, {
   "schema_name": "genomic_research_wgs",
   "data_element_id": "3f00fac0df834cbfbcf359ec36ce9628",
@@ -417,12 +417,12 @@
   "schema_name": "genomic_research_array",
   "data_element_id": "c07d2c98e67148d8aad694c745a7261b",
   "display_name": "sex_at_birth",
-  "active_flag": "true"
+  "active_flag": "false"
 }, {
   "schema_name": "genomic_research_array",
   "data_element_id": "7c4c49b41d974fcf826e9b6183d912b8",
   "display_name": "genome_type",
-  "active_flag": "true"
+  "active_flag": "false"
 }, {
   "schema_name": "genomic_research_array",
   "data_element_id": "3f00fac0df834cbfbcf359ec36ce9628",

--- a/rdr_service/spot/initialization.py
+++ b/rdr_service/spot/initialization.py
@@ -75,6 +75,7 @@ default_rdr_ods_tables = [
              'data_element_id', 'STRING', 'NULLABLE', 'data_element_id from rdr_ods.data_element', ()),
          bigquery.SchemaField('value_string', 'STRING', 'NULLABLE', 'value of of data element.', ()),
          bigquery.SchemaField('created_timestamp', 'TIMESTAMP', 'NULLABLE', 'timestamp of record insertion.', ()),
+         bigquery.SchemaField('genome_type', 'STRING', 'NULLABLE', 'genome_type from RDR for sample_id', ()),
      ]}
 ]
 data_file_path = os.path.join(os.path.dirname(__file__), "data")

--- a/rdr_service/spot/procedures/sp_export_pivot_array.txt
+++ b/rdr_service/spot/procedures/sp_export_pivot_array.txt
@@ -20,6 +20,7 @@ EXECUTE IMMEDIATE
       , sample_id
       , research_id
       , es.display_name
+      , sde.genome_type
       , LAST_VALUE(value_string)
       OVER (
         PARTITION BY sde.data_element_id, sample_id
@@ -35,6 +36,7 @@ EXECUTE IMMEDIATE
         , sde.sample_id
         , pde.research_id
         , es.display_name
+        , "AOU_ARRAY" as genome_type
         , LAST_VALUE(pde.value_string)
         OVER (
           PARTITION BY pde.data_element_id, pde.participant_id
@@ -52,6 +54,7 @@ EXECUTE IMMEDIATE
         , sde.sample_id
         , cde.research_id
         , es.display_name
+        , "AOU_ARRAY" as genome_type
         , LAST_VALUE(cde.value_string)
         OVER (
           PARTITION BY cde.data_element_id, cde.participant_id

--- a/rdr_service/spot/procedures/sp_export_pivot_wgs.txt
+++ b/rdr_service/spot/procedures/sp_export_pivot_wgs.txt
@@ -20,6 +20,7 @@ EXECUTE IMMEDIATE
       , sample_id
       , research_id
       , es.display_name
+      , sde.genome_type
       , LAST_VALUE(value_string)
       OVER (
         PARTITION BY sde.data_element_id, sample_id
@@ -35,6 +36,7 @@ EXECUTE IMMEDIATE
         , sde.sample_id
         , pde.research_id
         , es.display_name
+        , "AOU_WGS" as genome_type
         , LAST_VALUE(pde.value_string)
         OVER (
           PARTITION BY pde.data_element_id, pde.participant_id
@@ -52,6 +54,7 @@ EXECUTE IMMEDIATE
         , sde.sample_id
         , cde.research_id
         , es.display_name
+        , "AOU_WGS" as genome_type
         , LAST_VALUE(cde.value_string)
         OVER (
           PARTITION BY cde.data_element_id, cde.participant_id

--- a/rdr_service/tools/tool_libs/spot_utils.py
+++ b/rdr_service/tools/tool_libs/spot_utils.py
@@ -509,6 +509,7 @@ class SpotTool(ToolBase):
         rdr_attributes = [
             GenomicSetMember.participantId,
             GenomicSetMember.sampleId,
+            GenomicSetMember.genomeType,
             Participant.researchId,
             func.now().label('created_timestamp'),
         ]
@@ -663,6 +664,7 @@ class SpotTool(ToolBase):
                     'participant_id': old_row.participantId,
                     'research_id': old_row.researchId,
                     'sample_id': old_row.sampleId,
+                    'genome_type': old_row.genomeType.upper(),
                     'data_element_id': data_element.data_element_id,
                     'value_string': de_val,
                     'created_timestamp': old_row.created_timestamp.isoformat()


### PR DESCRIPTION
## Resolves *[DA-3039](https://precisionmedicineinitiative.atlassian.net/browse/DA-3039)*


## Description of changes/additions
This PR adds `genome_type` as a field on the sample_data_element table in BigQuery and populates it during the transfer from the genomics tables. Previously, this field was treated as a data element. This was causing discrepancies during the export of data mart snapshots. The export stored procedures were updated as well. 
Additionally, the data elements for the GC `sex_at_birth` and `genome_type` were marked inactive in the initialization data JSON files.

## Tests
- Manual Testing on Sandbox and Prod.


