### PR TITLE
Remove last-run-time from context manager.

### DIFF
--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -134,7 +134,6 @@ class GenomicJobController:
     def __enter__(self):
         logging.info(f'Beginning {self.job_id.name} workflow')
         self.job_run = self._create_run(self.job_id)
-        self.last_run_time = self._get_last_successful_run_time()
         slack_config = config.getSettingJson(RDR_SLACK_WEBHOOKS, {})
         webbook_url = None
 
@@ -1019,7 +1018,7 @@ class GenomicJobController:
         self.job_result = GenomicSubProcessResult.SUCCESS
 
     def reconcile_pdr_data(self):
-        last_job_run = self.last_run_time
+        last_job_run = self._get_last_successful_run_time()
 
         reconcile_daos = [
             self.set_dao,
@@ -1345,7 +1344,7 @@ class GenomicJobController:
 
         # Setup date
         timezone = pytz.timezone('Etc/Greenwich')
-        date_limit = timezone.localize(self.last_run_time)
+        date_limit = timezone.localize(self._get_last_successful_run_time())
 
         new_failure_files = dict()
 


### PR DESCRIPTION
## Resolves *[DA-3354](https://precisionmedicineinitiative.atlassian.net/browse/DA-3354)*


## Description of changes/additions
This PR removes setting the `last_run_time` in the `GenomicJobController` context manager. All jobs that depend on this setting should invoke `get_last_successful_run_time()` directly.

## Tests
- [x] unit tests




[DA-3354]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ