### PR TITLE
Fixed incorrect field name and related tests

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -217,7 +217,7 @@ class Participant(ObjectType):
             from the AoU participant_summary table’s suspension columns
         '''
     )
-    nphEnrollmentStatus = SortableField(
+    aouEnrollmentStatus = SortableField(
         Event,
         name="aouEnrollmentStatus",
         description='''
@@ -263,7 +263,7 @@ class Participant(ObjectType):
     awardee_external_id = SortableField(String, name="nphPairedAwardee", description='Sourced from NPH Schema.',
                                         sort_modifier=lambda context: context.set_order_expression(
                                             nphSite.awardee_external_id))
-    nph_enrollment_status = SortableField(Event, name="enrollmentStatus", description='Sourced from NPH Schema.')
+    nph_enrollment_status = SortableField(Event, name="nphEnrollmentStatus", description='Sourced from NPH Schema.')
     nph_withdrawal_status = SortableField(Event, name="nphWithdrawalStatus", description='Sourced from NPH Schema.')
     nph_deactivation_status = SortableField(Event, name="nphDeactivationStatus", description='Sourced from NPH Schema.')
     # Bio-specimen

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -289,14 +289,14 @@ class TestQueryExecution(BaseTestCase):
         nph_id = str(prefix) + str(participant_nph_id)
         self.assertEqual(nph_id, resulting_participant_data.get('participantNphId'))
 
-    def test_enrollmentStatus_fields(self):
-        field_to_test = "enrollmentStatus {value time} "
+    def test_nphEnrollmentStatus_fields(self):
+        field_to_test = "nphEnrollmentStatus {value time} "
         query = simple_query(field_to_test)
         mock_load_participant_data(self.session)
         executed = app.test_client().post('/rdr/v1/nph_participant', data=query)
         result = json.loads(executed.data.decode('utf-8'))
         self.assertEqual(2, len(result.get('participant').get('edges')))
-        actual_result = result.get('participant').get('edges')[0].get('node').get('enrollmentStatus')
+        actual_result = result.get('participant').get('edges')[0].get('node').get('nphEnrollmentStatus')
         self.assertIn("time", actual_result)
         self.assertIn("value", actual_result)
 


### PR DESCRIPTION
## Resolves *[DA-3368](https://precisionmedicineinitiative.atlassian.net/browse/DA-3368)*


## Description of changes/additions
Modified API Field names in `rdr_service/api/nph_participant_api_schemas/schema.py`
* ~`aouBasicStatus`~ => `aouBasicsStatus`
* ~`enrollmentStatus`~ => `aouEnrollmentStatus` & `nphEnrollmentStatus` respectively on `Line 220` & `Line 266` 

## Tests
`PASSED` all the tests in `tests/api_tests/test_nph_participant_api.py`

[DA-3368]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ