### PR TITLE
Convert contamination to int for task payload

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1254,6 +1254,7 @@ class GenomicFileIngester:
             members_to_update.append(member_dict)
 
             # upsert metrics record via cloud task
+            row_copy['contamination_category'] = int(row_copy['contamination_category'])
             self.controller.execute_cloud_task({
                 'metric_id': metric_id,
                 'payload_dict': row_copy,


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Need to convert enum value for contamination since JSON conversion in payload convert class obj to string and therefore fails insertion.

## Tests
- [] unit tests
* Tested manually on sandbox in pub sub event and verified GC metrics record was created successfully
** all unit tests should pass


