### PR TITLE
[DA-3148] Split result withdrawal email

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1894,18 +1894,24 @@ class GenomicJobController:
         result_withdrawal_dao.insert_bulk(batch)
 
         notification_emails = config.getSettingJson(config.RDR_GENOMICS_NOTIFICATION_EMAIL, default=None)
-        if notification_emails:
-            message = 'The following participants have withdrawn from the program and are currently'
-            message += ' in the genomics result pipelines:\n\n'
-            message += '\n'.join([f'P{participant.participant_id}' for participant in result_withdrawals])
 
-            EmailService.send_email(
-                Email(
-                    recipients=notification_emails,
-                    subject='Participants that have withdrawn and are currently in results pipeline(s)',
-                    plain_text_content=message
+        if notification_emails:
+            for email_type in ['GEM', 'HEALTH']:
+                current_list = list(
+                    filter(lambda x: x.array_results is True if 'GEM' in email_type else x.cvl_results is True,
+                           result_withdrawals))
+                message = 'The following participants have withdrawn from the program and are currently '
+                message += f'in the genomics {email_type} result pipeline\n\n'
+                message += '\n'.join([f'P{participant.participant_id}' for participant in current_list])
+                message += '\n'
+
+                EmailService.send_email(
+                    Email(
+                        recipients=notification_emails,
+                        subject=f'Withdrawn participants in genomic results pipeline(s): {email_type}',
+                        plain_text_content=message
+                    )
                 )
-            )
 
         self.job_result = GenomicSubProcessResult.SUCCESS
 

--- a/tests/genomics_tests/test_genomic_job_controller.py
+++ b/tests/genomics_tests/test_genomic_job_controller.py
@@ -888,8 +888,12 @@ class GenomicJobControllerTest(BaseTestCase):
         with GenomicJobController(GenomicJob.RESULTS_PIPELINE_WITHDRAWALS) as controller:
             controller.check_results_withdrawals()
 
-        # mock checks
-        self.assertEqual(email_mock.call_count, 1)
+        # mock checks should be two => 1 GEM 1 HEALTH
+        self.assertEqual(email_mock.call_count, 2)
+        call_args = email_mock.call_args_list
+
+        self.assertTrue(any('GEM' in call.args[0].subject for call in call_args))
+        self.assertTrue(any('HEALTH' in call.args[0].subject for call in call_args))
 
         job_runs = self.job_run_dao.get_all()
         current_job_run = list(filter(lambda x: x.jobId == GenomicJob.RESULTS_PIPELINE_WITHDRAWALS, job_runs))[0]
@@ -913,8 +917,8 @@ class GenomicJobControllerTest(BaseTestCase):
         with GenomicJobController(GenomicJob.RESULTS_PIPELINE_WITHDRAWALS) as controller:
             controller.check_results_withdrawals()
 
-        # mock checks should still be one on account of no records
-        self.assertEqual(email_mock.call_count, 1)
+        # mock checks should still be two on account of no records
+        self.assertEqual(email_mock.call_count, 2)
 
         job_runs = self.job_run_dao.get_all()
         current_job_run = list(filter(lambda x: x.jobId == GenomicJob.RESULTS_PIPELINE_WITHDRAWALS, job_runs))[1]


### PR DESCRIPTION
## Resolves *[ticket DA-3148]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3148

## Description of changes/additions
Need to split the result withdrawal email based on the pipeline type

## Tests
- [x] unit tests


