### PR TITLE
Additional NPH Biobank file drop fixes

### DIFF
--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any, Iterable, Optional
 from json import dump
 
 from sqlalchemy import and_
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, aliased
 from google.cloud import storage
 from rdr_service import config
 from rdr_service.api_util import open_cloud_file
@@ -115,14 +115,18 @@ def _get_code_obj_from_sex_id(sex_id: int) -> Code:
 
 def _get_ordered_samples(order_id: int) -> List[OrderedSample]:
     ordered_sample_dao = NphOrderedSampleDao()
+    child_sample = aliased(OrderedSample)
     with ordered_sample_dao.session() as session:
-        query = session.query(OrderedSample).filter(
-            and_(
+        query = (
+            session.query(OrderedSample).outerjoin(
+                child_sample,
+                child_sample.parent_sample_id == OrderedSample.id
+            ).filter(
                 OrderedSample.order_id == order_id,
-                OrderedSample.aliquot_id.isnot(None)
+                child_sample.id.is_(None)
+            ).options(
+                joinedload(OrderedSample.parent)
             )
-        ).options(
-            joinedload(OrderedSample.parent)
         )
         return query.all()
 
@@ -137,13 +141,13 @@ def _convert_ordered_samples_to_samples(
         supplemental_fields = ordered_sample.supplemental_fields if ordered_sample.supplemental_fields else {}
         notes = ", ".join([f"{key}: {value}" for key, value in supplemental_fields.items()])
         sample = {
-            "sampleID": ordered_sample.aliquot_id,
-            "specimenCode": ordered_sample.identifier,
-            "kitID": order_id if ordered_sample.identifier.startswith("ST") else "",
+            "sampleID": (ordered_sample.aliquot_id or ordered_sample.nph_sample_id),
+            "specimenCode": (ordered_sample.identifier or ordered_sample.test),
+            "kitID": order_id if (ordered_sample.identifier or ordered_sample.test).startswith("ST") else "",
             "volume": ordered_sample.volume,
             "volumeUOM": ordered_sample.volumeUnits,
             "collectionDateUTC": _format_timestamp(ordered_sample.collected),
-            "processingDateUTC": _format_timestamp(ordered_sample.parent.finalized),
+            "processingDateUTC": _format_timestamp((ordered_sample.parent or ordered_sample).finalized),
             "cancelledFlag": "Y" if ordered_cancelled else "N",
             "notes": notes,
         }
@@ -176,7 +180,7 @@ def _convert_orders_to_collections(
     collections = []
     for order in orders:
         samples = _convert_ordered_samples_to_samples(
-            order_id=order.id,
+            order_id=order.nph_order_id,
             ordered_samples=_get_ordered_samples(order_id=order.id),
             ordered_cancelled=order.status == "cancelled"
         )
@@ -302,13 +306,13 @@ def main():
         }
         orders_file_drop.append(json_object)
 
-    today_dt_ts = datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S")
-    bucket_name = config.getSetting(config.NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP)
-    json_filepath = f"nph-orders/NPH_Orders_{today_dt_ts}.json"
-    orders_filename = f"{bucket_name}/{json_filepath}"
-    with open_cloud_file(orders_filename, mode='w') as dest:
+    # today_dt_ts = datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S")
+    # bucket_name = config.getSetting(config.NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP)
+    # json_filepath = f"nph-orders/NPH_Orders_{today_dt_ts}.json"
+    # orders_filename = f"{bucket_name}/{json_filepath}"
+    with open_cloud_file('test_output_file.json', mode='w') as dest:
         dump(orders_file_drop, dest, default=str)
 
-    sample_updates_for_orders = _get_all_sample_updates_related_to_orders(orders)
-    biobank_file_export = _create_biobank_file_export_reference(bucket_name, json_filepath)
-    _create_sample_export_references_for_sample_updates(biobank_file_export.id, sample_updates_for_orders)
+    # sample_updates_for_orders = _get_all_sample_updates_related_to_orders(orders)
+    # biobank_file_export = _create_biobank_file_export_reference(bucket_name, json_filepath)
+    # _create_sample_export_references_for_sample_updates(biobank_file_export.id, sample_updates_for_orders)

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -307,7 +307,7 @@ def main():
         orders_file_drop.append(json_object)
 
     today_dt_ts = datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S")
-    bucket_name = 'stable-nph-sample-data-biobank'
+    bucket_name = config.getSetting(config.NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP)
     json_filepath = f"nph-orders/NPH_Orders_{today_dt_ts}.json"
     orders_filename = f"{bucket_name}/{json_filepath}"
     with open_cloud_file(orders_filename, mode='w') as dest:

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -306,13 +306,13 @@ def main():
         }
         orders_file_drop.append(json_object)
 
-    # today_dt_ts = datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S")
-    # bucket_name = config.getSetting(config.NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP)
-    # json_filepath = f"nph-orders/NPH_Orders_{today_dt_ts}.json"
-    # orders_filename = f"{bucket_name}/{json_filepath}"
-    with open_cloud_file('test_output_file.json', mode='w') as dest:
+    today_dt_ts = datetime.utcnow().strftime("%Y_%m_%d_%H_%M_%S")
+    bucket_name = 'stable-nph-sample-data-biobank'
+    json_filepath = f"nph-orders/NPH_Orders_{today_dt_ts}.json"
+    orders_filename = f"{bucket_name}/{json_filepath}"
+    with open_cloud_file(orders_filename, mode='w') as dest:
         dump(orders_file_drop, dest, default=str)
 
-    # sample_updates_for_orders = _get_all_sample_updates_related_to_orders(orders)
-    # biobank_file_export = _create_biobank_file_export_reference(bucket_name, json_filepath)
-    # _create_sample_export_references_for_sample_updates(biobank_file_export.id, sample_updates_for_orders)
+    sample_updates_for_orders = _get_all_sample_updates_related_to_orders(orders)
+    biobank_file_export = _create_biobank_file_export_reference(bucket_name, json_filepath)
+    _create_sample_export_references_for_sample_updates(biobank_file_export.id, sample_updates_for_orders)

--- a/rdr_service/tools/tool_libs/study_nph_biobank_file_export.py
+++ b/rdr_service/tools/tool_libs/study_nph_biobank_file_export.py
@@ -67,8 +67,8 @@ def run():
 
     with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
         try:
-            # nph_biobank_file_export_job = nph_study_biobank_file_export_for_run(args, gcp_env)
-            exit_code = StudyNphBioBankFileExport(args, gcp_env).run()
+            nph_biobank_file_export_job = nph_study_biobank_file_export_for_run(args, gcp_env)
+            exit_code = nph_biobank_file_export_job.run()
         # pylint: disable=broad-except
         except Exception as e:
             print_exc()

--- a/rdr_service/tools/tool_libs/study_nph_biobank_file_export.py
+++ b/rdr_service/tools/tool_libs/study_nph_biobank_file_export.py
@@ -67,8 +67,8 @@ def run():
 
     with GCPProcessContext(tool_cmd, args.project, args.account, args.service_account) as gcp_env:
         try:
-            nph_biobank_file_export_job = nph_study_biobank_file_export_for_run(args, gcp_env)
-            exit_code = nph_biobank_file_export_job.run()
+            # nph_biobank_file_export_job = nph_study_biobank_file_export_for_run(args, gcp_env)
+            exit_code = StudyNphBioBankFileExport(args, gcp_env).run()
         # pylint: disable=broad-except
         except Exception as e:
             print_exc()


### PR DESCRIPTION
## Resolves *no ticket*
- We weren't sending stool samples because they aren't aliquots. Updated the query to send any leaf samples (samples that don't have children)
- Because some samples sent aren't aliquots, updated what is sent for: `sampleID`, `specimenCode`, and `processingDateUTC`. Also updated the condition for determining stool samples for `kitID`.
- Passing the NPH order id rather than the internal order id to `_convert_ordered_samples_to_samples`

## Tests
- [ ] unit tests


