### PR TITLE
[DA-3395] AW3 WGS (3.4.12) distinct mitigation

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4003,7 +4003,8 @@ class GenomicQueriesDao(BaseDao):
             return []
 
         # only updated dragen version files will be placed in 'dragen_v' subfolder
-        data_file_path = pipeline_id if pipeline_id == config.GENOMIC_UPDATED_WGS_DRAGEN else '/'
+        is_dragen_path = True if pipeline_id == config.GENOMIC_UPDATED_WGS_DRAGEN else False
+        dragen_path_text = '%dragen_%'
 
         with self.session() as session:
 
@@ -4073,56 +4074,73 @@ class GenomicQueriesDao(BaseDao):
                 and_(
                     hard_filtered_vcf_gz.file_type == 'hard-filtered.vcf.gz',
                     hard_filtered_vcf_gz.identifier_value == GenomicSetMember.sampleId,
-                    hard_filtered_vcf_gz.file_path.contains(data_file_path)
+                    hard_filtered_vcf_gz.file_path.contains(dragen_path_text) if is_dragen_path else
+                    hard_filtered_vcf_gz.file_path.notlike(dragen_path_text),
+                    hard_filtered_vcf_gz.ignore_flag != 1
                 )
             ).join(
                 hard_filtered_vcf_gz_tbi,
                 and_(
                     hard_filtered_vcf_gz_tbi.file_type == 'hard-filtered.vcf.gz.tbi',
                     hard_filtered_vcf_gz_tbi.identifier_value == GenomicSetMember.sampleId,
-                    hard_filtered_vcf_gz_tbi.file_path.contains(data_file_path)
+                    hard_filtered_vcf_gz_tbi.file_path.contains(dragen_path_text) if is_dragen_path else
+                    hard_filtered_vcf_gz_tbi.file_path.notlike(dragen_path_text),
+                    hard_filtered_vcf_gz_tbi.ignore_flag != 1
                 )
             ).join(
                 hard_filtered_vcf_gz_md5_sum,
                 and_(
                     hard_filtered_vcf_gz_md5_sum.file_type == 'hard-filtered.vcf.gz.md5sum',
                     hard_filtered_vcf_gz_md5_sum.identifier_value == GenomicSetMember.sampleId,
-                    hard_filtered_vcf_gz_md5_sum.file_path.contains(data_file_path)
+                    hard_filtered_vcf_gz_md5_sum.file_path.contains(dragen_path_text) if is_dragen_path else
+                    hard_filtered_vcf_gz_md5_sum.file_path.notlike(dragen_path_text),
+                    hard_filtered_vcf_gz_md5_sum.ignore_flag != 1
                 )
             ).join(
                 cram,
                 and_(
                     cram.file_type == 'cram',
                     cram.identifier_value == GenomicSetMember.sampleId,
-                    cram.file_path.contains(data_file_path)
+                    cram.file_path.contains(dragen_path_text) if is_dragen_path else cram.file_path.notlike(
+                        dragen_path_text),
+                    cram.ignore_flag != 1
                 )
             ).join(
                 cram_md5_sum,
                 and_(
                     cram_md5_sum.file_type == 'cram.md5sum',
                     cram_md5_sum.identifier_value == GenomicSetMember.sampleId,
-                    cram_md5_sum.file_path.contains(data_file_path)
+                    cram_md5_sum.file_path.contains(
+                        dragen_path_text) if is_dragen_path else cram_md5_sum.file_path.notlike(
+                        dragen_path_text),
+                    cram_md5_sum.ignore_flag != 1
                 )
             ).join(
                 cram_crai,
                 and_(
                     cram_crai.file_type == 'cram.crai',
                     cram_crai.identifier_value == GenomicSetMember.sampleId,
-                    cram_crai.file_path.contains(data_file_path)
+                    cram_crai.file_path.contains(dragen_path_text) if is_dragen_path else cram_crai.file_path.notlike(
+                        dragen_path_text),
+                    cram_crai.ignore_flag != 1
                 )
             ).join(
                 hard_filtered_gvcf_gz,
                 and_(
                     hard_filtered_gvcf_gz.file_type == 'hard-filtered.gvcf.gz',
                     hard_filtered_gvcf_gz.identifier_value == GenomicSetMember.sampleId,
-                    hard_filtered_gvcf_gz.file_path.contains(data_file_path)
+                    hard_filtered_gvcf_gz.file_path.contains(dragen_path_text) if is_dragen_path else
+                    hard_filtered_gvcf_gz.file_path.notlike(dragen_path_text),
+                    hard_filtered_gvcf_gz.ignore_flag != 1
                 )
             ).join(
                 hard_filtered_gvcf_gz_md5_sum,
                 and_(
                     hard_filtered_gvcf_gz_md5_sum.file_type == 'hard-filtered.gvcf.gz.md5sum',
                     hard_filtered_gvcf_gz_md5_sum.identifier_value == GenomicSetMember.sampleId,
-                    hard_filtered_gvcf_gz_md5_sum.file_path.contains(data_file_path)
+                    hard_filtered_gvcf_gz_md5_sum.file_path.contains(dragen_path_text) if is_dragen_path else
+                    hard_filtered_gvcf_gz_md5_sum.file_path.notlike(dragen_path_text),
+                    hard_filtered_gvcf_gz_md5_sum.ignore_flag != 1
                 )
             ).outerjoin(
                 GenomicAW3Raw,


### PR DESCRIPTION
## Resolves *[ticket DA-3395](link to ticket)*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3395

## Description of changes/additions
Since the new `dragen` files are dropping the samples that were are receiving on the reprocessed AW2s are having issues in utilizing the distinct filter because of similar data file paths. 

## Tests
- [x] unit tests


