### PR TITLE
creating sample_update records for patched order

### DIFF
--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -1,8 +1,8 @@
-from sqlalchemy import (
-    Column, Integer, BigInteger, String, ForeignKey, Index, event)
+from typing import List
 
+from sqlalchemy import Column, Integer, BigInteger, String, ForeignKey, Index, event
 from sqlalchemy.dialects.mysql import TINYINT, JSON
-from sqlalchemy.orm import relation
+from sqlalchemy.orm import relation, relationship
 
 from rdr_service.model.base import NphBase, model_insert_listener, model_update_listener
 from rdr_service.model.study_nph_enums import StoredSampleStatus
@@ -84,6 +84,8 @@ class Order(NphBase):
     notes = Column(JSON, nullable=False)
     status = Column(String(128))
 
+    samples: List['OrderedSample'] = relationship('OrderedSample', back_populates='order')
+
 
 Index("order_participant_id", Order.participant_id)
 Index("order_created_site", Order.created_site)
@@ -115,6 +117,8 @@ class OrderedSample(NphBase):
     supplemental_fields = Column(JSON, nullable=True)
     parent = relation("OrderedSample", remote_side=[id])
     children = relation("OrderedSample", remote_side=[parent_sample_id], uselist=True)
+
+    order = relationship(Order, back_populates='samples')
 
 
 class Activity(NphBase):

--- a/tests/api_tests/test_nph_participant_biobank_order_api.py
+++ b/tests/api_tests/test_nph_participant_biobank_order_api.py
@@ -235,6 +235,7 @@ class TestNPHParticipantOrderAPI(BaseTestCase):
                 self.assertIsNotNone(each.ordered_sample_json)
 
     def tearDown(self):
+        super().tearDown()
         self.clear_table_after_test("nph.ordered_sample")
         self.clear_table_after_test("nph.order")
         self.clear_table_after_test("nph.site")


### PR DESCRIPTION
## Resolves *no ticket*
This PR sets the NPH Order API to create SampleUpdate records when the order is modified with a PATCH request. This way the JSON file export to the Biobank will include the PATCH updates too.

edit: I also cleaned up some try/catch statements that weren't really doing anything

## Tests
- [x] unit tests


