### PR TITLE
using first primary consent date rather than possible reconsent

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -690,7 +690,7 @@ class ParticipantSummaryDao(UpdatableDao):
         enrollment_info = EnrollmentCalculation.get_enrollment_info(
             EnrollmentDependencies(
                 consent_cohort=summary.consentCohort,
-                primary_consent_authored_time=summary.consentForStudyEnrollmentAuthored,
+                primary_consent_authored_time=summary.consentForStudyEnrollmentFirstYesAuthored,
                 gror_authored_time=summary.consentForGenomicsRORAuthored,
                 basics_authored_time=summary.questionnaireOnTheBasicsAuthored,
                 overall_health_authored_time=summary.questionnaireOnOverallHealthAuthored,


### PR DESCRIPTION
## Partially Resolves *[DA-3033](https://precisionmedicineinitiative.atlassian.net/browse/DA-3033)*
Updates the v3 enrollment status calculations to set the Participant status date to the first consent for Primary consent.


## Tests
- [ ] unit tests


