### PR TITLE
processing and storing subsequent consent consent validation records

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -433,22 +433,34 @@ class _ValidationOutputHelper:
 
     @classmethod
     def _is_file_in_collection(cls, file: ParsingResult, file_collection: Collection[ParsingResult]):
-        if file.file_exists:
-            return any(
-                [file.file_path == possible_matching_file.file_path for possible_matching_file in file_collection]
-            ) or any(
-                [file.type == possible_matching_file.type
-                 and possible_matching_file.sync_status in
-                 (ConsentSyncStatus.READY_FOR_SYNC, ConsentSyncStatus.SYNC_COMPLETE)
-                 and file.participant_id == possible_matching_file.participant_id
-                 for possible_matching_file in file_collection]
+        return any([
+            cls._matches_existing_result(
+                new_result=file,
+                existing_result=possible_matching_file
+            )
+            for possible_matching_file in file_collection
+        ])
+
+    @classmethod
+    def _matches_existing_result(cls, new_result: ParsingResult, existing_result: ParsingResult):
+        """Provides whether a new validation result matches the given existing result"""
+        is_same_type = new_result.type == existing_result.type
+        is_same_participant = new_result.participant_id == existing_result.participant_id
+        is_same_path = new_result.file_path == existing_result.file_path
+        is_ready_to_sync = new_result.sync_status in (ConsentSyncStatus.READY_FOR_SYNC, ConsentSyncStatus.SYNC_COMPLETE)
+
+        # Determine if it's for the same consent response, regardless of the date actually on the file
+        is_for_same_date = new_result.expected_sign_date == existing_result.expected_sign_date
+
+        if new_result.file_exists:
+            return (
+                is_same_path
+                or (
+                    is_same_type and is_same_participant and is_ready_to_sync and is_for_same_date
+                )
             )
         else:
-            return any([
-                file.type == possible_matching_file.type
-                and file.participant_id == possible_matching_file.participant_id
-                for possible_matching_file in file_collection
-            ])
+            return is_same_type and is_same_participant and is_for_same_date
 
 
 class ConsentValidationController:

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -447,7 +447,9 @@ class _ValidationOutputHelper:
         is_same_type = new_result.type == existing_result.type
         is_same_participant = new_result.participant_id == existing_result.participant_id
         is_same_path = new_result.file_path == existing_result.file_path
-        is_ready_to_sync = new_result.sync_status in (ConsentSyncStatus.READY_FOR_SYNC, ConsentSyncStatus.SYNC_COMPLETE)
+        is_possible_match_valid = existing_result.sync_status in (
+            ConsentSyncStatus.READY_FOR_SYNC, ConsentSyncStatus.SYNC_COMPLETE
+        )
 
         # Determine if it's for the same consent response, regardless of the date actually on the file
         is_for_same_date = new_result.expected_sign_date == existing_result.expected_sign_date
@@ -456,7 +458,7 @@ class _ValidationOutputHelper:
             return (
                 is_same_path
                 or (
-                    is_same_type and is_same_participant and is_ready_to_sync and is_for_same_date
+                    is_same_type and is_same_participant and is_possible_match_valid and is_for_same_date
                 )
             )
         else:


### PR DESCRIPTION
## Resolves *no ticket*
It's possible for participants to consent again for EHR and GROR, we need to be able to store those results (especially for EHR because it affects other statuses for participant summary). Currently newer validation results are ignored if we already have a valid consent of the same type. This updates the code to look for whether a matching consent validation record has the same expected signing date as a previous one and stores the newer record if they don't match.


## Tests
- [x] unit tests


