### PR TITLE
Removing unique constraint from crc32c column

### DIFF
--- a/rdr_service/alembic/nph/versions/7c2bea760b6e_removing_unique_contraint_on_check_sum.py
+++ b/rdr_service/alembic/nph/versions/7c2bea760b6e_removing_unique_contraint_on_check_sum.py
@@ -1,0 +1,32 @@
+"""removing unique contraint on check sum
+
+Revision ID: 7c2bea760b6e
+Revises: 9d100aca2518
+Create Date: 2023-02-09 10:24:59.119481
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '7c2bea760b6e'
+down_revision = '9d100aca2518'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+
+def upgrade_nph():
+    op.drop_index(op.f('crc32c_checksum'), table_name='biobank_file_export', schema='nph')
+
+
+def downgrade_nph():
+    op.create_index('crc32c_checksum', 'biobank_file_export', ['crc32c_checksum'], unique=True)

--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -271,7 +271,7 @@ class BiobankFileExport(NphBase):
     id = Column("id", BigInteger, autoincrement=True, primary_key=True)
     created = Column(UTCDateTime)
     file_name = Column(String(256))
-    crc32c_checksum = Column(String(64), unique=True, nullable=False)
+    crc32c_checksum = Column(String(64), nullable=False)
 
 
 event.listen(BiobankFileExport, "before_insert", model_insert_listener)

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -46,7 +46,7 @@ NPH_ANCILLARY_STUDY_ID = 2
 
 
 def _format_timestamp(timestamp: datetime) -> str:
-    return timestamp.strftime('%Y-%m-%dT%H:%M:%SZ') if timestamp else ''
+    return timestamp.strftime('%Y-%m-%dT%H:%M:%SZ') if timestamp else None
 
 
 def _get_nph_participant(participant_id: int) -> NphParticipant:

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -251,12 +251,12 @@ def _get_crc32c_checksum_from_gcs_blob(bucket_name: str, blob_name: str):
 def _create_biobank_file_export_reference(bucket_name: str, blob_name: str) -> BiobankFileExport:
     crc32c_checksum = _get_crc32c_checksum_from_gcs_blob(bucket_name, blob_name)
     biobank_file_export_dao = NphBiobankFileExportDao()
-    biobank_file_export_params = {
-        "file_name": f"{bucket_name}/{blob_name}",
-        "crc32c_checksum": str(crc32c_checksum)
-    }
-    biobank_file_export = BiobankFileExport(**biobank_file_export_params)
-    return biobank_file_export_dao.insert(biobank_file_export)
+    return biobank_file_export_dao.insert(
+        BiobankFileExport(
+            file_name=f"{bucket_name}/{blob_name}",
+            crc32c_checksum=crc32c_checksum
+        )
+    )
 
 
 def _create_sample_export_references_for_sample_updates(


### PR DESCRIPTION
## Resolves *no ticket*
After reading a bit more into crc32c, it seems like there's a chance that the file hashes could collide. This removes the unique constraint that could cause errors when that happens.

This also sets the formatted time to null in the file when there isn't a date (rather than an empty string).

## Tests
- [ ] unit tests


