### PR TITLE
[DA-3315] Rebuilding PDR data when EHR status gets updated

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -92,11 +92,14 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
                 session=self._session
             )
             # Rebuild for PDR
+            additional_args = {}
+            if self._project_name is not None:
+                additional_args['project_id'] = self._project_name
             self._task.execute(
                 'rebuild_one_participant_task',
                 payload={'p_id': participant_id},
                 in_seconds=30,
-                project_id=self._project_name
+                **additional_args
             )
 
         self._session.commit()  # release the for_update lock obtained on the participant_summary


### PR DESCRIPTION
## Resolves *[DA-3315](https://precisionmedicineinitiative.atlassian.net/browse/DA-3315)*
This rebuilds the participant's PDR data when the consent validation would update their EHR status.


## Tests
- [ ] unit tests




[DA-3315]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ