### PR TITLE
DA-3368: Update NPH Participant API Field names

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -184,7 +184,7 @@ class Participant(ObjectType):
     )
     questionnaireOnTheBasics = SortableField(
         Event,
-        name="aouBasicStatus",
+        name="aouBasicsStatus",
         description='''
             Provides submission status and authored time for the participant’s completion of TheBasics module.
             Value should be UNSET or SUBMITTED and time should be the authored time. Both should be sourced from
@@ -217,7 +217,7 @@ class Participant(ObjectType):
             from the AoU participant_summary table’s suspension columns
         '''
     )
-    enrollmentStatus = SortableField(
+    nphEnrollmentStatus = SortableField(
         Event,
         name="aouEnrollmentStatus",
         description='''

--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -86,7 +86,7 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
             'aianStatus': summary.aian,
             'suspensionStatus': {"value": check_field_value(summary.suspensionStatus),
                                  "time": summary.suspensionTime},
-            'enrollmentStatus': {"value": check_field_value(summary.enrollmentStatus),
+            'nphEnrollmentStatus': {"value": check_field_value(summary.enrollmentStatus),
                                  "time": summary.dateOfBirth},
             'questionnaireOnTheBasics': {
                 "value": check_field_value(summary.questionnaireOnTheBasics),
@@ -120,7 +120,7 @@ def schema_field_lookup(value):
                     "value": ParticipantSummaryModel.dateOfBirth},
             "aouAianStatus": {"field": "aian", "table": ParticipantSummaryModel,
                               "value": ParticipantSummaryModel.aian},
-            "aouBasicStatus": {"field": "questionnaireOnTheBasics", "table": ParticipantSummaryModel,
+            "aouBasicsStatus": {"field": "questionnaireOnTheBasics", "table": ParticipantSummaryModel,
                                "value": ParticipantSummaryModel.questionnaireOnTheBasics},
             "aouDeceasedStatus": {"field": "deceasedStatus", "table": ParticipantSummaryModel,
                                   "value": ParticipantSummaryModel.deceasedStatus,

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -36,7 +36,7 @@ foodIsecurity{current{value time} historical{value time}} aouBasicsQuestionnaire
 sampleSa1{ordered{parent{current{value time}}} }} } } }'''
 
 QUERY_WITH_NONE_VALUE = '''
-{ participant  { edges { node { aouLifestyleStatus{ value time } aouBasicStatus{ value time }
+{ participant  { edges { node { aouLifestyleStatus{ value time } aouBasicsStatus{ value time }
 aouOverallHealthStatus{ value time } aouLifestyleStatus{ value time } aouSDOHStatus{ value time }}}}}
 '''
 


### PR DESCRIPTION
## Resolves *[DA-3368](https://precisionmedicineinitiative.atlassian.net/browse/DA-3368)*


## Description of changes/additions
Modified API Field names 
* ~`aouBasicStatus`~ => `aouBasicsStatus`
* ~`enrollmentStatus`~ => `nphEnrollmentStatus`

## Tests
`PASSED` all the tests in `tests/api_tests/test_nph_participant_api.py`




[DA-3368]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ