### PR TITLE
[DA-3423] Populate consent_response_id in ConsentFile records when re…

### DIFF
--- a/rdr_service/model/consent_file.py
+++ b/rdr_service/model/consent_file.py
@@ -36,7 +36,7 @@ CONSENT_TYPE_MODULE_NAMES = {
     ConsentType.CABOR: ['ConsentPII'],
     ConsentType.EHR: ['EHRConsentPII'],
     ConsentType.GROR: ['GROR'],
-    ConsentType.PRIMARY_UPDATE: ['ProgramUpdate'],
+    ConsentType.PRIMARY_UPDATE: ['PrimaryConsentUpdate'],
     ConsentType.WEAR: ['wear_consent'],
     ConsentType.PRIMARY_RECONSENT: ['vaprimaryreconsent_c1_2', 'vaprimaryreconsent_c3', 'nonvaprimaryreconsent'],
     ConsentType.EHR_RECONSENT: ['vaehrreconsent'],

--- a/rdr_service/model/consent_file.py
+++ b/rdr_service/model/consent_file.py
@@ -30,6 +30,21 @@ class ConsentType(messages.Enum):
     EHR_RECONSENT = 9
     ETM = 10
 
+# DA-3423: Map ConsentType values to their possible module strings, for use in QuestionnaireResponse query filtering
+CONSENT_TYPE_MODULE_NAMES = {
+    ConsentType.PRIMARY: ['ConsentPII'],
+    ConsentType.CABOR: ['ConsentPII'],
+    ConsentType.EHR: ['EHRConsentPII'],
+    ConsentType.GROR: ['GROR'],
+    ConsentType.PRIMARY_UPDATE: ['ProgramUpdate'],
+    ConsentType.WEAR: ['wear_consent'],
+    ConsentType.PRIMARY_RECONSENT: ['vaprimaryreconsent_c1_2', 'vaprimaryreconsent_c3', 'nonvaprimaryreconsent'],
+    ConsentType.EHR_RECONSENT: ['vaehrreconsent'],
+    # TODO: Currently seeing both ETM module strings in lower env test payloads.  Confirm if both will be needed
+    ConsentType.ETM: ['welcome_to_etm', 'english_exploring_the_mind_consent_form']
+    # ConsentType.UNKNOWN intentionally omitted
+}
+
 
 class ConsentSyncStatus(messages.Enum):
     NEEDS_CORRECTING = 1

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -587,13 +587,6 @@ class ConsentValidationController:
         dispatch_check_consent_errors_task(origin='vibrent', in_seconds=28800)
         dispatch_check_consent_errors_task(origin='careevolution', in_seconds=28800)
 
-        # set all pdfminer logging to WARN: https://stackoverflow.com/questions/29762706/warnings-on-pdfminer
-        # trying to prevent unusable Python 2 info logging that shows up in GCP logs from pdfinterp.py and pdfpage.py
-        pdfminer_logs = [logging.getLogger(name)
-                         for name in logging.root.manager.loggerDict if name.startswith('pdfminer')]
-        for ll in pdfminer_logs:
-            ll.setLevel(logging.WARNING)
-
         # Retrieve consent response objects that need to be validated
         is_last_batch = False
         while not is_last_batch:

--- a/rdr_service/tools/tool_libs/tool_base.py
+++ b/rdr_service/tools/tool_libs/tool_base.py
@@ -13,10 +13,11 @@ logger = logging.getLogger("rdr_logger")
 
 
 class ToolBase:
-    def __init__(self, args, gcp_env=None, tool_name=None):
+    def __init__(self, args, gcp_env=None, tool_name=None, replica=False):
         self.args = args
         self.tool_cmd = tool_name
         self.gcp_env = gcp_env
+        self.replica = replica
 
     def initialize_process_context(self, tool_cmd=None, project=None, account=None, service_account=None):
         if tool_cmd is None:
@@ -41,7 +42,7 @@ class ToolBase:
             return self.run()
 
     def run(self):
-        proxy_pid = self.gcp_env.activate_sql_proxy()
+        proxy_pid = self.gcp_env.activate_sql_proxy(replica=self.replica)
         if not proxy_pid:
             logger.error("activating google sql proxy failed.")
             return 1
@@ -66,7 +67,7 @@ class ToolBase:
             # convert ids from a list of strings to a list of integers.
             return [int(i) for i in ids if i.strip()]
 
-def cli_run(tool_cmd, tool_desc, tool_class: Type[ToolBase], parser_hook=None, defaults={}):
+def cli_run(tool_cmd, tool_desc, tool_class: Type[ToolBase], parser_hook=None, defaults={}, replica=False):
     # Set global debug value and setup application logging.
     if hasattr(tool_class, 'logger_name'):
         global logger
@@ -88,5 +89,5 @@ def cli_run(tool_cmd, tool_desc, tool_class: Type[ToolBase], parser_hook=None, d
         parser_hook(parser)
 
     args = parser.parse_args()
-    process = tool_class(args, tool_name=tool_cmd)
+    process = tool_class(args, tool_name=tool_cmd, replica=replica)
     return process.run_process()

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -8,7 +8,6 @@ from typing import Collection, List
 from rdr_service.services.consent import files
 from tests.helpers.unittest_base import BaseTestCase
 
-
 class ConsentFileParsingTest(BaseTestCase):
     def __init__(self, *args, **kwargs):
         super(ConsentFileParsingTest, self).__init__(*args, **kwargs)


### PR DESCRIPTION
…conciling validation errors

## Resolves *[DA-3423](https://precisionmedicineinitiative.atlassian.net/browse/DA-3423)*



## Description of changes/additions
When the `consents` tool was run to manually execute consent validations/reconciliations, the `ConsentFile` records that were created were sometimes not being associated with the related `ConsentResponse` record (`consent_response_id` field was left null).   This adds logic to `ReplacementOutputStrategy` so it will scan the associated `QuestionnaireResponse`/`ConsentResponse` table records and look for the response related to the PDF name being validated to populate in its results (`ConsentFile`) records.

Other changes:

-  Add the ability to set a `consent_response_id` value with the `consents modify` tool option
-  Update `ToolBase` class to allow specification of replica, for reporting tools only need read-only DB access 

## Tests
- [x] unit tests
Tested on stable (`consent_response_id` values populated) and production (dry run only) for recent `ConsentFile` records where `consent_response_id` was null.




[DA-3423]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ