### PR TITLE
[DA-3105] Checking enrollment status after EHR receipt

### DIFF
--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -115,13 +115,10 @@ def update_participant_summaries_from_job(job, project_id=GAE_PROJECT):
                     new_ids_with_status_checked.add(participant_id)
 
             _track_historical_participant_ehr_data(session, parameter_sets)
-            query_result = summary_dao.bulk_update_ehr_status_with_session(session, parameter_sets)
+            summary_dao.bulk_update_ehr_status_with_session(session, parameter_sets)
             session.commit()
 
-            total_rows = query_result.rowcount
-            LOG.info("Affected {} rows.".format(total_rows))
-
-            if total_rows > 0:
+            if parameter_sets:
                 # Rebuild participants in the page that have new data available. Checking that the participant
                 #  ehr receipts were created since the job started (offsetting by an hour to account for any
                 #  difference between server times)

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -115,10 +115,13 @@ def update_participant_summaries_from_job(job, project_id=GAE_PROJECT):
                     new_ids_with_status_checked.add(participant_id)
 
             _track_historical_participant_ehr_data(session, parameter_sets)
-            summary_dao.bulk_update_ehr_status_with_session(session, parameter_sets)
+            query_result = summary_dao.bulk_update_ehr_status_with_session(session, parameter_sets)
             session.commit()
 
-            if parameter_sets:
+            total_rows = query_result.rowcount
+            LOG.info("Affected {} rows.".format(total_rows))
+
+            if total_rows > 0:
                 # Rebuild participants in the page that have new data available. Checking that the participant
                 #  ehr receipts were created since the job started (offsetting by an hour to account for any
                 #  difference between server times)

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -83,6 +83,7 @@ def _track_historical_participant_ehr_data(session, parameter_sets):
 def update_participant_summaries_from_job(job, project_id=GAE_PROJECT):
     summary_dao = ParticipantSummaryDao()
     participant_ids_that_previously_had_ehr = summary_dao.get_participant_ids_with_ehr_data_available()
+    new_ids_with_status_checked = set()  # Any participant ids with new files that have already had their status updated
     summary_dao.prepare_for_ehr_status_update()
     job_start_time = datetime.utcnow()
 
@@ -99,9 +100,16 @@ def update_participant_summaries_from_job(job, project_id=GAE_PROJECT):
                     "pid": participant_id,
                     "receipt_time": file_upload_time
                 })
-                # Remove any participants that are part of the current page, they're being rebuilt currently, so they
-                #  won't need to rebuilt again at the end (when we get the ones that are no longer in the view)
-                participant_ids_that_previously_had_ehr.discard(participant_id)
+                if participant_id in participant_ids_that_previously_had_ehr:
+                    # Remove any participants that are part of the current page, they're being rebuilt currently, so
+                    # they won't need to rebuilt again at the end (when we get the ones that are no longer in the view)
+                    participant_ids_that_previously_had_ehr.discard(participant_id)
+                elif participant_id not in new_ids_with_status_checked:
+                    # For any participants that got EHR files for the first time: check their enrollment status and
+                    # make sure we don't check it again if they have another file
+                    summary = summary_dao.get_for_update(session=session, obj_id=participant_id)
+                    summary_dao.update_enrollment_status(session=session, summary=summary)
+                    new_ids_with_status_checked.add(participant_id)
 
             _track_historical_participant_ehr_data(session, parameter_sets)
             query_result = summary_dao.bulk_update_ehr_status_with_session(session, parameter_sets)

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -108,7 +108,10 @@ def update_participant_summaries_from_job(job, project_id=GAE_PROJECT):
                     # For any participants that got EHR files for the first time: check their enrollment status and
                     # make sure we don't check it again if they have another file
                     summary = summary_dao.get_for_update(session=session, obj_id=participant_id)
-                    summary_dao.update_enrollment_status(session=session, summary=summary)
+                    if summary is None:
+                        LOG.error(f'No summary found for P{participant_id}')
+                    else:
+                        summary_dao.update_enrollment_status(session=session, summary=summary)
                     new_ids_with_status_checked.add(participant_id)
 
             _track_historical_participant_ehr_data(session, parameter_sets)

--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -306,7 +306,7 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase, PDRGeneratorTestMixin):
     @mock.patch('rdr_service.offline.update_ehr_status.dispatch_participant_rebuild_tasks')
     @mock.patch('rdr_service.offline.update_ehr_status.make_update_participant_summaries_job')
     def test_participant_pdr_patch_requests(self, mock_summary_job, mock_rebuild_tasks):
-        """Checking that participant ehr data gets patched und different scenarios"""
+        """Checking that participant ehr data gets patched under different scenarios"""
 
         # There are four different scenarios tested here, each of them requiring that different data be sent to PDR:
         #   1 - participants that still appear in the view, but don't have a new file upload timestamp should not be
@@ -387,6 +387,21 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase, PDRGeneratorTestMixin):
                 fourth_upload_time
             )
         ], mock_rebuild_tasks)
+
+    @mock.patch('rdr_service.offline.update_ehr_status.make_update_participant_summaries_job')
+    @mock.patch('rdr_service.dao.participant_summary_dao.ParticipantSummaryDao.update_enrollment_status')
+    def test_ehr_receipt_updates_enrollment_status(self, update_status_mock, mock_summary_job):
+        """Checking that a participant's enrollment status gets updated when they have EHR submitted for them"""
+
+        test_participant_id = self.data_generator.create_database_participant_summary().participantId
+        view_data = self.EhrUpdatePidRow(test_participant_id, datetime.datetime(2020, 3, 12, 10))
+
+        mock_summary_job.return_value.__iter__.return_value = [[view_data]]
+        update_ehr_status.update_ehr_status_participant()
+
+        # Check that the participant was handed off to the status update method
+        checked_participant_id = update_status_mock.call_args.kwargs['summary'].participantId
+        self.assertEqual(test_participant_id, checked_participant_id)
 
 
     @mock.patch("rdr_service.offline.update_ehr_status.make_update_organizations_job")

--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -22,7 +22,7 @@ from tests.helpers.unittest_base import BaseTestCase, PDRGeneratorTestMixin
 class UpdateEhrStatusMakeJobsTestCase(BaseTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.uses_database = False\
+        self.uses_database = False
 
     @mock.patch("rdr_service.cloud_utils.bigquery.build")
     @mock.patch("rdr_service.cloud_utils.bigquery.GAE_PROJECT")

--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -22,11 +22,7 @@ from tests.helpers.unittest_base import BaseTestCase, PDRGeneratorTestMixin
 class UpdateEhrStatusMakeJobsTestCase(BaseTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.uses_database = False
-
-    # pylint: disable=unused-argument
-    def setUp(self, use_mysql=False, with_data=False, with_consent_codes=False):
-        super(UpdateEhrStatusMakeJobsTestCase, self).setUp()
+        self.uses_database = False\
 
     @mock.patch("rdr_service.cloud_utils.bigquery.build")
     @mock.patch("rdr_service.cloud_utils.bigquery.GAE_PROJECT")
@@ -402,6 +398,8 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase, PDRGeneratorTestMixin):
         # Check that the participant was handed off to the status update method
         checked_participant_id = update_status_mock.call_args.kwargs['summary'].participantId
         self.assertEqual(test_participant_id, checked_participant_id)
+
+        self.clear_table_after_test(ParticipantEhrReceipt.__tablename__)
 
 
     @mock.patch("rdr_service.offline.update_ehr_status.make_update_organizations_job")


### PR DESCRIPTION
## Partially Resolves *[DA-3105](https://precisionmedicineinitiative.atlassian.net/browse/DA-3105)*
As of enrollment status version 3.1, receiving EHR files for participants can affect enrollment status. This adds a check I had missed previously. Now when a the RDR receives the first EHR file for a participant, the enrollment status for that participant will be recalculated.


## Tests
- [x] unit tests


