### PR TITLE
[PDR-1649]  PDR generator collect_type and status values for PM data

### DIFF
--- a/rdr_service/resource/constants.py
+++ b/rdr_service/resource/constants.py
@@ -175,3 +175,13 @@ class RetentionTypeEnum(IntEnum):
     ACTIVE = 1
     PASSIVE = 2
     ACTIVE_AND_PASSIVE = 3
+
+# PDR-1649:  Extending the RDR PhysicalMeasurementsStatus Enum class for PDR
+class PDRPhysicalMeasurementsStatus(IntEnum):
+    """The state of the participant's physical measurements."""
+
+    UNSET = 0
+    COMPLETED = 1
+    CANCELLED = 2
+    AMENDED = 3
+    RESTORED = 4  # not currently used by PDR generator

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -938,7 +938,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         query = ro_session.query(PhysicalMeasurements.physicalMeasurementsId, PhysicalMeasurements.created,
                                  PhysicalMeasurements.createdSiteId, PhysicalMeasurements.cancelledSiteId,
                                  PhysicalMeasurements.finalizedSiteId,
-                                 PhysicalMeasurements.final, PhysicalMeasurements.finalizedSiteId,
+                                 PhysicalMeasurements.final, PhysicalMeasurements.finalized,
                                  PhysicalMeasurements.collectType, PhysicalMeasurements.origin,
                                  PhysicalMeasurements.originMeasurementUnit,
                                  PhysicalMeasurements.questionnaireResponseId,
@@ -963,7 +963,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             elif row.createdSiteId or row.finalizedSiteId or row.cancelledSiteId or row.created < remote_pm_start_date:
                 collection_type = PhysicalMeasurementsCollectType.SITE
             else:
-                # "should never happen", but this would flag records that are missing expected values
+                # "should never happen", but this would flag records that are missing all expected details
                 collection_type = PhysicalMeasurementsCollectType.UNSET
 
             pm_list.append({
@@ -1007,6 +1007,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :param ro_session: Readonly DAO session object
         :return:
         """
+        # PDR-1432: Workaround for an edge case where HPRO created an "orphaned" biobank order that should be ignored
+        # TODO: When DA-3150 is implemented, need to adjust the biobank table queries in this method to filter on
+        # ignore flags, as appropriate
+        ignore_biobank_orders = ['WEBF77CR2BX5',]
+
         def _get_stored_sample_row(stored_samples, ordered_sample):
             """
             Search a list of biobank_stored_sample rows to find a match to the biobank_ordered_sample record
@@ -1098,7 +1103,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                    bo.finalized_time,
                    case when bmko.id is not null then 1 else 2 end as collection_method
              from biobank_order bo left outer join biobank_mail_kit_order bmko on bmko.biobank_order_id = bo.biobank_order_id
-             where bo.participant_id = :p_id and (bo.ignore_flag is null or bo.ignore_flag = 0)
+             where bo.participant_id = :p_id
              order by bo.created desc;
          """
 
@@ -1118,9 +1123,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             select
                 (select p.participant_id from participant p where p.biobank_id = bss.biobank_id) as participant_id,
                 (select distinct boi.biobank_order_id from biobank_order_identifier boi
-                   left join biobank_order bo on boi.biobank_order_id = bo.biobank_order_id
-                   where boi.`value` = bss.biobank_order_identifier
-                         and (bo.ignore_flag is null or bo.ignore_flag = 0)
+                   where boi.`value` = bss.biobank_order_identifier and boi.biobank_order_id not in :ignore_orders
                 ) as biobank_order_id,
                 bss.*
             from biobank_stored_sample bss
@@ -1131,9 +1134,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         data = {}
         orders = list()
         activity = list()
-        # Find all valid (not flagged "ignore") biobank orders associated with this participant.
+        # Find all biobank orders associated with this participant.  PDR-1432 WORKAROUND:  Certain biobank orders may
+        # be excluded from the list due to rare occurrences of "orphaned" orders created by HPRO
+        # TODO:  Update to use a new ignore column as filter when implemented for DA-3150 and backfill is completed
         cursor = ro_session.execute(_biobank_orders_sql, {'p_id': p_id})
-        biobank_orders = [r for r in cursor if r.biobank_order_id]
+        biobank_orders = [r for r in cursor if r.biobank_order_id not in ignore_biobank_orders]
         # Create a unique identifier for each biobank order. This uid must be repeatable, so we sort by 'created'.
         # This unique biobank order id will be used as the prefix of the unique id for each biobank sample record.
         # Note: This is why every database table should have an 'id' integer field as the primary key, so we don't
@@ -1147,7 +1152,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         # Find stored samples associated with this participant. For any stored samples for which there
         # is no known biobank order, create a separate list that will be consolidated into a "pseudo" order record
-        cursor = ro_session.execute(_biobank_stored_samples_sql, {'bb_id': p_bb_id})
+        cursor = ro_session.execute(_biobank_stored_samples_sql, {'bb_id': p_bb_id,
+                                                                  'ignore_orders': ignore_biobank_orders})
         bss_results = [r for r in cursor]
         bss_missing_orders = list(filter(lambda r: r.biobank_order_id is None, bss_results))
 

--- a/rdr_service/services/gcp_config.py
+++ b/rdr_service/services/gcp_config.py
@@ -48,7 +48,7 @@ GCP_INSTANCES = {  # List of RDR's GCP projects mapped to their database instanc
 }
 
 GCP_REPLICA_INSTANCES = {
-    "all-of-us-rdr-prod": "all-of-us-rdr-prod:us-central1:rdrbackupdb-a",
+    "all-of-us-rdr-prod": "all-of-us-rdr-prod:us-central1:rdrbackupdb-d",
     "all-of-us-rdr-stable": "all-of-us-rdr-stable:us-central1:rdrbackupdb",
     "all-of-us-rdr-staging": "all-of-us-rdr-staging:us-central1:rdrbackupdb",
     "all-of-us-rdr-sandbox": "all-of-us-rdr-sandbox:us-central1:rdrmaindb",


### PR DESCRIPTION
## Resolves *[PDR-1649](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1649)*


## Description of changes/additions
When remote PM functionality was enabled in 6/22, new `physical_measurements` records  in RDR began having their `collect_type` field populated but old records were not backfilled.  This results in UNSET values in PDR for records that were from earlier site PM&B activity.

When `collect_type` is null, the PDR generator will look at other elements of the record to determine what value to assign.
As a convenience for PDR users, we'll also set records that have an `amended_measurements_id` value to a PDR-specific status of AMENDED so that filtering by status will be easier in PDR.

Also fixing the replica reference in the `gcp_config` for tools that explicitly specify a replica connection.

## Tests
- [x] unit tests

[PDR-1649]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ