### PR TITLE
DA-3405: Implement NPH Biospecimen in the NPH Participant API

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -65,6 +65,25 @@ class GraphQLConsentEvent(Event):
     opt_in = Field(NonNull(String))
 
 
+class GraphQLNphBioSpecimen(ObjectType):
+    orderID = Field(String)
+    studyID = Field(String)
+    visitID = Field(String)
+    specimenCode = Field(String)
+    timepointID = Field(String)
+    volume  = Field(String)
+    volumeUOM = Field(String)
+    status = Field(String)
+    clientID = Field(String)
+    collectionDateUTC = Field(String)
+    processingDateUTC = Field(String)
+    finalizedDateUTC = Field(String)
+    sampleID = Field(String)
+    kitID = Field(String)
+    limsID = Field(String)
+    biobankStatus = Field(String)
+
+
 class EventCollection(ObjectType):
     current = SortableField(Event)
     # TODO: historical field need to sort by newest to oldest for a given aspect of a participant’s data
@@ -270,6 +289,7 @@ class Participant(ObjectType):
     nphModule1ConsentStatus = List(
         GraphQLConsentEvent, name="nphModule1ConsentStatus", description="Sourced from NPH Schema"
     )
+    nphBiospecimens = List(GraphQLNphBioSpecimen, name="nphBiospecimens", description="NPH Biospecimens")
     nphWithdrawalStatus = SortableField(Event, name="nphWithdrawalStatus", description='Sourced from NPH Schema.')
     nphDeactivationStatus = SortableField(Event, name="nphDeactivationStatus", description='Sourced from NPH Schema.')
     nphDateOfBirth = Field(String, name="nphDateOfBirth", description='Sourced from NPH Schema.')

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -65,6 +65,15 @@ class GraphQLConsentEvent(Event):
     opt_in = Field(NonNull(String))
 
 
+class GraphQLNphBiobankStatus(ObjectType):
+    """
+    ObjectType to serialize biobankStatus field as a list of dictionaries.
+    """
+    limsID = Field(String)
+    biobankModified = Field(String)
+    status = Field(String)
+
+
 class GraphQLNphBioSpecimen(ObjectType):
     orderID = Field(String)
     studyID = Field(String)
@@ -81,7 +90,7 @@ class GraphQLNphBioSpecimen(ObjectType):
     sampleID = Field(String)
     kitID = Field(String)
     limsID = Field(String)
-    biobankStatus = Field(String)
+    biobankStatus = Field(List(GraphQLNphBiobankStatus))
 
 
 class EventCollection(ObjectType):

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -82,14 +82,13 @@ class GraphQLNphBioSpecimen(ObjectType):
     timepointID = Field(String)
     volume  = Field(String)
     volumeUOM = Field(String)
-    status = Field(String)
+    orderedSampleStatus = Field(String)
     clientID = Field(String)
     collectionDateUTC = Field(String)
     processingDateUTC = Field(String)
     finalizedDateUTC = Field(String)
     sampleID = Field(String)
     kitID = Field(String)
-    limsID = Field(String)
     biobankStatus = Field(List(GraphQLNphBiobankStatus))
 
 

--- a/rdr_service/api/nph_participant_api_schemas/util.py
+++ b/rdr_service/api/nph_participant_api_schemas/util.py
@@ -1,17 +1,14 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, Tuple, Any, Iterable, Iterator
+from typing import Dict
 from graphene import List as GrapheneList
 
 from sqlalchemy.orm import Query, aliased
 
 from rdr_service.ancillary_study_resources.nph.enums import ParticipantOpsElementTypes, ConsentOptInTypes
 from rdr_service.api_util import parse_date
-from rdr_service.model.study_nph import Participant as NphParticipant, Order, OrderedSample, StoredSample
-from rdr_service.dao.study_nph_dao import NphOrderDao, NphOrderedSampleDao, NphStoredSampleDao
-from rdr_service.offline.study_nph_biobank_file_export import (
-    _get_parent_study_category, _get_study_category, _format_timestamp
-)
+from rdr_service.model.study_nph import Participant as NphParticipant
+from rdr_service.dao.study_nph_dao import NphOrderDao
 from rdr_service.model.participant_summary import ParticipantSummary as ParticipantSummaryModel
 from rdr_service.participant_enums import QuestionnaireStatus
 
@@ -81,91 +78,9 @@ def load_participant_summary_data(query, prefix, biobank_prefix):
             consent_data
         ))
 
-    def _is_order_cancelled(order: Order) -> bool:
-        return order.status == "cancelled"
-
-    def _is_ordered_sample_cancelled(ordered_sample: OrderedSample) -> bool:
-        return ordered_sample.status == "cancelled"
-
-    def _get_biobank_status_and_lims_id(
-        nph_participant: NphParticipant, ordered_sample: OrderedSample
-    ) -> Iterable[Tuple[str]]:
-        participant_biobank_id = nph_participant.biobank_id
-        stored_sample_dao = NphStoredSampleDao()
-        with stored_sample_dao.session() as session:
-            stored_samples: Iterable[StoredSample] = session.query(StoredSample)\
-                .order_by(StoredSample.id.desc())\
-                .filter(
-                    StoredSample.biobank_id == participant_biobank_id,
-                    StoredSample.sample_id == ordered_sample.nph_sample_id
-                )\
-                .all()
-
-        return [
-            {
-                "limsID": stored_sample.lims_id,
-                "biobankModified": _format_timestamp(stored_sample.biobank_modified),
-                "status": str(stored_sample.status),
-            } for stored_sample in stored_samples
-        ]
-
-    def _get_biospecimens_for_order(order: Order) -> Iterator[Dict[str, Any]]:
-        nph_ordered_sample_dao = NphOrderedSampleDao()
-        with nph_ordered_sample_dao.session() as session:
-            ordered_samples_for_participant: Iterable[OrderedSample] = list(
-                session.query(OrderedSample).filter(OrderedSample.order_id == order.id).all()
-            )
-            for ordered_sample in ordered_samples_for_participant:
-                parent_study_category = _get_parent_study_category(order.category_id)
-                nph_module_id = _get_parent_study_category(parent_study_category.id)
-                sample_processing_ts = ordered_sample.collected if not ordered_sample.parent is None else None
-                collectionDateUTC = _format_timestamp((ordered_sample.parent or ordered_sample).collected)
-                processingDateUTC = _format_timestamp(sample_processing_ts)
-                finalizedDateUTC = _format_timestamp(ordered_sample.finalized) if ordered_sample.finalized else None
-                sample_is_cancelled = (
-                    _is_order_cancelled(order) or
-                    _is_ordered_sample_cancelled(ordered_sample)
-                )
-                kit_id = ""
-                if (ordered_sample.identifier or ordered_sample.test).startswith("ST"):
-                    kit_id = order.nph_order_id
-
-                sample_status = "Cancelled" if sample_is_cancelled else "Active"
-                biospecimen_dict = {
-                    "orderID": order.nph_order_id,
-                    "visitID": parent_study_category.name if parent_study_category else "",
-                    "studyID": f"NPH Module {nph_module_id.name}",
-                    "specimenCode": (ordered_sample.identifier or ordered_sample.test),
-                    "timepointID": _get_study_category(order.category_id).name,
-                    "volume": ordered_sample.volume,
-                    "volumeUOM": ordered_sample.volumeUnits,
-                    "status": sample_status,
-                    "clientID": order.client_id,
-                    "collectionDateUTC": collectionDateUTC,
-                    "processingDateUTC": processingDateUTC,
-                    "finalizedDateUTC": finalizedDateUTC,
-                    "sampleID": (ordered_sample.aliquot_id or ordered_sample.nph_sample_id),
-                    "kitID": kit_id,
-                    "biobankStatus": None,
-                }
-                biobank_status_and_lims_id = _get_biobank_status_and_lims_id(nph_participant, ordered_sample)
-                if biobank_status_and_lims_id:
-                    biospecimen_dict.update({"biobankStatus": biobank_status_and_lims_id})
-                yield biospecimen_dict
-
-
     def get_nph_biospecimens_for_participant(nph_participant: NphParticipant):
         nph_order_dao = NphOrderDao()
-        with nph_order_dao.session() as session:
-            orders_for_participant: Iterable[Order] = list(
-                session.query(Order).filter(Order.participant_id == nph_participant.id).all()
-            )
-
-        biospecimens: Iterable[Dict[str, Any]] = []
-        for order in orders_for_participant:
-            for biospecimen in _get_biospecimens_for_order(order):
-                biospecimens.append(biospecimen)
-        return biospecimens
+        return nph_order_dao.get_nph_biospecimens_for_participant(nph_participant)
 
     def get_value_from_ops_data(participant_ops_data, enum):
         if not participant_ops_data:

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Tuple, Dict, List, Any, Optional
+from datetime import datetime
+from typing import Tuple, Dict, List, Any, Optional, Iterator, Iterable
 import json
 from types import SimpleNamespace as Namespace
 from typing import Optional
@@ -21,6 +22,10 @@ from rdr_service.config import NPH_MIN_BIOBANK_ID, NPH_MAX_BIOBANK_ID
 
 
 _logger = logging.getLogger("rdr_logger")
+
+
+def _format_timestamp(timestamp: datetime) -> str:
+    return timestamp.strftime('%Y-%m-%dT%H:%M:%SZ') if timestamp else None
 
 
 class OrderStatus(messages.Enum):
@@ -170,6 +175,14 @@ class NphStudyCategoryDao(UpdatableDao):
             if result:
                 return True, result
         return False, None
+
+    def get_study_category(self, study_category_id: int) -> StudyCategory:
+        with self.session() as session:
+            return session.query(StudyCategory).get(study_category_id)
+
+    def get_parent_study_category(self, study_category_id: int) -> StudyCategory:
+        study_category = self.get_study_category(study_category_id)
+        return self.get_study_category(study_category.parent_id)
 
 
 class NphSiteDao(BaseDao):

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -539,7 +539,7 @@ class NphOrderedSampleDao(UpdatableDao):
                     "timepointID": nph_study_category_dao.get_study_category(order.category_id).name,
                     "volume": ordered_sample.volume,
                     "volumeUOM": ordered_sample.volumeUnits,
-                    "status": sample_status,
+                    "orderedSampleStatus": sample_status,
                     "clientID": order.client_id,
                     "collectionDateUTC": collectionDateUTC,
                     "processingDateUTC": processingDateUTC,

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -930,7 +930,7 @@ class NphStoredSampleDao(BaseDao):
             {
                 "limsID": stored_sample.lims_id,
                 "biobankModified": _format_timestamp(stored_sample.biobank_modified),
-                "status": stored_sample.status.name,
+                "status": stored_sample.status.name if stored_sample.status else None,
             } for stored_sample in stored_samples
         ]
 

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -911,6 +911,26 @@ class NphStoredSampleDao(BaseDao):
     def get_id(self, obj: StoredSample):
         return obj.id
 
+    def get_biobank_status_and_lims_id(
+        self, nph_participant: Participant, ordered_sample: OrderedSample
+    ) -> Iterable[Tuple[str]]:
+        participant_biobank_id = nph_participant.biobank_id
+        with self.session() as session:
+            stored_samples: Iterable[StoredSample] = session.query(StoredSample)\
+                .order_by(StoredSample.id.desc())\
+                .filter(
+                    StoredSample.biobank_id == participant_biobank_id,
+                    StoredSample.sample_id == ordered_sample.nph_sample_id,
+                )\
+                .all()
+
+        return [
+            {
+                "limsID": stored_sample.lims_id,
+                "biobankModified": _format_timestamp(stored_sample.biobank_modified),
+                "status": str(stored_sample.status),
+            } for stored_sample in stored_samples
+        ]
 
 class NphIncidentDao(UpdatableDao):
     def __init__(self):

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -479,6 +479,19 @@ class NphOrderDao(UpdatableDao):
         session.refresh(order)
         return order
 
+    def get_nph_biospecimens_for_participant(self, nph_participant: Participant):
+        with self.session() as session:
+            orders_for_participant: Iterable[Order] = list(
+                session.query(Order).filter(Order.participant_id == nph_participant.id).all()
+            )
+
+        biospecimens: Iterable[Dict[str, Any]] = []
+        nph_ordered_sample_dao = NphOrderedSampleDao()
+        for order in orders_for_participant:
+            for biospecimen in nph_ordered_sample_dao.get_biospecimens_for_order(nph_participant, order):
+                biospecimens.append(biospecimen)
+        return biospecimens
+
 
 class NphOrderedSampleDao(UpdatableDao):
     def __init__(self):

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -27,6 +27,7 @@ from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao as RdrParticipantSummaryDao
 from rdr_service.dao.rex_dao import RexParticipantMappingDao
 from rdr_service.dao.study_nph_dao import (
+    _format_timestamp,
     NphParticipantDao,
     NphStudyCategoryDao,
     NphOrderDao,
@@ -43,10 +44,6 @@ _logger = logging.getLogger("rdr_logger")
 
 # FILE_BUFFER_SIZE_IN_BYTES = 1024 * 1024 # 1MB File Buffer
 NPH_ANCILLARY_STUDY_ID = 2
-
-
-def _format_timestamp(timestamp: datetime) -> str:
-    return timestamp.strftime('%Y-%m-%dT%H:%M:%SZ') if timestamp else None
 
 
 def _get_nph_participant(participant_id: int) -> NphParticipant:

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -118,6 +118,7 @@ def mock_load_participant_data(session):
 
     for _ in range(2):
         participant = nph_data_gen.create_database_participant()
+        participants.append(participant)
         nph_data_gen.create_database_pairing_event(
             participant_id=participant.id,
             event_authored_time=datetime(2023, 1, 1, 12, 0),

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -13,13 +13,22 @@ from rdr_service.model import study_nph
 from rdr_service.model.participant import Participant as aouParticipant
 from rdr_service.model.participant_summary import ParticipantSummary as ParticipantSummaryModel
 from rdr_service.model.rex import ParticipantMapping, Study
-from rdr_service.model.study_nph import PairingEvent, ConsentEventType, ConsentEvent
+from rdr_service.model.study_nph import (
+    PairingEvent, ConsentEventType, ConsentEvent, Participant as NphParticipant, Site as NphSite
+)
 from rdr_service.participant_enums import QuestionnaireStatus
 from rdr_service.main import app
 from tests.helpers.unittest_base import BaseTestCase
 from rdr_service.data_gen.generators.nph import NphDataGenerator
 import rdr_service.api.nph_participant_api as api
 from rdr_service import config
+from rdr_service.data_gen.generators.study_nph import (
+    generate_fake_study_categories,
+    generate_fake_orders,
+    generate_fake_ordered_samples,
+    generate_fake_sample_updates,
+    generate_fake_stored_samples,
+)
 
 NPH_BIOBANK_PREFIX = NPH_PROD_BIOBANK_PREFIX if config.GAE_PROJECT == "all-of-us-rdr-prod" else NPH_TEST_BIOBANK_PREFIX
 
@@ -405,6 +414,40 @@ class TestQueryExecution(BaseTestCase):
         no_nph_dob = result.get('participant').get('edges')[1].get('node')
         self.assertTrue(no_nph_dob.get('nphDateOfBirth') == 'UNSET')
 
+    def _create_test_sample_updates(self):
+        participant_query = Query(NphParticipant)
+        participant_query.session = self.session
+        nph_participants = list(participant_query.all())
+
+        nph_sites_query = Query(NphSite)
+        nph_sites_query.session = self.session
+        sites = list(nph_sites_query.all())
+        study_categories = generate_fake_study_categories()
+        orders = generate_fake_orders(
+            fake_participants=nph_participants,
+            fake_study_categories=study_categories,
+            fake_sites=sites,
+        )
+        ordered_samples = generate_fake_ordered_samples(fake_orders=orders)
+        generate_fake_sample_updates(fake_ordered_samples=ordered_samples)
+        generate_fake_stored_samples(nph_participants)
+
+    def test_nph_biospecimen_for_participant(self):
+        mock_load_participant_data(self.session)
+        self._create_test_sample_updates()
+        field_to_test = "nphBiospecimens {orderID specimenCode studyID visitID timepointID limsID biobankStatus} "
+        query = simple_query(field_to_test)
+
+        executed = app.test_client().post('/rdr/v1/nph_participant', data=query)
+        result = json.loads(executed.data.decode('utf-8'))
+        self.assertEqual(2, len(result.get('participant').get('edges')))
+        n_participants = len(result.get('participant').get('edges'))
+        for i in range(n_participants):
+            self.assertEqual(
+                12,
+                len(result.get("participant").get("edges")[i].get("node").get("nphBiospecimens"))
+            )
+
     def test_graphql_syntax_error(self):
         executed = app.test_client().post('/rdr/v1/nph_participant', data=QUERY_WITH_SYNTAX_ERROR)
         result = json.loads(executed.data.decode('utf-8'))
@@ -432,6 +475,10 @@ class TestQueryExecution(BaseTestCase):
         self.clear_table_after_test("nph.activity")
         self.clear_table_after_test("nph.pairing_event_type")
         self.clear_table_after_test("nph.site")
+        self.clear_table_after_test("nph.order")
+        self.clear_table_after_test("nph.ordered_sample")
+        self.clear_table_after_test("nph.sample_update")
+        self.clear_table_after_test("nph.stored_sample")
         self.clear_table_after_test("nph.participant_event_activity")
         self.clear_table_after_test("nph.pairing_event")
         self.clear_table_after_test("nph.enrollment_event")

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -118,7 +118,6 @@ def mock_load_participant_data(session):
 
     for _ in range(2):
         participant = nph_data_gen.create_database_participant()
-        participants.append(participant)
         nph_data_gen.create_database_pairing_event(
             participant_id=participant.id,
             event_authored_time=datetime(2023, 1, 1, 12, 0),


### PR DESCRIPTION
## Resolves *[DA-3405](https://precisionmedicineinitiative.atlassian.net/browse/DA-3405)*


## Description of changes/additions
1. Added GraphQL Schema `GraphQLNphBioSpecimen` object type to serialize the response for `nphBiospecimens` query
2. Added `get_nph_biospecimens_for_participant` method to get the biospecimen information for an nph participant
3. Added `GenFakeStoredSample` class, `generate_fake_stored_samples` method to generate fake stored samples and other misc. updates
4. Added a unittest to test nphBiospecimens query

## Tests
**Tested on `localhost`**
```python
$ python -m unittest -v tests.api_tests.test_nph_participant_api
CPUs: 10.
test_client_biobank_id_prefix (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_filter_parameter (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_none_value_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_awardee_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_organization_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site_with_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_check_length (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_participant_summary (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_single_result (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_date_of_birth (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_deceased_status (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_field_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_syntax_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDateOfBirth_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDeactivationStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphEnrollmentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphModule1ConsentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphWithdrawalStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nph_biospecimen_for_participant (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_validation_error (tests.api_tests.test_nph_participant_api.TestQueryValidator) ... ok
test_validation_no_error (tests.api_tests.test_nph_participant_api.TestQueryValidator) ... ok

----------------------------------------------------------------------
Ran 22 tests in 27.876s

OK
```





[DA-3405]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ