### PR TITLE
[PDR-1638] (Partial) Corrections to UpdateEhrStatus job PDR data builds

### DIFF
--- a/tests/cron_job_tests/test_update_ehr_status.py
+++ b/tests/cron_job_tests/test_update_ehr_status.py
@@ -176,8 +176,8 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase, PDRGeneratorTestMixin):
 
         # The first_seen and last_seen fields are set with mysql's NOW function,
         #   so check that the time is close to what is expected
-        self.assertAlmostEqual(first_seen, record.firstSeen, delta=datetime.timedelta(seconds=1))
-        self.assertAlmostEqual(last_seen, record.lastSeen, delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEquals(first_seen, record.firstSeen, delta=datetime.timedelta(seconds=1))
+        self.assertAlmostEquals(last_seen, record.lastSeen, delta=datetime.timedelta(seconds=1))
 
         # Check generated data.
         ps_data = self.make_participant_resource(participant_id)
@@ -271,7 +271,6 @@ class UpdateEhrStatusUpdatesTestCase(BaseTestCase, PDRGeneratorTestMixin):
                                   enrollment_status_v_3_1_time=None):
 
         # Additional Goal 1 data elements that will be part of the patch update upon receipt of EHR
-        # enrollment_status_baseline_time = None
         was_ehr_available = (is_ehr_available or first_ehr_time is not None)
         health_datastream_status = DigitalHealthSharingStatusV31.NEVER_SHARED
         health_datastream_status_time = None


### PR DESCRIPTION
## Partially resolves *[PDR-1638](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1638)*


## Description of changes/additions
During recent Goal 1 QC to validate NIH enrollment status report previews, found a number of participants that RDR had as BASELINE but were still showing CORE in PDR data.

Traced this back to an omission when Goal 1 fields were added to RDR.  The RDR UpdateEhrStatus cron job can bulk update so many participants per night that the PDR generator has a special path to patch a subset of fields in the PDR participant data record, rather than rebuild the entire record.   The patch data dictionary had not been updated to include the most recently added Goal 1 fields from `participant_summary`, so some details (such as `enrollment_status_v_3_1` from RDR) were not staying in sync with the RDR data.

## Tests
- [x] unit tests - updated to reflect changes to the patch data




[PDR-1638]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ