### PR TITLE
Fix export_organizations.sh

### DIFF
--- a/rdr_service/tools/export_organizations.sh
+++ b/rdr_service/tools/export_organizations.sh
@@ -2,8 +2,8 @@
 
 SHEET_EXPORT_BASE="https://docs.google.com/spreadsheets/d/1CcIGRV0Bd6BIz7PeuvrV6QDGDRQkp83CJUkWAl-fG58/export?format=csv&gid="
 
-curl "${SHEET_EXPORT_BASE}1076878570" > data/awardees.csv
-curl "${SHEET_EXPORT_BASE}1098779958" > data/organizations.csv
-curl "${SHEET_EXPORT_BASE}0" > data/sites.csv
+curl -L "${SHEET_EXPORT_BASE}1076878570" > data/awardees.csv
+curl -L "${SHEET_EXPORT_BASE}1098779958" > data/organizations.csv
+curl -L "${SHEET_EXPORT_BASE}0" > data/sites.csv
 
 echo "Done."


### PR DESCRIPTION
## Resolves *[No Ticket]*


## Description of changes/additions
This script is saving the redirect notice from Google instead of the expected csv data. Adds a flag to curl to follow redirects.

## Tests
Script was tested locally.


