### PR TITLE
[DA-2937] Updating ExamOne check to match value being sent

### DIFF
--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -250,7 +250,7 @@ class MailKitOrderDao(UpdatableDao):
             order.zipCode = fhir_address.postalCode
 
             order.orderType = fhir_resource.extension.get(url=DV_ORDER_URL).valueString
-            order.is_exam_one_order = order.orderType == 'Salivary Order of ExamOne Order'
+            order.is_exam_one_order = order.orderType == 'Exam One Order'
 
             if id_ is None:
                 order.version = 1

--- a/tests/api_tests/test_mail_kit_order_api.py
+++ b/tests/api_tests/test_mail_kit_order_api.py
@@ -460,7 +460,7 @@ class MailKitOrderApiTestPostSupplyDelivery(MailKitOrderApiTestBase):
 
         # Send a request for an ExamOne order
         supply_request_json = self.get_payload("dv_order_api_post_supply_request.json")
-        supply_request_json['extension'][1]['valueString'] = 'Salivary Order of ExamOne Order'
+        supply_request_json['extension'][1]['valueString'] = 'Exam One Order'
         self.send_post(
             "SupplyRequest",
             request_data=supply_request_json,


### PR DESCRIPTION
## Resolves *[DA-2937](https://precisionmedicineinitiative.atlassian.net/browse/DA-2937)*
Vibrent is sending a different value than originally specified for ExamOne orders. This updates the code to match what Vibrent is actually sending.


## Tests
- [x] unit tests


