### PR TITLE
[DA-3314] Revert scheduling for notes as last event

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2390,7 +2390,6 @@ class GenomicSchedulingDao(BaseDao):
         ).subquery()
 
         note_alias = aliased(GenomicAppointmentEvent)
-        event_alias = aliased(GenomicAppointmentEvent)
 
         with self.session() as session:
             records = session.query(
@@ -2412,12 +2411,6 @@ class GenomicSchedulingDao(BaseDao):
                     else_=False
                 ).label('note_available'),
             ).join(
-                max_event_authored_time_subquery,
-                and_(
-                    GenomicAppointmentEvent.participant_id == max_event_authored_time_subquery.c.participant_id,
-                    GenomicAppointmentEvent.module_type == max_event_authored_time_subquery.c.module_type,
-                )
-            ).join(
                 max_appointment_id_subquery,
                 and_(
                     GenomicAppointmentEvent.participant_id == max_appointment_id_subquery.c.participant_id,
@@ -2431,19 +2424,11 @@ class GenomicSchedulingDao(BaseDao):
                     note_alias.module_type == GenomicAppointmentEvent.module_type,
                     note_alias.appointment_id == max_appointment_id_subquery.c.max_appointment_id
                 )
-            ).outerjoin(
-                event_alias,
-                and_(
-                    event_alias.event_type.notlike('%note_available'),
-                    event_alias.participant_id == GenomicAppointmentEvent.participant_id,
-                    event_alias.module_type == GenomicAppointmentEvent.module_type,
-                    GenomicAppointmentEvent.event_authored_time < event_alias.event_authored_time
-                )
             ).filter(
                 and_(
                     GenomicAppointmentEvent.appointment_id == max_appointment_id_subquery.c.max_appointment_id,
-                    event_alias.id.is_(None),
-                    GenomicAppointmentEvent.event_type.notlike('%note_available')
+                    GenomicAppointmentEvent.event_authored_time ==
+                    max_event_authored_time_subquery.c.max_event_authored_time
                 )
             )
 
@@ -2457,8 +2442,7 @@ class GenomicSchedulingDao(BaseDao):
                 )
             if start_date:
                 records = records.filter(
-                    or_(GenomicAppointmentEvent.event_authored_time > start_date,
-                        note_alias.event_authored_time > start_date),
+                    GenomicAppointmentEvent.event_authored_time > start_date,
                     GenomicAppointmentEvent.event_authored_time < end_date
                 )
 

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -2262,7 +2262,7 @@ class GenomicSchedulingApiTest(GenomicApiTestBase):
         )
 
         # note_available should have changes to True
-        self.assertTrue(all(obj['status'] == 'scheduled' for obj in resp['data']))
+        self.assertTrue(all(obj['status'] == 'note_available' for obj in resp['data']))
         self.assertTrue(all(obj['note_available'] is True for obj in resp['data']))
 
     def test_module_params(self):


### PR DESCRIPTION
## Resolves *[ticket DA-3314]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3314

## Description of changes/additions
Need to revert to show the last event available even if it's a `note_available` event.

## Tests
- [x] unit tests


