### PR TITLE
[DA-3332] Updating timestamps sent to Biobank for NPH orders

### DIFF
--- a/rdr_service/alembic/nph/versions/9d100aca2518_allowing_for_string_on_sum_check.py
+++ b/rdr_service/alembic/nph/versions/9d100aca2518_allowing_for_string_on_sum_check.py
@@ -1,0 +1,43 @@
+"""allowing for string on sum-check
+
+Revision ID: 9d100aca2518
+Revises: 1cdbe0f0608e, d3461d54e75d
+Create Date: 2023-02-07 14:32:12.187401
+
+"""
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision = '9d100aca2518'
+down_revision = ('1cdbe0f0608e', 'd3461d54e75d')
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+def upgrade_nph():
+    op.alter_column(
+        'biobank_file_export',
+        'crc32c_checksum',
+        type_=mysql.VARCHAR(length=64),
+        existing_type=mysql.INTEGER(display_width=11)
+    )
+
+
+def downgrade_nph():
+    op.alter_column(
+        'biobank_file_export',
+        'crc32c_checksum',
+        type_=mysql.INTEGER(display_width=11),
+        existing_type=mysql.VARCHAR(length=64)
+    )

--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -271,7 +271,7 @@ class BiobankFileExport(NphBase):
     id = Column("id", BigInteger, autoincrement=True, primary_key=True)
     created = Column(UTCDateTime)
     file_name = Column(String(256))
-    crc32c_checksum = Column(BigInteger, unique=True, nullable=False)
+    crc32c_checksum = Column(String(64), unique=True, nullable=False)
 
 
 event.listen(BiobankFileExport, "before_insert", model_insert_listener)

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -144,14 +144,15 @@ def _convert_ordered_samples_to_samples(
     for ordered_sample in ordered_samples:
         supplemental_fields = ordered_sample.supplemental_fields if ordered_sample.supplemental_fields else {}
         notes = ", ".join([f"{key}: {value}" for key, value in supplemental_fields.items()])
+        processing_timestamp = ordered_sample.collected if not ordered_sample.parent is None else None
         sample = {
             "sampleID": (ordered_sample.aliquot_id or ordered_sample.nph_sample_id),
             "specimenCode": (ordered_sample.identifier or ordered_sample.test),
             "kitID": order_id if (ordered_sample.identifier or ordered_sample.test).startswith("ST") else "",
             "volume": ordered_sample.volume,
             "volumeUOM": ordered_sample.volumeUnits,
-            "collectionDateUTC": _format_timestamp(ordered_sample.collected),
-            "processingDateUTC": _format_timestamp((ordered_sample.parent or ordered_sample).finalized),
+            "collectionDateUTC": _format_timestamp((ordered_sample.parent or ordered_sample).collected),
+            "processingDateUTC": _format_timestamp(processing_timestamp),
             "cancelledFlag": "Y" if ordered_cancelled else "N",
             "notes": notes,
         }

--- a/rdr_service/tools/generate_schema_nph.sh
+++ b/rdr_service/tools/generate_schema_nph.sh
@@ -20,4 +20,4 @@ then
 fi
 
 (source tools/set_path.sh; cd ${APP_DIR};
- alembic -c alembic_nph.ini revision --autogenerate -m "$1")
+ alembic -c alembic_nph.ini revision --autogenerate -m "$1" --head heads)


### PR DESCRIPTION
## Resolves *[DA-3332](https://precisionmedicineinitiative.atlassian.net/browse/DA-3332)*
- The collection date we send in the file should now be the parent's collection date for aliquots
- The processing date we send should now be an aliquot's collected time, or nothing if a sample is not an aliquot
- Also updating to allow strings for the crc32c checksum (so the server's cron job for generating the file can start working)
- Also updating the generate_schema script to allow for multiple heads to exist

## Tests
- [ ] unit tests




[DA-3332]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ