### PR TITLE
[DA-3447] Allowing for reuse of mayo tracking numbers too

### DIFF
--- a/rdr_service/dao/biobank_order_dao.py
+++ b/rdr_service/dao/biobank_order_dao.py
@@ -284,7 +284,7 @@ class BiobankOrderDao(UpdatableDao):
         # TODO(mwf) FHIR validation for identifiers?
         # Verify that no identifier is in use by another order.
         for identifier in obj.identifiers:
-            if identifier.system != FEDEX_TRACKING_NUMBER_URL:  # skip the check for fedex tracking numbers
+            if not identifier.system.endswith('tracking-number'):  # skip the check for tracking numbers
                 for existing in (
                     session.query(BiobankOrderIdentifier).filter(
                         BiobankOrderIdentifier.system == identifier.system,

--- a/tests/dao_tests/test_biobank_order_dao.py
+++ b/tests/dao_tests/test_biobank_order_dao.py
@@ -362,6 +362,29 @@ class BiobankOrderDaoTest(BaseTestCase):
         )
         self.assertEqual(2, identifier_query.count())
 
+    def test_mayo_tracking_number_reuse(self):
+        recycled_tracking_number = '121212'
+        mayo_tracking_url = 'https://orders.mayomedicallaboratories.com/tracking-number'
+        self.data_generator.create_database_biobank_order_identifier(
+            system=mayo_tracking_url,
+            value=recycled_tracking_number
+        )
+
+        another_order = self.data_generator._biobank_order()
+        another_order.identifiers.append(self.data_generator._biobank_order_identifier(
+            system=mayo_tracking_url,
+            value=recycled_tracking_number
+        ))
+
+        self.dao.insert(another_order)
+
+        # Verify that there are two identifiers with the tracking number now
+        identifier_query = self.session.query(BiobankOrderIdentifier).filter(
+            BiobankOrderIdentifier.system == mayo_tracking_url,
+            BiobankOrderIdentifier.value == recycled_tracking_number
+        )
+        self.assertEqual(2, identifier_query.count())
+
     def test_ignored_order(self):
         ParticipantSummaryDao().insert(self.participant_summary(self.participant))
         self.dao.insert(self._make_biobank_order(ignoreFlag=1))


### PR DESCRIPTION
## Resolves *[DA-3447](https://precisionmedicineinitiative.atlassian.net/browse/DA-3447)*
Previously the RDR code allowed for the reuse of Fedex tracking numbers for biobank orders. This adds to that to allow using Mayolink tracking numbers too (by allowing any reused identifiers if their system ends with "tracking-number").


## Tests
- [x] unit tests




[DA-3447]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ