### PR TITLE
[DA-3384] Enrollment, Withdrawal, and Deactivation for NPH Participant API

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -57,7 +57,7 @@ def check_field_value(value):
 
 def load_participant_summary_data(query, prefix, biobank_prefix):
     results = []
-    for summary, site, nph_site, mapping in query.all():
+    for summary, site, nph_site, mapping, enrollment_time, enrollment_name, deactivated, withdrawn in query.all():
         results.append({
             'participantNphId': f"{prefix}{mapping.ancillary_participant_id}",
             'lastModified': summary.lastModified,
@@ -74,15 +74,17 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
             'withdrawalStatus': {"value": check_field_value(summary.withdrawalStatus),
                                  "time": summary.withdrawalAuthored},
             'nph_deactivation_status': {
-                "value": QuestionnaireStatus.UNSET,
-                "time": None
+                "value": "Deactivate" if deactivated else "NULL",
+                "time": deactivated.event_authored_time if deactivated else None
             },
             'nph_withdrawal_status': {
-                "value": QuestionnaireStatus.UNSET,
-                "time": None
+                "value": "Withdrawn" if withdrawn else "NULL",
+                "time": withdrawn.event_authored_time if withdrawn else None
             },
-            'nph_enrollment_status': {"value": QuestionnaireStatus.UNSET,
-                                      "time": None},
+            'nph_enrollment_status': {
+                "value": check_field_value(enrollment_name.name),
+                "time": enrollment_time.event_authored_time
+            },
             'aianStatus': summary.aian,
             'suspensionStatus': {"value": check_field_value(summary.suspensionStatus),
                                  "time": summary.suspensionTime},

--- a/rdr_service/data_gen/generators/nph.py
+++ b/rdr_service/data_gen/generators/nph.py
@@ -2,6 +2,7 @@ from rdr_service.dao import database_factory
 from rdr_service.model.study_nph import Participant, Site, PairingEvent, ParticipantEventActivity, Activity, \
     PairingEventType, ConsentEvent, ConsentEventType, EnrollmentEventType, EnrollmentEvent, WithdrawalEvent, \
     DeactivatedEvent
+from rdr_service.ancillary_study_resources.nph import enums
 
 
 class NphDataGenerator:
@@ -123,9 +124,13 @@ class NphDataGenerator:
 
     def create_database_enrollment_event(self, participant_id, **kwargs):
         event_id = kwargs.get('event_id')
-        if event_id is None:
-            ee = self.create_database_enrollment_event_type()
-            event_id = ee.id
+        if not event_id:
+            pea = self.create_database_participant_event_activity(
+                activity_id=enums.Activity.ENROLLMENT.number,
+                participant_id=participant_id,
+                resource={}
+            )
+            event_id = pea.id
 
         fields = {
             "participant_id": participant_id,


### PR DESCRIPTION
## Resolves *[DA-3384](https://precisionmedicineinitiative.atlassian.net/browse/DA-3384)*


## Description of changes/additions
Refactored Participant API query to include withdrawal and deactivation events and removed unnecessary joins. Updated unit tests and NPH data generator to support tests.

## Tests
- [x] unit tests




[DA-3384]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ