### PR TITLE
update replica in config to e instead of d

### DIFF
--- a/rdr_service/services/gcp_config.py
+++ b/rdr_service/services/gcp_config.py
@@ -48,7 +48,7 @@ GCP_INSTANCES = {  # List of RDR's GCP projects mapped to their database instanc
 }
 
 GCP_REPLICA_INSTANCES = {
-    "all-of-us-rdr-prod": "all-of-us-rdr-prod:us-central1:rdrbackupdb-d",
+    "all-of-us-rdr-prod": "all-of-us-rdr-prod:us-central1:rdrbackupdb-e",
     "all-of-us-rdr-stable": "all-of-us-rdr-stable:us-central1:rdrbackupdb",
     "all-of-us-rdr-staging": "all-of-us-rdr-staging:us-central1:rdrbackupdb",
     "all-of-us-rdr-sandbox": "all-of-us-rdr-sandbox:us-central1:rdrmaindb",

--- a/rdr_service/services/gcp_db_daemon.py
+++ b/rdr_service/services/gcp_db_daemon.py
@@ -47,7 +47,7 @@ def run():
             self.environment_proxy_port_map = {
                 RdrEnvironment.PROD: ProxyData(
                     primary=DatabaseProxy(name='rdrmaindb', port=9900),
-                    replica=DatabaseProxy(name='rdrbackupdb-d', port=9905)
+                    replica=DatabaseProxy(name='rdrbackupdb-e', port=9905)
                 ),
                 RdrEnvironment.STABLE: ProxyData(
                     primary=DatabaseProxy(name='rdrmaindb', port=9910),


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
The tools use the GCP_REPLICA_INSTANCES dict. This PR updates the config to reference `rdrbackupdb-e`.

## Tests
- [] unit tests


