### PR TITLE
Change offline nstance class to B4_1G

### DIFF
--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -4,10 +4,9 @@ runtime: python37
 service: offline
 entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 --max-requests 10 --max-requests-jitter 3 rdr_service.offline.main:app
 
-# RDR Cron Jobs run for longer than 10 minutes, B4_1G allows basic scaling, which handles requests up to 24 ours.
+# RDR Cron Jobs run for longer than 10 minutes, B4_1G allows basic scaling, which handles requests up to 24 hours.
 # https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#scaling_elements
 instance_class: B4_1G
-# We need to specify basic scaling in order to use a backend instance class.
 basic_scaling:
   max_instances: 10
   idle_timeout: 1m

--- a/rdr_service/offline.yaml
+++ b/rdr_service/offline.yaml
@@ -4,10 +4,11 @@ runtime: python37
 service: offline
 entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 --max-requests 10 --max-requests-jitter 3 rdr_service.offline.main:app
 
-# Because we are changing to an auto-scaled class, need to specify automatic_scaling
+# RDR Cron Jobs run for longer than 10 minutes, B4_1G allows basic scaling, which handles requests up to 24 ours.
 # https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#scaling_elements
-instance_class: F4_1G
-automatic_scaling:
-  min_idle_instances: automatic
-  max_pending_latency: automatic
+instance_class: B4_1G
+# We need to specify basic scaling in order to use a backend instance class.
+basic_scaling:
+  max_instances: 10
+  idle_timeout: 1m
 


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR changes the `offline` instance class to `B4_1G`. This class allows basic scaling. The RDR cron jobs need more than 10 minutes to run, and auto-scaled instance classes have a non-configurable limit of 10 minutes. Basic-scaling allows for up to 24 hours for a request.


