### PR TITLE
[DA-3315] Setting ParticipantSummary EHR consent status based on validation result of PDF file

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -958,8 +958,11 @@ class QuestionnaireResponseDao(BaseDao):
                     code.value.lower() if self._is_digital_health_share_code(code.value) else code.value)
                 if summary_field:
                     new_status = QuestionnaireStatus.SUBMITTED
-                    if code.value == CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE and not ehr_consent:
-                        new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT
+                    if code.value == CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE:
+                        if ehr_consent:
+                            new_status = QuestionnaireStatus.SUBMITTED_NOT_VALIDATED
+                        else:
+                            new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT
                     elif code.value == CONSENT_FOR_DVEHR_MODULE:
                         new_status = dvehr_consent
                     elif code.value == CONSENT_FOR_GENOMICS_ROR_MODULE:

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -105,6 +105,7 @@ class QuestionnaireStatus(messages.Enum):
     SUBMITTED_NO_CONSENT = 2
     SUBMITTED_NOT_SURE = 3
     SUBMITTED_INVALID = 4
+    SUBMITTED_NOT_VALIDATED = 5
 
 
 class QuestionnaireDefinitionStatus(messages.Enum):

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1888,7 +1888,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
             participant_id_1, questionnaire_id, CONSENT_PERMISSION_YES_CODE, time=TIME_2
         )
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
-        self.assertEqual("SUBMITTED", ps_1["consentForElectronicHealthRecords"])
+        self.assertEqual("SUBMITTED_NOT_VALIDATED", ps_1["consentForElectronicHealthRecords"])
         self.assertEqual(TIME_2.isoformat(), ps_1.get("enrollmentStatusParticipantPlusEhrV3_1Time"))
 
     def _submit_dvehr_consent_questionnaire_response(
@@ -2160,6 +2160,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._submit_consent_questionnaire_response(
             participant_id_1, questionnaire_id_1, CONSENT_PERMISSION_YES_CODE, time=TIME_6
         )
+        self._mark_ehr_valid_in_summary(participant_id=from_client_participant_id(participant_id_1))
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual(TIME_6.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
@@ -2230,6 +2231,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._submit_consent_questionnaire_response(
             participant_id_1, questionnaire_id_1, CONSENT_PERMISSION_YES_CODE, time=TIME_6
         )
+        self._mark_ehr_valid_in_summary(participant_id=from_client_participant_id(participant_id_1))
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual(TIME_6.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
@@ -2326,6 +2328,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._submit_consent_questionnaire_response(
             participant_id_1, questionnaire_id_1, CONSENT_PERMISSION_YES_CODE, time=TIME_6
         )
+        self._mark_ehr_valid_in_summary(participant_id=from_client_participant_id(participant_id_1))
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual(TIME_6.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
@@ -2417,6 +2420,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self._submit_consent_questionnaire_response(
             participant_id_1, questionnaire_id_1, CONSENT_PERMISSION_YES_CODE, time=TIME_6
         )
+        self._mark_ehr_valid_in_summary(participant_id=from_client_participant_id(participant_id_1))
 
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
         self.assertEqual(TIME_6.isoformat(), ps_1.get("enrollmentStatusMemberTime"))
@@ -3002,7 +3006,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual("UNSET", new_ps_2["clinicPhysicalMeasurementsStatus"])
         self.assertEqual("SUBMITTED", new_ps_2["consentForStudyEnrollment"])
         self.assertIsNotNone(new_ps_2["consentForStudyEnrollmentAuthored"])
-        self.assertEqual("SUBMITTED", new_ps_2["consentForElectronicHealthRecords"])
+        self.assertEqual("SUBMITTED_NOT_VALIDATED", new_ps_2["consentForElectronicHealthRecords"])
         self.assertIsNotNone(new_ps_2["consentForElectronicHealthRecordsAuthored"])
         self.assertIsNone(new_ps_2.get("clinicPhysicalMeasurementsTime"))
         self.assertEqual("UNSET", new_ps_2["genderIdentity"])

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -351,6 +351,7 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
         with FakeClock(datetime.datetime(2020, 3, 12)):
             self.submit_ehr_questionnaire(participant_id, CONSENT_PERMISSION_YES_CODE, None,
                                           datetime.datetime(2020, 2, 12))
+            self._mark_ehr_valid_in_summary(from_client_participant_id(participant_id))
         summary = self.send_get("Participant/{0}/Summary".format(participant_id))
         self.assertEqual(summary.get('consentForElectronicHealthRecordsAuthored'), '2020-02-12T00:00:00')
         self.assertEqual(summary.get('enrollmentStatusMemberTime'), '2020-02-12T00:00:00')
@@ -437,6 +438,7 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
         with FakeClock(datetime.datetime(2020, 4, 12)):
             self.submit_ehr_questionnaire(participant_id, CONSENT_PERMISSION_YES_CODE, None,
                                           datetime.datetime(2020, 4, 11))
+            self._mark_ehr_valid_in_summary(from_client_participant_id(participant_id))
         summary = self.send_get("Participant/{0}/Summary".format(participant_id))
         self.assertEqual(summary.get('consentForElectronicHealthRecordsAuthored'), '2020-04-11T00:00:00')
         self.assertEqual(summary.get('enrollmentStatusMemberTime'), '2020-02-12T00:00:00')

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -36,6 +36,7 @@ from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.bigquery_sync import BigQuerySync
 from rdr_service.model.code import Code, CodeType
 from rdr_service.model.participant import Participant
+from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.offline import sql_exporter
 from rdr_service.resource.generators.code import CodeGenerator
 from rdr_service.resource.generators.participant import ParticipantSummaryGenerator
@@ -913,6 +914,13 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         self.addCleanup(patcher.stop)
 
         return mock_instance
+
+    def _mark_ehr_valid_in_summary(self, participant_id):
+        summary: ParticipantSummary = self.session.query(ParticipantSummary).filter(
+            ParticipantSummary.participantId == participant_id
+        ).one()
+        summary.consentForElectronicHealthRecords = participant_enums.QuestionnaireStatus.SUBMITTED
+        self.session.commit()
 
 
 class InMemorySqlExporter(sql_exporter.SqlExporter):

--- a/tests/service_tests/consent_tests/test_validation_strategies.py
+++ b/tests/service_tests/consent_tests/test_validation_strategies.py
@@ -9,15 +9,15 @@ from tests.helpers.unittest_base import BaseTestCase
 class ValidationOutputStrategyIntegrationTest(BaseTestCase):
     def test_store_strategy_updates_pdr(self):
         # Initialize the data
-        participant = self.data_generator.create_database_participant()
+        participant_id = self.data_generator.create_database_participant_summary().participantId
         existing_result = self.data_generator.create_database_consent_file(
-            participant_id=participant.participantId,
+            participant_id=participant_id,
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
             file_exists=False
         )
         new_result = ConsentFile(
-            participant_id=participant.participantId,
+            participant_id=participant_id,
             type=ConsentType.PRIMARY,
             sync_status=ConsentSyncStatus.READY_FOR_SYNC,
             file_exists=True,


### PR DESCRIPTION
## Resolves *[DA-3315](https://precisionmedicineinitiative.atlassian.net/browse/DA-3315)*
The participant summary should only show EHR status as SUBMITTED if we also have a valid PDF file for their consent.


## Tests
- [ ] unit tests




[DA-3315]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ