### PR TITLE
[DA-3432] Upgrade offline to F4_1G

### DIFF
--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -4,12 +4,9 @@ runtime: python37
 service: offline
 entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 --max-requests 10 --max-requests-jitter 3 rdr_service.offline.main:app
 
-# Default AppEngine configuration (B1) has only 128 MB of RAM and 600 MhZ CPU, which makes
-# the metrics pipeline run very slowly. Bumping up to 1 GB of RAM and 2.4 GHz to speed things up.
-# https://cloud.google.com/appengine/docs/standard/
+# Because we are changing to an auto-scaled class, need to specify automatic_scaling
+# https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#scaling_elements
 instance_class: F4_1G
-# We need to specify basic scaling in order to use a backend instance class.
-basic_scaling:
-  max_instances: 10
-  idle_timeout: 1m
+automatic_scaling:
+  min_idle_instances: 10
 

--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -8,5 +8,6 @@ entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 
 # https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#scaling_elements
 instance_class: F4_1G
 automatic_scaling:
-  min_idle_instances: 10
+  min_idle_instances: automatic
+  max_pending_latency: automatic
 

--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -7,7 +7,7 @@ entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 
 # Default AppEngine configuration (B1) has only 128 MB of RAM and 600 MhZ CPU, which makes
 # the metrics pipeline run very slowly. Bumping up to 1 GB of RAM and 2.4 GHz to speed things up.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: B4
+instance_class: F4_1G
 # We need to specify basic scaling in order to use a backend instance class.
 basic_scaling:
   max_instances: 10


### PR DESCRIPTION
## Resolves *[DA-3432](https://precisionmedicineinitiative.atlassian.net/browse/DA-3432)*


## Description of changes/additions
Upgrading offline app instances to F4_1G. This instance class supports automatic scaling.

## Tests
- [x] unit tests




[DA-3432]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ