### PR TITLE
[PDR-1649] Fix to the original PR for setting PM AMENDED status

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -948,13 +948,16 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # sql = self.dao.query_to_text(query)
         results = query.all()
 
+        if len(results):
+            amended_ids = set([r.amendedMeasurementsId for r in results])
+
         for row in results:
             # Imitate some of the RDR 'participant_summary' table logic, the PM status value defaults to COMPLETED
             # unless PM status is CANCELLED.  So we set all NULL values to COMPLETED status here.  As of PDR-1649,
             # will map the RDR messages.enum to a PDR IntEnum class that includes an explicit AMENDED status
             pm_status = PDRPhysicalMeasurementsStatus(int(row.status) if row.status\
                                                                       else PDRPhysicalMeasurementsStatus.COMPLETED)
-            if row.amendedMeasurementsId is not None:
+            if row.physicalMeasurementsId in amended_ids:
                 pm_status = PDRPhysicalMeasurementsStatus.AMENDED
             origin_measurements_type = OriginMeasurementUnit(row.originMeasurementUnit or OriginMeasurementUnit.UNSET)
 


### PR DESCRIPTION
## Resolves *[PDR-1649](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1649)* (fix to PR #3369)


## Description of changes/additions
I had the orientation of how amended records are identified in RDR backwards.   The new/updated  record has the old records `physical_measurements_id` as its `amended_measurements_id` value, not the other way around.   This adjusts the logic for setting AMENDED status on the original record.

## Tests
- [x] unit tests




[PDR-1649]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ