### PR TITLE
Update JIRA to utilize API tokens for basic auth

### DIFF
--- a/rdr_service/services/jira_utils.py
+++ b/rdr_service/services/jira_utils.py
@@ -19,7 +19,7 @@ class JiraTicketHandler:
     """
     def __init__(self):
         self._jira_user = os.environ.get('JIRA_API_USER_NAME', None)
-        self._jira_password = os.environ.get('JIRA_API_USER_PASSWORD', None)
+        self._jira_api_token = os.environ.get('JIRA_API_TOKEN', None)
         self._jira_watchers = os.environ.get('JIRA_WATCHER_NAMES', None)
         self._jira_connection = None
         self.required_tags = {
@@ -59,7 +59,7 @@ class JiraTicketHandler:
         """
         jira_creds = config.getSettingJson(config.JIRA_CREDS)
         self._jira_user = jira_creds.get("jira_rdr_username", None)
-        self._jira_password = jira_creds.get("jira_rdr_password", None)
+        self._jira_api_token = jira_creds.get("jira_api_token", None)
 
     def _connect_to_jira(self):
         """
@@ -70,14 +70,22 @@ class JiraTicketHandler:
 
         if not self._jira_connection:
             if config.GAE_PROJECT == "localhost":
-                if not self._jira_user or not self._jira_password:
-                    raise ValueError('Jira user name or password not set in environment.')
+                if not self._jira_user or not self._jira_api_token:
+                    raise ValueError('Jira user name or api token not set in environment.')
             else:
                 self.set_jira_credentials_from_config()
-                if not self._jira_user or not self._jira_password:
-                    raise ValueError('Jira user name or password not set in config.')
+                if not self._jira_user or not self._jira_api_token:
+                    raise ValueError('Jira user name or api token not set in config.')
+
+            # https://jira.readthedocs.io/examples.html#username-api-token
             self._jira_connection = jira.JIRA(
-                _JIRA_INSTANCE_URL, options=options, basic_auth=(self._jira_user, self._jira_password))
+                _JIRA_INSTANCE_URL,
+                options=options,
+                basic_auth=(
+                    self._jira_user,
+                    self._jira_api_token
+                )
+            )
 
     def current_user(self):
         return self._jira_connection.current_user()

--- a/rdr_service/tools/tool_libs/app_engine_manager.py
+++ b/rdr_service/tools/tool_libs/app_engine_manager.py
@@ -507,7 +507,7 @@ class DeployAppClass(ToolBase):
                 return 1
 
             self.deploy_version = self.args.deploy_as if self.args.deploy_as else \
-                                    self.args.git_target.replace('.', '-')
+                self.args.git_target.replace('.', '-')
 
             running_services = gcp_get_app_versions(running_only=True)
             if not running_services:
@@ -521,7 +521,7 @@ class DeployAppClass(ToolBase):
             _logger.info('  App Source Path       : {0}'.format(clr.fmt(self.deploy_root)))
             _logger.info('  Promote               : {0}'.format(clr.fmt('No' if self.args.no_promote else 'Yes')))
 
-            if 'JIRA_API_USER_NAME' in os.environ and 'JIRA_API_USER_PASSWORD' in os.environ:
+            if 'JIRA_API_USER_NAME' in os.environ and 'JIRA_API_TOKEN' in os.environ:
                 self.jira_ready = True
                 self._jira_handler = JiraTicketHandler()
 


### PR DESCRIPTION
## Resolves *[ticket DA-3263]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3263

## Description of changes/additions
JIRA has deprecated the use of basic auth with only user name and password, need to utilize API keys with username.

## Tests
- [] unit tests

