### PR TITLE
[DA-3105] Retrieving history of DNA samples for enrollment calculation dates

### DIFF
--- a/rdr_service/dao/biobank_stored_sample_dao.py
+++ b/rdr_service/dao/biobank_stored_sample_dao.py
@@ -1,5 +1,8 @@
 import logging
 
+from sqlalchemy.orm import Session
+
+from rdr_service import config
 from rdr_service.code_constants import BIOBANK_TESTS_SET
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.model.biobank_order import BiobankOrderIdentifier, BiobankOrder
@@ -60,3 +63,13 @@ class BiobankStoredSampleDao(BaseDao):
                 return getattr(results, 'siteId')
             else:
                 return
+
+    @classmethod
+    def load_confirmed_dna_samples(cls, session: Session, biobank_id):
+        return session.query(
+            BiobankStoredSample
+        ).filter(
+            BiobankStoredSample.biobankId == biobank_id,
+            BiobankStoredSample.confirmed.isnot(None),
+            BiobankStoredSample.test.in_(config.getSettingList(config.DNA_SAMPLE_TEST_CODES))
+        ).all()

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -27,6 +27,7 @@ from rdr_service.api_util import (
 from rdr_service.app_util import is_care_evo_and_not_prod
 from rdr_service.code_constants import BIOBANK_TESTS, ORIGINATING_SOURCES, PMI_SKIP_CODE, PPI_SYSTEM, UNSET
 from rdr_service.dao.base_dao import UpdatableDao
+from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.database_utils import get_sql_and_params_for_array, replace_null_safe_equals
 from rdr_service.dao.hpo_dao import HPODao
@@ -669,14 +670,15 @@ class ParticipantSummaryDao(UpdatableDao):
             summary.clinicPhysicalMeasurementsFinalizedTime,
             summary.selfReportedPhysicalMeasurementsAuthored
         ])
+
         earliest_biobank_received_dna_time = None
         if summary.samplesToIsolateDNA == SampleStatus.RECEIVED:
+            confirmed_dna_sample_list = BiobankStoredSampleDao.load_confirmed_dna_samples(
+                session=session,
+                biobank_id=summary.biobankId
+            )
             earliest_biobank_received_dna_time = min_or_none([
-                summary.sampleStatus1ED10Time,
-                summary.sampleStatus2ED10Time,
-                summary.sampleStatus1ED04Time,
-                summary.sampleStatus1SALTime,
-                summary.sampleStatus1SAL2Time
+                sample.confirmed for sample in confirmed_dna_sample_list
             ])
 
         ehr_consent_ranges = QuestionnaireResponseRepository.get_interest_in_sharing_ehr_ranges(

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -272,7 +272,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             ParticipantSummary.participantId == core_minus_pm_participant_id
         ).one()
         self.assertEqual(core_minus_pm_summary.enrollmentStatus, EnrollmentStatus.CORE_MINUS_PM)
-        self.assertEqual(core_minus_pm_summary.enrollmentStatusCoreMinusPMTime, datetime(2017, 11, 30, 2, 59, 42))
+        self.assertEqual(core_minus_pm_summary.enrollmentStatusCoreMinusPMTime, datetime(2017, 11, 29, 22, 10, 17))
 
         core_summary = self.session.query(ParticipantSummary).filter(
             ParticipantSummary.participantId == core_participant_id

--- a/tests/dao_tests/test_participant_summary_dao.py
+++ b/tests/dao_tests/test_participant_summary_dao.py
@@ -13,6 +13,7 @@ from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
+from rdr_service.logic.enrollment_info import EnrollmentInfo
 from rdr_service.model.biobank_order import BiobankOrder, BiobankOrderIdentifier, BiobankOrderedSample
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.measurements import PhysicalMeasurements
@@ -1066,6 +1067,39 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         self.assertEqual(results["selfReportedPhysicalMeasurementsStatus"], "COMPLETED")
         self.assertEqual(results["physicalMeasurementsFinalizedTime"], TIME_3.isoformat())
         self.assertEqual(results["physicalMeasurementsCollectType"], "SITE")
+
+    @mock.patch('rdr_service.logic.enrollment_info.EnrollmentCalculation.get_enrollment_info')
+    @mock.patch('rdr_service.dao.participant_summary_dao.BiobankStoredSampleDao')
+    def test_status_calculation_uses_earliest_dna_time(self, sample_dao_mock, enrollment_calculation_mock):
+        """
+        The enrollment status calculation code should be provided with the earliest sample collection time,
+        even if multiple samples of the same type have been collected
+        """
+
+        enrollment_calculation_mock.return_value = EnrollmentInfo(
+            version_legacy_status=EnrollmentStatus.INTERESTED,
+            version_3_0_status=EnrollmentStatusV30.PARTICIPANT,
+            version_3_1_status=EnrollmentStatusV31.PARTICIPANT
+        )
+
+        earliest_sample_time = datetime.datetime(2022, 1, 27)
+        later_sample_time = datetime.datetime(2022, 3, 1)
+        summary = ParticipantSummary(
+            enrollmentStatus=EnrollmentStatus.INTERESTED,
+            samplesToIsolateDNA=SampleStatus.RECEIVED,
+            enrollmentStatusV3_0=EnrollmentStatusV30.PARTICIPANT,
+            enrollmentStatusV3_1=EnrollmentStatusV31.PARTICIPANT,
+            sampleStatus1SALTime=later_sample_time
+        )
+        sample_dao_mock.load_confirmed_dna_samples.return_value = [
+            BiobankStoredSample(test='1SAL2', confirmed=earliest_sample_time),
+            BiobankStoredSample(test='1SAL2', confirmed=later_sample_time)
+        ]
+
+        self.dao.update_enrollment_status(summary=summary, session=mock.MagicMock())
+
+        participant_info = enrollment_calculation_mock.call_args[0][0]
+        self.assertEqual(earliest_sample_time, participant_info.earliest_biobank_received_dna_time)
 
     def test_parse_enums_from_resource(self):
         resource = {

--- a/tests/dao_tests/test_participant_summary_dao.py
+++ b/tests/dao_tests/test_participant_summary_dao.py
@@ -82,6 +82,14 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         self.mock_ehr_interest_ranges.return_value = []
         self.addCleanup(response_dao_patch.stop)
 
+        sample_dao_patch = mock.patch(
+            'rdr_service.dao.participant_summary_dao.BiobankStoredSampleDao'
+        )
+        sample_dao_mock = sample_dao_patch.start()
+        self.received_samples_mock = sample_dao_mock.load_confirmed_dna_samples
+        self.received_samples_mock.return_value = []
+        self.addCleanup(sample_dao_patch.stop)
+
     def assert_no_results(self, query):
         results = self.dao.query(query)
         self.assertEqual([], results.items)
@@ -444,6 +452,10 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         self.assertEqual(ehr_consent_authored_time, summary.enrollmentStatusParticipantPlusEhrV3_1Time)
 
         sample_time = datetime.datetime(2019, 3, 1)
+
+        self.received_samples_mock.return_value = [
+            BiobankStoredSample(confirmed=sample_time)
+        ]
         summary = ParticipantSummary(
             participantId=1,
             biobankId=2,
@@ -458,7 +470,6 @@ class ParticipantSummaryDaoTest(BaseTestCase):
             clinicPhysicalMeasurementsStatus=PhysicalMeasurementsStatus.UNSET,
             selfReportedPhysicalMeasurementsStatus=SelfReportedPhysicalMeasurementsStatus.UNSET,
             enrollmentStatus=EnrollmentStatus.MEMBER,
-            sampleStatus2ED10Time=sample_time,
             enrollmentStatusV3_0=EnrollmentStatusV30.PARTICIPANT,
             enrollmentStatusV3_1=EnrollmentStatusV31.PARTICIPANT
         )
@@ -479,6 +490,9 @@ class ParticipantSummaryDaoTest(BaseTestCase):
         ]
 
         sample_time = datetime.datetime(2019, 3, 1)
+        self.received_samples_mock.return_value = [
+            BiobankStoredSample(confirmed=sample_time)
+        ]
         summary = ParticipantSummary(
             participantId=1,
             biobankId=2,
@@ -493,7 +507,6 @@ class ParticipantSummaryDaoTest(BaseTestCase):
             questionnaireOnTheBasicsAuthored=ehr_consent_authored_time,
             questionnaireOnLifestyleAuthored=ehr_consent_authored_time,
             questionnaireOnOverallHealthAuthored=ehr_consent_authored_time,
-            sampleStatus2ED10Time=sample_time,
             enrollmentStatusV3_0=EnrollmentStatusV30.PARTICIPANT,
             enrollmentStatusV3_1=EnrollmentStatusV31.PARTICIPANT
         )


### PR DESCRIPTION
## Partially Resolves *[DA-3105](https://precisionmedicineinitiative.atlassian.net/browse/DA-3105)*
Participant summary gets updated with later dates for received samples, so can't be relied on to find the earliest received sample when finding enrollment status dates. This switches the code over to using the history of stored samples we have for the participants.


## Tests
- [x] unit tests


