### PR TITLE
allowing for quoted numbers when validating surveys

### DIFF
--- a/rdr_service/services/response_validation/validation.py
+++ b/rdr_service/services/response_validation/validation.py
@@ -468,7 +468,7 @@ class _ConstraintParser(_BaseParser):
         answer_code = ''.join(self._answer_chars)
 
         if self._comparison_operation == '>':
-            condition = Question(question_code).answer_greater_than(int(answer_code))
+            condition = Question(question_code).answer_greater_than(answer_code)
         else:
             condition = Question(question_code).is_answered_with(answer_code)
 

--- a/rdr_service/services/response_validation/validation.py
+++ b/rdr_service/services/response_validation/validation.py
@@ -414,7 +414,10 @@ class _ConstraintParser(_BaseParser):
             self._read_comparison(char)
         elif self._state == _ConstraintParserState.READING_ANSWER:
             if char in ["'", " "]:
-                self.finish_constraint()
+                if self._answer_chars:
+                    # Number comparisons can have quotes in the answer, only finalize answer if we're not starting
+                    # a quoted answer
+                    self.finish_constraint()
             else:
                 self._answer_chars.append(char)
         else:

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -242,6 +242,11 @@ class TestConditionalFromBranchingLogic(BaseTestCase):
         result = Condition.from_branching_logic(branching_logic)
         self.assertEqual(branching_logic, str(result))
 
+    def test_number_comparison_with_quotes(self):
+        branching_logic = "[a] > '7'"
+        result = Condition.from_branching_logic(branching_logic)
+        self.assertEqual('[a] > 7', str(result))
+
     def test_checkbox_constraint(self):
         branching_logic = "[a(option_1)] = '1'"
         result = Condition.from_branching_logic(branching_logic)


### PR DESCRIPTION
## Resolves *no ticket*
A recent codebook import showed that Redcap's branching logic is able to support quotes around number values in a comparison. This updates the response validation code so that it is able to parse the branching logic statement when that happens.

## Tests
- [x] unit tests


