### PR TITLE
[DA-3117] Update Outreach Filter for reconcile

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2161,7 +2161,10 @@ class GenomicOutreachDaoV2(BaseDao):
                     )
                 if start_date:
                     decision_loop = decision_loop.filter(
-                        GenomicInformingLoop.event_authored_time > start_date,
+                        or_(
+                            GenomicInformingLoop.event_authored_time > start_date,
+                            GenomicInformingLoop.created > start_date
+                        ),
                         GenomicInformingLoop.event_authored_time < end_date
                     )
                     ready_loop = ready_loop.filter(
@@ -2239,11 +2242,17 @@ class GenomicOutreachDaoV2(BaseDao):
 
                 if start_date:
                     result_ready_query = result_ready_query.filter(
-                        GenomicMemberReportState.event_authored_time > start_date,
+                        or_(
+                            GenomicMemberReportState.event_authored_time > start_date,
+                            GenomicMemberReportState.created > start_date
+                        ),
                         GenomicMemberReportState.event_authored_time < end_date,
                     )
                     result_viewed_query = result_viewed_query.filter(
-                        GenomicResultViewed.event_authored_time > start_date,
+                        or_(
+                            GenomicResultViewed.event_authored_time > start_date,
+                            GenomicResultViewed.created > start_date
+                        ),
                         GenomicResultViewed.event_authored_time < end_date,
                     )
 

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -809,6 +809,7 @@ def genomic_aw3_ready_missing_files_report():
     genomic_pipeline.notify_aw3_ready_missing_data_files()
     return '{"success": "true"}'
 
+
 @app_util.auth_required_cron
 @run_genomic_cron_job('notify_appointment_gror_changed')
 def genomic_appointment_gror_changed():

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -915,7 +915,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 participantId=participant.participantId
             )
 
-            self.data_generator.create_database_genomic_member_report_state(
+            report_obj = self.data_generator.create_database_genomic_member_report_state(
                 genomic_set_member_id=gen_member.id,
                 participant_id=participant.participantId,
                 module=module,
@@ -923,8 +923,13 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 event_authored_time=fake_date_two if num > 4 else fake_date_one
             )
 
+            # update created
+            report = self.report_dao.get(report_obj.id)
+            report.created = fake_date_two if num > 4 else fake_date_one
+            self.report_dao.update(report)
+
             if num % 2 == 0:
-                self.data_generator.create_database_genomic_informing_loop(
+                loop_obj = self.data_generator.create_database_genomic_informing_loop(
                     message_record_id=1,
                     event_type='informing_loop_decision',
                     module_type=module,
@@ -932,6 +937,11 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                     decision_value='maybe_later',
                     event_authored_time=fake_date_two
                 )
+
+                # update created
+                loop = self.loop_dao.get(loop_obj.id)
+                loop.created = fake_date_two
+                self.loop_dao.update(loop)
 
         total_num_set = self.loop_dao.get_all() + self.report_dao.get_all()
         self.assertEqual(len(total_num_set), 15)
@@ -1168,7 +1178,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 participantId=participant.participantId,
             )
 
-            self.data_generator.create_database_genomic_member_report_state(
+            report_obj = self.data_generator.create_database_genomic_member_report_state(
                 genomic_set_member_id=gen_member.id,
                 participant_id=participant.participantId,
                 module=module,
@@ -1176,7 +1186,12 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 event_authored_time=fake_date_two if num % 2 == 0 else fake_date_one
             )
 
-            self.data_generator.create_database_genomic_informing_loop(
+            # update created
+            report = self.report_dao.get(report_obj.id)
+            report.created = fake_date_two if num % 2 == 0 else fake_date_one
+            self.report_dao.update(report)
+
+            loop_obj = self.data_generator.create_database_genomic_informing_loop(
                 message_record_id=1,
                 event_type='informing_loop_decision',
                 module_type=module,
@@ -1184,6 +1199,11 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 decision_value='maybe_later',
                 event_authored_time=fake_date_two if num % 2 == 0 else fake_date_one
             )
+
+            # update created
+            loop = self.loop_dao.get(loop_obj.id)
+            loop.created = fake_date_two if num % 2 == 0 else fake_date_one
+            self.loop_dao.update(loop)
 
         total_num_set = self.loop_dao.get_all() + self.report_dao.get_all()
         self.assertEqual(len(total_num_set), 20)
@@ -1695,7 +1715,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             participantId=participant.participantId,
         )
 
-        self.data_generator.create_database_genomic_member_report_state(
+        gem_member_report_state = self.data_generator.create_database_genomic_member_report_state(
             genomic_set_member_id=gem_member.id,
             participant_id=participant.participantId,
             module=gem_module,
@@ -1703,6 +1723,11 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             event_authored_time=fake_date_one,
             sample_id=gem_member.sampleId
         )
+
+        # update created to exclude report state
+        gem_member_report_state = self.report_dao.get(gem_member_report_state.id)
+        gem_member_report_state.created = fake_date_one
+        self.report_dao.update(gem_member_report_state)
 
         self.data_generator.create_genomic_result_viewed(
             participant_id=participant.participantId,
@@ -1735,7 +1760,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             participantId=participant.participantId,
         )
 
-        self.data_generator.create_database_genomic_member_report_state(
+        hdr_report_state = self.data_generator.create_database_genomic_member_report_state(
             genomic_set_member_id=hdr_member.id,
             participant_id=participant.participantId,
             module=hdr_module,
@@ -1745,12 +1770,19 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             report_revision_number=0
         )
 
+        # update created to exclude report state
+        hdr_report_state = self.report_dao.get(hdr_report_state.id)
+        hdr_report_state.created = fake_date_one
+        self.report_dao.update(hdr_report_state)
+
         self.data_generator.create_genomic_result_viewed(
             participant_id=participant.participantId,
             event_type='result_viewed',
             event_authored_time=fake_date_two,
             module_type=hdr_module,
-            sample_id=hdr_member.sampleId
+            sample_id=hdr_member.sampleId,
+            created=fake_date_two,
+            modified=fake_date_two
         )
 
         resp = self.send_get(f'GenomicOutreachV2?participant_id={participant.participantId}')


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Need to update the outreach API query to take into account the created timestamp when partners are throttling POSTs to Message Broker or when reconciliation adds records


## Tests
- [x] unit tests


