### PR TITLE
[HOTFIX] Updating ignore_flag check

### DIFF
--- a/rdr_service/dao/biobank_order_dao.py
+++ b/rdr_service/dao/biobank_order_dao.py
@@ -229,7 +229,7 @@ class BiobankOrderDao(UpdatableDao):
             total_query = session.query(BiobankOrder)\
                 .outerjoin(BiobankQuestOrderSiteAddress,
                            BiobankQuestOrderSiteAddress.biobankOrderId == BiobankOrder.biobankOrderId
-                ).filter(BiobankOrder.ignoreFlag != 1)
+                ).filter(BiobankOrder.is_not_ignored())
             total_query = self._add_filter_for_biobank_order_search(total_query, states, cities, zip_codes, origin,
                                                                     start_date, end_date)
             total = total_query.count()
@@ -240,7 +240,7 @@ class BiobankOrderDao(UpdatableDao):
                     .join(Participant, Participant.participantId == BiobankOrder.participantId) \
                     .outerjoin(BiobankQuestOrderSiteAddress,
                                BiobankQuestOrderSiteAddress.biobankOrderId == BiobankOrder.biobankOrderId
-                    ).filter(BiobankOrder.ignoreFlag != 1)
+                    ).filter(BiobankOrder.is_not_ignored())
             query = self._add_filter_for_biobank_order_search(query, states, cities, zip_codes, origin, start_date,
                                                               end_date)
 
@@ -309,7 +309,7 @@ class BiobankOrderDao(UpdatableDao):
         query = session.query(BiobankOrder).options(
             subqueryload(BiobankOrder.identifiers), subqueryload(BiobankOrder.samples),
             subqueryload(BiobankOrder.questSiteAddress)
-        ).filter(BiobankOrder.ignoreFlag != 1)
+        ).filter(BiobankOrder.is_not_ignored())
 
         if for_update:
             query = query.with_for_update()
@@ -326,7 +326,7 @@ class BiobankOrderDao(UpdatableDao):
         with self.session() as session:
             return session.query(BiobankOrder).filter(
                 BiobankOrder.participantId == pid,
-                BiobankOrder.ignoreFlag != 1
+                BiobankOrder.is_not_ignored()
             ).all()
 
     def get_biobank_orders_with_children_for_participant(self, pid):
@@ -339,7 +339,7 @@ class BiobankOrderDao(UpdatableDao):
                         subqueryload(BiobankOrder.questSiteAddress)).\
                 filter(
                 BiobankOrder.participantId == pid,
-                BiobankOrder.ignoreFlag != 1
+                BiobankOrder.is_not_ignored()
             ).all()
 
     def get_biobank_order_by_kit_id(self, kit_id):
@@ -353,7 +353,7 @@ class BiobankOrderDao(UpdatableDao):
                     filter(BiobankOrder.biobankOrderId == BiobankOrderIdentifier.biobankOrderId,
                            BiobankOrderIdentifier.system == KIT_ID_SYSTEM,
                            BiobankOrderIdentifier.value == kit_id,
-                           BiobankOrder.ignoreFlag != 1)
+                           BiobankOrder.is_not_ignored())
                     .all()
                     )
     def get_ordered_samples_for_participant(self, participant_id):
@@ -364,7 +364,7 @@ class BiobankOrderDao(UpdatableDao):
                 .join(BiobankOrder)
                 .filter(
                     BiobankOrder.participantId == participant_id,
-                    BiobankOrder.ignoreFlag != 1
+                    BiobankOrder.is_not_ignored()
                 )
                 .all()
             )
@@ -445,7 +445,7 @@ class BiobankOrderDao(UpdatableDao):
             session.query(BiobankOrder)
             .filter(BiobankOrder.participantId == participantId)
             .filter(or_(BiobankOrder.orderStatus != BiobankOrderStatus.CANCELLED, BiobankOrder.orderStatus == None),
-                    BiobankOrder.ignoreFlag != 1)
+                    BiobankOrder.is_not_ignored())
             .order_by(BiobankOrder.created)
             .all()
         )

--- a/rdr_service/dao/biobank_stored_sample_dao.py
+++ b/rdr_service/dao/biobank_stored_sample_dao.py
@@ -34,7 +34,7 @@ class BiobankStoredSampleDao(BaseDao):
             ).filter(
                 Site.siteType == "Diversion Pouch",
                 BiobankStoredSample.biobankStoredSampleId == biobank_stored_sample_id,
-                BiobankOrder.ignoreFlag != 1
+                BiobankOrder.is_not_ignored()
             ).distinct().one_or_none()
 
             if results:

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1081,7 +1081,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
                 BiobankOrder.biobankOrderId == BiobankOrderIdentifier.biobankOrderId
             ).filter(
                 GenomicSetMember.id == informing_loop_ready.c.id,
-                BiobankOrder.ignoreFlag != 1
+                BiobankOrder.is_not_ignored()
             ).order_by(
                 BiobankOrder.finalizedTime
             )

--- a/rdr_service/model/biobank_order.py
+++ b/rdr_service/model/biobank_order.py
@@ -1,6 +1,6 @@
 import logging
 
-from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, UnicodeText, event, SmallInteger
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, UnicodeText, event, SmallInteger, or_
 from sqlalchemy.dialects.mysql import JSON
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
@@ -175,6 +175,13 @@ class BiobankOrder(BiobankOrderBase, Base):
                                     backref="biobank_order")
     ignoreFlag = Column("ignore_flag", SmallInteger, default=0)
     ignoreReason = Column("ignore_reason", String(100))
+
+    @classmethod
+    def is_not_ignored(cls):
+        return or_(
+            BiobankOrder.ignoreFlag.is_(None),
+            BiobankOrder.ignoreFlag != 1
+        )
 
 
 class BiobankQuestOrderSiteAddress(Base):


### PR DESCRIPTION
## Resolves *no ticket*

This was released as hotfix 1.140.2.

We were seeing errors about missing Biobank orders that we could see in the database. The errors were appearing because comparing to Null in MySQL results if False, so the check for `ignore_flag != 1` made it appear as if the orders should be ignored when their ignore flag was Null.


## Tests
- [ ] unit tests


