### PR TITLE
[DA-3471] Updating consent validation frequency to hourly

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -1,7 +1,7 @@
 cron:
 - description: Validate the previous day's consent files
   url: /offline/ValidateConsentFiles
-  schedule: every day 02:00
+  schedule: every 1 hours
   timezone: America/New_York
   target: offline
 - description: Check for any corrections to invalid consent files

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -594,8 +594,8 @@ class ConsentValidationController:
 
         # Workaround for this job frequently failing (OOM killer) before it can launch these tasks on a normal exit:
         # Pre-schedule the error reporting tasks to run in 8 hours.  Ensures the error report check occurs once a day.
-        dispatch_check_consent_errors_task(origin='vibrent', in_seconds=28800)
-        dispatch_check_consent_errors_task(origin='careevolution', in_seconds=28800)
+        dispatch_check_consent_errors_task(origin='vibrent', in_seconds=1800)
+        dispatch_check_consent_errors_task(origin='careevolution', in_seconds=1800)
 
         # Retrieve consent response objects that need to be validated
         is_last_batch = False


### PR DESCRIPTION
## Resolves *[DA-3471](https://precisionmedicineinitiative.atlassian.net/browse/DA-3471)*
We've been asked to update the frequency of the consent validation cron job. This PR updates it to hourly.


## Tests
- [ ] unit tests




[DA-3471]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ