### PR TITLE
DA-3468 - Remove enrollment event insertion from profile update

### DIFF
--- a/rdr_service/api/profile_update_api.py
+++ b/rdr_service/api/profile_update_api.py
@@ -280,7 +280,8 @@ class ProfileUpdateApi(Resource, ApiUtilMixin):
         self._record_request(json)
         return json
 
-    def _process_request(self, json):
+    @classmethod
+    def _process_request(cls, json):
         update_payload = PatientPayload(json)
         update_field_list = {
             'participant_id': from_client_participant_id(update_payload.participant_id)
@@ -318,10 +319,10 @@ class ProfileUpdateApi(Resource, ApiUtilMixin):
             study_interface = EnrollmentInterface(update_payload.ancillary_study_code)
             study_interface.create_study_participant(
                 aou_pid=update_field_list['participant_id'],
-                ancillary_pid=update_payload.ancillary_study_pid,
-                event_authored_time=update_payload.ancillary_event_authored_time
+                ancillary_pid=update_payload.ancillary_study_pid
             )
 
-    def _record_request(self, json):
+    @classmethod
+    def _record_request(cls, json):
         repository = ProfileUpdateRepository()
         repository.store_update_json(json)

--- a/rdr_service/services/ancillary_studies/study_enrollment.py
+++ b/rdr_service/services/ancillary_studies/study_enrollment.py
@@ -1,16 +1,14 @@
-from rdr_service.ancillary_study_resources.nph.enums import Activity, EnrollmentEventTypes
-from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.rex_dao import RexParticipantMappingDao
 from rdr_service.dao.study_nph_dao import NphParticipantDao
-from rdr_service.config import NPH_STUDY_ID, AOU_STUDY_ID, GAE_PROJECT
+from rdr_service.config import NPH_STUDY_ID, AOU_STUDY_ID
 
 
 class EnrollmentInterface:
     def __init__(self, study_code):
         self.study_code = study_code
 
-    def create_study_participant(self, aou_pid, ancillary_pid, event_authored_time=None, enrollment_event=True):
+    def create_study_participant(self, aou_pid, ancillary_pid):
         cln_study_pid = int(ancillary_pid[4:])
 
         # We have to use the AoU research ID
@@ -24,22 +22,6 @@ class EnrollmentInterface:
         self.participant_dao.insert_participant_with_random_biobank_id(
             self.participant_dao.model_type(**insert_params))
         self.create_rex_participant_mapping(aou_pid, cln_study_pid)
-
-        if enrollment_event:
-            # Task API Payload
-            data = {
-                'study': 'nph',
-                'participant_id': cln_study_pid,
-                'activity_id': Activity.ENROLLMENT.number,
-                'event_type_id': EnrollmentEventTypes.REFERRED.number,
-                'event_authored_time': event_authored_time
-            }
-            # Call cloud task
-            if GAE_PROJECT == 'localhost':
-                pass
-            else:
-                _task = GCPCloudTask()
-                _task.execute(endpoint='insert_study_event_task', payload=data, queue='nph')
 
     def create_rex_participant_mapping(self, aou_pid, study_pid):
         rex_dao = RexParticipantMappingDao()

--- a/tests/api_tests/test_profile_update_api.py
+++ b/tests/api_tests/test_profile_update_api.py
@@ -486,6 +486,5 @@ class ProfileUpdateApiTest(BaseTestCase):
 
         study_mock.assert_called_with(
             aou_pid=123123123,
-            ancillary_pid='1000578448930',
-            event_authored_time="2015-02-07T13:28:17.239+02:00"
+            ancillary_pid='1000578448930'
         )


### PR DESCRIPTION
## Resolves *[ticket DA-3468]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3468

## Description of changes/additions
Remove adding enrollment event via profile update since we recieve the referred event from the intake API request

## Tests
- [] unit tests
** all tests should still pass


