### PR TITLE
[DA-3250] Genomic Scheduling return all data regardless of event type

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2349,7 +2349,7 @@ class GenomicSchedulingDao(BaseDao):
             }
 
         for appointment in payload_dict.get('data'):
-            status = appointment.status.split('_')[-1]
+            status = appointment.status.split('_', 1)[-1]
             participant_id = f'P{appointment.participant_id}'
             appointment = {k: v for k, v in appointment._asdict().items() if v is not None}
             appointment['participant_id'] = participant_id
@@ -2389,7 +2389,6 @@ class GenomicSchedulingDao(BaseDao):
         ).subquery()
 
         note_alias = aliased(GenomicAppointmentEvent)
-        event_alias = aliased(GenomicAppointmentEvent)
 
         with self.session() as session:
             records = session.query(
@@ -2411,12 +2410,6 @@ class GenomicSchedulingDao(BaseDao):
                     else_=False
                 ).label('note_available'),
             ).join(
-                max_event_authored_time_subquery,
-                and_(
-                    GenomicAppointmentEvent.participant_id == max_event_authored_time_subquery.c.participant_id,
-                    GenomicAppointmentEvent.module_type == max_event_authored_time_subquery.c.module_type,
-                )
-            ).join(
                 max_appointment_id_subquery,
                 and_(
                     GenomicAppointmentEvent.participant_id == max_appointment_id_subquery.c.participant_id,
@@ -2430,19 +2423,11 @@ class GenomicSchedulingDao(BaseDao):
                     note_alias.module_type == GenomicAppointmentEvent.module_type,
                     note_alias.appointment_id == max_appointment_id_subquery.c.max_appointment_id
                 )
-            ).outerjoin(
-                event_alias,
-                and_(
-                    event_alias.event_type.notlike('%note_available'),
-                    event_alias.participant_id == GenomicAppointmentEvent.participant_id,
-                    event_alias.module_type == GenomicAppointmentEvent.module_type,
-                    GenomicAppointmentEvent.event_authored_time < event_alias.event_authored_time
-                )
             ).filter(
                 and_(
                     GenomicAppointmentEvent.appointment_id == max_appointment_id_subquery.c.max_appointment_id,
-                    event_alias.id.is_(None),
-                    GenomicAppointmentEvent.event_type.notlike('%note_available')
+                    GenomicAppointmentEvent.event_authored_time ==
+                    max_event_authored_time_subquery.c.max_event_authored_time
                 )
             )
 
@@ -2456,8 +2441,7 @@ class GenomicSchedulingDao(BaseDao):
                 )
             if start_date:
                 records = records.filter(
-                    or_(GenomicAppointmentEvent.event_authored_time > start_date,
-                        note_alias.event_authored_time > start_date),
+                    GenomicAppointmentEvent.event_authored_time > start_date,
                     GenomicAppointmentEvent.event_authored_time < end_date
                 )
 

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -2261,8 +2261,7 @@ class GenomicSchedulingApiTest(GenomicApiTestBase):
             f"GenomicScheduling?participant_id=P{participant_data.participantId}"
         )
 
-        # should still be scheduled as the status, note event should be filtered out
-        self.assertTrue(all(obj['status'] == 'scheduled' for obj in resp['data']))
+        self.assertTrue(all(obj['status'] == 'note_available' for obj in resp['data']))
         self.assertTrue(all(obj['note_available'] is True for obj in resp['data']))
 
     def test_module_params(self):

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -2261,6 +2261,7 @@ class GenomicSchedulingApiTest(GenomicApiTestBase):
             f"GenomicScheduling?participant_id=P{participant_data.participantId}"
         )
 
+        # note_available should have changes to True
         self.assertTrue(all(obj['status'] == 'note_available' for obj in resp['data']))
         self.assertTrue(all(obj['note_available'] is True for obj in resp['data']))
 


### PR DESCRIPTION
## Resolves *[DA-3209]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3209

## Description of changes/additions
Need scheduling API  to return all events and attributing data via payload regardless of event type 

## Tests
- [x] unit tests




[DA-3209]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ