### PR TITLE
[DA-3475] Running consent validation cron job on all environments

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -264,4 +264,9 @@ cron:
   timezone: America/New_York
   schedule: every day 04:30
   target: offline
+- description: Validate the consent files
+  url: /offline/ValidateConsentFiles
+  schedule: every 1 hours
+  timezone: America/New_York
+  target: offline
 

--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -1,9 +1,4 @@
 cron:
-- description: Validate the previous day's consent files
-  url: /offline/ValidateConsentFiles
-  schedule: every 1 hours
-  timezone: America/New_York
-  target: offline
 - description: Check for any corrections to invalid consent files
   url: /offline/CorrectConsentFiles
   schedule: 7, 14, 21, 28 of month 20:00

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -596,7 +596,7 @@ class ConsentValidationController:
         # Workaround for this job frequently failing (OOM killer) before it can launch these tasks on a normal exit:
         # Pre-schedule the error reporting tasks to run in 8 hours.  Ensures the error report check occurs once each
         # time the validation runs.
-        if config.GAE_PROJECT == RdrEnvironment.PROD.name:
+        if self._report_validation_errors():
             # Only dispatch error reports for prod
             dispatch_check_consent_errors_task(origin='vibrent', in_seconds=1800)
             dispatch_check_consent_errors_task(origin='careevolution', in_seconds=1800)
@@ -763,6 +763,10 @@ class ConsentValidationController:
 
         logging.warning(f"Unable to find suitable original file for P{participant_id}'s {reconsent_type}")
         return None
+
+    @classmethod
+    def _report_validation_errors(cls) -> bool:
+        return config.GAE_PROJECT == RdrEnvironment.PROD.name
 
 
 class ConsentValidator:

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -51,7 +51,11 @@ class ConsentControllerTest(BaseTestCase):
         )
         self.store_strategy = StoreResultStrategy(session=mock.MagicMock(), consent_dao=self.consent_dao_mock)
 
-    def test_new_consent_validation(self):
+    @mock.patch(
+        'rdr_service.services.consent.validation.ConsentValidationController._report_validation_errors',
+        return_value=True
+    )
+    def test_new_consent_validation(self, _):
         """The controller should find all recent participant summary consents authored and validate files for them"""
         primary_and_ehr_participant_id = 123
         cabor_participant_id = 456


### PR DESCRIPTION
## Resolves *[DA-3475](https://precisionmedicineinitiative.atlassian.net/browse/DA-3475)*
Scheduling consent validation cron job on all environments. This also only sends error reports for Prod.

## Tests
- [ ] unit tests




[DA-3475]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ