### PR TITLE
DA-3503: Cron Jobs to schedule Nph Biospecimen Cron Jobs

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -119,3 +119,13 @@ cron:
   timezone: America/New_York
   schedule: every day 22:15
   target: offline
+- description: NPH Biobank Nightly File Drop (Daily)
+  schedule: every day 05:30
+  target: offline
+  timezone: America/New_York
+  url: /offline/NphBiobankNightlyFileDrop
+- description: NPH Biobank Nightly Inventory File Import (Daily)
+  schedule: every day 06:00
+  target: offline
+  timezone: America/New_York
+  url: /offline/NphBiobankInventoryFileImport

--- a/rdr_service/cron_stable.yaml
+++ b/rdr_service/cron_stable.yaml
@@ -5,7 +5,12 @@ cron:
   schedule: every day 1:15
   target: offline
 - description: NPH Biobank Nightly File Drop (Daily)
-  schedule: every day 06:30
+  schedule: every day 05:30
   target: offline
   timezone: America/New_York
   url: /offline/NphBiobankNightlyFileDrop
+- description: NPH Biobank Nightly Inventory File Import (Daily)
+  schedule: every day 06:00
+  target: offline
+  timezone: America/New_York
+  url: /offline/NphBiobankInventoryFileImport

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -1393,6 +1393,13 @@ def _build_pipeline_app():
         methods=['GET']
     )
 
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + 'NphBiobankInventoryFileImport',
+        endpoint="nph_biobank_inventory_file_import",
+        view_func=nph_biobank_inventory_file_import,
+        methods=["GET"]
+    )
+
     offline_app.add_url_rule('/_ah/start', endpoint='start', view_func=flask_start, methods=["GET"])
     offline_app.add_url_rule("/_ah/stop", endpoint="stop", view_func=flask_stop, methods=["GET"])
 


### PR DESCRIPTION
## Resolves *[DA-3503](https://precisionmedicineinitiative.atlassian.net/browse/DA-3503)*

## Description of changes/additions
1. Added url endpoint for Nph Biobank Inventory File Import
2. Added cron job entries for `nph_biobank_nightly_file_drop` and `nph_biobank_inventory_file_import` in both `rdr-stable` & `rdr-prod`

## Tests
N/A




[DA-3503]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ