### PR TITLE
DA-3367: Fix bugs in Biobank File Inventory Import Process

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -199,6 +199,9 @@
   "aw1f_alert_recipients": [
     "test-genomic@vumc.org"
   ],
+  "nph_sample_data_biobank_bucket_name": [
+    "stable-nph-sample-data-biobank"
+  ],
   "metrics_shards": [
     "10"
   ],


### PR DESCRIPTION
## Resolves *[DA-3367](https://precisionmedicineinitiative.atlassian.net/browse/DA-3367)*

## Description of changes/additions
* Set the day before timestamp that is used to pull all the files that are dropped in the last 24 hours to be timezone aware
* Added `nph_sample_data_biobank_bucket_name` mapping to `rdr_service/.configs/current_config.json` file

## Tests
N/A




[DA-3367]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ