### PR TITLE
Fix queueing of PDR rebuild task

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -96,6 +96,7 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
             # Rebuild for PDR
             self._task.execute(
                 'rebuild_one_participant_task',
+                queue='resource-tasks',
                 payload={'p_id': participant_id},
                 in_seconds=30
             )


### PR DESCRIPTION
## Resolves *(No ticket)*


## Description of changes/additions
PDR rebuild tasks were being directed to the `default` queue, which was quietly dropping them (warning and HTTP 404) when it didn't recognize the task endpoint.   Updating to the correct `resource-tasks` queue.

## Tests
- [x] unit tests


