### PR TITLE
Edit key name for metric paths

### DIFF
--- a/rdr_service/gcloud_functions/genomic_ingest_metrics_function/main.py
+++ b/rdr_service/gcloud_functions/genomic_ingest_metrics_function/main.py
@@ -36,8 +36,8 @@ class GenomicIngestMetricsFunction(FunctionPubSubHandler):
         self.task_root = '/resource/task/'
 
         self.task_mappings = {
-            "user_metrics": "IngestUserEventMetricsApi",
-            "appointment_metrics": "IngestAppointmentMetricsApi"
+            "user_events": "IngestUserEventMetricsApi",
+            "appointment_events": "IngestAppointmentMetricsApi"
         }
 
     def run(self):
@@ -116,6 +116,7 @@ def genomic_ingest_metrics_function(_event, _context):
     with GCPCloudFunctionContext(function_name, None) as gcp_env:
         func = GenomicIngestMetricsFunction(gcp_env, _event, _context)
         func.run()
+
 
 """ --- Main Program Call --- """
 if __name__ == '__main__':


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
An earlier PR set the key name for the mappings as `_metrics` but it needs to be `_events`

## Tests
- [] unit tests
** Manual testing has been performed on lower envs
** all unit tests should still pass

