### PR TITLE
[DA-2975] Add Count Data for U.S. Territories to Public Metrics API

### DIFF
--- a/rdr_service/census_regions.py
+++ b/rdr_service/census_regions.py
@@ -51,4 +51,12 @@ census_regions = {
     "HI": "WEST",
     "OR": "WEST",
     "WA": "WEST",
+    "AS": "TERRITORIES",
+    "FM": "TERRITORIES",
+    "GU": "TERRITORIES",
+    "MH": "TERRITORIES",
+    "MP": "TERRITORIES",
+    "PR": "TERRITORIES",
+    "PW": "TERRITORIES",
+    "VI": "TERRITORIES"
 }

--- a/rdr_service/dao/metrics_cache_dao.py
+++ b/rdr_service/dao/metrics_cache_dao.py
@@ -1960,7 +1960,8 @@ class MetricsRegionCacheDao(BaseDao):
                             'NORTHEAST': 0,
                             'MIDWEST': 0,
                             'SOUTH': 0,
-                            'WEST': 0
+                            'WEST': 0,
+                            'TERRITORIES': 0
                         }
                     }
                     new_item['metrics'][census_name] = int(record.total)
@@ -1987,7 +1988,8 @@ class MetricsRegionCacheDao(BaseDao):
                             'NORTHEAST': 0,
                             'MIDWEST': 0,
                             'SOUTH': 0,
-                            'WEST': 0
+                            'WEST': 0,
+                            'TERRITORIES': 0
                         }
                     }
                     new_item['metrics'][census_name] = int(record.total)

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -1905,9 +1905,20 @@ class PublicMetricsApiTest(BaseTestCase):
             mapped=True,
         )
 
+        code4 = Code(
+            codeId=4,
+            system="c",
+            value="PIIState_PR",
+            display="PIIState_PR",
+            topic="c",
+            codeType=CodeType.MODULE,
+            mapped=True,
+        )
+
         self.code_dao.insert(code1)
         self.code_dao.insert(code2)
         self.code_dao.insert(code3)
+        self.code_dao.insert(code4)
 
         p1 = Participant(participantId=1, biobankId=4)
         self._insert(
@@ -1993,6 +2004,20 @@ class PublicMetricsApiTest(BaseTestCase):
             state_id=1,
         )
 
+        p6 = Participant(participantId=7, biobankId=10)
+        self._insert(
+            p6,
+            "Angela",
+            "Alligator",
+            "PITT",
+            "PITT_BANNER_HEALTH",
+            time_int=self.time1,
+            time_study=self.time1,
+            time_mem=self.time2,
+            time_fp_stored=self.time3,
+            state_id=4,
+        )
+
         calculate_participant_metrics()
 
         qs1 = "&stratification=GEO_STATE" "&endDate=2017-12-31"
@@ -2062,15 +2087,24 @@ class PublicMetricsApiTest(BaseTestCase):
                     "KY": 0,
                     "OR": 0,
                     "SD": 0,
+                    "AS": 0,
+                    "FM": 0,
+                    "GU": 0,
+                    "MH": 0,
+                    "MP": 0,
+                    "PR": 1,
+                    "PW": 0,
+                    "VI": 0
                 },
             },
             results1,
         )
         self.assertIn(
-            {"date": "2018-01-01", "metrics": {"WEST": 0, "NORTHEAST": 0, "MIDWEST": 3, "SOUTH": 0}}, results2
+            {"date": "2018-01-01", "metrics": {"WEST": 0, "NORTHEAST": 0, "MIDWEST": 3, "SOUTH": 0, "TERRITORIES": 1}},
+            results2
         )
         self.assertIn({"date": "2018-01-02", "count": 1, "hpo": "UNSET"}, results3)
-        self.assertIn({"date": "2018-01-02", "count": 2, "hpo": "PITT"}, results3)
+        self.assertIn({"date": "2018-01-02", "count": 3, "hpo": "PITT"}, results3)
         self.assertIn({"date": "2018-01-02", "count": 2, "hpo": "AZ_TUCSON"}, results3)
 
     def test_public_metrics_get_lifecycle_api(self):


### PR DESCRIPTION
## Resolves *[DA-2975](https://precisionmedicineinitiative.atlassian.net/browse/DA-2975)*


## Description of changes/additions
Updates Public Metrics API to include counts for U.S. territories 


## Tests
- [x] unit tests


