### PR TITLE
Minor fixes for nph biobank pipeline

### DIFF
--- a/rdr_service/alembic/nph/versions/b1685b23d87e_adding_volume_units_column.py
+++ b/rdr_service/alembic/nph/versions/b1685b23d87e_adding_volume_units_column.py
@@ -1,0 +1,32 @@
+"""adding volume units column
+
+Revision ID: b1685b23d87e
+Revises: 3d78e7cfe123
+Create Date: 2023-01-31 11:30:10.093355
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b1685b23d87e'
+down_revision = '3d78e7cfe123'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+def upgrade_nph():
+    op.add_column('ordered_sample', sa.Column('volumeUnits', sa.String(length=128), nullable=True))
+
+
+def downgrade_nph():
+    op.drop_column('ordered_sample', 'volumeUnits')

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -431,7 +431,8 @@ class NphOrderedSampleDao(UpdatableDao):
                              identifier=aliquot.identifier,
                              collected=aliquot.collected,
                              container=aliquot.container,
-                             volume=aliquot.volume
+                             volume=aliquot.volume,
+                             volumeUnits=aliquot.units
                              )
 
     @staticmethod

--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -108,6 +108,7 @@ class OrderedSample(NphBase):
     identifier = Column(String(128))
     container = Column(String(128))
     volume = Column(String(128))
+    volumeUnits = Column(String(128))
     status = Column(String(128))
     supplemental_fields = Column(JSON, nullable=True)
     parent = relation("OrderedSample", remote_side=[id])

--- a/tests/api_tests/test_nph_participant_biobank_order_api.py
+++ b/tests/api_tests/test_nph_participant_biobank_order_api.py
@@ -70,21 +70,24 @@ BLOOD_SAMPLE = {
         "id": "123",
         "identifier": "LHPSTP1",
         "container": "1.4mL Matrix Tube (500 uL)",
-        "volume": "450uL",
+        "volume": "450",
+        "units": "uL",
         "description": "1.4 mL matrix tubes",
         "collected": "2022-11-03T09:45:49Z"
     }, {
         "id": "456",
         "identifier": "LHPSTP1",
         "container": "1.4mL Matrix Tube (1000 uL)",
-        "volume": "970uL",
+        "volume": "970",
+        "units": "uL",
         "description": "1.4 mL matrix tubes",
         "collected": "2022-11-03T09:45:49Z"
     }, {
         "id": "789",
         "identifier": "LHPSTP1",
         "container": "1.4mL Matrix Tube (1000 uL)",
-        "volume": "970uL",
+        "volume": "970",
+        "units": "uL",
         "description": "1.4 mL matrix tubes",
         "collected": "2022-11-03T09:45:49Z"
     }, ],

--- a/tests/dao_tests/test_study_nph_dao.py
+++ b/tests/dao_tests/test_study_nph_dao.py
@@ -145,21 +145,24 @@ TEST_URINE_SAMPLE = {
         "id": "123",
         "identifier": "RU1",
         "container": "1.4mL Matrix Tube (1000 uL)",
-        "volume": "970uL",
+        "volume": "970",
+        "units": "uL",
         "description": "1.4 mL matrix tubes",
         "collected": "2022-11-03T09:45:49Z"
     }, {
         "id": "456",
         "identifier": "RU2",
         "container": "6mL Matrix Tube (5 mL)",
-        "volume": "3mL",
+        "volume": "3",
+        "units": "mL",
         "description": "1.4 mL matrix tubes",
         "collected": "2022-11-03T09:45:49Z"
     }, {
         "id": "789",
         "identifier": "RU2",
         "container": "6mL Matrix Tube (5 mL)",
-        "volume": "3mL",
+        "volume": "3",
+        "units": "mL",
         "description": "1.4 mL matrix tubes",
         "collected": "2022-11-03T09:45:49Z"
     }, ],
@@ -917,7 +920,8 @@ class NphOrderedSampleDaoTest(BaseTestCase):
             "finalized": finalized_ts.strftime("%Y-%m-%d %H:%M:%S"),
             "aliquot_id": str(uuid4()),
             "container": "container 1",
-            "volume": "volume 2",
+            "volume": "25",
+            "volumeUnits": "mL",
             "status": "2 aliquots restored",
             "supplemental_fields": None,
             "identifier": None
@@ -958,6 +962,7 @@ class NphOrderedSampleDaoTest(BaseTestCase):
         self.assertEqual(aos.collected, aliquot.collected)
         self.assertEqual(aos.container, aliquot.container)
         self.assertEqual(aos.volume, aliquot.volume)
+        self.assertEqual(aos.volumeUnits, aliquot.units)
 
     def test_fetch_supplemental_fields(self):
         request = json.loads(json.dumps(TEST_URINE_SAMPLE), object_hook=lambda d: Namespace(**d))


### PR DESCRIPTION
## Resolves *no ticket*
This addresses three things that the Biobank brought up as issues with the latest file:
- `collectionDateUTC` and `processingDateUTC` need to provide the timezone
- `processingDateUTC` needs to provide the finalized date of the parent sample
- The volume units need to be provided. (An update was needed to store the units in the way HPRO is sending them)


## Tests
- [x] unit tests


