### PR TITLE
[DA-3113] - Investigate: Participant Summary API Sample Time Fields

### DIFF
--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -286,7 +286,8 @@ class ParticipantSummary(Base):
     # The time when we get a DNA order
     enrollmentStatusCoreOrderedSampleTime = Column("enrollment_status_core_ordered_sample_time", UTCDateTime)
     """
-    Present when a participant has completed all baseline modules, physical measurements, and has DNA samples stored.
+    Present when a participant has completed all baseline modules, physical measurements, and DNA samples have been
+    ordered
 
     Is the latest date from the list of:
 


### PR DESCRIPTION
## Resolves *[DA-3113](https://precisionmedicineinitiative.atlassian.net/browse/DA-3113)*


## Description of changes/additions

Updating the description of enrollmentStatusCoreOrderedSampleTime to make it a bit more clear compared to enrollmentStatusCoreStoredSampleTime

## Tests
- [] unit tests


