### PR TITLE
Added 'opt_in' field when creating ConsentEvent using create_database_consent_event

### DIFF
--- a/rdr_service/data_gen/generators/nph.py
+++ b/rdr_service/data_gen/generators/nph.py
@@ -162,6 +162,7 @@ class NphDataGenerator:
             "participant_id": participant_id,
             "event_id": event_id,
             "event_type_id": 1,
+            "opt_in": enums.ConsentOptInTypes.PERMIT,
         }
         fields.update(kwargs)
         consent_event = self._consent_event(**fields)
@@ -194,5 +195,3 @@ class NphDataGenerator:
         deactivated_event = self._deactivated_event(**kwargs)
         self._commit_to_database(deactivated_event)
         return deactivated_event
-
-


### PR DESCRIPTION
## Resolves *[DA-3402](https://precisionmedicineinitiative.atlassian.net/browse/DA-3402)*

## Description of changes/additions
Added missing `opt_in` field when creating `ConsentEvent` object using `create_database_consent_event` method

## Tests
N/A




[DA-3402]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ