### PR TITLE
[DA-3033] Updating which EHR receipt field is used to calculate enrollment status

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -690,7 +690,7 @@ class ParticipantSummaryDao(UpdatableDao):
                 basics_authored_time=summary.questionnaireOnTheBasicsAuthored,
                 overall_health_authored_time=summary.questionnaireOnOverallHealthAuthored,
                 lifestyle_authored_time=summary.questionnaireOnLifestyleAuthored,
-                earliest_ehr_file_received_time=summary.firstEhrReceiptTime,
+                earliest_ehr_file_received_time=summary.ehrReceiptTime,
                 earliest_physical_measurements_time=earliest_physical_measurements_time,
                 earliest_biobank_received_dna_time=earliest_biobank_received_dna_time,
                 ehr_consent_date_range_list=ehr_consent_ranges,


### PR DESCRIPTION
## Resolves *[DA-3033](https://precisionmedicineinitiative.atlassian.net/browse/DA-3033)*
The enrollment status calculation needs to identify whether a participant has previously had EHR files, but the wrong field was used the first time. I had used a field that gets filled in by the DAO for the API, but doesn't actually come from the database and was always `None` when running the backfill.

## Description of changes/additions
This updates to use the field that gets filled in by the ORM. The backfill will be run again to catch any participants that would have upgraded to Baseline.

## Tests
- [ ] unit tests


