### PR TITLE
[DA-3265] Enhancements to backfill-enrollment tool

### DIFF
--- a/rdr_service/tools/tool_libs/backfill_enrollment.py
+++ b/rdr_service/tools/tool_libs/backfill_enrollment.py
@@ -7,20 +7,26 @@ from rdr_service.services.system_utils import list_chunks
 from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
 
 tool_cmd = 'backfill-enrollment'
-tool_desc = 'Backfill enrollement status fields for version 3 of data glossary'
-
+tool_desc = 'Backfill enrollment status fields for version 3 of data glossary'
 
 class BackfillEnrollment(ToolBase):
     logger_name = None
 
     def run(self):
         super(BackfillEnrollment, self).run()
-
         with self.get_session() as session:
             summary_dao = ParticipantSummaryDao()
-            participant_id_list = session.query(
-                ParticipantSummary.participantId
-            ).order_by(ParticipantSummary.participantId).all()
+            # --id option takes precedence over --from-file option
+            if self.args.id:
+                participant_id_list = [int(i) for i in self.args.id.split(',')]
+            elif self.args.from_file:
+                participant_id_list = self.get_int_ids_from_file(self.args.from_file)
+            else:
+                # Default to all participant_summary ids
+                participant_id_list = session.query(
+                    ParticipantSummary.participantId
+                ).order_by(ParticipantSummary.participantId).all()
+
             count = 0
             last_id = None
 
@@ -38,12 +44,19 @@ class BackfillEnrollment(ToolBase):
                 for summary in summary_list:
                     summary_dao.update_enrollment_status(
                         summary=summary,
-                        session=session
+                        session=session,
+                        allow_downgrade=self.args.allow_downgrade
                     )
                     last_id = summary.participantId
 
                 session.commit()
 
-
+def add_additional_arguments(parser):
+    parser.add_argument('--id', required=False,
+                        help="Single participant id or comma-separated list of id integer values to backfill")
+    parser.add_argument('--from-file', required=False,
+                        help="file of integer participant id values to backfill")
+    parser.add_argument('--allow-downgrade', default=False, action="store_true",
+                        help='Force recalculation of enrollment status, and allow status to revert to a lower status')
 def run():
-    return cli_run(tool_cmd, tool_desc, BackfillEnrollment)
+    return cli_run(tool_cmd, tool_desc, BackfillEnrollment, add_additional_arguments)

--- a/rdr_service/tools/tool_libs/tool_base.py
+++ b/rdr_service/tools/tool_libs/tool_base.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 from typing import Type
 
@@ -57,6 +58,13 @@ class ToolBase:
             **kwargs
         ).session()
 
+    @staticmethod
+    def get_int_ids_from_file(file_path):
+        """ Ingest a file of integer ids, such as participant_id or table record ids """
+        with open(os.path.expanduser(file_path)) as id_list:
+            ids = id_list.readlines()
+            # convert ids from a list of strings to a list of integers.
+            return [int(i) for i in ids if i.strip()]
 
 def cli_run(tool_cmd, tool_desc, tool_class: Type[ToolBase], parser_hook=None, defaults={}):
     # Set global debug value and setup application logging.


### PR DESCRIPTION
## Related to *[DA-3265](https://precisionmedicineinitiative.atlassian.net/browse/DA-3265)*


## Description of changes/additions
Updates the enrollment status handling and the `backfill-enrollment-tool` so it can be used for targeted remediations.

-  Adds `--allow-downgrade` option to the tool/parameter to `update_enrollment_status()` to forcibly correct/reset V3.* enrollment statuses that may trigger a reversion to a lower status.   This will not impact legacy status values which are already in use for HPRO, etc.
-  Changes the `update_enrollment_status()` handling to always allow timestamp value corrections even if the `participant_summary` field is already populated with a value
-  Adds options to allow running `backfill-enrollment-tool` for targeted lists of participants, including getting ids from file

## Tests
- [x] unit tests




[DA-3265]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ