### PR TITLE
[DA-3240] Adding patient url and a mechanism for further versioning

### DIFF
--- a/rdr_service/api_util.py
+++ b/rdr_service/api_util.py
@@ -270,3 +270,7 @@ def dispatch_task(endpoint: str, payload: dict, in_seconds=30, quiet=True, proje
             quiet=quiet,
             project_id=project_id
         )
+
+
+def get_versioned_url_prefix(version):
+    return f'/rdr/v{version}/'

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -10,7 +10,7 @@ from flask_restful import Api
 from sqlalchemy.exc import DBAPIError
 from werkzeug.exceptions import HTTPException
 
-from rdr_service import app_util, config_api, version_api
+from rdr_service import api_util, app_util, config_api, version_api
 from rdr_service.api import metrics_ehr_api
 from rdr_service.api.awardee_api import AwardeeApi
 from rdr_service.api.bigquery_participant_summary_api import BQParticipantSummaryApi
@@ -334,7 +334,8 @@ api.add_resource(
 
 api.add_resource(
     ProfileUpdateApi,
-    API_PREFIX + 'Participant/ProfileUpdate',
+    api_util.get_versioned_url_prefix(version=1) + 'Participant/ProfileUpdate',
+    api_util.get_versioned_url_prefix(version=1) + 'Patient',
     endpoint='profile_update',
     methods=['POST']
 )

--- a/tests/api_tests/test_profile_update_api.py
+++ b/tests/api_tests/test_profile_update_api.py
@@ -19,7 +19,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_first_name_update(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'name': [{
@@ -36,7 +36,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_middle_name_update(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'name': [{
@@ -55,7 +55,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_last_name_update(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'name': [{
@@ -70,7 +70,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clearing_middle_name(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'name': [{
@@ -89,7 +89,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clearing_family_name(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'name': [{
@@ -104,7 +104,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clearing_full_name(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'name': []
@@ -119,7 +119,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_phone_number(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'telecom': [
@@ -137,7 +137,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_phone_number(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'telecom': [
@@ -155,7 +155,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_email(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'telecom': [
@@ -173,7 +173,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_email(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'telecom': [
@@ -191,7 +191,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_birthdate(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'birthDate': '2017-01-01'
@@ -204,7 +204,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_birthdate(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'birthDate': ''
@@ -217,7 +217,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_address_line1(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -237,7 +237,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_address_line1(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -257,7 +257,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_address_line2(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -278,7 +278,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_address_line2(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -298,7 +298,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_address_city(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -315,7 +315,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_address_city(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -332,7 +332,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_address_state(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -349,7 +349,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_address_state(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -366,7 +366,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_address_zip_code(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -383,7 +383,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_address_zip_code(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'address': [
@@ -400,7 +400,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_update_language(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'communication': [
@@ -424,7 +424,7 @@ class ProfileUpdateApiTest(BaseTestCase):
 
     def test_clear_language(self):
         self.send_post(
-            'Participant/ProfileUpdate',
+            'Patient',
             request_data={
                 'id': 'P123123123',
                 'communication': []


### PR DESCRIPTION
## Resolves *[DA-3240](https://precisionmedicineinitiative.atlassian.net/browse/DA-3240)*
This implements a couple of requests that Vibrent has requested for the ProfileUpdate/Patient endpoint:
- To better match with FHIR standard, we're changing the URL from `Participant/ProfileUpdate` to `Patient`. Note: `Participant/ProfileUpdate` is being left in place now so as to not disrupt any testing they have in progress. It will continue to function until they confirm they have switched to the `Patient` URL.
- To help with future changes in the API (when changing the behavior of an endpoint and not necessarily the URL) we're putting a mechanism in place to make versioned endpoints available. With this change we'll be able to implement updates to how the RDR handles requests, but still leave the current behavior and endpoint in place until partners can make the switch to a higher version of the endpoint later.


## Tests
- [x] unit tests




[DA-3240]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ