### PR TITLE
Check for validated EHR status when calculating enrollment status

### DIFF
--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -525,6 +525,8 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
             database_patch.start()
             self.addCleanup(database_patch.stop)
 
+        config.override_setting('ENROLLMENT_STATUS_SKIP_VALIDATION', True)
+
     def tearDown(self):
         super(BaseTestCase, self).tearDown()
         if self.uses_database:


### PR DESCRIPTION
## Resolves *no ticket*
Currently the enrollment status is being set to having EHR before we validate the PDF file. This is a bug and the changes here correct for it. The enrollment status calculation has been updated to only look for EHR consent responses that have a corresponding PDF file that has been validated.

## Tests
- [x] unit tests


