### PR TITLE
Add manifest ingestion exception alerts

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4321,7 +4321,7 @@ class GenomicQueriesDao(BaseDao):
                     GenomicSetMember.sampleId.in_(sample_ids)
                 )
 
-            return query.all()
+            return query.distinct().all()
 
     def get_data_ready_for_w2w_manifest(self, cvl_id: str, sample_ids=None):
         gc_site_id = self.transform_cvl_site_id(cvl_id)

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -241,7 +241,16 @@ class GenomicFileIngester:
 
                 # pylint: disable=broad-except
                 except Exception as e:
-                    logging.error(f'Exception occured when ingesting manifest {current_file.filePath}: {e}')
+                    logging.error(f'Exception occurred when ingesting manifest {current_file.filePath}: {e}')
+                    self.controller.create_incident(
+                        source_job_run_id=self.controller.job_run.id,
+                        source_file_processed_id=current_file.id,
+                        code=GenomicIncidentCode.MANIFEST_INGESTION_EXCEPTION.name,
+                        message=f"{self.job_id.name}: Exception occurred when ingesting manifest "
+                                f"{current_file.filePath}: {e}",
+                        slack=True,
+                        manifest_file_name=current_file.fileName
+                    )
                     self.file_queue.popleft()
                 except IndexError:
                     logging.info('No files left in file queue.')

--- a/rdr_service/genomic_enums.py
+++ b/rdr_service/genomic_enums.py
@@ -344,6 +344,7 @@ class GenomicIncidentCode(messages.Enum):
     FILE_VALIDATION_INVALID_FILE_NAME = 10
     INFORMING_LOOP_TO_EVENTS_MISMATCH = 11
     UNABLE_TO_RESOLVE_MESSAGE_BROKER_RECORD = 12
+    MANIFEST_INGESTION_EXCEPTION = 13
 
 
 class GenomicIncidentStatus(messages.Enum):

--- a/rdr_service/offline/genomic_cvl_pipeline.py
+++ b/rdr_service/offline/genomic_cvl_pipeline.py
@@ -14,7 +14,6 @@ def cvl_w1il_manifest_workflow(cvl_site_bucket_map, module_type):
             'pgx': GenomicManifestTypes.CVL_W1IL_PGX,
             'hdr': GenomicManifestTypes.CVL_W1IL_HDR
         }[module_type]
-
         with GenomicJobController(
             GenomicJob.CVL_W1IL_WORKFLOW,
             bucket_name=cvl_bucket_name_key,


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
When a manifest ingestion exception occurs we need to be notified of the issue instead of only relying on logs to catch data issues. This adds a tracking incident and a slack alert notification when this occurs. 

## Tests
- [] unit tests
* all tests should pass


