### PR TITLE
[DA-3033] Checking for received DNA sample status during enrollment calculation

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -669,13 +669,15 @@ class ParticipantSummaryDao(UpdatableDao):
             summary.clinicPhysicalMeasurementsFinalizedTime,
             summary.selfReportedPhysicalMeasurementsAuthored
         ])
-        earliest_biobank_received_dna_time = min_or_none([
-            summary.sampleStatus1ED10Time,
-            summary.sampleStatus2ED10Time,
-            summary.sampleStatus1ED04Time,
-            summary.sampleStatus1SALTime,
-            summary.sampleStatus1SAL2Time
-        ])
+        earliest_biobank_received_dna_time = None
+        if summary.samplesToIsolateDNA == SampleStatus.RECEIVED:
+            earliest_biobank_received_dna_time = min_or_none([
+                summary.sampleStatus1ED10Time,
+                summary.sampleStatus2ED10Time,
+                summary.sampleStatus1ED04Time,
+                summary.sampleStatus1SALTime,
+                summary.sampleStatus1SAL2Time
+            ])
 
         ehr_consent_ranges = QuestionnaireResponseRepository.get_interest_in_sharing_ehr_ranges(
             participant_id=summary.participantId,


### PR DESCRIPTION
## Partially Resolves *[DA-3033](https://precisionmedicineinitiative.atlassian.net/browse/DA-3033)*
When writing the enrollment status calculation I had assumed that timestamps on the participant summary for DNA samples meant that those samples had been successfully received, but I was wrong.

## Description of changes/additions
This updates the new enrollment calculation code to better match the original logic. The field for `samplesToIsolateDNA` on participant summary gets set when there is a successfully received sample and that was part of the original calculation code. This PR updates the new status calculation logic to check for the value of the `samplesToIsolateDNA` field.

## Tests
- [ ] unit tests


