### PR TITLE
Updating code to make it easier to run EhrStatusUpdater locally

### DIFF
--- a/rdr_service/environment.py
+++ b/rdr_service/environment.py
@@ -1,0 +1,11 @@
+
+from rdr_service.config import GAE_PROJECT
+
+
+class EnvironmentManager:
+    target_project_id = GAE_PROJECT
+    """
+    This is the GAE project that the code should be operating on.
+    Meaning that the project's database would be used by default, any tasks would be queued here,
+    etc.
+    """

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -46,11 +46,10 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
     a EHR PDF is encountered.
     """
 
-    def __init__(self, project_name, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._summary_dao = ParticipantSummaryDao()
         self._task = GCPCloudTask()
-        self._project_name = project_name
 
     def process_results(self, result_list: List[ParsingResult]):
         # Filter down to just the EHR results and organize them by participant
@@ -93,14 +92,10 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
                 session=self._session
             )
             # Rebuild for PDR
-            additional_args = {}
-            if self._project_name is not None:
-                additional_args['project_id'] = self._project_name
             self._task.execute(
                 'rebuild_one_participant_task',
                 payload={'p_id': participant_id},
-                in_seconds=30,
-                **additional_args
+                in_seconds=30
             )
 
         self._session.commit()  # release the for_update lock obtained on the participant_summary

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -46,10 +46,11 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
     a EHR PDF is encountered.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, project_name=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._summary_dao = ParticipantSummaryDao()
         self._task = GCPCloudTask()
+        self._project_name = project_name
 
     def process_results(self, result_list: List[ParsingResult]):
         # Filter down to just the EHR results and organize them by participant


### PR DESCRIPTION
## Resolves *no ticket*
When trying to run the consent file validation locally, I hit an issue with the EHRStatusUpdater class creating tasks. This updates the task code so that it's possible to have a script/tool specify the target environment (for things like task queueing) without needing to pass the project id through everywhere.


## Tests
- [ ] unit tests


