### PR TITLE
[DA-3460] Preventing updates to enrollment status fields based on subsequent participant activity

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -673,7 +673,8 @@ class ParticipantSummaryDao(UpdatableDao):
 
     @classmethod
     def _update_timestamp_value(cls, summary, field_name, new_value):
-        if new_value and getattr(summary, field_name) != new_value:
+        existing_value = getattr(summary, field_name)
+        if new_value and existing_value != new_value and existing_value is None:
             setattr(summary, field_name, new_value)
 
     def _clear_timestamp_if_set(cls, summary, field_name):


### PR DESCRIPTION
## Resolves *[DA-3460](https://precisionmedicineinitiative.atlassian.net/browse/DA-3460)*
When a participant reaches core status, their core stored sample timestamp gets set. If they then have later activity, such as physical measurements, then the time is updated to match the latest physical measurements.

This PR updates the date storage logic to only set the date if there wasn't already one there.


## Tests
- [x] unit tests




[DA-3460]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ