### PR TITLE
[ROC-1545] Fix for bug letting v3 enrollment status dates through

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1221,16 +1221,16 @@ class ParticipantSummaryDao(UpdatableDao):
             del result['enrollmentStatusV3_0']
             del result['enrollmentStatusV3_1']
             for field_name in [
-                'enrollmentStatusParticipantV3_0Time'
-                'enrollmentStatusParticipantPlusEhrV3_0Time'
-                'enrollmentStatusPmbEligibleV3_0Time'
-                'enrollmentStatusCoreMinusPmV3_0Time'
-                'enrollmentStatusCoreV3_0Time'
-                'enrollmentStatusParticipantV3_1Time'
-                'enrollmentStatusParticipantPlusEhrV3_1Time'
-                'enrollmentStatusParticipantPlusBasicsV3_1Time'
-                'enrollmentStatusCoreMinusPmV3_1Time'
-                'enrollmentStatusCoreV3_1Time'
+                'enrollmentStatusParticipantV3_0Time',
+                'enrollmentStatusParticipantPlusEhrV3_0Time',
+                'enrollmentStatusPmbEligibleV3_0Time',
+                'enrollmentStatusCoreMinusPmV3_0Time',
+                'enrollmentStatusCoreV3_0Time',
+                'enrollmentStatusParticipantV3_1Time',
+                'enrollmentStatusParticipantPlusEhrV3_1Time',
+                'enrollmentStatusParticipantPlusBasicsV3_1Time',
+                'enrollmentStatusCoreMinusPmV3_1Time',
+                'enrollmentStatusCoreV3_1Time',
                 'enrollmentStatusParticipantPlusBaselineV3_1Time'
             ]:
                 if field_name in result:


### PR DESCRIPTION
## Partially Resolves *[ROC-1545](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1545)*
Enrollment status v3 fields should still be blocked, but when originally blocking them from being visible I didn't set the filter up correctly. This corrects the filter so they're removed from the API results.

## Tests
- [ ] unit tests




[ROC-1545]: https://precisionmedicineinitiative.atlassian.net/browse/ROC-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ