### PR TITLE
[DA-3357] Upsert stored sample regardless of state of specimen

### DIFF
--- a/tests/api_tests/test_biobank_specimen_api.py
+++ b/tests/api_tests/test_biobank_specimen_api.py
@@ -1205,3 +1205,13 @@ class BiobankOrderApiTest(BaseTestCase):
         dataset = specimen['aliquots'][0]['datasets'][1]
         self.assertEqual('updated', dataset['status'])
         self.assertEqual('foobar', dataset['datasetItems'][0]['displayValue'])
+
+    def test_new_specimen_with_existing_stored_sample(self):
+        """
+        When the API started creating stored samples, some requests would crash when trying to create
+        stored samples that already existed. This ensures that issue was fixed.
+        """
+        payload = self.get_minimal_specimen_json()
+        rlims_id = payload['rlimsID']
+        self.data_generator.create_database_biobank_stored_sample(biobankStoredSampleId=rlims_id)
+        self.send_put(f'Biobank/specimens/{rlims_id}', request_data=payload)


### PR DESCRIPTION
## Resolves *[DA-3357](https://precisionmedicineinitiative.atlassian.net/browse/DA-3357)*
A recent change to the Biobank Specimen API introduced functionality to create stored samples based on the sample data being received. The API was set up to create a new stored samples when the corresponding specimen data didn't exist. But there are some stored samples that were created by the last few SIRs that have not yet been sent to the Specimen API. Now when they try to send the data to the Specimen API, it produces an error when trying to create the stored sample (because it already exists).

This updates the Specimen API to always upsert the stored sample regardless of whether the specimen data was received through the API previously.


## Tests
- [x] unit tests




[DA-3357]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ