### PR TITLE
Re-append prefix for response Intake API

### DIFF
--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -222,7 +222,7 @@ class NphIntakeAPI(BaseApi):
             participant_id = self.extract_participant_id(participant_obj=participant_obj)
 
             participant_response.append({
-                'nph_participant_id': participant_id
+                'nph_participant_id': f'{self.nph_prefix}{participant_id}'
             })
 
             applicable_entries = [obj for obj in resource['entry'] if obj['resource']['resourceType'].lower() in [

--- a/tests/api_tests/test_nph_intake_api.py
+++ b/tests/api_tests/test_nph_intake_api.py
@@ -81,9 +81,10 @@ class NphIntakeAPITest(BaseTestCase):
 
         # response
         response = self.send_post('nph/Intake', request_data=consent_json)
+        response_participant_ids = [f'1000{obj}' for obj in all_participant_ids]
 
         self.assertEqual(len(response), len(all_participant_ids))
-        self.assertTrue(all(int(obj['nph_participant_id']) in all_participant_ids for obj in response))
+        self.assertTrue(all(obj['nph_participant_id'] in response_participant_ids for obj in response))
 
         # participant event activities
         participant_event_activities = self.nph_participant_activity_dao.get_all()
@@ -162,7 +163,7 @@ class NphIntakeAPITest(BaseTestCase):
         response = self.send_post('nph/Intake', request_data=consent_json)
 
         self.assertEqual(len(response), 1)
-        self.assertTrue(all(int(obj['nph_participant_id']) == current_participant_id for obj in response))
+        self.assertTrue(all(obj['nph_participant_id'] == f'1000{current_participant_id}' for obj in response))
 
         # participant event activities
         participant_event_activities = self.nph_participant_activity_dao.get_all()
@@ -230,7 +231,7 @@ class NphIntakeAPITest(BaseTestCase):
         response = self.send_post('nph/Intake', request_data=consent_json)
 
         self.assertEqual(len(response), 1)
-        self.assertTrue(all(int(obj['nph_participant_id']) == current_participant_id for obj in response))
+        self.assertTrue(all(obj['nph_participant_id'] == f'1000{current_participant_id}' for obj in response))
 
         # participant event activities
         participant_event_activities = self.nph_participant_activity_dao.get_all()


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Need to add back prefix that is stripped to the response participant_ids for the intake api

## Tests
- [x] unit tests


