### PR TITLE
Fixing PATCH issue on NPH Order API

### DIFF
--- a/rdr_service/api/nph_participant_biobank_order_api.py
+++ b/rdr_service/api/nph_participant_biobank_order_api.py
@@ -101,11 +101,8 @@ class NphOrderApi(UpdatableApi):
                     order.id = rdr_order_id
                     return construct_response(order), 200
             except NotFound as not_found:
-                logging.error(not_found.description)
+                logging.error(not_found.description, exc_info=True)
                 return construct_response(order), 404
             except BadRequest as bad_request:
-                logging.error(bad_request.description)
-                return construct_response(order), 400
-            except exc.SQLAlchemyError as sql:
-                logging.error(sql)
+                logging.error(bad_request.description, exc_info=True)
                 return construct_response(order), 400

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -279,8 +279,7 @@ class NphOrderDao(UpdatableDao):
             sample_update_dao = NphSampleUpdateDao()
             for ordered_sample in db_order.samples:
                 sample_update_dict = {
-                    "rdr_ordered_sample_id": ordered_sample.id,
-                    "ordered_sample_json": ordered_sample.asdict()
+                    "rdr_ordered_sample_id": ordered_sample.id
                 }
                 sample_update_dao.insert(SampleUpdate(**sample_update_dict))
 


### PR DESCRIPTION
## Resolves *no ticket*
HealthPro is seeing an error on the NPH Order API. When they try to send PATCH requests to update orders the API hits a SQLAlchemy error. The SampleUpdate tries to store the OrderedSample object data in a JSON field, and if it has something unserializable (like a datetime) then it fails.

This resolves the issue by leaving that field blank. If we'd like to continue keeping a history of the data, we can track it another way in the future.

## Tests
- [x] unit tests


