### PR TITLE
[DA-3151] Creating endpoint for ProfileUpdate API

### DIFF
--- a/rdr_service/api/profile_update_api.py
+++ b/rdr_service/api/profile_update_api.py
@@ -2,6 +2,8 @@
 from flask import request
 from flask_restful import Resource
 
+from rdr_service.api_util import PTC
+from rdr_service.app_util import auth_required
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.utils import from_client_participant_id
 from rdr_service.lib_fhir.fhirclient_4_0_0.models.patient import Patient as FhirPatient
@@ -242,6 +244,7 @@ class PatientPayload:
 
 
 class ProfileUpdateApi(Resource):
+    @auth_required(PTC)
     def post(self):
         update_payload = PatientPayload(request.json)
         update_field_list = {

--- a/rdr_service/api/profile_update_api.py
+++ b/rdr_service/api/profile_update_api.py
@@ -1,0 +1,276 @@
+
+from flask import request
+from flask_restful import Resource
+
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.model.utils import from_client_participant_id
+from rdr_service.lib_fhir.fhirclient_4_0_0.models.patient import Patient as FhirPatient
+
+
+class PatientPayload:
+    def __init__(self, json):
+        self._fhir_patient = FhirPatient(json)
+        self._json = json
+
+    @property
+    def participant_id(self):
+        return self._fhir_patient.id
+
+    @property
+    def has_first_name_update(self):
+        return self._has_value_provided(
+            field_name='given',
+            path_to_field=['name'],
+            json=self._json
+        )
+
+    @property
+    def first_name(self):
+        name_list = self._fhir_patient.name
+        if not name_list:
+            return None
+
+        name_object = name_list[0]
+        if not name_object.given:
+            return None
+
+        return name_object.given[0] or None
+
+    @property
+    def has_middle_name_update(self):
+        if self._has_value_provided(
+            field_name='given',
+            path_to_field=['name'],
+            json=self._json
+        ):
+            name_list = self._json['name']
+            if not name_list:
+                return True
+
+            name_json = name_list[0]
+            provided_name_list = name_json['given']
+            return provided_name_list and len(provided_name_list) > 1
+
+        return False
+
+    @property
+    def middle_name(self):
+        name_list = self._fhir_patient.name
+        if not name_list:
+            return None
+
+        name_object = name_list[0]
+        if not name_object.given or len(name_object.given) < 2:
+            return None
+
+        return name_object.given[1] or None
+
+    @property
+    def has_last_name_update(self):
+        return self._has_value_provided(
+            field_name='family',
+            path_to_field=['name'],
+            json=self._json
+        )
+
+    @property
+    def last_name(self):
+        name_list = self._fhir_patient.name
+        if not name_list:
+            return None
+
+        name_object = name_list[0]
+        return name_object.family or None
+
+    @property
+    def has_phone_number_update(self):
+        if not self._fhir_patient.telecom:
+            return False
+
+        return any([telecom_object.system == 'phone' for telecom_object in self._fhir_patient.telecom])
+
+    @property
+    def phone_number(self):
+        for telecom_object in self._fhir_patient.telecom:
+            if telecom_object.system == 'phone':
+                return telecom_object.value or None
+
+    @property
+    def has_email_update(self):
+        if not self._fhir_patient.telecom:
+            return False
+
+        return any([telecom_object.system == 'email' for telecom_object in self._fhir_patient.telecom])
+
+    @property
+    def email(self):
+        for telecom_object in self._fhir_patient.telecom:
+            if telecom_object.system == 'email':
+                return telecom_object.value or None
+
+    @property
+    def has_birthdate_update(self):
+        return 'birthDate' in self._json
+
+    @property
+    def birthdate(self):
+        fhir_date = self._fhir_patient.birthDate
+        if not fhir_date:
+            return None
+
+        return fhir_date.date
+
+    @property
+    def has_address_line1_update(self):
+        if not self._fhir_patient.address:
+            return False
+
+        address_object = self._fhir_patient.address[0]
+        return address_object.line is not None
+
+    @property
+    def address_line1(self):
+        address_line_list = self._fhir_patient.address[0].line
+        if not address_line_list:
+            return None
+        return address_line_list[0] or None
+
+    @property
+    def has_address_line2_update(self):
+        return self.has_address_line1_update
+
+    @property
+    def address_line2(self):
+        address_line_list = self._fhir_patient.address[0].line
+        if not address_line_list or len(address_line_list) < 2:
+            return None
+
+        return address_line_list[1] or None
+
+    @property
+    def has_address_city_update(self):
+        return self._has_value_provided(
+            field_name='city',
+            path_to_field=['address'],
+            json=self._json
+        )
+
+    @property
+    def address_city(self):
+        return self._fhir_patient.address[0].city or None
+
+    @property
+    def has_address_state_update(self):
+        return self._has_value_provided(
+            field_name='state',
+            path_to_field=['address'],
+            json=self._json
+        )
+
+    @property
+    def address_state(self):
+        return self._fhir_patient.address[0].state or None
+
+    @property
+    def has_address_zip_code_update(self):
+        return self._has_value_provided(
+            field_name='postalCode',
+            path_to_field=['address'],
+            json=self._json
+        )
+
+    @property
+    def address_zip_code(self):
+        return self._fhir_patient.address[0].postalCode or None
+
+    @property
+    def has_language_update(self):
+        return 'communication' in self._json
+
+    @property
+    def preferred_language(self):
+        communication_list = self._fhir_patient.communication
+
+        preferred_communication = None
+        for communication in communication_list:
+            if communication.preferred:
+                preferred_communication = communication
+                break
+
+        if not preferred_communication and len(communication_list) == 1:
+            preferred_communication = communication_list[0]
+
+        if preferred_communication:
+            return preferred_communication.language.coding[0].code
+
+        return None
+
+    @classmethod
+    def _has_value_provided(cls, field_name, path_to_field, json):
+        """
+        Determine if the provided JSON payload has a value specified for a given field,
+        or if the field was missing entirely (which would mean there should be no update for that field).
+        """
+
+        # If there is no path to the field, then it's not nested and should be searched for at the root of the json
+        if not path_to_field:
+            return field_name in json
+
+        # If there is a path to a field provided, then we should first check to see if the first item in the path
+        # is available on the current json. If it's not then we haven't been given a value.
+        next_path_field = path_to_field[0]
+        if next_path_field not in json:
+            return False
+
+        # If the next path structure is explicitly given a value, but it's been cleared then we can assume anything
+        # specified within it should be cleared too.
+        next_nested_json = json[next_path_field]
+        if not next_nested_json:
+            return True
+
+        # The "name" and "address structures are lists with one object in them,
+        # in that case we should pass the object in it rather than the list
+        if next_path_field in ['name', 'address']:
+            next_nested_json = next_nested_json[0]
+
+        # Recursively return whether the nested json has the value
+        return cls._has_value_provided(
+            field_name=field_name,
+            path_to_field=path_to_field[1:],
+            json=next_nested_json
+        )
+
+
+class ProfileUpdateApi(Resource):
+    def post(self):
+        update_payload = PatientPayload(request.json)
+        update_field_list = {
+            'participant_id': from_client_participant_id(update_payload.participant_id)
+        }
+
+        if update_payload.has_first_name_update:
+            update_field_list['first_name'] = update_payload.first_name
+        if update_payload.has_middle_name_update:
+            update_field_list['middle_name'] = update_payload.middle_name
+        if update_payload.has_last_name_update:
+            update_field_list['last_name'] = update_payload.last_name
+        if update_payload.has_phone_number_update:
+            update_field_list['phone_number'] = update_payload.phone_number
+        if update_payload.has_email_update:
+            update_field_list['email'] = update_payload.email
+        if update_payload.has_birthdate_update:
+            update_field_list['birthdate'] = update_payload.birthdate
+        if update_payload.has_address_line1_update:
+            update_field_list['address_line1'] = update_payload.address_line1
+        if update_payload.has_address_line2_update:
+            update_field_list['address_line2'] = update_payload.address_line2
+        if update_payload.has_address_city_update:
+            update_field_list['address_city'] = update_payload.address_city
+        if update_payload.has_address_state_update:
+            update_field_list['address_state'] = update_payload.address_state
+        if update_payload.has_address_zip_code_update:
+            update_field_list['address_zip_code'] = update_payload.address_zip_code
+        if update_payload.has_language_update:
+            update_field_list['preferred_language'] = update_payload.preferred_language
+
+        ParticipantSummaryDao.update_profile_data(**update_field_list)

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1347,6 +1347,10 @@ class ParticipantSummaryDao(UpdatableDao):
             )
             session.execute(query, {'file_upload_date': upload_date})
 
+    @classmethod
+    def update_profile_data(cls, participant_id: int, first_name=None, middle_name=None, last_name=None, email=None):
+        ...
+
 
 def _initialize_field_type_sets():
     """Using reflection, populate _DATE_FIELDS, _ENUM_FIELDS, and _CODE_FIELDS, which are

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -32,6 +32,7 @@ from rdr_service.api.participant_summary_api import ParticipantSummaryApi, \
     ParticipantSummaryModifiedApi, ParticipantSummaryCheckLoginApi
 from rdr_service.api.patient_status import PatientStatusApi, PatientStatusHistoryApi
 from rdr_service.api.physical_measurements_api import PhysicalMeasurementsApi, sync_physical_measurements
+from rdr_service.api.profile_update_api import ProfileUpdateApi
 from rdr_service.api.public_metrics_api import PublicMetricsApi
 from rdr_service.api.questionnaire_api import QuestionnaireApi
 from rdr_service.api.questionnaire_response_api import ParticipantQuestionnaireAnswers, QuestionnaireResponseApi
@@ -326,6 +327,13 @@ api.add_resource(
     DeceasedReportApi,
     API_PREFIX + 'Participant/<string:participant_id>/Observation',
     endpoint='observation',
+    methods=['POST']
+)
+
+api.add_resource(
+    ProfileUpdateApi,
+    API_PREFIX + 'Participant/ProfileUpdate',
+    endpoint='profile_update',
     methods=['POST']
 )
 

--- a/tests/api_tests/test_general_api_configuration.py
+++ b/tests/api_tests/test_general_api_configuration.py
@@ -14,8 +14,7 @@ class FlaskAppConfigTest(BaseTestCase):
 
         self.api_patches = [
             mock.patch('rdr_service.api.participant_api.ParticipantApi.get', return_value='success'),
-            mock.patch('rdr_service.api.deceased_report_api.DeceasedReportApi.post', return_value='success'),
-            mock.patch('rdr_service.dao.database_factory.get_database')  # Prevents errors in DAO inits
+            mock.patch('rdr_service.api.deceased_report_api.DeceasedReportApi.post', return_value='success')
         ]
         for patcher in self.api_patches:
             patcher.start()

--- a/tests/api_tests/test_profile_update_api.py
+++ b/tests/api_tests/test_profile_update_api.py
@@ -153,8 +153,6 @@ class ProfileUpdateApiTest(BaseTestCase):
             phone_number=None
         )
 
-        # TODO: do I need to worry about login_phone_number?
-
     def test_update_email(self):
         self.send_post(
             'Participant/ProfileUpdate',

--- a/tests/api_tests/test_profile_update_api.py
+++ b/tests/api_tests/test_profile_update_api.py
@@ -1,0 +1,438 @@
+from datetime import date
+import mock
+
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class ProfileUpdateApiTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super(ProfileUpdateApiTest, self).__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs):
+        super(ProfileUpdateApiTest, self).setUp(*args, **kwargs)
+
+        dao_patch = mock.patch('rdr_service.api.profile_update_api.ParticipantSummaryDao')
+        dao_mock = dao_patch.start()
+        self.update_mock = dao_mock.update_profile_data
+        self.addCleanup(dao_patch.stop)
+
+    def test_first_name_update(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'name': [{
+                    'given': [
+                        'Peter'
+                    ]
+                }]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            first_name='Peter'
+        )
+
+    def test_middle_name_update(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'name': [{
+                    'given': [
+                        'Peter',
+                        'Joshua'
+                    ]
+                }]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            first_name='Peter',
+            middle_name='Joshua'
+        )
+
+    def test_last_name_update(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'name': [{
+                    'family': 'Bishop',
+                }]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            last_name='Bishop'
+        )
+
+    def test_clearing_middle_name(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'name': [{
+                    'given': [
+                        'Peter',
+                        ''
+                    ]
+                }]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            first_name='Peter',
+            middle_name=None
+        )
+
+    def test_clearing_family_name(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'name': [{
+                    'family': None
+                }]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            last_name=None
+        )
+
+    def test_clearing_full_name(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'name': []
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            first_name=None,
+            middle_name=None,
+            last_name=None
+        )
+
+    def test_update_phone_number(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'telecom': [
+                    {
+                        'system': 'phone',
+                        'value': '1234567890'
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            phone_number='1234567890'
+        )
+
+    def test_clear_phone_number(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'telecom': [
+                    {
+                        'system': 'phone',
+                        'value': ''
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            phone_number=None
+        )
+
+        # TODO: do I need to worry about login_phone_number?
+
+    def test_update_email(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'telecom': [
+                    {
+                        'system': 'email',
+                        'value': 'test@example.org'
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            email='test@example.org'
+        )
+
+    def test_clear_email(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'telecom': [
+                    {
+                        'system': 'email',
+                        'value': None
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            email=None
+        )
+
+    def test_update_birthdate(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'birthDate': '2017-01-01'
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            birthdate=date(2017, 1, 1)
+        )
+
+    def test_clear_birthdate(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'birthDate': ''
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            birthdate=None
+        )
+
+    def test_update_address_line1(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'line': [
+                            '123 Main St.'
+                        ]
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_line1='123 Main St.',
+            address_line2=None
+        )
+
+    def test_clear_address_line1(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'line': [
+                            ''
+                        ]
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_line1=None,
+            address_line2=None
+        )
+
+    def test_update_address_line2(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'line': [
+                            '123 Main St.',
+                            'Apt C'
+                        ]
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_line1='123 Main St.',
+            address_line2='Apt C'
+        )
+
+    def test_clear_address_line2(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'line': [
+                            '123 Main St.'
+                        ]
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_line1='123 Main St.',
+            address_line2=None
+        )
+
+    def test_update_address_city(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'city': 'New Haven'
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_city='New Haven'
+        )
+
+    def test_clear_address_city(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'city': ''
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_city=None
+        )
+
+    def test_update_address_state(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'state': 'CA'
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_state='CA'
+        )
+
+    def test_clear_address_state(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'state': None
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_state=None
+        )
+
+    def test_update_address_zip_code(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'postalCode': '12345'
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_zip_code='12345'
+        )
+
+    def test_clear_address_zip_code(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'address': [
+                    {
+                        'postalCode': ''
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            address_zip_code=None
+        )
+
+    def test_update_language(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'communication': [
+                    {
+                        'preferred': True,
+                        'language': {
+                            'coding': [
+                                {
+                                    'code': 'es'
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            preferred_language='es'
+        )
+
+    def test_clear_language(self):
+        self.send_post(
+            'Participant/ProfileUpdate',
+            request_data={
+                'id': 'P123123123',
+                'communication': []
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            preferred_language=None
+        )

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -518,6 +518,11 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
 
             self.session = database_factory.get_database().make_session()
             self.data_generator = DataGenerator(self.session, self.fake)
+        else:
+            # Some side effects of common code (like auth_required) use the database.
+            database_patch = mock.patch('rdr_service.dao.database_factory.get_database')
+            database_patch.start()
+            self.addCleanup(database_patch.stop)
 
     def tearDown(self):
         super(BaseTestCase, self).tearDown()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -7,13 +7,6 @@ from tests.helpers.unittest_base import BaseTestCase
 
 
 class TestEnvironment(BaseTestCase):
-    """
-    Test our python environment
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.uses_database = False
-
     def test_python_version(self):
         """ Make sure we are using Python 3.7 or higher """
         self.assertEqual(sys.version_info[0], 3)


### PR DESCRIPTION
## Work in progress for *[DA-3151](https://precisionmedicineinitiative.atlassian.net/browse/DA-3151)*
This makes a new endpoint available for Vibrent to send updates to participant profile information. This will replace receiving repeated updates to the ConsentPII and TheBasics surveys that update the same information.

A future PR will integrate the API endpoint with the database to update the participant summary, as well as save the full request sent.

## Tests
- [x] unit tests


