### PR TITLE
Updating source of NPH order export cancelled flag

### DIFF
--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -138,6 +138,7 @@ def _convert_ordered_samples_to_samples(
     samples = []
     for ordered_sample in ordered_samples:
         processing_timestamp = ordered_sample.collected if not ordered_sample.parent is None else None
+        sample_cancelled = ordered_cancelled or ordered_sample.status == 'cancelled'
         sample = {
             "sampleID": (ordered_sample.aliquot_id or ordered_sample.nph_sample_id),
             "specimenCode": (ordered_sample.identifier or ordered_sample.test),
@@ -146,7 +147,7 @@ def _convert_ordered_samples_to_samples(
             "volumeUOM": ordered_sample.volumeUnits,
             "collectionDateUTC": _format_timestamp((ordered_sample.parent or ordered_sample).collected),
             "processingDateUTC": _format_timestamp(processing_timestamp),
-            "cancelledFlag": "Y" if ordered_cancelled else "N",
+            "cancelledFlag": "Y" if sample_cancelled else "N",
             "notes": notes,
         }
         samples.append(sample)


### PR DESCRIPTION
## Resolves *no ticket*
In the JSON export file we send to the Biobank for NPH order information, each aliquot gives a `cancelledFlag` field to specify whether that specific aliquot is cancelled. The API has the functionality for canceling individual aliquots, but the file export only sets the `cancelledFlag` as "Y" if the order is cancelled.

This updates the field to show as "Y" if the aliquot itself is cancelled as well.

## Tests
- [ ] unit tests


