### PR TITLE
[DA-2991] Adding "updatedSince" parameter to Summary API

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -560,6 +560,8 @@ class ParticipantSummaryDao(UpdatableDao):
             if value not in ORIGINATING_SOURCES:
                 raise BadRequest(f"No origin source found for {value}")
             return super(ParticipantSummaryDao, self).make_query_filter(field_name, value)
+        if field_name == 'updatedSince':
+            return self._make_updated_since_filter(value)
 
         return super(ParticipantSummaryDao, self).make_query_filter(field_name, value)
 
@@ -594,6 +596,9 @@ class ParticipantSummaryDao(UpdatableDao):
             filter_obj = FieldJsonContainsFilter(field_name, Operator.EQUALS, filter_value)
 
         return filter_obj
+
+    def _make_updated_since_filter(self, updated_since_value):
+        return FieldFilter('lastModified', Operator.GREATER_THAN_OR_EQUALS, updated_since_value)
 
     def update_from_biobank_stored_samples(self, participant_id=None, biobank_ids=None):
         """Rewrites sample-related summary data. Call this after updating BiobankStoredSamples.


### PR DESCRIPTION
## Resolves *[DA-2991](https://precisionmedicineinitiative.atlassian.net/browse/DA-2991)*
Sorting by `lastModified` isn't a great way to get the latest changes, and sorting by a mutable field poses its own problems anyway.

## Description of changes/additions
This adds a feature to the ParticipantSummary API for getting data for any participants that has been updated since a specific date.

## Tests
- [x] unit tests


