### PR TITLE
Revert schedule api lastest events

### DIFF
--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -2262,7 +2262,7 @@ class GenomicSchedulingApiTest(GenomicApiTestBase):
         )
 
         # note_available should have changes to True
-        self.assertTrue(all(obj['status'] == 'note_available' for obj in resp['data']))
+        self.assertTrue(all(obj['status'] == 'scheduled' for obj in resp['data']))
         self.assertTrue(all(obj['note_available'] is True for obj in resp['data']))
 
     def test_module_params(self):


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Do to a breakdown in requirements/conversation with external partners, need to revert getting latest schedule events query.

## Tests
- [x] unit tests


