### PR TITLE
[DA-2897] Remove Incorrect VA Reconsents Field Name

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1057,11 +1057,6 @@ class ParticipantSummaryDao(UpdatableDao):
             if has_consent_path:
                 result[value_path_key] = has_consent_path[0].file_path
 
-        # DA-2895: Copy reconsentForStudyEnrollmentFilePath value to incorrect field name.
-        # This can be removed after HealthPro updates.
-        if 'reconsentForStudyEnrollmentFilePath' in result:
-            result['reconsentForStudyEnrollementFilePath'] = result['reconsentForStudyEnrollmentFilePath']
-
         return result
 
     def get_participant_incentives(self, result):

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -720,10 +720,6 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
         self.assertEqual(first_count, len(consents_map.keys()))
 
-        # DA-2895: This assertion should be removed once the misspelled field name is no longer needed.
-        self.assertEqual(first_summary["reconsentForStudyEnrollmentFilePath"],
-                         first_summary["reconsentForStudyEnrollementFilePath"])
-
         self.overwrite_test_user_roles([PTC])
 
         first_summary = self.send_get(f"Participant/P{first_pid}/Summary")


### PR DESCRIPTION
## Resolves *[DA-2897](https://precisionmedicineinitiative.atlassian.net/browse/DA-2897)*


## Description of changes/additions
Removes incorrectly spelled field name, reconsentForStudyEnrollementFilePath, from ParticipantSummary

## Tests
Passes current unit tests.


