### PR TITLE
PDR generator fixes for RWB and for in-progress EHR data

### DIFF
--- a/rdr_service/dao/bq_workbench_dao.py
+++ b/rdr_service/dao/bq_workbench_dao.py
@@ -140,6 +140,8 @@ class BQRWBWorkspaceUsersGenerator(BigQueryGenerator):
             data['orig_id'] = row.id
             data['orig_created'] = row.created
             data['orig_modified'] = row.modified
+            data['researcher_id'] = row.researcher_Id
+            del data['researcher_Id']
 
             if row.role:
                 data['role'] = str(WorkbenchWorkspaceUserRole(row.role))

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -721,6 +721,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     continue
                 consent_added = False
                 module_name = self._lookup_code_value(row.codeId, ro_session)
+
+                # DA-3076 Workaround:  Exclude IN_PROGRESS (classification type PARTIAL) EHR responses sent in error
+                # to RDR, until RDR cleans these by flagging as invalid/DUPLICATE
+                if (module_name == 'EHRConsentPII'
+                        and row.classificationType == QuestionnaireResponseClassificationType.PARTIAL):
+                    continue
                 # Start with a default submittal status.  May be updated if this is a consent module with a specific
                 # consent question/answer that determines module submittal status
                 module_status = BQModuleStatusEnum.SUBMITTED


### PR DESCRIPTION
## Resolves *No ticket*


## Description of changes/additions
Resolving two issues with PDR generators found during PDR RWB work and after early Goal 1 V3.0 QC:
1. RDR `workbench_workspace_user` table has a column with a capital letter (`researcher_Id`) that was not being automatically mapped to the corresponding PDR column name `researcher_id`.  This resulted in all null values for the PDR column.

2.  PDR generators generally include partial/IN_PROGRESS questionnaire responses (e.g., for COPE), but the recent issue with the faulty in-progress EHR payloads being sent to RDR had unintended side effects for the  PDR enrollment status calculations.  These partial EHR responses will be ignored in PDR for now (will eventually be automatically excluded by the SQLAlchemy query when they are marked as invalid/DUPLICATE by RDR).

## Tests
- [x] unit tests


