### PR TITLE
[DA-3421] Setting aliquot status based on received data

### DIFF
--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -560,6 +560,7 @@ class NphOrderedSampleDao(UpdatableDao):
         session.add(db_parent_order_sample)
         session.commit()
         sample_update_dao = NphSampleUpdateDao()
+
         for ordered_sample in ordered_sample_list:
             sample_update_dict = {
                 "rdr_ordered_sample_id": ordered_sample.id,
@@ -606,13 +607,17 @@ class NphOrderedSampleDao(UpdatableDao):
 
     @staticmethod
     def _update_restored_child_order(obj: Namespace, order_sample: OrderedSample, nph_sample_id: str) -> OrderedSample:
+        incoming_status = getattr(obj, 'status', None)
+        if 'cancel' in incoming_status:
+            incoming_status = 'cancelled'
+
         order_sample.nph_sample_id = nph_sample_id
         order_sample.identifier = obj.identifier
         order_sample.container = obj.container
         order_sample.volume = obj.volume
         order_sample.description = obj.description
         order_sample.collected = obj.collected
-        order_sample.status = "restored"
+        order_sample.status = incoming_status or "restored"
         return order_sample
 
     @staticmethod

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -608,7 +608,7 @@ class NphOrderedSampleDao(UpdatableDao):
     @staticmethod
     def _update_restored_child_order(obj: Namespace, order_sample: OrderedSample, nph_sample_id: str) -> OrderedSample:
         incoming_status = getattr(obj, 'status', None)
-        if 'cancel' in incoming_status:
+        if incoming_status is not None and 'cancel' in incoming_status:
             incoming_status = 'cancelled'
 
         order_sample.nph_sample_id = nph_sample_id


### PR DESCRIPTION
## Resolves *[DA-3421](https://precisionmedicineinitiative.atlassian.net/browse/DA-3421)*
NPH Order API requests should be able to set the aliquot status to cancelled. This adds in functionality to use the incoming status as an override to the `restored` status.


## Tests
- [x] unit tests




[DA-3421]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ