### PR TITLE
[DA-2869] Fixing error in detecting reconsent module code

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1498,7 +1498,7 @@ class QuestionnaireResponseDao(BaseDao):
 
     @classmethod
     def _code_in_list(cls, code_value: str, code_list: List[str]):
-        return code_value.lower in [list_value.lower for list_value in code_list]
+        return code_value.lower in [list_value.lower() for list_value in code_list]
 
 
 def _validate_consent_pdfs(resource):


### PR DESCRIPTION
## Resolves *[DA-2869](https://precisionmedicineinitiative.atlassian.net/browse/DA-2869)*
Reconsents weren't automatically detected as needing validation. This updates the code to fix what caused them to be missed.

## Tests
- [ ] unit tests


