### PR TITLE
Checking for sample_id on reconcile

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4574,7 +4574,8 @@ class GenomicCVLResultPastDueDao(UpdatableDao, GenomicDaoMixin):
                 result_attributes.get('w1il_run_id').isnot(None),
                 GenomicSetMember.genomeType == config.GENOME_TYPE_WGS,
                 genomic_past_due_alias.id.is_(None),
-                GenomicW4WRRaw.id.is_(None)
+                GenomicW4WRRaw.id.is_(None),
+                GenomicSetMember.sampleId.isnot(None)
             )
             return records.all()
 


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
There is some downstrean affects to the query that was ran to mitigate all the duplicate sample_ids from replates, so there is one record attached to genomic_set_member (804259) that has a null sample_id. 
Adding check for null sample_ids so PGX results can be created.

## Tests
- [] unit tests
** all tests should still pass

