### PR TITLE
[DA-3429] Implement Nesting for Enrollment Status

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -83,7 +83,7 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
                 "time": withdrawn.event_authored_time if withdrawn else None
             },
             'nph_enrollment_status': {
-                "value": check_field_value(enrollment_name.name),
+                "value": check_field_value(enrollment_name.source_name),
                 "time": enrollment_time.event_authored_time
             },
             'aianStatus': summary.aian,

--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -4,6 +4,8 @@ from typing import Optional, Dict
 from graphene import List
 
 from sqlalchemy.orm import Query, aliased
+
+from rdr_service.api_util import parse_date
 from rdr_service.model.participant_summary import ParticipantSummary as ParticipantSummaryModel
 from rdr_service.participant_enums import QuestionnaireStatus
 
@@ -57,8 +59,14 @@ def check_field_value(value):
 
 def load_participant_summary_data(query, prefix, biobank_prefix):
     results = []
-    for summary, site, nph_site, mapping, nph_participant, enrollment_time, enrollment_name, \
-            deactivated, withdrawn in query.all():
+    records = query.all()
+    for summary, site, nph_site, mapping, nph_participant, enrollment, \
+            deactivated, withdrawn in records:
+        # NPH Enrollment Statuses are nested
+        enrollment_statuses = list(map(
+            lambda x: {'value': x['value'], 'time': parse_date(x['time']) if x['time'] else None},
+            enrollment['enrollment_json']
+        ))
         results.append({
             'participantNphId': f"{prefix}{mapping.ancillary_participant_id}",
             'lastModified': summary.lastModified,
@@ -82,14 +90,11 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
                 "value": "Withdrawn" if withdrawn else "NULL",
                 "time": withdrawn.event_authored_time if withdrawn else None
             },
-            'nph_enrollment_status': {
-                "value": check_field_value(enrollment_name.source_name),
-                "time": enrollment_time.event_authored_time
-            },
+            'nph_enrollment_status': enrollment_statuses,
             'aianStatus': summary.aian,
             'suspensionStatus': {"value": check_field_value(summary.suspensionStatus),
                                  "time": summary.suspensionTime},
-            'nphEnrollmentStatus': {"value": check_field_value(summary.enrollmentStatus),
+            'aouEnrollmentStatus': {"value": check_field_value(summary.enrollmentStatus),
                                  "time": summary.dateOfBirth},
             'questionnaireOnTheBasics': {
                 "value": check_field_value(summary.questionnaireOnTheBasics),

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -86,7 +86,7 @@ def mock_load_participant_data(session):
 
         nph_data_gen.create_database_pairing_event_type(name="INITIAL")
 
-        status = ['referred']
+        status = ['referred', 'consented']
 
         for name in status:
             nph_data_gen.create_database_enrollment_event_type(name=name, source_name=f'module1_{name}')
@@ -300,14 +300,26 @@ class TestQueryExecution(BaseTestCase):
     def test_nphEnrollmentStatus_fields(self):
         field_to_test = "nphEnrollmentStatus {value time} "
         query = simple_query(field_to_test)
+
         mock_load_participant_data(self.session)
+        nph_datagen = NphDataGenerator()
+        for nph_id in [100000000, 100000001]:
+            nph_datagen.create_database_enrollment_event(participant_id=nph_id,
+                                                         event_type_id=2,
+                                                         event_authored_time=datetime.now())
+
         executed = app.test_client().post('/rdr/v1/nph_participant', data=query)
         result = json.loads(executed.data.decode('utf-8'))
+
         self.assertEqual(2, len(result.get('participant').get('edges')))
-        actual_result = result.get('participant').get('edges')[0].get('node').get('nphEnrollmentStatus')
-        self.assertIn("time", actual_result)
-        self.assertIn("value", actual_result)
-        self.assertEqual(actual_result['value'], 'module1_referred')
+
+        enrollment_statuses = result.get('participant').get('edges')[0].get('node').get('nphEnrollmentStatus')
+
+        for status in enrollment_statuses:
+            self.assertIn("time", status)
+            self.assertIn("value", status)
+            if status['time']:
+                self.assertEqual(status['value'], 'module1_consented')
 
     def test_nphWithdrawalStatus_fields(self):
         field_to_test = "nphWithdrawalStatus {value time} "

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -89,7 +89,7 @@ def mock_load_participant_data(session):
         status = ['referred']
 
         for name in status:
-            nph_data_gen.create_database_enrollment_event_type(name=name)
+            nph_data_gen.create_database_enrollment_event_type(name=name, source_name=f'module1_{name}')
         participant_mapping_query = Query(ParticipantMapping)
         participant_mapping_query.session = session
         participant_mapping_result = participant_mapping_query.all()
@@ -307,6 +307,7 @@ class TestQueryExecution(BaseTestCase):
         actual_result = result.get('participant').get('edges')[0].get('node').get('nphEnrollmentStatus')
         self.assertIn("time", actual_result)
         self.assertIn("value", actual_result)
+        self.assertEqual(actual_result['value'], 'module1_referred')
 
     def test_nphWithdrawalStatus_fields(self):
         field_to_test = "nphWithdrawalStatus {value time} "


### PR DESCRIPTION
## Resolves *[DA-3429](https://precisionmedicineinitiative.atlassian.net/browse/DA-3429)*


## Description of changes/additions
This PR modifies the NPH Participant API. A future PR will clean up the Participant API implementation, as some code can be reorganized. Due to short time-frames, this is deferred until later.
The changes to the Participant API include:
- Changing the nph_enrollment_status field definition to a List to allow nesting.
- Updating the query to remove unneeded joins
- Created an enrollment subquery and aggregating the needed values into a JSON object.
- Updating the output schema to correctly parse the nested enrollment statuses
- Updated unit tests

## Tests
- [x] unit tests




[DA-3429]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ