### PR TITLE
[PDR-1577] Update PDR generators to handle existing EtM consent payloads

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -84,7 +84,7 @@ _consent_module_question_map = {
     'vaprimaryreconsent_c3': 'vaprimaryreconsent_c3_agree',
     'vaehrreconsent': 'vaehrreconsent_agree',
     'nonvaprimaryreconsent': 'nonvaprimaryreconsent_agree',
-    # Workaround:  PTSC sending concept code for ETM consent module that differs from REDCap survey definition
+    # TODO: Getting clarification on which is correct module code string for EtM consent.  Recognize either for now
     'english_exploring_the_mind_consent_form': 'etm_consent',  # Key/concept code value seen in PTSC payloads
     'welcome_to_etm': 'etm_consent'  # Key/module code value from REDCap
 }
@@ -122,13 +122,10 @@ _consent_answer_status_map = {
     'Decision_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
     'WEAR_Yes': BQModuleStatusEnum.SUBMITTED,
     'WEAR_No': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
-    # VA/Non-VA reconsent modules consent answer options (note:  agree_no is defined but may not be transmitted to RDR,
-    # participants who decline reconsent may be updated to withdrawn status by PTSC instead)
+    # Generic yes/no answer codes that apply to multiple consents (e.g., VA/non-VA reconsents and EtM consents)
     'agree_yes': BQModuleStatusEnum.SUBMITTED,
     'agree_no': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
-    # These answer codes defined in REDCap for ETM consent question, but PTSC currently sending agree_yes/agree_no codes
-    'etm_yes': BQModuleStatusEnum.SUBMITTED,
-    'etm_no': BQModuleStatusEnum.SUBMITTED_NO_CONSENT
+
 }
 
 # PDR-252:  When RDR starts accepting QuestionnaireResponse payloads for withdrawal screens, AIAN participants

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -83,7 +83,10 @@ _consent_module_question_map = {
     'vaprimaryreconsent_c1_2': 'vaprimaryreconsent_c1_2_agree',
     'vaprimaryreconsent_c3': 'vaprimaryreconsent_c3_agree',
     'vaehrreconsent': 'vaehrreconsent_agree',
-    'nonvaprimaryreconsent': 'nonvaprimaryreconsent_agree'
+    'nonvaprimaryreconsent': 'nonvaprimaryreconsent_agree',
+    # Workaround:  PTSC sending concept code for ETM consent module that differs from REDCap survey definition
+    'english_exploring_the_mind_consent_form': 'etm_consent',  # Key/concept code value seen in PTSC payloads
+    'welcome_to_etm': 'etm_consent'  # Key/module code value from REDCap
 }
 
 # _consent_expired_question_map, for expired consents. { module: question code string }
@@ -122,7 +125,10 @@ _consent_answer_status_map = {
     # VA/Non-VA reconsent modules consent answer options (note:  agree_no is defined but may not be transmitted to RDR,
     # participants who decline reconsent may be updated to withdrawn status by PTSC instead)
     'agree_yes': BQModuleStatusEnum.SUBMITTED,
-    'agree_no': BQModuleStatusEnum.SUBMITTED_NO_CONSENT
+    'agree_no': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    # These answer codes defined in REDCap for ETM consent question, but PTSC currently sending agree_yes/agree_no codes
+    'etm_yes': BQModuleStatusEnum.SUBMITTED,
+    'etm_no': BQModuleStatusEnum.SUBMITTED_NO_CONSENT
 }
 
 # PDR-252:  When RDR starts accepting QuestionnaireResponse payloads for withdrawal screens, AIAN participants


### PR DESCRIPTION
## Partially resolves *[PDR-1577](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1577)*


## Description of changes/additions
PDR needs to surface who has consented to and who has declined participation in EtM.  The consent payloads/FHIR docs RDR has received so far from PTSC do not align with the `welcome_to_etm` REDCap survey ingestion details, so the PDR generator code will look for either set of likely codes.

## Tests
Rebuilt test pid 618659248 in RDR (prod).  This pid has multiple EtM consent payloads from PTSC with both yes/no consent responses. Confirmed resulting `resource` JSON in the `bigquery_sync` table.




[PDR-1577]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ