### PR TITLE
[PDR-1625] Add support for EHR SUBMITTED_NOT_VALIDATED/INVALID statuses

### DIFF
--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -21,7 +21,9 @@ class BQModuleStatusEnum(Enum):
     SUBMITTED = 1
     SUBMITTED_NO_CONSENT = 2
     SUBMITTED_NOT_SURE = 3
+    # See: DA-3278, these status can now depend on state of the consent PDF validation
     SUBMITTED_INVALID = 4
+    SUBMITTED_NOT_VALIDATED = 5
 
 
 class BQConsentCohort(Enum):

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -720,6 +720,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             last_answer_hash = None  # Track the answer hash of the payload of the last response processed (PDR-484)
             last_mod_processed = {}
             last_consent_processed = {}
+            prior_ehr_submitted_status = False
             for row in results:
                 # ROC-692 Exclude CE replayed ConsentPII responses that contain an invalid minimum authored date.
                 if row.authored and row.authored < min_valid_authored:
@@ -804,6 +805,16 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                                     qnan.get(_consent_expired_question_map[module_name] or 'None', None)
                             # TODO: Should we have also have a 'consent_expired_id', if so what would the integer
                             #  value be (there is only a question code_id in the code table, no answer code_id)?
+
+                        # DA-3278 : "Yes" EHR consents now have module_status determined by consent PDF validation state
+                        # Make sure once a participant has a SUBMITTED EHR module_status in their history, that sticks.
+                        # Participants whose consent PDF validation failed prior to rolling out the new
+                        # DA-3278/PDR-1625 changes, should still keep a SUBMITTED status if they answered "Yes"
+                        if (module_name == 'EHRConsentPII' and module_status == BQModuleStatusEnum.SUBMITTED
+                                and not prior_ehr_submitted_status):
+                            module_status = self.get_pdf_validation_status(row.questionnaireResponseId,
+                                                                           row.authored, ro_session)
+                            prior_ehr_submitted_status = module_status == BQModuleStatusEnum.SUBMITTED
 
                         module_data['status'] = module_status.name
                         module_data['status_id'] = module_status.value
@@ -1658,13 +1669,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         consent_status = _consent_answer_status_map.get(answer_code, None) if answer_code else None
         if not consent_status:
             if module == 'EHRConsentPII':
-                # PDR-979:  Match RDR by defaulting to SUBMITTED_NO_CONSENT for (sensitive) EHRConsentPII if
-                # there was not a recognized "yes" consent answer
+                # PDR-979:  Match RDR, default to SUBMITTED_NO_CONSENT for (sensitive) EHRConsentPII if there was no
+                # recognized "yes" consent answer.
                 consent_status = BQModuleStatusEnum.SUBMITTED_NO_CONSENT
             else:
-                # For other modules/cases where there wasn't any recognized consent answer found in the payload
-                # (not even PMI_SKIP, which maps to UNSET)
-                consent_status = BQModuleStatusEnum.SUBMITTED_INVALID
+                # PDR-1625: SUBMITTED_INVALID has a revised meaning for PDF validation, so use UNSET for missing answers
+                consent_status = BQModuleStatusEnum.UNSET
 
         return answer_code, consent_status
 
@@ -1828,6 +1838,47 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         data['ubr_overall'] = ubr.ubr_overall(data)
 
         return data
+
+    @staticmethod
+    def get_pdf_validation_status(qr_id, consent_authored, ro_session=None):
+        """
+        Determines consent status based on PDF validation status. Initially only applies to EHR PDF validation
+        :param qr_id:  A questionnaire_response_id value
+        :param consent_authored: An authored date for the consent
+        :param ro_session:  A read-only session object
+        """
+        # Cutoff for avoiding incorrectly assuming SUBMITTED_NOT_VALIDATED.  Based on expected release date
+        # of RDR changes that will begin using SUBMITTED_NOT_VALIDATED/SUBMITTED_INVALID statuses.
+        pdf_validation_start_date = datetime.datetime(2023, 3, 10)
+        status = BQModuleStatusEnum.SUBMITTED  # Default, this method is only called for "Yes" consents that have PDF
+        dao = None
+        if not ro_session:
+            dao = ResourceDataDao(backup=True)
+            ro_session = dao.session()
+
+        # Find consent validation result associated with this questionnaire response.  Note, many older consent
+        # validation results do not have a consent_response record because that relation/table was added later
+        sql = """
+             select cf.created, cf.sync_status
+             from consent_response cr
+             join consent_file cf on cr.id = cf.consent_response_id
+             where cr.questionnaire_response_id = :qr_id
+
+        """
+        result = ro_session.execute(sql, {'qr_id': qr_id}).fetchone()
+        if result:
+            if (result.created > pdf_validation_start_date and
+                   result.sync_status in (int(ConsentSyncStatus.NEEDS_CORRECTING), int(ConsentSyncStatus.OBSOLETE))):
+                status = BQModuleStatusEnum.SUBMITTED_INVALID
+
+        elif consent_authored > pdf_validation_start_date:
+            # No consent_file (consent_response) record yet to match to the questionnaire_response_id
+            status = BQModuleStatusEnum.SUBMITTED_NOT_VALIDATED
+
+        if dao is not None:
+            dao.session().close()
+
+        return status
 
     @staticmethod
     def generate_primary_consent_metrics(p_id, ro_session=None):


### PR DESCRIPTION
## Resolves *[PDR-1625](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1625)*


## Description of changes/additions
RDR will now roll up EHR status details into `participant summary.consent_for_electronic_health_records` which can include new statuses (SUBMITTED_NOT_VALIDATED, SUBMITTED_INVALID) to indicate the EHR PDF has not yet been validated, or failed validation and we don't have a good PDF copy of the consent on file yet.

PDR generators must determine the EHR consent status (SUBMITTED, SUBMITTED_NO_CONSENT, ...) for each `questionnaire_response` in the participant's history.  This used to be based solely on the consent question answer found for the response (e.g., `ConsentPermission_Yes`).  Now it will have to include checking the PDF validation status, using data from the `consent_file` and `consent_response` tables.

Older consent payloads will essentially skip the new logic, since in RDR it only applies to new incoming consents received after the RDR release supporting the new SUBMITTED_NOT_VALIDATED and SUBMITTED invalid statuses for `participant_summary.consent_for_electronic_health_records`.  

## Tests
- Did dry run PDR participant data builds (nothing saved to the DB) for a number of participants who had EHR validation results in RDR prod and verified the generated data.




[PDR-1625]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ