### PR TITLE
[DA-3233] Add column exclusion manifest(s)

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4064,8 +4064,7 @@ class GenomicQueriesDao(BaseDao):
                     sqlalchemy.sql.expression.literal("False")),
                 GenomicSetMember.blockResearchReason,
                 GenomicGCValidationMetrics.pipelineId,
-                (GenomicGCValidationMetrics.processingCount + 1).label('processingCount'),
-                GenomicSetMember.id.label('genomic_set_member_id')
+                (GenomicGCValidationMetrics.processingCount + 1).label('processingCount')
             ).join(
                 ParticipantSummary,
                 ParticipantSummary.participantId == GenomicSetMember.participantId

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4064,7 +4064,8 @@ class GenomicQueriesDao(BaseDao):
                     sqlalchemy.sql.expression.literal("False")),
                 GenomicSetMember.blockResearchReason,
                 GenomicGCValidationMetrics.pipelineId,
-                (GenomicGCValidationMetrics.processingCount + 1).label('processingCount')
+                (GenomicGCValidationMetrics.processingCount + 1).label('processingCount'),
+                GenomicSetMember.id.label('genomic_set_member_id')
             ).join(
                 ParticipantSummary,
                 ParticipantSummary.participantId == GenomicSetMember.participantId

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -146,7 +146,8 @@ class GenomicQueryClass:
                         sqlalchemy.func.IF(ParticipantSummary.consentForGenomicsROR
                                            == QuestionnaireStatus.SUBMITTED,
                                            sqlalchemy.sql.expression.literal("yes"),
-                                           sqlalchemy.sql.expression.literal("no"))
+                                           sqlalchemy.sql.expression.literal("no")),
+                        # GenomicSetMember.id.label('genomic_set_member_id')
                     ]
                 ).select_from(
                     sqlalchemy.join(

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -147,7 +147,7 @@ class GenomicQueryClass:
                                            == QuestionnaireStatus.SUBMITTED,
                                            sqlalchemy.sql.expression.literal("yes"),
                                            sqlalchemy.sql.expression.literal("no")),
-                        # GenomicSetMember.id.label('genomic_set_member_id')
+                        GenomicSetMember.id.label('genomic_set_member_id')
                     ]
                 ).select_from(
                     sqlalchemy.join(

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -146,7 +146,7 @@ class GenomicQueryClass:
                         sqlalchemy.func.IF(ParticipantSummary.consentForGenomicsROR
                                            == QuestionnaireStatus.SUBMITTED,
                                            sqlalchemy.sql.expression.literal("yes"),
-                                           sqlalchemy.sql.expression.literal("no")),
+                                           sqlalchemy.sql.expression.literal("no"))
                     ]
                 ).select_from(
                     sqlalchemy.join(

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -514,6 +514,7 @@ def genomic_aw2f_remainder_workflow():
     genomic_pipeline.send_remainder_contamination_manifests()
     return '{"success": "true"}'
 
+
 @app_util.auth_required_cron
 @run_genomic_cron_job('a1_manifest_workflow')
 def genomic_gem_a1_workflow():


### PR DESCRIPTION
## Resolves *[ticket DA-3233]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3233

## Description of changes/additions
Need to add a column that can be excluded when manifest are generated, specifically the `genomic_set_member.id`
for being able to tag correct record with current run ids to mitigate being sent twice.

** Logic for this works by adding the correct set member record to the manifest query
and utilizing it in the logic flows for updating the correct `genomic_set_member` record by being evaluated at a certain part of the logic and then removed from manifest rows during write execution.  

This is kind of a first-pass @ this, if we wanted to have a dedicated exclusion list and be able to filter on the `keys()` sent from queries we would need to tag the manifest(s) that have SqlAlchemy "evaluated" columns, like the biobank concatenation, with a corresponding label, since those do not get tagged as object attributes.

The AW2f is the only manifest query with this added column as of this PR.

## Tests
- [x] unit tests


