### PR TITLE
[DA-3325] Improving memory efficiency in VA export cron job

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -407,7 +407,7 @@ class ParticipantSummaryDao(UpdatableDao):
                 ParticipantSummary.participantId == participant_id
             ).one_or_none()
 
-    def get_by_hpo(self, hpo):
+    def get_by_hpo(self, hpo, yield_batch_size=1000):
         """ Returns participants for HPO except test and ghost participants"""
         with self.session() as session:
             return session.query(
@@ -419,7 +419,7 @@ class ParticipantSummaryDao(UpdatableDao):
                 Participant.isTestParticipant != 1,
                 # Just filtering on isGhostId != 1 will return no results
                 or_(Participant.isGhostId != 1, Participant.isGhostId == None)
-            ).all()
+            ).yield_per(yield_batch_size)
 
     def _validate_update(self, session, obj, existing_obj):  # pylint: disable=unused-argument
         """Participant summaries don't have a version value; drop it from validation logic."""

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -407,19 +407,18 @@ class ParticipantSummaryDao(UpdatableDao):
                 ParticipantSummary.participantId == participant_id
             ).one_or_none()
 
-    def get_by_hpo(self, hpo, yield_batch_size=1000):
+    def get_by_hpo(self, hpo, session, yield_batch_size=1000):
         """ Returns participants for HPO except test and ghost participants"""
-        with self.session() as session:
-            return session.query(
-                ParticipantSummary
-            ).join(
-                Participant, Participant.participantId == ParticipantSummary.participantId
-            ).filter(
-                ParticipantSummary.hpoId == hpo.hpoId,
-                Participant.isTestParticipant != 1,
-                # Just filtering on isGhostId != 1 will return no results
-                or_(Participant.isGhostId != 1, Participant.isGhostId == None)
-            ).yield_per(yield_batch_size)
+        return session.query(
+            ParticipantSummary
+        ).join(
+            Participant, Participant.participantId == ParticipantSummary.participantId
+        ).filter(
+            ParticipantSummary.hpoId == hpo.hpoId,
+            Participant.isTestParticipant != 1,
+            # Just filtering on isGhostId != 1 will return no results
+            or_(Participant.isGhostId != 1, Participant.isGhostId == None)
+        ).yield_per(yield_batch_size)
 
     def _validate_update(self, session, obj, existing_obj):  # pylint: disable=unused-argument
         """Participant summaries don't have a version value; drop it from validation logic."""

--- a/rdr_service/offline/export_va_workqueue.py
+++ b/rdr_service/offline/export_va_workqueue.py
@@ -37,7 +37,7 @@ class ParticipantSummaryJsonIterable(list):
 
     def __len__(self):
         # Need to return something larger than 0 for json module to iterate
-        return 1
+        return self._source.count()
 
 
 def generate_workqueue_report():
@@ -52,12 +52,16 @@ def generate_workqueue_report():
     # Retrieve data
     hpo_dao = HPODao()
     summary_dao = ParticipantSummaryDao()
-    participants = summary_dao.get_by_hpo(hpo_dao.get_by_name('VA'))
+    with summary_dao.session() as session:
+        participants = summary_dao.get_by_hpo(
+            hpo=hpo_dao.get_by_name('VA'),
+            session=session
+        )
 
-    # Write participant JSON to file
-    json_generator = ParticipantSummaryJsonIterable.from_source(participants)
-    with open_cloud_file(export_path, mode='w') as export_file:
-        json.dump(json_generator, export_file)
+        # Write participant JSON to file
+        json_generator = ParticipantSummaryJsonIterable.from_source(participants)
+        with open_cloud_file(export_path, mode='w') as export_file:
+            json.dump(json_generator, export_file)
 
 
 def delete_old_reports():


### PR DESCRIPTION
## Resolves *[DA-3325](https://precisionmedicineinitiative.atlassian.net/browse/DA-3325)*
### Finding the issue
Checking a week's worth of cron job errors showed that the VA export job was consistently involved with a server running out of memory. Attempting to run the job in isolation (during the day, when fewer other tasks were running concurrently) showed that it was likely to run out of memory on its own.

Running the code locally (with some modifications to prevent storing the file anywhere, and to track memory usage at each step of the process) indicated that the process used a high amount of memory, enough to cause the offline instance to be over the 1G limit that it previously had.

When testing with a limit of 15k participants on Stable multiple runs consistently showed the following memory usage for each phase of the file generation:
- Loading the participant summaries into memory: about 200mb
- Each participant summary converted into it's corresponding JSON dictionary: about 80mb
- Converting the list of dictionary objects into a json string: about 120mb

In total this results in the cron job using more than 400mb.

### Reducing the memory footprint
This PR refactors the code a bit so we're mostly only keeping data in memory if it's needed. Rather than loading all of the participant summaries from the database at once, we load them in batches now using the `yield_per` method. And rather than dumping the json into a string, we have the json library write directly to the file instead. This also uses a generator to only convert the summaries into a dictionary one at a time.

Using the test data (15k participants from stable), the file is able be generated using just under 100mb of memory.

## Tests
- [x] unit tests




[DA-3325]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ