### PR TITLE
[DA-3484] Fix over-counting in Genomic Ingestion Report

### DIFF
--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -550,11 +550,11 @@ class GenomicQueryClass:
                     LEFT JOIN genomic_manifest_file mf ON mf.file_path = raw.file_path
                     LEFT JOIN genomic_file_processed f ON f.genomic_manifest_file_id = mf.id
                     LEFT JOIN genomic_set_member m ON m.aw1_file_processed_id = f.id
+                        AND m.ignore_flag = 0
                     LEFT JOIN genomic_incident i ON i.source_file_processed_id = f.id
                 WHERE TRUE
                     AND raw.created >= :from_date
                     AND raw.ignore_flag = 0
-                    AND m.ignore_flag = 0
                     AND raw.biobank_id <> ""
                 GROUP BY raw.file_path, file_type
                 UNION
@@ -579,11 +579,11 @@ class GenomicQueryClass:
                     LEFT JOIN genomic_manifest_file mf ON mf.file_path = raw.file_path
                     LEFT JOIN genomic_file_processed f ON f.genomic_manifest_file_id = mf.id
                     LEFT JOIN genomic_gc_validation_metrics m ON m.genomic_file_processed_id = f.id
+                        AND m.ignore_flag = 0
                     LEFT JOIN genomic_incident i ON i.source_file_processed_id = f.id
                 WHERE TRUE
                     AND raw.created >=  :from_date
                     AND raw.ignore_flag = 0
-                    AND m.ignore_flag = 0
                     AND raw.biobank_id <> ""
                 GROUP BY raw.file_path, file_type
             """

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -554,6 +554,7 @@ class GenomicQueryClass:
                 WHERE TRUE
                     AND raw.created >= :from_date
                     AND raw.ignore_flag = 0
+                    AND m.ignore_flag = 0
                     AND raw.biobank_id <> ""
                 GROUP BY raw.file_path, file_type
                 UNION
@@ -582,6 +583,7 @@ class GenomicQueryClass:
                 WHERE TRUE
                     AND raw.created >=  :from_date
                     AND raw.ignore_flag = 0
+                    AND m.ignore_flag = 0
                     AND raw.biobank_id <> ""
                 GROUP BY raw.file_path, file_type
             """


### PR DESCRIPTION
## Resolves *[DA-3484](https://precisionmedicineinitiative.atlassian.net/browse/DA-3484)*


## Description of changes/additions
This PR adds an ignore_flag condition to the joins in the report query to prevent ignored records from being counted.

## Tests
- [x] unit tests




[DA-3484]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ