### PR TITLE
MIGRATION: Initialize Enrollment Event Types for Intake API testing

### DIFF
--- a/rdr_service/alembic/nph/versions/fa9281091ce8_initialize_enrollment_event_type.py
+++ b/rdr_service/alembic/nph/versions/fa9281091ce8_initialize_enrollment_event_type.py
@@ -6,6 +6,7 @@ Create Date: 2023-02-01 15:35:38.743254
 
 """
 from alembic import op
+import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'fa9281091ce8'
@@ -23,34 +24,40 @@ def downgrade(engine_name):
 
 
 def upgrade_nph():
+    op.add_column('consent_event_type', sa.Column('source_name', sa.String(length=128), nullable=True))
+    op.add_column('enrollment_event_type', sa.Column('source_name', sa.String(length=128), nullable=True))
+    op.add_column('pairing_event_type', sa.Column('source_name', sa.String(length=128), nullable=True))
     # Enrollment Event Types
     op.execute("""
                 INSERT INTO nph.enrollment_event_type
-                (created, modified, ignore_flag, name)
+                (created, modified, ignore_flag, name, source_name)
                 VALUES
-                (now(), now(), 0, "Module 1 Consented"),
-                (now(), now(), 0, "Module 1 Eligibility Confirmed"),
-                (now(), now(), 0, "Module 1 Eligibility Failed"),
-                (now(), now(), 0, "Module 1 Started"),
-                (now(), now(), 0, "Module 1 Complete"),
-                (now(), now(), 0, "Module 2 Consented"),
-                (now(), now(), 0, "Module 2 Eligibility Confirmed"),
-                (now(), now(), 0, "Module 2 Eligibility Failed"),
-                (now(), now(), 0, "Module 2 Started"),
-                (now(), now(), 0, "Module 2 Diet Assigned"),
-                (now(), now(), 0, "Module 2 Complete"),
-                (now(), now(), 0, "Module 3 Consented"),
-                (now(), now(), 0, "Module 3 Eligibility Confirmed"),
-                (now(), now(), 0, "Module 3 Eligibility Failed"),
-                (now(), now(), 0, "Module 3 Started"),
-                (now(), now(), 0, "Module 3 Diet Assigned"),
-                (now(), now(), 0, "Module 3 Complete"),
-                (now(), now(), 0, "Withdrawn"),
-                (now(), now(), 0, "Deactivated")
+                (now(), now(), 0, "Module 1 Consented", null),
+                (now(), now(), 0, "Module 1 Eligibility Confirmed", "eligibilityConfirmed"),
+                (now(), now(), 0, "Module 1 Eligibility Failed", null),
+                (now(), now(), 0, "Module 1 Started", null),
+                (now(), now(), 0, "Module 1 Complete", null),
+                (now(), now(), 0, "Module 2 Consented", null),
+                (now(), now(), 0, "Module 2 Eligibility Confirmed", null),
+                (now(), now(), 0, "Module 2 Eligibility Failed", null),
+                (now(), now(), 0, "Module 2 Started", null),
+                (now(), now(), 0, "Module 2 Diet Assigned", null),
+                (now(), now(), 0, "Module 2 Complete", null),
+                (now(), now(), 0, "Module 3 Consented", null),
+                (now(), now(), 0, "Module 3 Eligibility Confirmed", null),
+                (now(), now(), 0, "Module 3 Eligibility Failed", null),
+                (now(), now(), 0, "Module 3 Started", null),
+                (now(), now(), 0, "Module 3 Diet Assigned", null),
+                (now(), now(), 0, "Module 3 Complete", null),
+                (now(), now(), 0, "Withdrawn", null),
+                (now(), now(), 0, "Deactivated", null)
             """)
 
 
 def downgrade_nph():
+    op.drop_column('pairing_event_type', 'source_name')
+    op.drop_column('enrollment_event_type', 'source_name')
+    op.drop_column('consent_event_type', 'source_name')
     op.execute("""DELETE FROM nph.enrollent_event_type WHERE name IN (
                 "Module 1 Consented",
                 "Module 1 Eligibility Confirmed",

--- a/rdr_service/alembic/nph/versions/fa9281091ce8_initialize_enrollment_event_type.py
+++ b/rdr_service/alembic/nph/versions/fa9281091ce8_initialize_enrollment_event_type.py
@@ -51,4 +51,23 @@ def upgrade_nph():
 
 
 def downgrade_nph():
-    op.execute("""DELETE FROM nph.enrollent_event_type WHERE name IN ()""")
+    op.execute("""DELETE FROM nph.enrollent_event_type WHERE name IN (
+                "Module 1 Consented",
+                "Module 1 Eligibility Confirmed",
+                "Module 1 Eligibility Failed",
+                "Module 1 Started",
+                "Module 1 Complete",
+                "Module 2 Consented",
+                "Module 2 Eligibility Confirmed",
+                "Module 2 Eligibility Failed",
+                "Module 2 Started",
+                "Module 2 Diet Assigned",
+                "Module 2 Complete",
+                "Module 3 Consented",
+                "Module 3 Eligibility Confirmed",
+                "Module 3 Eligibility Failed",
+                "Module 3 Started",
+                "Module 3 Diet Assigned",
+                "Module 3 Complete",
+                "Withdrawn",
+                "Deactivated")""")

--- a/rdr_service/alembic/nph/versions/fa9281091ce8_initialize_enrollment_event_type.py
+++ b/rdr_service/alembic/nph/versions/fa9281091ce8_initialize_enrollment_event_type.py
@@ -1,0 +1,54 @@
+"""initialize enrollment_event_type
+
+Revision ID: fa9281091ce8
+Revises: b1685b23d87e
+Create Date: 2023-02-01 15:35:38.743254
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'fa9281091ce8'
+down_revision = 'b1685b23d87e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+def upgrade_nph():
+    # Enrollment Event Types
+    op.execute("""
+                INSERT INTO nph.enrollment_event_type
+                (created, modified, ignore_flag, name)
+                VALUES
+                (now(), now(), 0, "Module 1 Consented"),
+                (now(), now(), 0, "Module 1 Eligibility Confirmed"),
+                (now(), now(), 0, "Module 1 Eligibility Failed"),
+                (now(), now(), 0, "Module 1 Started"),
+                (now(), now(), 0, "Module 1 Complete"),
+                (now(), now(), 0, "Module 2 Consented"),
+                (now(), now(), 0, "Module 2 Eligibility Confirmed"),
+                (now(), now(), 0, "Module 2 Eligibility Failed"),
+                (now(), now(), 0, "Module 2 Started"),
+                (now(), now(), 0, "Module 2 Diet Assigned"),
+                (now(), now(), 0, "Module 2 Complete"),
+                (now(), now(), 0, "Module 3 Consented"),
+                (now(), now(), 0, "Module 3 Eligibility Confirmed"),
+                (now(), now(), 0, "Module 3 Eligibility Failed"),
+                (now(), now(), 0, "Module 3 Started"),
+                (now(), now(), 0, "Module 3 Diet Assigned"),
+                (now(), now(), 0, "Module 3 Complete"),
+                (now(), now(), 0, "Withdrawn"),
+                (now(), now(), 0, "Deactivated")
+            """)
+
+
+def downgrade_nph():
+    op.execute("""DELETE FROM nph.enrollent_event_type WHERE name IN ()""")

--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -154,6 +154,7 @@ class EnrollmentEventType(NphBase):
     modified = Column(UTCDateTime)
     ignore_flag = Column(TINYINT, default=0)
     name = Column(String(128))
+    source_name = Column(String(128))
     rule_codes = Column(JSON, nullable=True)
     version = Column(String(128), nullable=True)
 
@@ -187,6 +188,7 @@ class PairingEventType(NphBase):
     modified = Column(UTCDateTime)
     ignore_flag = Column(TINYINT, default=0)
     name = Column(String(1024))
+    source_name = Column(String(128))
     rule_codes = Column(JSON, nullable=True)
 
 
@@ -222,6 +224,7 @@ class ConsentEventType(NphBase):
     disable_flag = Column(TINYINT, default=0)
     disable_reason = Column(String(1024), nullable=True)
     name = Column(String(1024))
+    source_name = Column(String(128))
     rule_codes = Column(JSON, nullable=True)
     version = Column(String(128), nullable=True)
 


### PR DESCRIPTION
## Resolves *NPH Support*


## Description of changes/additions
This PR is to initialize the `nph.enrollment_event_type` records that are needed for testing.  Additionally, `source_name` was added to `consent`, `enrollment`, and `pairing` `_event_type` tables.

## Tests
- No tests


