### PR TITLE
[DA-3260] Exclude Profile Updates from CDR

### DIFF
--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -369,7 +369,8 @@ class CurationExportClass(ToolBase):
             QuestionnaireQuestion
         ).filter(
             QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
-            QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE
+            QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE,
+            QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.PROFILE_UPDATE
         )
         if cutoff_date:
             answers_by_module_select = answers_by_module_select.filter(
@@ -513,6 +514,7 @@ class CurationExportClass(ToolBase):
             ),
             QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
             QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE,
+            QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.PROFILE_UPDATE,
             and_(
                 ParticipantSummary.dateOfBirth.isnot(None),
                 ParticipantSummary.consentForStudyEnrollmentFirstYesAuthored.isnot(None),

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -650,3 +650,47 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
                 self.assertIsNone(src_clean_answer)
             else:
                 self.assertEqual(expected_answer, src_clean_answer.value_string)
+
+    def test_exclude_profile_update_questionnaire_response(self):
+        """Questionnaire Responses with PROFILE_UPDATE classification should be excluded"""
+
+
+        # Create a questionnaire response that would be used instead of the default for the test suite
+        self._setup_questionnaire_response(
+            self.participant,
+            self.questionnaire,
+            indexed_answers=[
+                (1, 'valueString', 'update'),
+                (3, 'valueString', 'final answer')
+            ],
+            authored=datetime(2020, 6, 10),
+            created=datetime(2020, 6, 10)
+        )
+
+        self._setup_questionnaire_response(
+            self.participant,
+            self.questionnaire,
+            indexed_answers=[
+                (1, 'valueString', 'profile update'),
+            ],
+            authored=datetime(2021, 6, 10),
+            created=datetime(2021, 6, 10),
+            classification_type=QuestionnaireResponseClassificationType.PROFILE_UPDATE
+        )
+
+        # Check that we are only seeing the answers from the latest questionnaire response
+        self.run_cdm_data_generation()
+        for question_index, question in enumerate(self.questionnaire.questions):
+            expected_answer = None
+            if question_index == 1:
+                expected_answer = 'update'
+            elif question_index == 3:
+                expected_answer = 'final answer'
+
+            src_clean_answer = self.session.query(SrcClean).filter(
+                SrcClean.question_code_id == question.codeId
+            ).one_or_none()
+            if expected_answer is None:
+                self.assertIsNone(src_clean_answer)
+            else:
+                self.assertEqual(expected_answer, src_clean_answer.value_string)


### PR DESCRIPTION
## Resolves *[DA-3260](https://precisionmedicineinitiative.atlassian.net/browse/DA-3260)*


## Description of changes/additions
Excludes PROFILE_UPDATE classified Questionnaire Responses from CDR to allow prior The Basics responses to be sent.

## Tests
- [x] unit tests




[DA-3260]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ