### PR TITLE
[PDR-1573] Add health datastream timestamp to PDR participant data

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -440,7 +440,8 @@ class BQParticipantSummarySchema(BQSchema):
                                                     BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     health_datastream_sharing_status_v3_1_id = BQField('health_datastream_sharing_status_v3_1_id',
                                                        BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
-
+    health_datastream_sharing_status_v3_1_time = BQField('health_datastream_sharing_status_v3_1_time',
+                                                         BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
 class BQParticipantSummary(BQTable):
     """ Participant Summary BigQuery Table """

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -249,6 +249,8 @@ class BQPDRParticipantSummarySchema(BQSchema):
                                                     BQFieldTypeEnum.STRING, BQFieldModeEnum.NULLABLE)
     health_datastream_sharing_status_v3_1_id = BQField('health_datastream_sharing_status_v3_1_id',
                                                        BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
+    health_datastream_sharing_status_v3_1_time = BQField('health_datastream_sharing_status_v3_1_time',
+                                                         BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
 
 
 class BQPDRParticipantSummary(BQTable):

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -397,6 +397,7 @@ class ParticipantSchema(Schema):
     enrollment_status_v3_1_participant_plus_baseline_time = fields.DateTime()
     health_datastream_sharing_status_v3_1 = fields.EnumString(enum=DigitalHealthSharingStatusV31)
     health_datastream_sharing_status_v3_1_id = fields.EnumInteger(enum=DigitalHealthSharingStatusV31)
+    health_datastream_sharing_status_v3_1_time = fields.DateTime()
     # These EHR fields are populated from Curation data.
     ehr_status = fields.EnumString(enum=EhrStatus)
     ehr_status_id = fields.EnumInteger(enum=EhrStatus)


### PR DESCRIPTION
## Resolves *[PDR-1573](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1573)*


## Description of changes/additions
Adding `health_datastream_sharing_status_v3_1_time` timestamp field to PDR participant data definitions.  It was left out of previous model/schema changes when the other Goal 1 values retrieved from RDR `participant_summary` were added to the PDR models/schemas.

## Tests
Verified PDR data generation via `resource` tool in RDR stable, confirmed `bigquery_sync` PDR record generation for participants with and without a health datastream timestamp value in their `participant_summary` RDR record. 




[PDR-1573]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ