### PR TITLE
[PDR-1438] Incorporate Life Functioning Survey responses into UBR disability calculations

### DIFF
--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -7,10 +7,11 @@
 #
 import re
 
-from dateutil.relativedelta import relativedelta
-from dateutil.parser import parse
 from enum import IntEnum
 from typing import Dict, List
+from dateutil.relativedelta import relativedelta
+from dateutil.parser import parse
+
 from rdr_service.resource.helpers import RURAL_ZIPCODES, RURAL_2020_CUTOFF
 
 

--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -213,7 +213,7 @@ class ParticipantUBRCalculator:
                         'Disability_WalkingClimbing', 'Disability_DressingBathing', 'Disability_ErrandsAlone',
                         'Disability_Deaf' and 'Disability_DifficultyConcentrating' from "TheBasics" and/or "lfs"
                         (Life Functioning Survey) surveys.  If list has both TheBasics and lfs responses, lfs answers
-                        be last in the ordered list
+                        should be last in the ordered list
         # List of "Prefer Not To Answer" answer values for each question:
          'Blind_PreferNotToAnswer', 'WalkingClimbing_PreferNotToAnswer', 'DressingBathing_PreferNotToAnswer',
          'ErrandsAlone_PreferNotToAnswer', 'Deaf_PreferNotToAnswer', 'DifficultyConcentrating_PreferNotToAnswer'
@@ -229,7 +229,7 @@ class ParticipantUBRCalculator:
                     answers.get('Disability_ErrandsAlone', None) == 'ErrandsAlone_Yes' or \
                     answers.get('Disability_Deaf', None) == 'Deaf_Yes' or \
                     answers.get('Disability_DifficultyConcentrating', None) == 'DifficultyConcentrating_Yes':
-                # Can return immediately as soon as a qualifying UBR response is detected
+                # Affirmative UBR answers from TheBasics are always honored, do not need to continue processing
                 return UBRValueEnum.UBR
 
             # Check and see if all question answers are either Null, 'Prefer Not To Answer' or PMI_Skip.
@@ -243,6 +243,7 @@ class ParticipantUBRCalculator:
                     null_skip = False
                     break
             if null_skip is True:
+                # This may be updated on subsequent pass, when/if processing additional lfs response data
                 ret = UBRValueEnum.NotAnswer_Skip
             else:
                 ret = UBRValueEnum.RBR

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1725,6 +1725,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :return: dict
         """
         data = dict()
+        basics_qnan, lfs_qnan = None, None
+        ubr_disability_responses = []
         # Return if participant has not yet submitted a primary consent response.
         if summary.get('enrl_status_id', 0) < PDREnrollmentStatusEnum.Participant:
             return data
@@ -1746,35 +1748,55 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # ubr_overall - This should be calculated here in case there is no TheBasics response available.
         data['ubr_overall'] = ubr.ubr_overall(data)
 
-        #### TheBasics UBR calculations.
+        #### TheBasics / lfs UBR calculations.
         # Note: Due to PDR-484 we can't rely on the summary having a record for each valid submission so we
         #       are going to do our own query to get the first TheBasics submission after consent.
         # As of RDR 1.113.1, can filter on new classification_type to filter on full (COMPLETE) TheBasics surveys
-        qr_id = self.find_questionnaire_response_id(
+        basics_qr_id = self.find_questionnaire_response_id(
             ro_session, p_id, "TheBasics", QuestionnaireResponseClassificationType.COMPLETE, ModuleLookupEnum.FIRST)
-        if not qr_id:
-            return data
+        # PDR-1438: lfs survey released in 9/2022 for participants whose early version of TheBasics may not have
+        # included physical disability questions.  lfs presents the same 6 questions (e.g., Disability_Blind) and
+        # needs to be factored into UBR disability calculation
+        lfs_qr_id = self.find_questionnaire_response_id(
+            ro_session, p_id, "lfs", QuestionnaireResponseClassificationType.COMPLETE, ModuleLookupEnum.FIRST)
 
-        qnan = self.get_module_answers(self.ro_dao, 'TheBasics', p_id=p_id, qr_id=qr_id)
+        if basics_qr_id:
+            basics_qnan = self.get_module_answers(self.ro_dao, 'TheBasics', p_id=p_id, qr_id=basics_qr_id)
+        if lfs_qr_id:
+            lfs_qnan = self.get_module_answers(self.ro_dao, 'lfs', p_id=p_id, qr_id=lfs_qr_id)
 
-        # ubr_sex
-        data['ubr_sex'] = ubr.ubr_sex(qnan.get('BiologicalSexAtBirth_SexAtBirth', None))
-        # ubr_sexual_orientation
-        data['ubr_sexual_orientation'] = ubr.ubr_sexual_orientation(qnan.get('TheBasics_SexualOrientation', None))
-        # ubr_gender_identity
-        data['ubr_gender_identity'] = ubr.ubr_gender_identity(qnan.get('BiologicalSexAtBirth_SexAtBirth', None),
-            qnan.get('Gender_GenderIdentity', None), qnan.get('Gender_CloserGenderDescription', None))
-        # ubr_sexual_gender_minority
-        data['ubr_sexual_gender_minority'] = \
-            ubr.ubr_sexual_gender_minority(data['ubr_sexual_orientation'], data['ubr_gender_identity'])
-        # ubr_ethnicity
-        data['ubr_ethnicity'] = ubr.ubr_ethnicity(qnan.get('Race_WhatRaceEthnicity', None))
-        # ubr_education
-        data['ubr_education'] = ubr.ubr_education(qnan.get('EducationLevel_HighestGrade', None))
-        # ubr_income
-        data['ubr_income'] = ubr.ubr_income(qnan.get('Income_AnnualIncome', None))
-        # ubr_disability
-        data['ubr_disability'] = ubr.ubr_disability(qnan)
+        # Add the response to the list for the ubr_disability calculator if it has content.    TODO: Confirm if RDR has
+        # any pids with valid answers (not all None/PMI_Skip) to disability questions in both surveys.  Not expected,
+        # but this ensures lfs answers take precedence by being last in the list to be processed in ubr_disability()
+        for qnan in [basics_qnan, lfs_qnan]:
+            if qnan:
+                ubr_disability_responses.append(qnan)
+
+        # Except for ubr_disability, other UBR categories determined only from TheBasics data
+        if basics_qnan:
+            # ubr_sex
+            data['ubr_sex'] = ubr.ubr_sex(basics_qnan.get('BiologicalSexAtBirth_SexAtBirth', None))
+            # ubr_sexual_orientation
+            data['ubr_sexual_orientation'] = ubr.ubr_sexual_orientation(basics_qnan.get('TheBasics_SexualOrientation',
+                                                                                        None))
+            # ubr_gender_identity
+            data['ubr_gender_identity'] = ubr.ubr_gender_identity(
+                basics_qnan.get('BiologicalSexAtBirth_SexAtBirth', None),
+                basics_qnan.get('Gender_GenderIdentity', None),
+                basics_qnan.get('Gender_CloserGenderDescription', None)
+            )
+            # ubr_sexual_gender_minority
+            data['ubr_sexual_gender_minority'] = \
+                ubr.ubr_sexual_gender_minority(data['ubr_sexual_orientation'], data['ubr_gender_identity'])
+            # ubr_ethnicity
+            data['ubr_ethnicity'] = ubr.ubr_ethnicity(basics_qnan.get('Race_WhatRaceEthnicity', None))
+            # ubr_education
+            data['ubr_education'] = ubr.ubr_education(basics_qnan.get('EducationLevel_HighestGrade', None))
+            # ubr_income
+            data['ubr_income'] = ubr.ubr_income(basics_qnan.get('Income_AnnualIncome', None))
+
+        # ubr_disability() will handle cases where neither TheBasics nor lfs response exists (param is empty list)
+        data['ubr_disability'] = ubr.ubr_disability(ubr_disability_responses)
         # ubr_overall
         data['ubr_overall'] = ubr.ubr_overall(data)
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1766,8 +1766,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             lfs_qnan = self.get_module_answers(self.ro_dao, 'lfs', p_id=p_id, qr_id=lfs_qr_id)
 
         # Add the response to the list for the ubr_disability calculator if it has content.    TODO: Confirm if RDR has
-        # any pids with valid answers (not all None/PMI_Skip) to disability questions in both surveys.  Not expected,
-        # but this ensures lfs answers take precedence by being last in the list to be processed in ubr_disability()
+        # any pids with valid answers (not all None/PMI_Skip) to disability questions in TheBasics but also have an
+        # lfs survey response (not an expected use case).
         for qnan in [basics_qnan, lfs_qnan]:
             if qnan:
                 ubr_disability_responses.append(qnan)


### PR DESCRIPTION
## Resolves *[PDR-1438](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1438)*


## Description of changes/additions
NIH has asked that UBR disability calculations be updated for any participants who recently completed the "Life Functioning Survey".

The access to the `lfs` survey is supposed to be limited to participants who did not see/provide answers to the disability questions via `TheBasics` (e.g., saw an early version of `TheBasics` questionnaire).    So, any affirmative answer to a disability question in `TheBasics` survey response will automatically result in a UBR status.  `lfs` answers take precedence otherwise.
## Tests
- [x] unit tests

