### PR TITLE
[DA-3312] Add SampleCollectionMethod to docs

### DIFF
--- a/doc/api_workflows/field_reference/enumerated_fields.rst
+++ b/doc/api_workflows/field_reference/enumerated_fields.rst
@@ -155,6 +155,15 @@ Below are the available options for sampleOrderStatus[1SST8, 1PST8, 1HEP4, 1ED04
   * PROCESSED
   * FINALIZED
 
+.. _sample_collection_method:
+
+sampleCollectionMethod
+------------------------------------------------------------
+
+  * UNSET
+  * MAIL_KIT
+  * ON_SITE
+
 .. _withdrawal_status:
 
 withdrawalStatus

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -1266,7 +1266,7 @@ class ParticipantSummary(Base):
     """
     Gives how the 1SAL2 sample was collected (ie on site or using a mail kit)
 
-    :ref:`Enumerated values <Sample_collection_method>`
+    :ref:`Enumerated values <sample_collection_method>`
     """
 
     sampleStatus1ED02 = Column("sample_status_1ed02", Enum(SampleStatus), default=SampleStatus.UNSET)


### PR DESCRIPTION
## Resolves *[DA-3312](https://precisionmedicineinitiative.atlassian.net/browse/DA-3312)*


## Description of changes/additions
The enumerated values for sample1SAL2CollectionMethod are not displayed on ReadTheDocs. Updates the documentation to display sampleCollectionMethod.

## Tests
- [] unit tests




[DA-3312]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ