### PR TITLE
DA-3450: Add Module 1 Consents & Opt-ins to NPH Participant API

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -50,6 +50,28 @@ class Event(ObjectType):
         raise ValueError(f"{value} : Invalid Key -- Event Object Type")
 
 
+class GraphQLConsentEvent(ObjectType):
+    """ NPH ConsentEvent """
+
+    value = SortableField(
+        NonNull(String), sort_modifier=lambda context: context.set_order_expression(context.sort_table.status)
+    )
+    time = SortableField(
+        DateTime,
+        sort_modifier=lambda context: context.set_order_expression(context.sort_table.time)  # Order by time
+    )
+
+    opt_in = Field(NonNull(String))
+
+    @staticmethod
+    def sort(context, sort_info, value):
+        if value.upper() == "TIME":
+            return context.set_order_expression(sort_info.get('time'))
+        if value.upper() == 'VALUE':
+            return context.set_order_expression(sort_info.get('value'))
+        raise ValueError(f"{value} : Invalid Key -- Event Object Type")
+
+
 class EventCollection(ObjectType):
     current = SortableField(Event)
     # TODO: historical field need to sort by newest to oldest for a given aspect of a participant’s data
@@ -252,7 +274,9 @@ class Participant(ObjectType):
                                       sort_modifier=lambda context: context.set_order_expression(
                                           nphSite.awardee_external_id))
     nphEnrollmentStatus = List(Event, name="nphEnrollmentStatus", description='Sourced from NPH Schema.')
-    nphModule1ConsentStatus = List(Event, name="nphModule1ConsentStatus", description="Sourced from NPH Schema")
+    nphModule1ConsentStatus = List(
+        GraphQLConsentEvent, name="nphModule1ConsentStatus", description="Sourced from NPH Schema"
+    )
     nphWithdrawalStatus = SortableField(Event, name="nphWithdrawalStatus", description='Sourced from NPH Schema.')
     nphDeactivationStatus = SortableField(Event, name="nphDeactivationStatus", description='Sourced from NPH Schema.')
     nphDateOfBirth = Field(String, name="nphDateOfBirth", description='Sourced from NPH Schema.')

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -50,26 +50,9 @@ class Event(ObjectType):
         raise ValueError(f"{value} : Invalid Key -- Event Object Type")
 
 
-class GraphQLConsentEvent(ObjectType):
+class GraphQLConsentEvent(Event):
     """ NPH ConsentEvent """
-
-    value = SortableField(
-        NonNull(String), sort_modifier=lambda context: context.set_order_expression(context.sort_table.status)
-    )
-    time = SortableField(
-        DateTime,
-        sort_modifier=lambda context: context.set_order_expression(context.sort_table.time)  # Order by time
-    )
-
     opt_in = Field(NonNull(String))
-
-    @staticmethod
-    def sort(context, sort_info, value):
-        if value.upper() == "TIME":
-            return context.set_order_expression(sort_info.get('time'))
-        if value.upper() == 'VALUE':
-            return context.set_order_expression(sort_info.get('value'))
-        raise ValueError(f"{value} : Invalid Key -- Event Object Type")
 
 
 class EventCollection(ObjectType):

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -6,7 +6,7 @@ from sqlalchemy import and_, func
 from sqlalchemy.dialects.mysql import JSON
 from rdr_service.config import NPH_PROD_BIOBANK_PREFIX, NPH_TEST_BIOBANK_PREFIX, NPH_STUDY_ID
 from rdr_service.model.study_nph import Participant as DbParticipant, Site as nphSite, PairingEvent, DeactivatedEvent, \
-    WithdrawalEvent, EnrollmentEvent, EnrollmentEventType, ParticipantOpsDataElement
+    WithdrawalEvent, EnrollmentEvent, EnrollmentEventType, ParticipantOpsDataElement, ConsentEvent, ConsentEventType
 from rdr_service.model.site import Site
 from rdr_service.model.rex import ParticipantMapping, Study
 from rdr_service.model.participant_summary import ParticipantSummary as ParticipantSummaryModel
@@ -252,6 +252,7 @@ class Participant(ObjectType):
                                       sort_modifier=lambda context: context.set_order_expression(
                                           nphSite.awardee_external_id))
     nphEnrollmentStatus = List(Event, name="nphEnrollmentStatus", description='Sourced from NPH Schema.')
+    nphModule1ConsentStatus = List(Event, name="nphModule1ConsentStatus", description="Sourced from NPH Schema")
     nphWithdrawalStatus = SortableField(Event, name="nphWithdrawalStatus", description='Sourced from NPH Schema.')
     nphDeactivationStatus = SortableField(Event, name="nphDeactivationStatus", description='Sourced from NPH Schema.')
     nphDateOfBirth = Field(String, name="nphDateOfBirth", description='Sourced from NPH Schema.')
@@ -319,6 +320,25 @@ class ParticipantQuery(ObjectType):
         with database_factory.get_database().session() as sessions:
             logging.info('root: %s, info: %s, kwargs: %s', root, info, filter_kwargs)
             pm2 = aliased(PairingEvent)
+
+            consent_subquery = sessions.query(
+                DbParticipant.id.label('consent_pid'),
+                func.json_object(
+                    'consent_json',
+                    func.json_arrayagg(
+                            func.json_object(
+                                'time', ConsentEvent.event_authored_time,
+                                'value', ConsentEventType.source_name)
+                    ), type_=JSON
+                ).label('consent_status'),
+            ).join(
+                ConsentEvent,
+                ConsentEvent.participant_id == DbParticipant.id
+            ).join(
+                 ConsentEventType,
+                 ConsentEventType.id == ConsentEvent.event_type_id,
+            ).group_by(DbParticipant.id).subquery()
+
             enrollment_subquery = sessions.query(
                 DbParticipant.id.label('enrollment_pid'),
                 func.json_object(
@@ -344,6 +364,7 @@ class ParticipantQuery(ObjectType):
                 ParticipantMapping,
                 DbParticipant,
                 enrollment_subquery.c.enrollment_status,
+                consent_subquery.c.consent_status,
                 DeactivatedEvent,
                 WithdrawalEvent,
                 ParticipantOpsDataElement
@@ -359,6 +380,9 @@ class ParticipantQuery(ObjectType):
             ).join(
                 enrollment_subquery,
                 enrollment_subquery.c.enrollment_pid == DbParticipant.id
+            ).join(
+                consent_subquery,
+                consent_subquery.c.consent_pid == DbParticipant.id
             ).join(
                 PairingEvent,
                 PairingEvent.participant_id == ParticipantMapping.ancillary_participant_id

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -351,8 +351,10 @@ class ParticipantQuery(ObjectType):
                     'consent_json',
                     func.json_arrayagg(
                             func.json_object(
-                                'time', ConsentEvent.event_authored_time,
-                                'value', ConsentEventType.source_name)
+                                "value", ConsentEventType.source_name,
+                                "time", ConsentEvent.event_authored_time,
+                                "opt_in", ConsentEvent.opt_in,
+                            )
                     ), type_=JSON
                 ).label('consent_status'),
             ).join(

--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -118,7 +118,6 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
                 "time": withdrawn.event_authored_time if withdrawn else None
             },
             'nphEnrollmentStatus': get_enrollment_statuses(enrollment['enrollment_json']),
-            # TODO: Add nphModule1ConsentStatus
             'nphModule1ConsentStatus': get_consent_statuses(consents['consent_json']),
             'aianStatus': summary.aian,
             'suspensionStatus': {"value": check_field_value(summary.suspensionStatus),

--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Optional, Dict
+from typing import Dict
 from graphene import List
 
 from sqlalchemy.orm import Query, aliased
@@ -14,7 +14,7 @@ from rdr_service.participant_enums import QuestionnaireStatus
 @dataclass
 class QueryBuilder:
     query: Query
-    order_expression: Optional = None
+    order_expression = None
     filter_expressions: List = field(default_factory=list)
     references: Dict = field(default_factory=dict)
     join_expressions: List = field(default_factory=list)
@@ -66,6 +66,12 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
             enrollment_data
         ))
 
+    # def get_consent_statutes(consent_data):
+    #     return list(map(
+    #         lambda x: {'value': x['value'], 'time': parse_date(x['time']) if x['time'] else None},
+    #         consent_data
+    #     ))
+
     def get_value_from_ops_data(participant_ops_data, enum):
         if not participant_ops_data:
             return QuestionnaireStatus.UNSET
@@ -77,7 +83,7 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
     results = []
     records = query.all()
 
-    for summary, site, nph_site, mapping, nph_participant, enrollment, \
+    for summary, site, nph_site, mapping, nph_participant, enrollment, consents, \
             deactivated, withdrawn, ops_data in records:
         results.append({
             'participantNphId': f"{prefix}{mapping.ancillary_participant_id}",
@@ -108,6 +114,8 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
                 "time": withdrawn.event_authored_time if withdrawn else None
             },
             'nphEnrollmentStatus': get_enrollment_statuses(enrollment['enrollment_json']),
+            # TODO: Add nphModule1ConsentStatus
+            'nphModule1ConsentStatus': get_enrollment_statuses(consents['consent_json']),
             'aianStatus': summary.aian,
             'suspensionStatus': {"value": check_field_value(summary.suspensionStatus),
                                  "time": summary.suspensionTime},

--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -5,7 +5,7 @@ from graphene import List
 
 from sqlalchemy.orm import Query, aliased
 
-from rdr_service.ancillary_study_resources.nph.enums import ParticipantOpsElementTypes
+from rdr_service.ancillary_study_resources.nph.enums import ParticipantOpsElementTypes, ConsentOptInTypes
 from rdr_service.api_util import parse_date
 from rdr_service.model.participant_summary import ParticipantSummary as ParticipantSummaryModel
 from rdr_service.participant_enums import QuestionnaireStatus
@@ -66,11 +66,15 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
             enrollment_data
         ))
 
-    # def get_consent_statutes(consent_data):
-    #     return list(map(
-    #         lambda x: {'value': x['value'], 'time': parse_date(x['time']) if x['time'] else None},
-    #         consent_data
-    #     ))
+    def get_consent_statuses(consent_data):
+        return list(map(
+            lambda x: {
+                'value': x['value'],
+                'time': parse_date(x['time']) if x['time'] else None,
+                'opt_in': str(ConsentOptInTypes(int(x['opt_in'])))
+            },
+            consent_data
+        ))
 
     def get_value_from_ops_data(participant_ops_data, enum):
         if not participant_ops_data:
@@ -115,7 +119,7 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
             },
             'nphEnrollmentStatus': get_enrollment_statuses(enrollment['enrollment_json']),
             # TODO: Add nphModule1ConsentStatus
-            'nphModule1ConsentStatus': get_enrollment_statuses(consents['consent_json']),
+            'nphModule1ConsentStatus': get_consent_statuses(consents['consent_json']),
             'aianStatus': summary.aian,
             'suspensionStatus': {"value": check_field_value(summary.suspensionStatus),
                                  "time": summary.suspensionTime},

--- a/rdr_service/data_gen/generators/nph.py
+++ b/rdr_service/data_gen/generators/nph.py
@@ -161,7 +161,7 @@ class NphDataGenerator:
         fields = {
             "participant_id": participant_id,
             "event_id": event_id,
-            "event_type_id": 1,
+            "event_type_id": kwargs.get("event_type_id", 1),
             "opt_in": enums.ConsentOptInTypes.PERMIT,
         }
         fields.update(kwargs)

--- a/rdr_service/data_gen/generators/nph.py
+++ b/rdr_service/data_gen/generators/nph.py
@@ -95,7 +95,6 @@ class NphDataGenerator:
             )
             event_id = pea.id
 
-        # Todo: Add more default fields as needed
         fields = {
             "participant_id": participant_id,
             "event_id": event_id,
@@ -163,7 +162,6 @@ class NphDataGenerator:
             )
             event_id = pea.id
 
-        # Todo: Add more default fields as needed
         fields = {
             "event_authored_time": TIME,
             "participant_id": participant_id,

--- a/rdr_service/data_gen/generators/nph.py
+++ b/rdr_service/data_gen/generators/nph.py
@@ -1,8 +1,14 @@
+from datetime import datetime
+
 from rdr_service.dao import database_factory
 from rdr_service.model.study_nph import Participant, Site, PairingEvent, ParticipantEventActivity, Activity, \
     PairingEventType, ConsentEvent, ConsentEventType, EnrollmentEventType, EnrollmentEvent, WithdrawalEvent, \
     DeactivatedEvent, ParticipantOpsDataElement
 from rdr_service.ancillary_study_resources.nph import enums
+
+
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+TIME = datetime.strptime(datetime.now().strftime(DATETIME_FORMAT), DATETIME_FORMAT)
 
 
 class NphDataGenerator:
@@ -159,6 +165,7 @@ class NphDataGenerator:
 
         # Todo: Add more default fields as needed
         fields = {
+            "event_authored_time": TIME,
             "participant_id": participant_id,
             "event_id": event_id,
             "event_type_id": kwargs.get("event_type_id", 1),

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -359,14 +359,6 @@ class TestQueryExecution(BaseTestCase):
         query = simple_query(field_to_test)
 
         mock_load_participant_data(self.session)
-        nph_datagen = NphDataGenerator()
-        for nph_id in [100000000, 100000001]:
-            nph_datagen.create_database_enrollment_event(
-                participant_id=nph_id,
-                event_type_id=2,
-                event_authored_time=datetime.now()
-            )
-
         executed = app.test_client().post('/rdr/v1/nph_participant', data=query)
         result = json.loads(executed.data.decode('utf-8'))
         self.assertEqual(2, len(result.get('participant').get('edges')))
@@ -377,7 +369,7 @@ class TestQueryExecution(BaseTestCase):
                 status["value"],
                 ["m1_consent_gps", "m1_consent_recontact", "m1_consent_tissue"]
             )
-            self.assertIn(status["optIn"], ["PERMIT", "DENY"])
+            self.assertIn(status["optIn"], ["PERMIT"])
 
     def test_nphWithdrawalStatus_fields(self):
         field_to_test = "nphWithdrawalStatus {value time} "


### PR DESCRIPTION
## Resolves *[DA-3450](https://precisionmedicineinitiative.atlassian.net/browse/DA-3450)*

## Description of changes/additions
* Added `GraphQLConsentEvent` to serialize the `nphModule1ConsentStatus` field
* Added `test_nphModule1ConsentStatus_fields` unittest
* Added subquery to fetch the consent status information in the query
* Added `get_consent_statuses` method to transform the consent status information

## Tests
Added `test_nphModule1ConsentStatus_fields` unittest
Ran all the `NPH Participant Api` unittests on `localhost`

```zsh
python -m unittest -v tests.api_tests.test_nph_participant_api
CPUs: 10.
test_client_biobank_id_prefix (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_filter_parameter (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_none_value_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_awardee_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_organization_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site_with_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_check_length (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_participant_summary (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_single_result (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_date_of_birth (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_deceased_status (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_field_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_syntax_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDateOfBirth_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDeactivationStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphEnrollmentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphModule1ConsentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphWithdrawalStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_validation_error (tests.api_tests.test_nph_participant_api.TestQueryValidator) ... ok
test_validation_no_error (tests.api_tests.test_nph_participant_api.TestQueryValidator) ... ok

----------------------------------------------------------------------
Ran 21 tests in 25.808s

OK
```




[DA-3450]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ