### PR TITLE
[DA-3364] Excluding ETM consents from the monthly consent sync

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -226,7 +226,8 @@ class ConsentDao(BaseDao):
                 or_(
                     Organization.externalId.in_(org_names),
                     HPO.name.in_(hpo_names)
-                )
+                ),
+                ConsentFile.type != ConsentType.ETM
             )
         )
         return query.all()

--- a/tests/cron_job_tests/test_consent_sync_controller.py
+++ b/tests/cron_job_tests/test_consent_sync_controller.py
@@ -7,6 +7,7 @@ from rdr_service.offline.sync_consent_files import ConsentSyncController, DEFAUL
 from rdr_service.storage import GoogleCloudStorageProvider
 from tests.helpers.unittest_base import BaseTestCase
 
+
 @mock.patch('rdr_service.offline.sync_consent_files.dispatch_rebuild_consent_metrics_tasks')
 class ConsentSyncControllerTest(BaseTestCase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Resolves *[ticket #](https://precisionmedicineinitiative.atlassian.net/browse/DA-3364)*
We shouldn't send any ancillary study consent files as part of the monthly consent sync. This filters out any ETM consent files when determining what should be sent.


## Tests
- [x] unit tests


