### PR TITLE
[PDR-1585] Add id verification data to PDR

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -147,7 +147,7 @@ class OnSiteIdVerificationBatchRebuildTaskApi(Resource):
         if not ov_ids:
             raise NotFound('OnSiteIdVerification record id list invalid')
 
-        logging.info(f'Rebuilding onsite_id_verification records')
+        logging.info('Rebuilding onsite_id_verification records')
         logging.debug(f'Rebuild id list: {ov_ids}')
         onsite_id_verification_batch_rebuild_task(ov_ids)
         logging.info('Complete.')

--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -8,6 +8,9 @@ from rdr_service.api.data_gen_api import generate_samples_task
 from rdr_service.api_util import parse_date, returns_success
 from rdr_service.app_util import task_auth_required
 from rdr_service.dao.bq_code_dao import rebuild_bq_codebook_task
+from rdr_service.dao.bq_hpo_dao import bq_hpo_update_all
+from rdr_service.dao.bq_organization_dao import bq_organization_update_all
+from rdr_service.dao.bq_site_dao import bq_site_update_all
 from rdr_service.dao.bq_participant_summary_dao import bq_participant_summary_update_task
 from rdr_service.dao.bq_questionnaire_dao import bq_questionnaire_update_task
 from rdr_service.dao.bq_workbench_dao import bq_workspace_batch_update, bq_workspace_user_batch_update, \
@@ -19,6 +22,8 @@ from rdr_service.resource.generators.code import rebuild_codebook_resources_task
 from rdr_service.resource.generators.participant import participant_summary_update_resource_task
 from rdr_service.resource.generators.workbench import res_workspace_batch_update, res_workspace_user_batch_update, \
     res_institutional_affiliations_batch_update, res_researcher_batch_update
+from rdr_service.resource.generators.onsite_id_verification import onsite_id_verification_build_task, \
+    onsite_id_verification_batch_rebuild_task
 from rdr_service.resource.tasks import batch_rebuild_participants_task, batch_rebuild_retention_metrics_task, \
     batch_rebuild_consent_metrics_task, batch_rebuild_user_event_metrics_task, check_consent_errors_task
 from rdr_service.services.participant_data_validation import ParticipantDataValidation
@@ -67,6 +72,86 @@ class RebuildOneParticipantTaskApi(Resource):
         logging.info('Complete.')
         return '{"success": "true"}'
 
+class RebuildHpoAllTaskApi(Resource):
+    """
+     Cloud Task endpoint: Rebuild all the HPO records for PDR
+     Triggered by resource tool, on resource-rebuild queue
+     No payload expected
+     """
+    @task_auth_required
+    def post(self):
+        log_task_headers()
+        logging.info('Rebuilding all HPO table records')
+        bq_hpo_update_all()
+        logging.info('Complete')
+        return '{"success": "true"}'
+
+class RebuildOrganizationAllTaskApi(Resource):
+    """
+     Cloud Task endpoint: Rebuild all the Organization records for PDR
+     Triggered by resource tool, on resource-rebuild queue
+     No payload expected
+     """
+    @task_auth_required
+    def post(self):
+        log_task_headers()
+        logging.info('Rebuilding all Organization table records')
+        bq_organization_update_all()
+        logging.info('Complete')
+        return '{"success": "true"}'
+
+class RebuildSiteAllTaskApi(Resource):
+    """
+     Cloud Task endpoint: Rebuild all the Organization records for PDR
+     Triggered by resource tool, on resource-rebuild queue
+     No payload expected
+     """
+    @task_auth_required
+    def post(self):
+        log_task_headers()
+        logging.info('Rebuilding all Site table records')
+        bq_site_update_all()
+        logging.info('Complete')
+        return '{"success": "true"}'
+
+class OnSiteIdVerificationBuildTaskApi(Resource):
+    """
+    Cloud Task endpoint:  Build a single OnSiteIdVerification resource record for PDR
+    Triggered by RDR POST /Onsite/Id/Verification/, on resource-tasks queue
+    Payload contains a single record id (primary key) to rebuild
+    """
+    @task_auth_required
+    def post(self):
+        log_task_headers()
+        data = request.get_json(force=True)
+        ov_id = data.get('onsite_verification_id', 0)
+        if not ov_id:
+            raise NotFound('OnSiteIdVerification record id invalid')
+
+        logging.info(f'Rebuilding onsite_id_verification record: {ov_id}')
+        onsite_id_verification_build_task(ov_id)
+        logging.info('Complete.')
+        return '{"success": "true"}'
+
+class OnSiteIdVerificationBatchRebuildTaskApi(Resource):
+    """
+    Cloud Task endpoint:  Rebuild a list of OnSiteIdVerification resource records for PDR
+    Triggered by resource tool on resource-rebuild queue.
+    Payload contains a list of integer ids (rec primary keys) to rebuild
+    """
+    @task_auth_required
+    def post(self):
+        log_task_headers()
+        data = request.get_json(force=True)
+        ov_ids = data.get('onsite_verification_id_list', [])
+        if not ov_ids:
+            raise NotFound('OnSiteIdVerification record id list invalid')
+
+        logging.info(f'Rebuilding onsite_id_verification records')
+        logging.debug(f'Rebuild id list: {ov_ids}')
+        onsite_id_verification_batch_rebuild_task(ov_ids)
+        logging.info('Complete.')
+        return '{"success": "true"}'
 
 class RebuildCodebookTaskApi(Resource):
     """

--- a/rdr_service/dao/bq_hpo_dao.py
+++ b/rdr_service/dao/bq_hpo_dao.py
@@ -2,6 +2,7 @@ import logging
 
 from sqlalchemy.sql import text
 
+from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_hpo import BQHPOSchema, BQHPO, BQOrganizationTypeEnum, BQObsoleteStatusEnum
@@ -41,7 +42,7 @@ class BQHPOGenerator(BigQueryGenerator):
             return BQRecord(schema=BQHPOSchema, data=data, convert_to_enum=convert_to_enum)
 
 
-def bq_hpo_update(project_id=None):
+def bq_hpo_update_all(project_id=GAE_PROJECT):
     """
     Generate all new HPO records for BQ. Since there is called from a tool, this is not deferred.
     :param project_id: Override the project_id
@@ -59,7 +60,7 @@ def bq_hpo_update(project_id=None):
             gen.save_bqrecord(row.hpoId, bqr, bqtable=BQHPO, w_dao=w_dao, w_session=w_session, project_id=project_id)
 
 
-def bq_hpo_update_by_id(hpo_id, project_id=None):
+def bq_hpo_update_by_id(hpo_id, project_id=GAE_PROJECT):
     gen = BQHPOGenerator()
     # get from main database in case the backup is not synch in time
     bqr = gen.make_bqrecord(hpo_id, backup=False)

--- a/rdr_service/dao/bq_organization_dao.py
+++ b/rdr_service/dao/bq_organization_dao.py
@@ -1,6 +1,7 @@
 import logging
 from sqlalchemy.sql import text
 
+from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_organization import BQOrganizationSchema, BQOrganization
@@ -35,7 +36,7 @@ class BQOrganizationGenerator(BigQueryGenerator):
             return BQRecord(schema=BQOrganizationSchema, data=data, convert_to_enum=convert_to_enum)
 
 
-def bq_organization_update(project_id=None):
+def bq_organization_update_all(project_id=GAE_PROJECT):
     """
     Generate all new Organization records for BQ. Since there is called from a tool, this is not deferred.
     :param project_id: Override the project_id
@@ -54,7 +55,7 @@ def bq_organization_update(project_id=None):
                               project_id=project_id)
 
 
-def bq_organization_update_by_id(org_id, project_id=None):
+def bq_organization_update_by_id(org_id, project_id=GAE_PROJECT):
     gen = BQOrganizationGenerator()
     bqr = gen.make_bqrecord(org_id, backup=False)
     w_dao = BigQuerySyncDao()

--- a/rdr_service/dao/bq_site_dao.py
+++ b/rdr_service/dao/bq_site_dao.py
@@ -1,6 +1,7 @@
 import logging
 from sqlalchemy.sql import text
 
+from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao, BigQueryGenerator
 from rdr_service.model.bq_base import BQRecord
 from rdr_service.model.bq_site import (
@@ -57,7 +58,7 @@ class BQSiteGenerator(BigQueryGenerator):
             return BQRecord(schema=BQSiteSchema, data=data, convert_to_enum=convert_to_enum)
 
 
-def bq_site_update(project_id=None):
+def bq_site_update_all(project_id=GAE_PROJECT):
     """
     Generate all new Site records for BQ. Since there is called from a tool, this is not deferred.
     :param project_id: Override the project_id
@@ -75,7 +76,7 @@ def bq_site_update(project_id=None):
             gen.save_bqrecord(row.siteId, bqr, bqtable=BQSite, w_dao=w_dao, w_session=w_session, project_id=project_id)
 
 
-def bq_site_update_by_id(site_id, project_id=None):
+def bq_site_update_by_id(site_id, project_id=GAE_PROJECT):
     gen = BQSiteGenerator()
     bqr = gen.make_bqrecord(site_id, backup=False)
     w_dao = BigQuerySyncDao()

--- a/rdr_service/model/__init__.py
+++ b/rdr_service/model/__init__.py
@@ -35,6 +35,7 @@ BQ_TABLES = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRGROR'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRWearConsent'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRLifeFunctioningSurvey'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRRemoteIdVerificationSurvey'),
 
     ('rdr_service.model.bq_pdr_participant_summary', 'BQPDRParticipantSummary'),
 
@@ -103,6 +104,7 @@ BQ_VIEWS = [
     ('rdr_service.model.bq_questionnaires', 'BQPDRGRORView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRWearConsentView'),
     ('rdr_service.model.bq_questionnaires', 'BQPDRLifeFunctioningSurveyView'),
+    ('rdr_service.model.bq_questionnaires', 'BQPDRRemoteIdVerificationSurveyView'),
 
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherView'),
     ('rdr_service.model.bq_workbench_researcher', 'BQRWBResearcherGenderView'),

--- a/rdr_service/model/bq_questionnaires.py
+++ b/rdr_service/model/bq_questionnaires.py
@@ -1355,6 +1355,32 @@ class BQPDRLifeFunctioningSurveyView(BQModuleView):
     __pk_id__ = ['participant_id', 'questionnaire_response_id']
     _show_created = True
 
+class BQPDRRemoteIdVerificationSurveySchema(_BQModuleSchema):
+    """ Remote ID verification survey response record """
+    _module = 'remote_id_verification'
+
+class BQPDRRemoteIdVerificationSurvey(BQTable):
+    __tablename__ = 'pdr_mod_remote_id_verification'
+    __schema__ = BQPDRRemoteIdVerificationSurveySchema
+
+class BQPDRRemoteIdVerificationSurveyView(BQModuleView):
+    __viewname__ = 'v_pdr_mod_remote_id_verification'
+    __viewdescr__ = 'Remote ID Verification Survey Module View'
+    __table__ = BQPDRRemoteIdVerificationSurvey
+    __pk_id__ = ['participant_id', 'questionnaire_response_id']
+    __sql__ = """
+        SELECT id, created, modified, authored, `language`,
+               participant_id, questionnaire_response_id, questionnaire_id,
+               external_id, `status`, status_id,
+               CASE WHEN remote_identity_verified = "true" THEN 1 ELSE 0 END AS remote_identity_verified,
+               CASE WHEN remote_identity_verified_on is not null
+                    -- Mimics RDR questionnaire_response_dao conversion of epoch string to python datetime object
+                    THEN DATETIME(TIMESTAMP_MILLIS(CAST(remote_identity_verified_on AS INT64))) ELSE null
+               END AS remote_identity_verified_on
+        FROM `{project}`.{dataset}.pdr_mod_remote_id_verification
+    """
+    _show_created = True
+
 #
 #
 #
@@ -1388,7 +1414,8 @@ PDR_MODULE_LIST = (
     BQPDRPostPMBFeedback,
     BQPDRPPIModuleFeedback,
     BQPDRWearConsent,
-    BQPDRLifeFunctioningSurvey
+    BQPDRLifeFunctioningSurvey,
+    BQPDRRemoteIdVerificationSurvey
 )
 
 # Create a dictionary of module codes and table object references.

--- a/rdr_service/offline/bigquery_sync.py
+++ b/rdr_service/offline/bigquery_sync.py
@@ -14,9 +14,9 @@ from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.bigquery_sync_dao import BigQuerySyncDao
 from rdr_service.dao.bq_code_dao import rebuild_bq_codebook_task
-from rdr_service.dao.bq_hpo_dao import bq_hpo_update
-from rdr_service.dao.bq_organization_dao import bq_organization_update
-from rdr_service.dao.bq_site_dao import bq_site_update
+from rdr_service.dao.bq_hpo_dao import bq_hpo_update_all
+from rdr_service.dao.bq_organization_dao import bq_organization_update_all
+from rdr_service.dao.bq_site_dao import bq_site_update_all
 from rdr_service.model.bigquery_sync import BigQuerySync
 from rdr_service.model.participant import Participant
 from rdr_service.resource.generators.code import rebuild_codebook_resources_task
@@ -128,11 +128,11 @@ def rebuild_bigquery_handler():
     rebuild_bq_codebook_task()
     rebuild_codebook_resources_task()
     # HPO Table
-    bq_hpo_update()
+    bq_hpo_update_all()
     # Organization Table
-    bq_organization_update()
+    bq_organization_update_all()
     # Site Table
-    bq_site_update()
+    bq_site_update_all()
 
 
 def daily_rebuild_bigquery_handler():

--- a/rdr_service/resource/__init__.py
+++ b/rdr_service/resource/__init__.py
@@ -122,7 +122,6 @@ class Schema(MarshmallowSchema):
     def __repr__(self):
         return self.Meta.name()
 
-
     class Meta:
         """
         schema_meta info declares how the schema and data is stored and organized in the Resource database tables.

--- a/rdr_service/resource/constants.py
+++ b/rdr_service/resource/constants.py
@@ -32,6 +32,7 @@ class SchemaID(IntEnum):
     patient_statuses = 2090
     ehr_recept = 2100
     pdr_participant = 2110
+    onsite_id_verification = 2200
     # Genomic schemas
     genomic_set = 3000
     genomic_set_member = 3010

--- a/rdr_service/resource/generators/__init__.py
+++ b/rdr_service/resource/generators/__init__.py
@@ -12,6 +12,7 @@ from .genomics import GenomicSetSchemaGenerator, GenomicManifestFileSchemaGenera
 from .workbench import WBWorkspaceGenerator, WBWorkspaceUsersGenerator, WBInstitutionalAffiliationsGenerator, \
     WBResearcherGenerator
 from .consent_metrics import ConsentMetricGenerator, ConsentErrorReportGenerator
+from .onsite_id_verification import OnSiteIdVerificationGenerator
 
 __all__ = [
     'BaseGenerator',
@@ -32,5 +33,6 @@ __all__ = [
     'WBWorkspaceGenerator',
     'WBWorkspaceUsersGenerator',
     'WBInstitutionalAffiliationsGenerator',
-    'WBResearcherGenerator'
+    'WBResearcherGenerator',
+    'OnSiteIdVerificationGenerator'
 ]

--- a/rdr_service/resource/generators/code.py
+++ b/rdr_service/resource/generators/code.py
@@ -27,6 +27,15 @@ class CodeGenerator(generators.BaseGenerator):
             data = ro_dao.to_resource_dict(row, schema=schemas.CodeSchema)
             return generators.ResourceRecordSet(schemas.CodeSchema, data)
 
+def rebuild_codebook_resources(_pk_ids):
+    """
+    Build
+    """
+    gen = CodeGenerator()
+    for pk_id in _pk_ids:
+        res = gen.make_resource(pk_id)
+        res.save()
+
 
 def rebuild_codebook_resources_task():
     """
@@ -34,10 +43,8 @@ def rebuild_codebook_resources_task():
     """
     ro_dao = ResourceDataDao(backup=True)
     with ro_dao.session() as ro_session:
-        gen = CodeGenerator()
         results = ro_session.query(Code.codeId).all()
-
-    logging.info('Code table: rebuilding {0} resource records...'.format(len(results)))
-    for row in results:
-        res = gen.make_resource(row.codeId)
-        res.save()
+        if len(results):
+            logging.info('Code table: rebuilding {0} resource records...'.format(len(results)))
+            id_list = [r.codeId for r in results]
+            rebuild_codebook_resources(id_list)

--- a/rdr_service/resource/generators/onsite_id_verification.py
+++ b/rdr_service/resource/generators/onsite_id_verification.py
@@ -1,0 +1,106 @@
+#
+# This file is subject to the terms and conditions defined in the
+# file 'LICENSE', which is part of this source code package.
+#
+import logging
+from werkzeug.exceptions import NotFound
+
+from rdr_service.dao.resource_dao import ResourceDataDao
+from rdr_service.participant_enums import OnSiteVerificationType, OnSiteVerificationVisitType
+from rdr_service.resource import generators, schemas
+
+class OnSiteIdVerificationGenerator(generators.BaseGenerator):
+
+    def __init__(self, ro_dao=None):
+        self.ro_dao = ro_dao
+
+    def make_resource(self, _pk):
+        """
+        Build a Resource object for the requested onsite_id_verification record
+        :param _pk: Primary key id value from onsite_id_verification table
+        :return: ResourceDataObject object
+        """
+        if not self.ro_dao:
+            self.ro_dao = ResourceDataDao(backup=True)
+
+        with self.ro_dao.session() as ro_session:
+            sql = """
+                select v.*, s.google_group as site
+                from onsite_id_verification v
+                left join site s on v.site_id = s.site_id
+                where id = :id
+            """
+
+            row = ro_session.execute(sql, {'id': _pk}).first()
+            if not row:
+                msg = f'Lookup failed for onsite_id_verification_record {id}'
+                logging.error(msg)
+                raise NotFound(msg)
+
+            data = self.ro_dao.to_dict(row)
+            # This will exclude the provider user_email that is in the RDR record; not expected to be needed in PDR
+            for field in schemas.OnSiteIdVerificationSchema.Meta.pii_fields:
+                if data[field]:
+                    del data[field]
+
+            # Populate Enum fields. Note: When Enums have a possible zero value, explicitly check for None.
+            if data['verification_type'] is not None:
+                enum = OnSiteVerificationType(data['verification_type'])
+                data['verification_type'] = str(enum)
+                data['verification_type_id'] = int(enum)
+            else:
+                data['verification_type'] = str(OnSiteVerificationType.UNSET)
+                data['verification_type_id'] = int(OnSiteVerificationType.UNSET)
+
+            if data['visit_type'] is not None:
+                enum = OnSiteVerificationVisitType(data['visit_type'])
+                data['visit_type'] = str(enum)
+                data['visit_type_id'] = int(enum)
+            else:
+                data['visit_type'] = str(OnSiteVerificationVisitType.UNSET)
+                data['visit_type_id'] = int(OnSiteVerificationVisitType.UNSET)
+
+            return generators.ResourceRecordSet(schemas.OnSiteIdVerificationSchema, data)
+
+def onsite_id_verification_build(_pk, gen=None, w_dao=None):
+    """
+    Generate a single OnSiteIdVerification resource record.
+    :param _pk: Primary Key integer value
+    :param gen: OnSiteIdVerificationGenerator object
+    :param w_dao: Writable DAO object.
+    """
+    if not w_dao:
+        w_dao = ResourceDataDao()
+    if not gen:
+        gen = OnSiteIdVerificationGenerator()
+    res = gen.make_resource(_pk)
+    res.save(w_dao=w_dao)
+
+def onsite_id_verification_batch_rebuild(_pk_ids):
+    """
+    Generate OnSiteIdVerification resource records for a batch/list of record ids.
+    :param _pk_ids: list of primary key id integer values
+    """
+    gen = OnSiteIdVerificationGenerator()
+    w_dao = ResourceDataDao()
+    for _pk in _pk_ids:
+        onsite_id_verification_build(_pk, gen=gen, w_dao=w_dao)
+
+def onsite_id_verification_build_task(_pk_id: int):
+    """
+    Task endpoint triggered by RDR POST /OnSite/Id/Verification.  Builds a single resource record
+    :param _pk_id:  Primary key id for RDR onsite_id_verification table
+    """
+    if not isinstance(_pk_id, int):
+        raise ValueError(f'Invalid primary key {_pk_id}.  Expected integer value')
+    onsite_id_verification_build(_pk_id)
+
+def onsite_id_verification_batch_rebuild_task(_pk_ids):
+    """
+    Task endpoint to rebuild a list of PDR OnSiteIdVerification resource records
+    Triggered by resource tool --batch mode
+    :param _pk_ids:  List of integer primary key ids for RDR onsite_id_verification table
+    """
+    if not isinstance(_pk_ids, list) or not all(isinstance(pk_id, int) for pk_id in _pk_ids):
+        raise ValueError(f'Invalid onsite_verification_id values {_pk_ids}.  Expected list of integer values')
+    onsite_id_verification_batch_rebuild(_pk_ids)

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -31,7 +31,7 @@ def _build_resource_app():
     # Task Queue API endpoint to rebuild ONE participant resource.
     _api.add_resource(cloud_tasks_api.RebuildOneParticipantTaskApi, TASK_PREFIX + "RebuildOneParticipantTaskApi",
                       endpoint="rebuild_one_participant_task", methods=["POST"])
-    # Task Queue API endpoing to rebuild codebook resources.
+    # Task Queue API endpoint to rebuild codebook resources.
     _api.add_resource(cloud_tasks_api.RebuildCodebookTaskApi, TASK_PREFIX + "RebuildCodebookTaskApi",
                       endpoint="rebuild_codebook_task", methods=["POST"])
     _api.add_resource(cloud_tasks_api.BQRebuildQuestionnaireTaskApi, TASK_PREFIX + "RebuildQuestionnaireTaskApi",
@@ -77,6 +77,27 @@ def _build_resource_app():
     _api.add_resource(cloud_tasks_api.RebuildUserEventMetricsApi,
                       TASK_PREFIX + "RebuildUserEventMetricsApi",
                       endpoint="batch_rebuild_user_event_metrics_task", methods=["POST"])
+
+    # OnSiteIdVerification resource build task endpoints
+    _api.add_resource(cloud_tasks_api.OnSiteIdVerificationBuildTaskApi,
+                      TASK_PREFIX + "OnSiteIdVerificationBuildTaskApi",
+                      endpoint="onsite_id_verification_build_task", methods=["POST"])
+
+    _api.add_resource(cloud_tasks_api.OnSiteIdVerificationBatchRebuildTaskApi,
+                      TASK_PREFIX + "OnSiteIdVerificationBatchRebuildTaskApi",
+                      endpoint="onsite_id_verification_batch_rebuild_task", methods=["POST"])
+
+    _api.add_resource(cloud_tasks_api.RebuildHpoAllTaskApi,
+                      TASK_PREFIX + "RebuildHpoAllTaskApi",
+                      endpoint="bq_hpo_update_all", methods=["POST"])
+
+    _api.add_resource(cloud_tasks_api.RebuildOrganizationAllTaskApi,
+                      TASK_PREFIX + "RebuildOrganizationAllTaskApi",
+                      endpoint="bq_organization_update_all", methods=["POST"])
+
+    _api.add_resource(cloud_tasks_api.RebuildSiteAllTaskApi,
+                      TASK_PREFIX + "RebuildSiteAllTaskApi",
+                      endpoint="bq_site_update_all", methods=["POST"])
 
     #
     # Begin Genomic Cloud Task API Endpoints
@@ -170,7 +191,7 @@ def _build_resource_app():
     #
 
     #
-    # Begin Ancillary Studies Cloud Task API endpoings
+    # Begin Ancillary Studies Cloud Task API endpoints
     #
 
     # Insert Study Events
@@ -179,7 +200,7 @@ def _build_resource_app():
                       endpoint="insert_study_event_task", methods=["POST"])
 
     #
-    # End Ancillary Studies Cloud Task API endpoings
+    # End Ancillary Studies Cloud Task API endpoints
     #
 
     #

--- a/rdr_service/resource/schemas/__init__.py
+++ b/rdr_service/resource/schemas/__init__.py
@@ -18,6 +18,7 @@ from .genomics import GenomicSetSchema, GenomicSetMemberSchema, GenomicJobRunSch
     GenomicAppointmentEventSchema
 from .retention_metrics import RetentionMetricSchema
 from .consent_metrics import ConsentMetricSchema
+from .onsite_id_verification import OnSiteIdVerificationSchema
 
 __all__ = [
     'ParticipantSchema',
@@ -46,5 +47,6 @@ __all__ = [
     'GenomicCVLResultPastDueSchema',
     'GenomicMemberReportStateSchema',
     'GenomicResultViewedSchema',
-    'GenomicAppointmentEventSchema'
+    'GenomicAppointmentEventSchema',
+    'OnSiteIdVerificationSchema'
 ]

--- a/rdr_service/resource/schemas/onsite_id_verification.py
+++ b/rdr_service/resource/schemas/onsite_id_verification.py
@@ -1,0 +1,54 @@
+#
+# This file is subject to the terms and conditions defined in the
+# file 'LICENSE', which is part of this source code package.
+#
+from enum import Enum
+
+from marshmallow import validate
+
+from rdr_service.resource import Schema, fields
+from rdr_service.resource.constants import SchemaID
+
+
+# TODO: RDR-PDR pipeline will require Enum classes to exist in PDR codebase, so define them here for easier migration
+# RDR Enum class:  OnsiteVerificationType
+class PDROnsiteVerificationType(Enum):
+    """Types of on site verification"""
+    UNSET = 0
+    PHOTO_AND_ONE_OF_PII = 1
+    TWO_OF_PII = 2
+
+# RDR Enum class: OnsiteVerificationVisitType
+class PDROnsiteVerificationVisitType(Enum):
+    """Types of on site visit"""
+    UNSET = 0
+    PMB_INITIAL_VISIT = 1
+    PHYSICAL_MEASUREMENTS_ONLY = 2
+    BIOSPECIMEN_COLLECTION_ONLY = 3
+    BIOSPECIMEN_REDRAW_ONLY = 4
+    RETENTION_ACTIVITIES = 5
+
+
+class OnSiteIdVerificationSchema(Schema):
+    """
+    A Participant OnSiteIdVerification record
+    """
+    id = fields.Int32(required=True)
+    created = fields.DateTime()
+    modified = fields.DateTime()
+    participant_id = fields.String(validate=validate.Length(max=10), required=True)
+    site = fields.String(validate=validate.Length(max=255),
+                         description='google_group string associated with the site')
+    site_id = fields.Int32(required=False)
+    verification_type = fields.EnumString(enum=PDROnsiteVerificationType)
+    verification_type_id = fields.EnumInteger(enum=PDROnsiteVerificationType)
+    visit_type = fields.EnumString(enum=PDROnsiteVerificationVisitType)
+    visit_type_id = fields.EnumInteger(enum=PDROnsiteVerificationVisitType)
+    verification_time = fields.DateTime()
+
+    class Meta:
+        schema_id = SchemaID.onsite_id_verification
+        resource_uri = 'OnSiteIdVerification'
+        resource_pk_field = 'id'
+        pii_fields = ('user_email',)  # List fields that contain PII data, to be excluded/filtered
+        pii_filter = {}  # dict(field: lambda function)

--- a/rdr_service/tools/import_organizations.py
+++ b/rdr_service/tools/import_organizations.py
@@ -20,9 +20,9 @@ import os
 import googlemaps
 from dateutil.parser import parse
 
-from rdr_service.dao.bq_hpo_dao import bq_hpo_update
-from rdr_service.dao.bq_organization_dao import bq_organization_update
-from rdr_service.dao.bq_site_dao import bq_site_update
+from rdr_service.dao.bq_hpo_dao import bq_hpo_update_all
+from rdr_service.dao.bq_organization_dao import bq_organization_update_all
+from rdr_service.dao.bq_site_dao import bq_site_update_all
 
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.organization_dao import OrganizationDao
@@ -656,9 +656,9 @@ def main(args):
 
     # Update Organization BigQuery records
     if not args.dry_run:
-        bq_hpo_update(args.project)
-        bq_organization_update(args.project)
-        bq_site_update(args.project)
+        bq_hpo_update_all(args.project)
+        bq_organization_update_all(args.project)
+        bq_site_update_all(args.project)
 
 
 if __name__ == "__main__":

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -25,6 +25,45 @@ class TaskApiTest(BaseTestCase):
             participant_id=1234,
             date_of_birth=datetime(2000, 3, 19)
         )
+    @mock.patch('rdr_service.api.cloud_tasks_api.onsite_id_verification_build_task')
+    def test_onsite_id_verification_build(self, onsite_build_task_mock):
+        self._call_task_endpoint(
+            task_path='OnSiteIdVerificationBuildTaskApi',
+            json={'onsite_verification_id': 1}
+        )
+        onsite_build_task_mock.assert_called_with(1)
+
+    @mock.patch('rdr_service.api.cloud_tasks_api.onsite_id_verification_batch_rebuild_task')
+    def test_onsite_id_verification_batch_rebuild(self, onsite_batch_rebuild_task_mock):
+        self._call_task_endpoint(
+            task_path='OnSiteIdVerificationBatchRebuildTaskApi',
+            json={'onsite_verification_id_list': [1, 2, 3]}
+        )
+        onsite_batch_rebuild_task_mock.assert_called_with([1, 2, 3])
+
+    @mock.patch('rdr_service.api.cloud_tasks_api.bq_hpo_update_all')
+    def test_hpo_rebuild_task(self, hpo_rebuild_task_mock):
+        self._call_task_endpoint(
+            task_path='RebuildHpoAllTaskApi',
+            json={}
+        )
+        self.assertEqual(hpo_rebuild_task_mock.call_count, 1)
+
+    @mock.patch('rdr_service.api.cloud_tasks_api.bq_organization_update_all')
+    def test_organization_rebuild_task(self, org_rebuild_task_mock):
+        self._call_task_endpoint(
+            task_path='RebuildOrganizationAllTaskApi',
+            json={}
+        )
+        self.assertEqual(org_rebuild_task_mock.call_count, 1)
+
+    @mock.patch('rdr_service.api.cloud_tasks_api.bq_site_update_all')
+    def test_site_rebuild_task(self, site_rebuild_task_mock):
+        self._call_task_endpoint(
+            task_path='RebuildSiteAllTaskApi',
+            json={}
+        )
+        self.assertEqual(site_rebuild_task_mock.call_count, 1)
 
     def _call_task_endpoint(self, task_path, json):
         response = self.send_post(


### PR DESCRIPTION
## Resolves *[PDR-1585](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1585)*


## Description of changes/additions
Adds interim / old RDR-PDR pipeline support for OnSite and Remote ID verification data.  Because these come in via different sources to RDR (`POST /OnSite/Id/Verification` endpoint and `POST /QuestionnaireResponse` for the `remote_id_verification` module, they are handled by different paths in the existing RDR-PDR pipeline:

- OnsiteIdRemoteVerification PDR data flows through RDR /resource API (NiFi GET requests), and the PDR generator will upsert records into the `resource_data` table in RDR.   Cloud task endpoints are added to handle the record rebuilds.  The RDR `default` service `post` handler for the OnsiteIdVerification API will queue the cloud task PDR build for the new RDR record before exiting.

- QuestionnaireResponse data for `remote_id_verification` module will flow through the existing module data build/ BigQuery sync process  (records built for `bigquery_sync` RDR table).    The new BigQuery `v_pdr_mod_remote_id_verification` view will use custom SQL to convert the `value_string` strings from the `remote_id_verification` questionnaire_response payloads for `remote_identity_verified` and `remote_identity_verified_on` into a smallint (0/1 instead of "true" or "false") and a datetime (from the seconds since epoch string value), respectively.

The `resource` tool which rebuilds PDR records on demand was refactored to consolidate builds for RDR `hpo`, `organization`, `site` and `code` table records into a generic `MiscResource` tool class. This class will also handle the new `onsite_id_verification` record rebuilds.  Batch rebuild requests via cloud tasks were enabled for the `hpo`, `site` and `organization` tables, when rebuilding all ids or large id sets (previously could only execute those table record rebuilds on the local server, which was very slow when large sets of records were being rebuilt).

## Tests
- [X] unit tests
Extended API unit tests for testing POST /OnSite/Id/Verification to also verify the PDR generator activity
Added `task_api` unit tests to verify the new task endpoints.



[PDR-1585]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ