### PR TITLE
[DA-3040] Disable PTSC Health Data Transfer slack alerts

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -198,7 +198,7 @@ class PtscHealthDataTransferValidTaskApi(Resource):
         logging.info(f'Ptsc Health Data Transfer Result: {data.get("attributes").get("eventType")}')
         # possible event types: TRANSFER_OPERATION_SUCCESS, TRANSFER_OPERATION_FAILED, TRANSFER_OPERATION_ABORTED
         event_type = data.get("attributes").get("eventType")
-        if event_type in ['TRANSFER_OPERATION_FAILED', 'TRANSFER_OPERATION_ABORTED']:
+        if event_type == 'TRANSFER_OPERATION_ABORTED':
             slack_config = config.getSettingJson(RDR_SLACK_WEBHOOKS, {})
             webhook_url = slack_config.get('rdr_ptsc_health_data_transfer_alerts')
             slack_alert_helper = SlackMessageHandler(webhook_url=webhook_url)


### PR DESCRIPTION
## Resolves *[DA-3040](https://precisionmedicineinitiative.atlassian.net/browse/DA-3040)*


## Description of changes/additions
The PTSC Health Data Transfer job is triggering an alert for TRANSFER_OPERATION_FAILED on every run. This update changes the alert condition so it will only alert on TRANSFER_OPERATION_ABORTED.

## Tests
- [] unit tests


