### PR TITLE
[DA-3383] NPH Participant API: temporarily disabling enrollment event integration

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -5,8 +5,7 @@ from sqlalchemy.orm import Query, aliased
 from sqlalchemy import and_
 
 from rdr_service.config import NPH_PROD_BIOBANK_PREFIX, NPH_TEST_BIOBANK_PREFIX
-from rdr_service.model.study_nph import Participant as DbParticipant, Site as nphSite, PairingEvent, EnrollmentEvent, \
-    EnrollmentEventType
+from rdr_service.model.study_nph import Participant as DbParticipant, Site as nphSite, PairingEvent
 from rdr_service.model.site import Site
 from rdr_service.model.rex import ParticipantMapping, Study
 from rdr_service.model.participant_summary import ParticipantSummary as ParticipantSummaryModel
@@ -331,49 +330,72 @@ class ParticipantQuery(ObjectType):
         with database_factory.get_database().session() as sessions:
             logging.info('root: %s, info: %s, kwargs: %s', root, info, filter_kwargs)
             pm2 = aliased(PairingEvent)
-            ee2 = aliased(EnrollmentEvent)
-            deactivated = aliased(EnrollmentEvent)
-            deactivated_type = aliased(EnrollmentEventType)
-            withdrawn = aliased(EnrollmentEvent)
-            withdrawn_type = aliased(EnrollmentEventType)
-            et2 = aliased(EnrollmentEventType)
-            query = sessions.query(ParticipantSummaryModel, Site, nphSite, ParticipantMapping, EnrollmentEvent,
-                                   EnrollmentEventType, deactivated, withdrawn
-                                   ).join(Site, ParticipantSummaryModel.siteId == Site.siteId
-                                          ).join(ParticipantMapping,
-                                                 ParticipantSummaryModel.participantId
-                                                 == ParticipantMapping.primary_participant_id
-                                                 ).join(EnrollmentEvent,
-                                                        EnrollmentEvent.participant_id
-                                                        == ParticipantMapping.
-                                                        ancillary_participant_id
-                                                        ).join(et2, EnrollmentEvent.event_type_id
-                                                               == et2.id
-                                                               ).join(PairingEvent, PairingEvent.participant_id
-                                                                      == ParticipantMapping.ancillary_participant_id
-                                                                      ).outerjoin(pm2, and_(PairingEvent.participant_id
-                                                                                            == pm2.participant_id,
-                                                                                            PairingEvent.event_type_id
-                                                                                            == pm2.event_type_id,
-                                                                                            PairingEvent.
-                                                                                            event_authored_time
-                                                                                            < pm2.event_authored_time)
-                                                                                  ).join(nphSite,
-                                                                                         nphSite.id == PairingEvent
-                                                                                         .site_id).outerjoin(
-                ee2, and_(EnrollmentEvent.participant_id == ee2.participant_id,
-                          EnrollmentEvent.event_authored_time < ee2.event_authored_time)).outerjoin(
-                deactivated, ParticipantMapping.ancillary_participant_id == deactivated.participant_id
-            ).outerjoin(deactivated_type, deactivated.event_type_id == deactivated_type.id).outerjoin(
-                withdrawn, ParticipantMapping.ancillary_participant_id == withdrawn.participant_id
-            ).outerjoin(withdrawn_type, withdrawn.event_type_id == withdrawn_type.id).join(
-                EnrollmentEventType, EnrollmentEventType.id
-                                     == EnrollmentEvent
-                                     .event_type_id).filter(
-                pm2.id.is_(None), ParticipantMapping.ancillary_study_id == 2).filter(ee2.id.is_(None)
-                                                                                     ).filter(
-                deactivated_type.name == "Deactivated").filter(withdrawn_type.name == "Withdrawn").filter(
-                EnrollmentEventType.name != "Deactivated", EnrollmentEventType.name != "Withdrawn")
+            # ee2 = aliased(EnrollmentEvent)
+            # deactivated = aliased(EnrollmentEvent)
+            # deactivated_type = aliased(EnrollmentEventType)
+            # withdrawn = aliased(EnrollmentEvent)
+            # withdrawn_type = aliased(EnrollmentEventType)
+            # et2 = aliased(EnrollmentEventType)
+            query = sessions.query(
+                ParticipantSummaryModel, Site, nphSite, ParticipantMapping,
+                # EnrollmentEvent, EnrollmentEventType, deactivated, withdrawn
+            ).join(
+                Site,
+                ParticipantSummaryModel.siteId == Site.siteId
+            ).join(
+                ParticipantMapping,
+                ParticipantSummaryModel.participantId == ParticipantMapping.primary_participant_id
+            # ).join(
+            #     EnrollmentEvent,
+            #     EnrollmentEvent.participant_id == ParticipantMapping.ancillary_participant_id
+            # ).join(
+            #     et2,
+            #     EnrollmentEvent.event_type_id == et2.id
+            ).join(
+                PairingEvent,
+                PairingEvent.participant_id == ParticipantMapping.ancillary_participant_id
+            ).outerjoin(
+                pm2,
+                and_(
+                    PairingEvent.participant_id == pm2.participant_id,
+                    PairingEvent.event_type_id == pm2.event_type_id,
+                    PairingEvent.event_authored_time < pm2.event_authored_time
+                )
+            ).join(
+                nphSite,
+                nphSite.id == PairingEvent.site_id
+            # ).outerjoin(
+            #     ee2,
+            #     and_(
+            #         EnrollmentEvent.participant_id == ee2.participant_id,
+            #         EnrollmentEvent.event_authored_time < ee2.event_authored_time
+            #     )
+            # ).outerjoin(
+            #     deactivated,
+            #     ParticipantMapping.ancillary_participant_id == deactivated.participant_id
+            # ).outerjoin(
+            #     deactivated_type,
+            #     deactivated.event_type_id == deactivated_type.id
+            # ).outerjoin(
+            #     withdrawn,
+            #     ParticipantMapping.ancillary_participant_id == withdrawn.participant_id
+            # ).outerjoin(
+            #     withdrawn_type,
+            #     withdrawn.event_type_id == withdrawn_type.id
+            # ).join(
+            #     EnrollmentEventType,
+            #     and_(
+            #         EnrollmentEventType.id == EnrollmentEvent.event_type_id,
+            #         EnrollmentEventType.name != "Deactivated",
+            #         EnrollmentEventType.name != "Withdrawn"
+            #     )
+            ).filter(
+                pm2.id.is_(None),
+                ParticipantMapping.ancillary_study_id == 2,
+                # ee2.id.is_(None),
+                # deactivated_type.name == "Deactivated",
+                # withdrawn_type.name == "Withdrawn"
+            )
             study_query = sessions.query(Study).filter(Study.schema_name == "nph")
             study = study_query.first()
             current_class = Participant

--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -57,7 +57,7 @@ def check_field_value(value):
 
 def load_participant_summary_data(query, prefix, biobank_prefix):
     results = []
-    for summary, site, nph_site, mapping, enrollment_time, enrollment_name, deactivated, withdrawn in query.all():
+    for summary, site, nph_site, mapping in query.all():
         results.append({
             'participantNphId': f"{prefix}{mapping.ancillary_participant_id}",
             'lastModified': summary.lastModified,
@@ -74,13 +74,15 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
             'withdrawalStatus': {"value": check_field_value(summary.withdrawalStatus),
                                  "time": summary.withdrawalAuthored},
             'nph_deactivation_status': {
-                "value": "Deactivate" if deactivated.event_authored_time else QuestionnaireStatus.UNSET,
-                "time": deactivated.event_authored_time if deactivated.event_authored_time else None},
+                "value": QuestionnaireStatus.UNSET,
+                "time": None
+            },
             'nph_withdrawal_status': {
-                "value": "Withdrawn" if withdrawn.event_authored_time else QuestionnaireStatus.UNSET,
-                "time": withdrawn.event_authored_time if withdrawn.event_authored_time else None},
-            'nph_enrollment_status': {"value": check_field_value(enrollment_name.name),
-                                      "time": enrollment_time.event_authored_time},
+                "value": QuestionnaireStatus.UNSET,
+                "time": None
+            },
+            'nph_enrollment_status': {"value": QuestionnaireStatus.UNSET,
+                                      "time": None},
             'aianStatus': summary.aian,
             'suspensionStatus': {"value": check_field_value(summary.suspensionStatus),
                                  "time": summary.suspensionTime},
@@ -88,20 +90,24 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
                                  "time": summary.dateOfBirth},
             'questionnaireOnTheBasics': {
                 "value": check_field_value(summary.questionnaireOnTheBasics),
-                "time": summary.questionnaireOnTheBasicsAuthored},
+                "time": summary.questionnaireOnTheBasicsAuthored
+            },
             'questionnaireOnHealthcareAccess': {
                 "value": check_field_value(summary.questionnaireOnHealthcareAccess),
-                "time": summary.questionnaireOnHealthcareAccessAuthored},
+                "time": summary.questionnaireOnHealthcareAccessAuthored
+            },
             'questionnaireOnLifestyle': {
                 "value": check_field_value(summary.questionnaireOnLifestyle),
-                "time": summary.questionnaireOnLifestyleAuthored},
+                "time": summary.questionnaireOnLifestyleAuthored
+            },
             'siteId': site.googleGroup,
             'external_id': nph_site.external_id,
             'organization_external_id': nph_site.organization_external_id,
             'awardee_external_id': nph_site.awardee_external_id,
-            'questionnaireOnSocialDeterminantsOfHealth':
-                {"value": check_field_value(summary.questionnaireOnSocialDeterminantsOfHealth),
-                 "time": summary.questionnaireOnSocialDeterminantsOfHealthAuthored}
+            'questionnaireOnSocialDeterminantsOfHealth': {
+                "value": check_field_value(summary.questionnaireOnSocialDeterminantsOfHealth),
+                 "time": summary.questionnaireOnSocialDeterminantsOfHealthAuthored
+            }
         })
 
     return results


### PR DESCRIPTION
## Partially Resolves *[DA-3383](https://precisionmedicineinitiative.atlassian.net/browse/DA-3383)*
In Stable the NPH Participant API is currently not returning any of the test participants. Recent changes to the API were released that require the participants to have EnrollmentEvents, but those don't currently exist. It also looks like this code may be requiring the participants to have Deactivate and Withdrawal events for them to appear on the API.

As most of the team that would be aware of the requirements for this is out, this PR removes that data from the API in order to get the API functional again until it can be determined how to update the test participants to work with the new functionality.

## Tests
- [ ] unit tests




[DA-3383]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ