### PR TITLE
Fix AW3 Missing Files Notification

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1905,7 +1905,7 @@ class GenomicJobController:
             message += '\n'.join([f'{f[1]},aou_wgs' for f in wgs_missing_data])
             EmailService.send_email(
                 Email(
-                    recipients=[notification_email_address],
+                    recipients=notification_email_address,
                     subject='AW3 ready samples with missing data files',
                     plain_text_content=message
                 )

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -6623,11 +6623,13 @@ class GenomicPipelineTest(BaseTestCase):
 
                 self.data_generator.create_database_gc_data_file_record(**test_file_dict)
 
-        config.override_setting(config.RDR_GENOMICS_NOTIFICATION_EMAIL, 'email@test.com')
+        config.override_setting(config.RDR_GENOMICS_NOTIFICATION_EMAIL, ['email@test.com', 'email2@test.com'])
         with GenomicJobController(GenomicJob.AW3_MISSING_DATA_FILE_REPORT) as controller:
             controller.check_aw3_ready_missing_files()
 
         # mock checks
         self.assertEqual(email_mock.call_count, 1)
+        self.assertEqual(email_mock.call_args[0][0].recipients, ['email@test.com', 'email2@test.com'])
+
 
 


### PR DESCRIPTION
## Resolves *[No ticket]*


## Description of changes/additions
The aw3 ready missing files notification job is passing the list of recipient emails inside of a list. This causes an error when the job calls Sendgrid.

## Tests
- [x] unit tests


