### PR TITLE
Generalizing EtM parsing

### DIFF
--- a/rdr_service/api/questionnaire_api.py
+++ b/rdr_service/api/questionnaire_api.py
@@ -3,7 +3,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from rdr_service import app_util
 from rdr_service.api.base_api import UpdatableApi
-from rdr_service.api.etm_api import ETM_OUTCOMES_EXT_URL, EtmApi
+from rdr_service.api.etm_api import EtmApi
 from rdr_service.api_util import PTC, PTC_AND_HEALTHPRO
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.dao.code_dao import CodeDao
@@ -35,13 +35,7 @@ class QuestionnaireApi(UpdatableApi):
         # Detect if this is an EtM Questionnaire
         request_json = request.json
 
-        if (
-            'extension' in request_json
-            and any(
-                extension.get('url') == ETM_OUTCOMES_EXT_URL
-                for extension in request_json['extension']
-            )
-        ):
+        if EtmApi.is_etm_payload(request_json):
             return EtmApi.post_questionnaire(request_json)
         else:
             return super(QuestionnaireApi, self).post()

--- a/rdr_service/api/questionnaire_response_api.py
+++ b/rdr_service/api/questionnaire_response_api.py
@@ -5,7 +5,7 @@ from rdr_service import app_util
 from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.bq_questionnaire_dao import bq_questionnaire_update_task
 from rdr_service.api.base_api import BaseApi
-from rdr_service.api.etm_api import EtmApi, ETM_EMOTIONAL_RECOGNITION_URL
+from rdr_service.api.etm_api import EtmApi
 from rdr_service.api_util import PTC, PTC_AND_HEALTHPRO
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao, raise_if_withdrawn
@@ -36,10 +36,7 @@ class QuestionnaireResponseApi(BaseApi):
         raise_if_withdrawn(participant)
 
         request_json = request.json
-        if (
-            'questionnaire' in request_json
-            and request_json['questionnaire'].get('reference') == ETM_EMOTIONAL_RECOGNITION_URL
-        ):
+        if EtmApi.is_etm_payload(request_json):
             return EtmApi.post_questionnaire_response(request_json)
         else:
             resp = super(QuestionnaireResponseApi, self).post(participant_id=p_id)

--- a/rdr_service/repository/etm.py
+++ b/rdr_service/repository/etm.py
@@ -43,6 +43,7 @@ class EtmQuestionnaireRepository(BaseRepository):
                     name_list = [
                         code_object['code']
                         for code_object in extension['valueCodeableConcept']['coding']
+                        if 'code' in code_object
                     ]
 
                     if is_metadata:


### PR DESCRIPTION
## Resolves *no ticket*
It's just been made clear that EtM will be releasing with a number of modules initially (rather than just emotional recognition). This updates the code to recognize and parse multiple different modules by removing specific references to emorecog.

## Description of changes/additions


## Tests
- [ ] unit tests


