### PR TITLE
[DA-3105] Checking for reconsent responses when calculating enrollment status

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -186,6 +186,7 @@ COPE_DEC_MODULE = "cope_dec"
 COPE_FEB_MODULE = "cope_feb"
 GENETIC_ANCESTRY_MODULE = 'GeneticAncestry'
 LIFE_FUNCTIONING_SURVEY = 'lfs'
+PRIMARY_CONSENT_UPDATE_MODULE = 'PrimaryConsentUpdate'
 
 VA_EHR_RECONSENT = 'vaehrreconsent'
 


### PR DESCRIPTION
## Partially Resolves *[DA-3105](https://precisionmedicineinitiative.atlassian.net/browse/DA-3105)*
Because of some data weirdness, the enrollment status calculation needs to use the responses directly rather than relying on date differences in the participant summary. This loads any reconsents for Cohort 1 and looks for any valid reconsents.

## Tests
- [ ] unit tests


