### PR TITLE
[DA-3378] Revert change for setting EHR status based on validation

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -958,11 +958,8 @@ class QuestionnaireResponseDao(BaseDao):
                     code.value.lower() if self._is_digital_health_share_code(code.value) else code.value)
                 if summary_field:
                     new_status = QuestionnaireStatus.SUBMITTED
-                    if code.value == CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE:
-                        if ehr_consent:
-                            new_status = QuestionnaireStatus.SUBMITTED_NOT_VALIDATED
-                        else:
-                            new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT
+                    if code.value == CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE and not ehr_consent:
+                        new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT
                     elif code.value == CONSENT_FOR_DVEHR_MODULE:
                         new_status = dvehr_consent
                     elif code.value == CONSENT_FOR_GENOMICS_ROR_MODULE:

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1888,7 +1888,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
             participant_id_1, questionnaire_id, CONSENT_PERMISSION_YES_CODE, time=TIME_2
         )
         ps_1 = self.send_get("Participant/%s/Summary" % participant_id_1)
-        self.assertEqual("SUBMITTED_NOT_VALIDATED", ps_1["consentForElectronicHealthRecords"])
+        self.assertEqual("SUBMITTED", ps_1["consentForElectronicHealthRecords"])
         self.assertEqual(TIME_2.isoformat(), ps_1.get("enrollmentStatusParticipantPlusEhrV3_1Time"))
 
     def _submit_dvehr_consent_questionnaire_response(
@@ -3006,7 +3006,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual("UNSET", new_ps_2["clinicPhysicalMeasurementsStatus"])
         self.assertEqual("SUBMITTED", new_ps_2["consentForStudyEnrollment"])
         self.assertIsNotNone(new_ps_2["consentForStudyEnrollmentAuthored"])
-        self.assertEqual("SUBMITTED_NOT_VALIDATED", new_ps_2["consentForElectronicHealthRecords"])
+        self.assertEqual("SUBMITTED", new_ps_2["consentForElectronicHealthRecords"])
         self.assertIsNotNone(new_ps_2["consentForElectronicHealthRecordsAuthored"])
         self.assertIsNone(new_ps_2.get("clinicPhysicalMeasurementsTime"))
         self.assertEqual("UNSET", new_ps_2["genderIdentity"])


### PR DESCRIPTION
## Resolves *[DA-3378](https://precisionmedicineinitiative.atlassian.net/browse/DA-3378)*
HPRO wasn't yet aware we'd be changing the behavior of the EHR status field. This removes the updates for when we ingest the EHR consent response so that the behavior of the status field will remain the same. We'll re-implement the changes when HPRO is ready for the new values.


## Tests
- [ ] unit tests




[DA-3378]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ