### PR TITLE
[DA-3418] Only requiring DNA update for cohort 1 in baseline status calculation

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -706,7 +706,7 @@ class ParticipantSummaryDao(UpdatableDao):
             session=session
         )
 
-        dna_update_time_list = [summary.questionnaireOnDnaProgramAuthored]
+        revised_consent_time_list = []
         response_collection = QuestionnaireResponseRepository.get_responses_to_surveys(
             session=session,
             survey_codes=[PRIMARY_CONSENT_UPDATE_MODULE],
@@ -717,8 +717,8 @@ class ParticipantSummaryDao(UpdatableDao):
             for response in program_update_response_list:
                 reconsent_answer = response.get_single_answer_for(PRIMARY_CONSENT_UPDATE_QUESTION_CODE).value.lower()
                 if reconsent_answer == COHORT_1_REVIEW_CONSENT_YES_CODE.lower():
-                    dna_update_time_list.append(response.authored_datetime)
-        dna_update_time = min_or_none(dna_update_time_list)
+                    revised_consent_time_list.append(response.authored_datetime)
+        revised_consent_time = min_or_none(revised_consent_time_list)
 
         enrollment_info = EnrollmentCalculation.get_enrollment_info(
             EnrollmentDependencies(
@@ -733,7 +733,7 @@ class ParticipantSummaryDao(UpdatableDao):
                 earliest_physical_measurements_time=earliest_physical_measurements_time,
                 earliest_biobank_received_dna_time=earliest_biobank_received_dna_time,
                 ehr_consent_date_range_list=ehr_consent_ranges,
-                dna_update_time=dna_update_time
+                dna_update_time=revised_consent_time
             )
         )
 

--- a/rdr_service/logic/enrollment_info.py
+++ b/rdr_service/logic/enrollment_info.py
@@ -217,15 +217,19 @@ class EnrollmentCalculation:
             if (
                 (participant_info.has_had_ehr_file_submitted or participant_info.has_had_mediated_ehr_submitted)
                 and (
-                    participant_info.consent_cohort not in (ParticipantCohort.COHORT_1, ParticipantCohort.COHORT_2)
+                    participant_info.consent_cohort != ParticipantCohort.COHORT_1
                     or participant_info.has_completed_dna_update
                 )
             ):
                 # Track the extra dates needed
                 # (definitely need the date of an ehr file, but also possibly the dna update time)
-                extra_dates_needed = [min_or_none([participant_info.earliest_ehr_file_received_time,
-                                                  participant_info.earliest_mediated_ehr_receipt_time])]
-                if participant_info.consent_cohort in [ParticipantCohort.COHORT_1, ParticipantCohort.COHORT_2]:
+                extra_dates_needed = [
+                    min_or_none([
+                        participant_info.earliest_ehr_file_received_time,
+                        participant_info.earliest_mediated_ehr_receipt_time
+                    ])
+                ]
+                if participant_info.consent_cohort == ParticipantCohort.COHORT_1:
                     extra_dates_needed.append(participant_info.dna_update_time)
 
                 enrollment.upgrade_3_1_status(

--- a/tests/logic_tests/test_enrollment_info.py
+++ b/tests/logic_tests/test_enrollment_info.py
@@ -289,8 +289,8 @@ class TestEnrollmentInfo(BaseTestCase):
             EnrollmentCalculation.get_enrollment_info(participant_info)
         )
 
-        # Check that BASELINE also needs the DNA update for earlier cohorts.
-        participant_info.consent_cohort = ParticipantCohort.COHORT_2
+        # Check that BASELINE also needs the DNA update for cohort 1.
+        participant_info.consent_cohort = ParticipantCohort.COHORT_1
         enrollment = EnrollmentCalculation.get_enrollment_info(participant_info)
         self.assertEqual(EnrollmentStatusV31.CORE_PARTICIPANT, enrollment.version_3_1_status)
 


### PR DESCRIPTION
## Partially Resolves *[DA-3418](https://precisionmedicineinitiative.atlassian.net/browse/DA-3418)*
Cohort 2 participants should not need the DNA program update module to be able to upgrade to baseline status. This updates the enrollment status calculation to only check for revised consent from cohort 1.


## Tests
- [x] unit tests




[DA-3418]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ