### PR TITLE
[DA-3366] enabling summary 3.0 fields and hiding 3.1 fields from documentation

### DIFF
--- a/doc/api_workflows/field_reference/participant_summary_field_list.rst
+++ b/doc/api_workflows/field_reference/participant_summary_field_list.rst
@@ -8,4 +8,8 @@ Participant Summary Field List
     :exclude-members: stateId, recontactMethodId, languageId, genderIdentityId, sexId, sexualOrientationId, educationId,
                       incomeId, clinicPhysicalMeasurementsCreatedSiteId, clinicPhysicalMeasurementsFinalizedSiteId,
                       organizationId, siteId, biospecimenSourceSiteId, biospecimenCollectedSiteId,
-                      biospecimenProcessedSiteId, biospecimenFinalizedSiteId, participant, enrollmentSiteId
+                      biospecimenProcessedSiteId, biospecimenFinalizedSiteId, participant, enrollmentSiteId,
+                      enrollmentStatusV3_1, enrollmentStatusParticipantV3_1Time,
+                      enrollmentStatusParticipantPlusEhrV3_1Time, enrollmentStatusParticipantPlusBasicsV3_1Time,
+                      enrollmentStatusCoreMinusPmV3_1Time, enrollmentStatusCoreV3_1Time,
+                      enrollmentStatusParticipantPlusBaselineV3_1Time

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1261,14 +1261,8 @@ class ParticipantSummaryDao(UpdatableDao):
 
         # Check to see if we should hide 3.0 and 3.1 fields
         if not config.getSettingJson(config.ENABLE_ENROLLMENT_STATUS_3, default=False):
-            del result['enrollmentStatusV3_0']
             del result['enrollmentStatusV3_1']
             for field_name in [
-                'enrollmentStatusParticipantV3_0Time',
-                'enrollmentStatusParticipantPlusEhrV3_0Time',
-                'enrollmentStatusPmbEligibleV3_0Time',
-                'enrollmentStatusCoreMinusPmV3_0Time',
-                'enrollmentStatusCoreV3_0Time',
                 'enrollmentStatusParticipantV3_1Time',
                 'enrollmentStatusParticipantPlusEhrV3_1Time',
                 'enrollmentStatusParticipantPlusBasicsV3_1Time',

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -3798,8 +3798,10 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual(later_shared_summary.participantId, participant_id_list[2])
 
     def test_disabling_data_glossary_3_fields(self):
-        """Check that the 3.x enrollment statuses and digital health sharing fields are disabled by default"""
+        """Check that the 3.1 enrollment statuses and digital health sharing fields are disabled by default"""
         summary = self.data_generator.create_database_participant_summary()
+        summary.enrollmentStatusParticipantV3_0Time = datetime.datetime.utcnow()
+        self.session.commit()
 
         # Override the default config, disabling the fields on the API
         self.temporarily_override_config_setting(config.ENABLE_ENROLLMENT_STATUS_3, False)
@@ -3807,9 +3809,12 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
         # Check that the new fields are hidden
         api_response = self.send_get(f'Participant/P{summary.participantId}/Summary')
-        self.assertNotIn('enrollmentStatusV3_0', api_response)
         self.assertNotIn('enrollmentStatusV3_1', api_response)
         self.assertNotIn('healthDataStreamSharingStatusV3_1', api_response)
+
+        # Make sure 3.0 fields are still there
+        self.assertIn('enrollmentStatusV3_0', api_response)
+        self.assertIn('enrollmentStatusParticipantV3_0Time', api_response)
 
     def test_mediated_ehr(self):
         """Check that the new set of participant mediated EHR data availability fields are present on the summary"""


### PR DESCRIPTION
## Resolves *[DA-3366](https://precisionmedicineinitiative.atlassian.net/browse/DA-3366)*
Previously, 3.0 and 3.1 enrollment status was unavailable on the API but still showed up in the API documentation. This enables the 3.0 fields on the API and removes the 3.1 fields from the documentation.

## Tests
- [x] unit tests




[DA-3366]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ