### PR TITLE
[DA-3016] Fix timeouts in AW2/Metrics ingestion

### DIFF
--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -712,8 +712,8 @@ class GenomicGCMetricsUpsertApi(BaseGenomicTaskApi):
             return {"success": False}
 
         self.metrics_dao.upsert_gc_validation_metrics_from_dict(
-            payload_dict,
-            metric_id
+            data_to_upsert=payload_dict,
+            existing_id=metric_id
         )
 
         logging.info('Complete.')

--- a/rdr_service/api/genomic_cloud_tasks_api.py
+++ b/rdr_service/api/genomic_cloud_tasks_api.py
@@ -13,7 +13,8 @@ from rdr_service.dao.bq_genomics_dao import bq_genomic_set_batch_update, bq_geno
     bq_genomic_job_run_batch_update, bq_genomic_file_processed_batch_update, \
     bq_genomic_gc_validation_metrics_batch_update, bq_genomic_manifest_file_batch_update, \
     bq_genomic_manifest_feedback_batch_update
-from rdr_service.dao.genomics_dao import GenomicManifestFileDao, GenomicCloudRequestsDao, GenomicSetMemberDao
+from rdr_service.dao.genomics_dao import GenomicManifestFileDao, GenomicCloudRequestsDao, GenomicSetMemberDao, \
+    GenomicGCValidationMetricsDao
 from rdr_service.genomic.genomic_job_components import GenomicFileIngester
 from rdr_service.genomic.genomic_job_controller import GenomicJobController
 from rdr_service.genomic_enums import GenomicJob, GenomicManifestTypes
@@ -34,6 +35,7 @@ class BaseGenomicTaskApi(Resource):
         self.data = None
         self.cloud_req_dao = GenomicCloudRequestsDao()
         self.member_dao = GenomicSetMemberDao()
+        self.metrics_dao = GenomicGCValidationMetricsDao()
         self.file_paths = None
         self.disallowed_jobs = []
 
@@ -695,3 +697,24 @@ class GenomicSetMemberUpdateApi(BaseGenomicTaskApi):
         logging.info('Complete.')
         return {"success": True}
 
+
+class GenomicGCMetricsUpsertApi(BaseGenomicTaskApi):
+    """
+    Cloud task endpoint: Upserts Genomic GC validation metric records
+    """
+    def post(self):
+        super().post()
+        metric_id = self.data.get('metric_id')
+        payload_dict = self.data.get('payload_dict')
+
+        if not metric_id or not payload_dict:
+            logging.warning('Combination of metric_id/payload_dict is required.')
+            return {"success": False}
+
+        self.metrics_dao.upsert_gc_validation_metrics_from_dict(
+            payload_dict,
+            metric_id
+        )
+
+        logging.info('Complete.')
+        return {"success": True}

--- a/rdr_service/cloud_utils/gcp_cloud_tasks.py
+++ b/rdr_service/cloud_utils/gcp_cloud_tasks.py
@@ -18,8 +18,8 @@ class GCPCloudTask(object):
     # Create a client.
     _client = None
 
-    def execute(self, endpoint: str, payload: (dict, list)=None, in_seconds: int = 0, project_id: str = GAE_PROJECT,
-               location: str = 'us-central1', queue: str = 'default', quiet=False):
+    def execute(self, endpoint: str, payload: (dict, list) = None, in_seconds: int = 0, project_id: str = GAE_PROJECT,
+                location: str = 'us-central1', queue: str = 'default', quiet=False):
         """
         Make GCP Cloud Task API request to run task later.
         :param endpoint: Flask API endpoint to call.

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -82,7 +82,7 @@ class GenomicDaoMixin:
 
     exclude_states = [GenomicWorkflowState.IGNORE]
 
-    def get_last_updated_records(self, from_date, _ids=True):
+    def get_last_updated_records(self, from_date, _ids=True) -> List:
         from_date = from_date.replace(microsecond=0)
         if not hasattr(self.model_type, 'modified'):
             return []
@@ -98,7 +98,7 @@ class GenomicDaoMixin:
             )
             return records.all()
 
-    def get_from_filepath(self, filepath):
+    def get_from_filepath(self, filepath) -> List:
         if not hasattr(self.model_type, 'file_path'):
             return []
 
@@ -110,11 +110,11 @@ class GenomicDaoMixin:
                 self.model_type.ignore_flag == 0,
             ).all()
 
-    def insert_bulk(self, batch):
+    def insert_bulk(self, batch: List[Dict]) -> None:
         with self.session() as session:
             session.bulk_insert_mappings(self.model_type, batch)
 
-    def bulk_update(self, model_objects: List[Dict]):
+    def bulk_update(self, model_objects: List[Dict]) -> None:
         with self.session() as session:
             session.bulk_update_mappings(self.model_type, model_objects)
 
@@ -1285,10 +1285,6 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
                     GenomicSetMember.sampleId.in_(sample_list)
                 )
             return members.all()
-
-    def bulk_update_members(self, members: List[Dict]):
-        with self.session() as session:
-            session.bulk_update_mappings(GenomicSetMember, members)
 
 
 class GenomicJobRunDao(UpdatableDao, GenomicDaoMixin):

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1238,8 +1238,11 @@ class GenomicFileIngester:
             if manifest_file is not None and existing_metrics_obj is None:
                 self.feedback_dao.increment_feedback_count(manifest_file.genomicManifestFileId)
 
+            self.update_member_for_aw2(member)
             # set lists of members to update workflow state
-            member_dict = {'id': member.id}
+            member_dict = {
+                'id': member.id
+            }
             if row_copy['genometype'] == GENOME_TYPE_ARRAY:
                 member_dict['genomicWorkflowState'] = int(GenomicWorkflowState.GEM_READY)
                 member_dict['genomicWorkflowStateStr'] = str(GenomicWorkflowState.GEM_READY)

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1181,8 +1181,8 @@ class GenomicFileIngester:
         :param rows:
         :return result code
         """
+
         members_to_update = []
-        # iterate over each row from CSV and insert into gc metrics table
         for row in rows:
             # change all key names to lower
             row_copy = self._clean_row_keys(row)
@@ -1194,52 +1194,7 @@ class GenomicFileIngester:
                 int(row_copy['sampleid']),
             )
 
-            if member:
-                row_copy = self.prep_aw2_row_attributes(row_copy, member)
-
-                if row_copy == GenomicSubProcessResult.ERROR:
-                    continue
-
-                # check whether metrics object exists for that member
-                existing_metrics_obj = self.metrics_dao.get_metrics_by_member_id(member.id)
-
-                if existing_metrics_obj is not None:
-
-                    if self.controller.skip_updates:
-                        # when running tool, updates can be skipped
-                        continue
-
-                    else:
-                        metric_id = existing_metrics_obj.id
-                else:
-                    metric_id = None
-                    if member.genomeType in [GENOME_TYPE_ARRAY, GENOME_TYPE_WGS]:
-
-                        if row_copy['contamination_category'] in [GenomicContaminationCategory.EXTRACT_WGS,
-                                                                  GenomicContaminationCategory.EXTRACT_BOTH]:
-                            # Insert a new member
-                            self.insert_member_for_replating(member, row_copy['contamination_category'])
-                self.metrics_dao.upsert_gc_validation_metrics_from_dict(row_copy, metric_id)
-                self.update_member_for_aw2(member)
-                # set lists of members to update workflow state
-                member_dict = {'id': member.id}
-                if row_copy['genometype'] == GENOME_TYPE_ARRAY:
-                    member_dict['genomicWorkflowState'] = int(GenomicWorkflowState.GEM_READY)
-                    member_dict['genomicWorkflowStateStr'] = str(GenomicWorkflowState.GEM_READY)
-                    member_dict['genomicWorkflowStateModifiedTime'] = clock.CLOCK.now()
-                    members_to_update.append(member_dict)
-                elif row_copy['genometype'] == GENOME_TYPE_WGS:
-                    member_dict['genomicWorkflowState'] = int(GenomicWorkflowState.CVL_READY)
-                    member_dict['genomicWorkflowStateStr'] = str(GenomicWorkflowState.CVL_READY)
-                    member_dict['genomicWorkflowStateModifiedTime'] = clock.CLOCK.now()
-                    members_to_update.append(member_dict)
-
-                # For feedback manifest loop
-                # Get the genomic_manifest_file
-                manifest_file = self.file_processed_dao.get(member.aw1FileProcessedId)
-                if manifest_file is not None and existing_metrics_obj is None:
-                    self.feedback_dao.increment_feedback_count(manifest_file.genomicManifestFileId)
-            else:
+            if not member:
                 bid = row_copy['biobankid']
                 if bid[0] in [get_biobank_id_prefix(), 'T']:
                     bid = bid[1:]
@@ -1254,8 +1209,56 @@ class GenomicFileIngester:
                                                 biobank_id=bid,
                                                 sample_id=row_copy['sampleid'],
                                                 )
+                continue
+
+            row_copy = self.prep_aw2_row_attributes(row_copy, member)
+            if row_copy == GenomicSubProcessResult.ERROR:
+                continue
+
+            # check whether metrics object exists for that member
+            existing_metrics_obj = self.metrics_dao.get_metrics_by_member_id(member.id)
+            metric_id = None
+
+            if existing_metrics_obj:
+                if self.controller.skip_updates:
+                    # when running tool, updates can be skipped
+                    continue
+                else:
+                    metric_id = existing_metrics_obj.id
+            else:
+                if member.genomeType in [GENOME_TYPE_ARRAY, GENOME_TYPE_WGS]:
+                    if row_copy['contamination_category'] in [GenomicContaminationCategory.EXTRACT_WGS,
+                                                              GenomicContaminationCategory.EXTRACT_BOTH]:
+                        # Insert a new member
+                        self.insert_member_for_replating(member, row_copy['contamination_category'])
+
+            # For feedback manifest loop
+            # Get the genomic_manifest_file
+            manifest_file = self.file_processed_dao.get(member.aw1FileProcessedId)
+            if manifest_file is not None and existing_metrics_obj is None:
+                self.feedback_dao.increment_feedback_count(manifest_file.genomicManifestFileId)
+
+            # set lists of members to update workflow state
+            member_dict = {'id': member.id}
+            if row_copy['genometype'] == GENOME_TYPE_ARRAY:
+                member_dict['genomicWorkflowState'] = int(GenomicWorkflowState.GEM_READY)
+                member_dict['genomicWorkflowStateStr'] = str(GenomicWorkflowState.GEM_READY)
+                member_dict['genomicWorkflowStateModifiedTime'] = clock.CLOCK.now()
+            elif row_copy['genometype'] == GENOME_TYPE_WGS:
+                member_dict['genomicWorkflowState'] = int(GenomicWorkflowState.CVL_READY)
+                member_dict['genomicWorkflowStateStr'] = str(GenomicWorkflowState.CVL_READY)
+                member_dict['genomicWorkflowStateModifiedTime'] = clock.CLOCK.now()
+            members_to_update.append(member_dict)
+
+            # upsert metrics record via cloud task
+            self.controller.execute_cloud_task({
+                'metric_id': metric_id,
+                'payload_dict': row_copy,
+            }, 'genomic_gc_metrics_upsert')
+
         if members_to_update:
-            self.member_dao.bulk_update_members(members_to_update)
+            self.member_dao.bulk_update(members_to_update)
+
         return GenomicSubProcessResult.SUCCESS
 
     def copy_member_for_replating(

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1804,7 +1804,7 @@ class GenomicJobController:
                 return
 
             logging.info(f'Updating {len(updated_members)} genomic member(s) blocklists')
-            self.member_dao.bulk_update_members(updated_members)
+            self.member_dao.bulk_update(updated_members)
 
             self.job_result = GenomicSubProcessResult.SUCCESS
 
@@ -1943,13 +1943,11 @@ class GenomicJobController:
 
     @staticmethod
     def execute_cloud_task(payload, endpoint):
-        if GAE_PROJECT != 'localhost':
-            _task = GCPCloudTask()
-            _task.execute(
-                endpoint,
-                payload=payload,
-                queue='genomics'
-            )
+        if GAE_PROJECT == 'localhost':
+            return
+
+        cloud_task = GCPCloudTask()
+        cloud_task.execute(endpoint=endpoint, payload=payload, queue='genomics')
 
     def _end_run(self):
         """Updates the genomic_job_run table with end result"""

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -159,6 +159,11 @@ def _build_resource_app():
                       TASK_PREFIX + "GenomicSetMemberUpdateApi",
                       endpoint="genomic_set_member_update_task", methods=["POST"])
 
+    # Upsert GC validation metrics
+    _api.add_resource(genomic_cloud_tasks_api.GenomicGCMetricsUpsertApi,
+                      TASK_PREFIX + "GenomicGCMetricsUpsertApi",
+                      endpoint="genomic_gc_metrics_upsert", methods=["POST"])
+
     #
     # End Genomic Cloud Task API endpoints
     #

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -3378,3 +3378,38 @@ class GenomicCloudTasksApiTest(BaseTestCase):
         self.assertEqual(bq_batch_mock.call_count, 1)
         self.assertEqual(batch_mock.call_count, 1)
 
+    @mock.patch('rdr_service.dao.genomics_dao.GenomicGCValidationMetricsDao.upsert_gc_validation_metrics_from_dict')
+    def test_call_gc_metrics_api(self, ingest_mock):
+
+        from rdr_service.resource import main as resource_main
+
+        data = {}
+
+        gc_metrics = self.send_post(
+            local_path='GenomicGCMetricsUpsertApi',
+            request_data=data,
+            prefix="/resource/task/",
+            test_client=resource_main.app.test_client(),
+        )
+
+        self.assertIsNotNone(gc_metrics)
+        self.assertEqual(gc_metrics['success'], False)
+        self.assertEqual(ingest_mock.call_count, 0)
+
+        data = {
+            'metric_id': 1,
+            'payload_dict': {
+                'test_key': 1
+            }
+        }
+
+        gc_metrics = self.send_post(
+            local_path='GenomicGCMetricsUpsertApi',
+            request_data=data,
+            prefix="/resource/task/",
+            test_client=resource_main.app.test_client(),
+        )
+
+        self.assertIsNotNone(gc_metrics)
+        self.assertEqual(gc_metrics['success'], True)
+        self.assertEqual(ingest_mock.call_count, 1)


### PR DESCRIPTION
## Resolves *[ticket DA-3016]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3016

## Description of changes/additions
Moved the metrics "upsertion" to a cloud to alleviate bottlenecks in AW2/Metrics ingestion

## Tests
- [x] unit tests


