### PR TITLE
[DA-3157] Filter participant summary payload

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -280,9 +280,9 @@ class BaseApi(Resource):
         if results.pagination_token:
             query_params = request.args.copy()
             query_params["_token"] = results.pagination_token
-
             next_url = main.api.url_for(self.__class__, _external=True, **query_params.to_dict(flat=False))
             bundle_dict["link"] = [{"relation": "next", "url": next_url}]
+
         entries = []
         for item in results.items:
             response_json = self._make_response(item)

--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -131,12 +131,12 @@ class BaseApi(Resource):
 
     def get(self, id_=None, participant_id=None):
         """Handle a GET request.
-
-    Args:
-      id: If provided this is the id of the object to fetch.  If this is not
-        present, this is assumed to be a "list" request, and the list() function
-        will be called.
-    """
+        Args:
+          id_: If provided this is the id of the object to fetch.  If this is not
+            present, this is assumed to be a "list" request, and the list() function
+            will be called.
+          participant_id:
+        """
         if id_ is None:
             return self.list(participant_id)
         obj = self.dao.get_with_children(id_) if self._get_returns_children else self.dao.get(id_)

--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -70,17 +70,17 @@ class ParticipantSummaryApi(BaseApi):
                 self._fetch_hpro_consents(pids=p_id)
                 self._fetch_participant_incentives(pids=p_id)
             return super(ParticipantSummaryApi, self).get(p_id)
-        else:
-            if auth_awardee:
-                # make sure request has awardee
-                requested_awardee = request.args.get("awardee")
-                hpo_lite_awardees = getSettingList(HPO_LITE_AWARDEE, default=[])
-                if requested_awardee == UNSET and auth_awardee in hpo_lite_awardees:
-                    # allow hpo lite awardee to access UNSET participants
-                    pass
-                elif requested_awardee != auth_awardee:
-                    raise Forbidden
-            return self._query("participantId")
+
+        if auth_awardee:
+            # make sure request has awardee
+            requested_awardee = request.args.get("awardee")
+            hpo_lite_awardees = getSettingList(HPO_LITE_AWARDEE, default=[])
+            if requested_awardee == UNSET and auth_awardee in hpo_lite_awardees:
+                # allow hpo lite awardee to access UNSET participants
+                pass
+            elif requested_awardee != auth_awardee:
+                raise Forbidden
+        return self._query("participantId")
 
     @auth_required(RDR_AND_PTC)
     @restrict_to_gae_project(PTC_ALLOWED_ENVIRONMENTS)
@@ -100,7 +100,7 @@ class ParticipantSummaryApi(BaseApi):
         if constraint_failed:
             raise BadRequest(f"{message}")
 
-        self.query_definition = super(ParticipantSummaryApi, self)._make_query(check_invalid)
+        self.query_definition = super()._make_query(check_invalid)
         self.query_definition.always_return_token = self._get_request_arg_bool("_sync")
         self.query_definition.backfill_sync = self._get_request_arg_bool("_backfill", True)
         self.query_definition.attributes = self.filtered_attributes
@@ -179,7 +179,6 @@ class ParticipantSummaryApi(BaseApi):
         for role in self.user_info.get('roles'):
             if role in role_payload_config:
                 return role_payload_config.get(role)['fields']
-        return None
 
     def _filter_by_user_site(self, participant_id=None):
         if not self.user_info.get('site'):

--- a/rdr_service/api_util.py
+++ b/rdr_service/api_util.py
@@ -24,6 +24,7 @@ RESOURCE = 'resource'
 DEV_MAIL = "example@example.com"
 GEM = "gem"
 BIOBANK = 'biobank'
+SUPPORT = 'support'
 RDR_AND_PTC = [RDR, PTC]
 RDR_AND_HEALTHPRO = [RDR, HEALTHPRO]
 PTC_AND_GEM = [PTC, GEM]

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -157,7 +157,7 @@ HEALTHPRO_CONSENTS_TRANSFER_LIMIT = 'hpro_consents_transfer_limit'
 CE_HEALTH_DATA_BUCKET_NAME = "ce_health_data_bucket_name"
 VA_WORKQUEUE_BUCKET_NAME = 'va_workqueue_bucket_name'
 VA_WORKQUEUE_SUBFOLDER = 'va_workqueue_subfolder'
-
+OPS_DATA_PAYLOAD_ROLES = 'ops_data_payload_roles'
 ENABLE_ENROLLMENT_STATUS_3 = 'enable_enrollment_status_3'
 ENABLE_HEALTH_SHARING_STATUS_3 = 'enable_health_sharing_status_3'
 ENABLE_PARTICIPANT_MEDIATED_EHR = 'enable_participant_mediated_ehr'

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -171,5 +171,18 @@
   },
   "genomic_skip_missing_file_types": {
     "aou_wgs": ["test.file"]
+  },
+  "ops_data_payload_roles": {
+    "support": {
+      "fields": [
+        "participantId",
+        "firstName",
+        "middleName",
+        "lastName",
+        "phoneNumber",
+        "email",
+        "participantOrigin"
+      ]
+    }
   }
 }

--- a/rdr_service/dao/base_dao.py
+++ b/rdr_service/dao/base_dao.py
@@ -340,7 +340,7 @@ class BaseDao(object):
             total = None
 
             query, field_names = self._make_query(session, query_def)
-            items = query.all()
+            items = query.with_session(session).all()
 
             if query_def.include_total:
                 total = self._count_query(session, query_def)

--- a/rdr_service/dao/hpro_consent_dao.py
+++ b/rdr_service/dao/hpro_consent_dao.py
@@ -33,23 +33,9 @@ class HealthProConsentDao(UpdatableDao):
 
             return needed_consents.all()
 
-    def get_by_participant(self, participant_id):
-        with self.session() as session:
-            return session.query(
-                HealthProConsentFile.file_path.label('file_path'),
-                HealthProConsentFile.participant_id.label('participant_id'),
-                ConsentFile.type.label('consent_type')
-            ).join(
-                ConsentFile,
-                ConsentFile.id == HealthProConsentFile.consent_file_id
-            ).filter(
-                HealthProConsentFile.participant_id == participant_id,
-                HealthProConsentFile.file_path.isnot(None)
-            ).all()
-
-    def batch_get_by_participant(self, participant_ids):
+    def get_by_participant(self, participant_ids):
         if type(participant_ids) is not list:
-            return []
+            participant_ids = [participant_ids]
 
         with self.session() as session:
             return session.query(

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -7,6 +7,7 @@ import sqlalchemy
 import sqlalchemy.orm
 
 from sqlalchemy import or_, and_
+from sqlalchemy.orm import Query
 from sqlalchemy.sql import expression
 from typing import Collection
 
@@ -434,7 +435,8 @@ class ParticipantSummaryDao(UpdatableDao):
                     parse_json_enum(resource, key, _cls)
         return resource
 
-    def _has_withdrawn_filter(self, query):
+    @staticmethod
+    def _has_withdrawn_filter(query):
         for field_filter in query.field_filters:
             if field_filter.field_name == "withdrawalStatus" and field_filter.value == WithdrawalStatus.NO_USE:
                 return True
@@ -442,7 +444,8 @@ class ParticipantSummaryDao(UpdatableDao):
                 return True
         return False
 
-    def _get_non_withdrawn_filter_field(self, query):
+    @staticmethod
+    def _get_non_withdrawn_filter_field(query):
         """Returns the first field referenced in query filters which isn't in
     WITHDRAWN_PARTICIPANT_FIELDS."""
         for field_filter in query.field_filters:
@@ -464,7 +467,11 @@ class ParticipantSummaryDao(UpdatableDao):
             # ordered by are in WITHDRAWN_PARTICIPANT_FIELDS.
             return super(ParticipantSummaryDao, self)._initialize_query(session, query_def)
         else:
-            query = super(ParticipantSummaryDao, self)._initialize_query(session, query_def)
+            if query_def.attributes:
+                eval_attrs = [eval(f'{self.model_type.__name__}.{attribute}') for attribute in query_def.attributes]
+                query = Query(eval_attrs)
+            else:
+                query = super(ParticipantSummaryDao, self)._initialize_query(session, query_def)
 
             withdrawn_visible_start = clock.CLOCK.now() - WITHDRAWN_PARTICIPANT_VISIBILITY_TIME
             if filter_client and non_withdrawn_field:
@@ -516,8 +523,8 @@ class ParticipantSummaryDao(UpdatableDao):
         else:
             return query.order_by(Code.display.desc())
 
-    def _make_query(self, session, query_def):
-        query, order_by_field_names = super(ParticipantSummaryDao, self)._make_query(session, query_def)
+    def _make_query(self, session, query_definition):
+        query, order_by_field_names = super(ParticipantSummaryDao, self)._make_query(session, query_definition)
         # Note: leaving for future use if we go back to using a relationship to PatientStatus table.
         # query.options(selectinload(ParticipantSummary.patientStatus))
         # sql = self.query_to_text(query)
@@ -1082,28 +1089,32 @@ class ParticipantSummaryDao(UpdatableDao):
         records = [self.incentive_dao.convert_json_obj(obj) for obj in records]
         return records
 
-    def to_client_json(self, model: ParticipantSummary, strip_none_values=True):
-        result = model.asdict()
+    def to_client_json(self, obj: ParticipantSummary, filter_payload=False):
+        if filter_payload:
+            return {k: v for k, v in list(obj._asdict().items())}
+        return self.build_default_obj_response(obj)
+
+    def build_default_obj_response(self, obj: ParticipantSummary):
+        result = obj.asdict()
         clinic_pm_time = result.get("clinicPhysicalMeasurementsFinalizedTime")
         self_reported_pm_time = result.get("selfReportedPhysicalMeasurementsAuthored")
         if self.hpro_consents:
             result = self.get_hpro_consent_paths(result)
-
         if self.participant_incentives:
             result['participantIncentives'] = self.get_participant_incentives(result)
 
-        is_the_basics_complete = model.questionnaireOnTheBasics == QuestionnaireStatus.SUBMITTED
+        is_the_basics_complete = obj.questionnaireOnTheBasics == QuestionnaireStatus.SUBMITTED
 
         # Participants that withdrew more than 48 hours ago should have fields other than
         # WITHDRAWN_PARTICIPANT_FIELDS cleared.
-        should_clear_fields_for_withdrawal = model.withdrawalStatus == WithdrawalStatus.NO_USE and (
-            model.withdrawalTime is None
-            or model.withdrawalTime < clock.CLOCK.now() - WITHDRAWN_PARTICIPANT_VISIBILITY_TIME
+        should_clear_fields_for_withdrawal = obj.withdrawalStatus == WithdrawalStatus.NO_USE and (
+            obj.withdrawalTime is None
+            or obj.withdrawalTime < clock.CLOCK.now() - WITHDRAWN_PARTICIPANT_VISIBILITY_TIME
         )
         if should_clear_fields_for_withdrawal:
             result = {k: result.get(k) for k in WITHDRAWN_PARTICIPANT_FIELDS}
 
-        result["participantId"] = to_client_participant_id(model.participantId)
+        result["participantId"] = to_client_participant_id(obj.participantId)
         biobank_id = result.get("biobankId")
         if biobank_id:
             result["biobankId"] = to_client_biobank_id(biobank_id)
@@ -1127,20 +1138,20 @@ class ParticipantSummaryDao(UpdatableDao):
 
         # Map demographic Enums if TheBasics was submitted and Skip wasn't in use
         if is_the_basics_complete and not should_clear_fields_for_withdrawal:
-            if model.genderIdentity is None or model.genderIdentity == GenderIdentity.UNSET:
+            if obj.genderIdentity is None or obj.genderIdentity == GenderIdentity.UNSET:
                 result['genderIdentity'] = GenderIdentity.PMI_Skip
 
-            if model.race is None or model.race == Race.UNSET:
+            if obj.race is None or obj.race == Race.UNSET:
                 result['race'] = Race.PMI_Skip
 
-        result["patientStatus"] = model.patientStatus
+        result["patientStatus"] = obj.patientStatus
 
         format_json_hpo(result, self.hpo_dao, "hpoId")
         result["awardee"] = result["hpoId"]
         _initialize_field_type_sets()
 
         for new_field_name, existing_field_name in self.get_aliased_field_map().items():
-            result[new_field_name] = getattr(model, existing_field_name)
+            result[new_field_name] = getattr(obj, existing_field_name)
 
             # register new field as date if field is date
             if type(result[new_field_name]) is datetime.datetime:
@@ -1161,9 +1172,9 @@ class ParticipantSummaryDao(UpdatableDao):
             format_json_enum(result, fieldname)
         for fieldname in _SITE_FIELDS:
             format_json_site(result, self.site_dao, fieldname)
-        if model.withdrawalStatus == WithdrawalStatus.NO_USE\
-                or model.suspensionStatus == SuspensionStatus.NO_CONTACT\
-                or model.deceasedStatus == DeceasedStatus.APPROVED:
+        if obj.withdrawalStatus == WithdrawalStatus.NO_USE\
+                or obj.suspensionStatus == SuspensionStatus.NO_CONTACT\
+                or obj.deceasedStatus == DeceasedStatus.APPROVED:
             result["recontactMethod"] = "NO_CONTACT"
 
         # fill in deprecated fields
@@ -1221,11 +1232,7 @@ class ParticipantSummaryDao(UpdatableDao):
                 if field_name in result:
                     del result[field_name]
 
-        # Strip None values.
-        if strip_none_values is True:
-            result = {k: v for k, v in list(result.items()) if v is not None}
-
-        return result
+        return {k: v for k, v in list(result.items()) if v is not None}
 
     @staticmethod
     def get_aliased_field_map():

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -9,7 +9,7 @@ import sqlalchemy.orm
 from sqlalchemy import or_, and_
 from sqlalchemy.orm import Query
 from sqlalchemy.sql import expression
-from typing import Collection
+from typing import Collection, List
 
 # Note: leaving for future use if we go back to using a relationship to PatientStatus table.
 # from sqlalchemy.orm import selectinload
@@ -1089,10 +1089,22 @@ class ParticipantSummaryDao(UpdatableDao):
         records = [self.incentive_dao.convert_json_obj(obj) for obj in records]
         return records
 
-    def to_client_json(self, obj: ParticipantSummary, filter_payload=False):
-        if filter_payload:
-            return {k: v for k, v in list(obj._asdict().items())}
+    def to_client_json(self, obj: ParticipantSummary, payload_attributes=None) -> dict:
+        if payload_attributes:
+            return self.build_filtered_obj_response(obj, payload_attributes)
         return self.build_default_obj_response(obj)
+
+    @classmethod
+    def build_filtered_obj_response(
+        cls,
+        obj: ParticipantSummary,
+        payload_attributes: List['str']
+    ) -> dict:
+        if hasattr(obj, '_asdict'):
+            obj = obj._asdict()
+        elif hasattr(obj, 'asdict'):
+            obj = obj.asdict()
+        return {k: v for k, v in list(obj.items()) if k in payload_attributes}
 
     def build_default_obj_response(self, obj: ParticipantSummary):
         result = obj.asdict()

--- a/rdr_service/query.py
+++ b/rdr_service/query.py
@@ -101,7 +101,8 @@ class Query(object):
         include_total=False,
         offset=False,
         options=None,
-        invalid_filters=None
+        invalid_filters=None,
+        attributes=None
     ):
         self.field_filters = field_filters
         self.order_by = order_by
@@ -113,6 +114,7 @@ class Query(object):
         self.include_total = include_total
         self.options = options
         self.invalid_filters = invalid_filters
+        self.attributes = attributes
 
 
 class Results(object):

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -10,7 +10,7 @@ from mock import patch
 from urllib.parse import urlencode
 
 from rdr_service import config, main
-from rdr_service.api_util import PTC, CURATION, HEALTHPRO
+from rdr_service.api_util import PTC, CURATION, HEALTHPRO, SUPPORT
 from rdr_service.clock import FakeClock
 from rdr_service.code_constants import (CONSENT_PERMISSION_NO_CODE, CONSENT_PERMISSION_YES_CODE,
                                         DVEHRSHARING_CONSENT_CODE_NO, DVEHRSHARING_CONSENT_CODE_NOT_SURE,
@@ -3974,7 +3974,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
             wa_participant_id
         ], response_ids)
 
-    #### begin POST to ParticipantSummary API
+    # Begin POST to ParticipantSummary API
     def test_response_for_pid_not_found_in_post(self):
         bad_pid = 'P12345'
 
@@ -4234,6 +4234,44 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual(len(responses), num_summary // 2)
         self.assertTrue(all(obj['resource']['site'] == monroe.googleGroup for obj in responses))
         self.assertFalse(any(obj['resource']['site'] == phoenix.googleGroup for obj in responses))
+
+    def test_filter_payload_roles(self):
+        num_summary, first_name = 4, 'Testy'
+
+        for num in range(num_summary):
+            self.data_generator.create_database_participant_summary(
+                firstName=first_name,
+                lastName=f'Tester_{num}',
+            )
+
+            # first_pid = ps.participantId if num == 0 else None
+
+        self.overwrite_test_user_roles([SUPPORT])
+        self.send_get(f"ParticipantSummary?firstName={first_name}")
+    #
+    #     print('Darryl')
+        # self.assertIsNotNone(response)
+        # self.assertEqual(response['site'], google_group)
+        #
+        # response = self.send_get(f"ParticipantSummary?firstName={first_name}")
+        # responses = response['entry']
+        #
+        # self.assertEqual(len(responses), num_summary)
+        # self.assertFalse(all(obj['resource']['site'] == monroe.googleGroup for obj in responses))
+        #
+        # self.overwrite_test_user_site(google_group)
+        #
+        # response = self.send_get(f"Participant/P{second_pid}/Summary")
+        #
+        # self.assertIsNotNone(response)
+        # self.assertEqual(response['site'], google_group)
+        #
+        # response = self.send_get(f"ParticipantSummary?firstName={first_name}")
+        # responses = response['entry']
+        #
+        # self.assertEqual(len(responses), num_summary // 2)
+        # self.assertTrue(all(obj['resource']['site'] == monroe.googleGroup for obj in responses))
+        # self.assertFalse(any(obj['resource']['site'] != monroe.googleGroup for obj in responses))
 
     def test_synthetic_pm_fields(self):
         questionnaire_id = self.create_questionnaire("all_consents_questionnaire.json")

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -4236,42 +4236,52 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertFalse(any(obj['resource']['site'] == phoenix.googleGroup for obj in responses))
 
     def test_filter_payload_roles(self):
-        num_summary, first_name = 4, 'Testy'
+        num_summary, first_name, first_pid = 4, 'Testy', None
 
         for num in range(num_summary):
-            self.data_generator.create_database_participant_summary(
+            ps = self.data_generator.create_database_participant_summary(
                 firstName=first_name,
                 lastName=f'Tester_{num}',
             )
+            if num == 0:
+                first_pid = ps.participantId
 
-            # first_pid = ps.participantId if num == 0 else None
-
+        # edit role to match config entry
         self.overwrite_test_user_roles([SUPPORT])
-        self.send_get(f"ParticipantSummary?firstName={first_name}")
-    #
-    #     print('Darryl')
-        # self.assertIsNotNone(response)
-        # self.assertEqual(response['site'], google_group)
-        #
-        # response = self.send_get(f"ParticipantSummary?firstName={first_name}")
-        # responses = response['entry']
-        #
-        # self.assertEqual(len(responses), num_summary)
-        # self.assertFalse(all(obj['resource']['site'] == monroe.googleGroup for obj in responses))
-        #
-        # self.overwrite_test_user_site(google_group)
-        #
-        # response = self.send_get(f"Participant/P{second_pid}/Summary")
-        #
-        # self.assertIsNotNone(response)
-        # self.assertEqual(response['site'], google_group)
-        #
-        # response = self.send_get(f"ParticipantSummary?firstName={first_name}")
-        # responses = response['entry']
-        #
-        # self.assertEqual(len(responses), num_summary // 2)
-        # self.assertTrue(all(obj['resource']['site'] == monroe.googleGroup for obj in responses))
-        # self.assertFalse(any(obj['resource']['site'] != monroe.googleGroup for obj in responses))
+
+        # only fields that should be returned
+        filtered_fields = config.getSettingJson(config.OPS_DATA_PAYLOAD_ROLES)['support']['fields']
+
+        response = self.send_get(f"ParticipantSummary?firstName={first_name}")
+        self.assertIsNotNone(response)
+        response_entries = response['entry']
+
+        for entry in response_entries:
+            resource = entry['resource']
+            # no extra keys in response resource
+            self.assertTrue(not len(resource.keys() - filtered_fields))
+
+        response = self.send_get(f"Participant/P{first_pid}/Summary")
+        self.assertIsNotNone(response)
+        # no extra keys in resource
+        self.assertTrue(not len(response.keys() - filtered_fields))
+
+        # change role to un-match config entry
+        self.overwrite_test_user_roles([HEALTHPRO])
+
+        response = self.send_get(f"ParticipantSummary?firstName={first_name}")
+        self.assertIsNotNone(response)
+        response_entries = response['entry']
+
+        for entry in response_entries:
+            resource = entry['resource']
+            # should have extra keys in response
+            self.assertTrue(len(resource.keys() - filtered_fields))
+
+        response = self.send_get(f"Participant/P{first_pid}/Summary")
+        self.assertIsNotNone(response)
+        # should have extra keys in response
+        self.assertTrue(len(response.keys() - filtered_fields))
 
     def test_synthetic_pm_fields(self):
         questionnaire_id = self.create_questionnaire("all_consents_questionnaire.json")

--- a/tests/dao_tests/test_hpro_consent_file_dao.py
+++ b/tests/dao_tests/test_hpro_consent_file_dao.py
@@ -93,24 +93,5 @@ class HealthProConsentDaoTest(BaseTestCase):
             records = self.dao.get_by_participant(pid)
             self.assertEqual(len(records), no_path_num)
 
-    def test_get_batch_records_by_pids(self):
-        num_pid_records, pids_inserted, no_path_num = 4, [], 2
-
-        for num in range(num_pid_records):
-            consent_file = self.data_generator.create_database_consent_file(
-                file_path=f'test_file_path/{num}'
-            )
-            pids_inserted.append(consent_file.participant_id)
-
-            for pid_num in range(num_pid_records):
-                self.data_generator.create_database_hpro_consent(
-                    file_path=f'test_two_file_path/{num}' if pid_num > 1 else None,
-                    participant_id=consent_file.participant_id,
-                    consent_file_id=consent_file.id
-                )
-
-        records = self.dao.batch_get_by_participant(pids_inserted)
-        self.assertEqual(len(records), num_pid_records * no_path_num)
-
 
 


### PR DESCRIPTION
## Resolves *[ticket DA-3157]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3157

## Description of changes/additions
Need to have a configurable framework in the participant summary for limiting the payload fields based on roles. First usage of this will be the Tactis/Support groups. 
If query is initialized other than a `get(id)` , the fields are passed in query build, otherwise extra fields are filtered out in the response method. 

## Tests
- [x] unit tests


