### PR TITLE
[DA-3355] isolating conditions to correct an error when attempting sample status

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -284,7 +284,7 @@ def _get_sample_sql_and_params(now):
             where_sql += " or "
         where_sql += _WHERE_SQL % {"test": lower_test, "sample_param_ref": sample_param_ref}
 
-    sql += " WHERE " + where_sql
+    sql += f" WHERE ({where_sql})"
 
     return sql, params
 
@@ -626,8 +626,10 @@ class ParticipantSummaryDao(UpdatableDao):
       samples_to_isolate_dna = {dna_tests_sql},
       last_modified = :now
     WHERE
-      num_baseline_samples_arrived != {baseline_tests_sql} OR
-      samples_to_isolate_dna != {dna_tests_sql}
+      (
+        num_baseline_samples_arrived != {baseline_tests_sql}
+        OR samples_to_isolate_dna != {dna_tests_sql}
+      )
     """.format(
             baseline_tests_sql=baseline_tests_sql, dna_tests_sql=dna_tests_sql
         )


### PR DESCRIPTION
## Resolves *[DA-3355](https://precisionmedicineinitiative.atlassian.net/browse/DA-3355)*
As of the latest release (1.140), the Biobank is reporting that the Specimen API is taking longer than usual to respond.

1.140 introduced behavior to the Specimen API that needed to update sample status's on the participant summary. Investigation shows that, while the code for updating the statuses allows for filtering to a specific participant, the logic had an error that would still run the sql UPDATE to check all participant summaries anyway.

This PR modifies the query so that only the one specific participant is checked. All WHERE conditions are wrapped in parenthesis. They contain statements that are OR-ed together, so when the participant id filter is AND-ed to the end the AND only operates on the last statement and everything else is applied to all participants.

## Tests
- [ ] unit tests




[DA-3355]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ