### PR TITLE
Updates to finding validated EHR for enrollment status calculation

### DIFF
--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -464,9 +464,9 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
 
         # send consent for ehr
         self._ehr_questionnaire_id = self.create_questionnaire("ehr_consent_questionnaire.json")
-        with FakeClock(datetime.datetime(2020, 3, 12)):
+        with FakeClock(datetime.datetime(2023, 3, 12)):
             self.submit_ehr_questionnaire(participant_id, CONSENT_PERMISSION_YES_CODE, None,
-                                          datetime.datetime(2020, 2, 12))
+                                          datetime.datetime(2023, 2, 12))
             self._mark_ehr_valid_in_summary(from_client_participant_id(participant_id))
 
         # Check that the enrollment status remains at INTERESTED


### PR DESCRIPTION
## Resolves *no ticket*
The enrollment status calculation now depends on finding a validated EHR consent file, but there are some cases where that doesn't work well.
- Occasionally the questionnaire response linked to the consent file that passes validation is marked as a duplicate, and is then ignored when looking for EHR consent responses
- For any responses received before the ConsentResponse functionality was added, the link between the EHR QuestionnaireResponse and a validated consent PDF wouldn't be found.

This PR updates the check for validated files: also checking for duplicated responses and not checking for validation on older files.

## Tests
- [ ] unit tests


