### PR TITLE
[DA-3219] updating etm module recognition

### DIFF
--- a/rdr_service/api/etm_api.py
+++ b/rdr_service/api/etm_api.py
@@ -42,7 +42,8 @@ class EtmApi:
         repository.store_questionnaire(questionnaire_obj)
 
         return {
-            'id': questionnaire_obj.id
+            'id': questionnaire_obj.id,
+            **questionnaire_json
         }
 
     @classmethod
@@ -62,7 +63,8 @@ class EtmApi:
             response_repository.store_response(response_obj)
 
             return {
-                'id': response_obj.id
+                'id': response_obj.id,
+                **questionnaire_response_json
             }
         else:
             validation_errors = ','.join(validation_result.errors)

--- a/tests/api_tests/test_etm_ingestion.py
+++ b/tests/api_tests/test_etm_ingestion.py
@@ -49,6 +49,15 @@ class EtmIngestionTest(BaseTestCase):
         ).one()
         self.assertEqual(2, second_questionnaire.version)
 
+    def test_questionnaire_api_response(self):
+        """Ensure that the full json sent is returned in the response"""
+        with open(data_path('etm_questionnaire.json')) as file:
+            questionnaire_json = json.load(file)
+        response = self.send_post('Questionnaire', questionnaire_json)
+
+        del response['id']
+        self.assertEqual(questionnaire_json, response)
+
     def test_questionnaire_response_ingestion(self):
         with open(data_path('etm_questionnaire.json')) as file:
             questionnaire_json = json.load(file)
@@ -122,6 +131,22 @@ class EtmIngestionTest(BaseTestCase):
             ],
             actual_list=saved_response.extension_list
         )
+
+    def test_questionnaire_response_api_response(self):
+        """Check that the QuestionnaireResponse data is returned by the API"""
+        with open(data_path('etm_questionnaire.json')) as file:
+            questionnaire_json = json.load(file)
+            self.send_post('Questionnaire', questionnaire_json)
+
+        participant_id = self.data_generator.create_database_participant().participantId
+
+        with open(data_path('etm_questionnaire_response.json')) as file:
+            questionnaire_response_json = json.load(file)
+        questionnaire_response_json['subject']['reference'] = f'Patient/P{participant_id}'
+        response = self.send_post(f'Participant/P{participant_id}/QuestionnaireResponse', questionnaire_response_json)
+
+        del response['id']
+        self.assertEqual(questionnaire_response_json, response)
 
     def assert_has_extensions(
         self,

--- a/tests/api_tests/test_etm_ingestion.py
+++ b/tests/api_tests/test_etm_ingestion.py
@@ -26,7 +26,7 @@ class EtmIngestionTest(BaseTestCase):
         questionnaire_obj: etm.EtmQuestionnaire = self.session.query(etm.EtmQuestionnaire).filter(
             etm.EtmQuestionnaire.etm_questionnaire_id == response['id']
         ).one()
-        self.assertEqual(questionnaire_json['id'], questionnaire_obj.questionnaire_type)
+        self.assertEqual('emorecog', questionnaire_obj.questionnaire_type)
         self.assertEqual(questionnaire_json['version'], questionnaire_obj.semantic_version)
         self.assertEqual(questionnaire_json['text']['div'], questionnaire_obj.title)
 

--- a/tests/test-data/etm_questionnaire.json
+++ b/tests/test-data/etm_questionnaire.json
@@ -1,7 +1,6 @@
 {
     "resourceType": "Questionnaire",
     "version": "EmoRecog_AoU.v1.Nov22",
-    "id": "emorecog",
     "text": {
         "div": "TestMyBrain Multiracial Emotion Identification",
         "status": "additional"
@@ -2496,5 +2495,11 @@
                 ]
             }
         ]
-    }
+    },
+    "identifier": [
+        {
+            "system": "https://research.joinallofus.org/fhir/module_identifier",
+            "value": "EmoRecog_AoU.v1.Nov22"
+        }
+    ]
 }


### PR DESCRIPTION
## Resolves *[DA-3219](https://precisionmedicineinitiative.atlassian.net/browse/DA-3219)*
When sending an EtM Questionnaire and QuestionnaireResponse, Vibrent needs us to respond with all the data sent as well as the `id` field filled in with RDR's internal id for the object.

As part of that, we needed to move where Vibrent identifies what module the Questionnaire is for (such as "emorecog"). This has been moved to the `identifier` section of the FHIR payload (and also changed to match the version syntax).

## Tests
- [x] unit tests




[DA-3219]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DA-3219]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ