### PR TITLE
[DA-3488] Add pipeline_id to SPoT sample_data_element

### DIFF
--- a/rdr_service/spot/procedures/sp_export_pivot_wgs.txt
+++ b/rdr_service/spot/procedures/sp_export_pivot_wgs.txt
@@ -31,6 +31,7 @@ EXECUTE IMMEDIATE
       JOIN `rdr_ods.export_schema_data_element` es ON es.data_element_id = sde.data_element_id
         and es.schema_name = "genomic_research_wgs"
       where sde.genome_type = "AOU_WGS"
+        and sde.pipeline_id = "dragen_3.4.12"
       UNION ALL
       # Survey Data
       SELECT DISTINCT pde.participant_id
@@ -49,6 +50,7 @@ EXECUTE IMMEDIATE
           and es.schema_name = "genomic_research_wgs"
         JOIN `rdr_ods.sample_data_element` sde ON sde.participant_id = pde.participant_id
           and sde.genome_type = "AOU_WGS"
+          and sde.pipeline_id = "dragen_3.4.12"
         WHERE pde.authored_timestamp < '%t'
       UNION ALL
       # Consent Data
@@ -68,6 +70,7 @@ EXECUTE IMMEDIATE
           and es.schema_name = "genomic_research_wgs"
         JOIN `rdr_ods.sample_data_element` sde ON sde.participant_id = cde.participant_id
           and sde.genome_type = "AOU_WGS"
+          and sde.pipeline_id = "dragen_3.4.12"
         WHERE cde.authored_timestamp < '%t'
       ) sub
   ) a

--- a/rdr_service/tools/tool_libs/spot_utils.py
+++ b/rdr_service/tools/tool_libs/spot_utils.py
@@ -390,7 +390,6 @@ class SpotTool(ToolBase):
 
         return 0
 
-
     @validate_args(arg_string="cutoff_date")
     def export_ods_data_to_datamart(self):
         """
@@ -510,6 +509,7 @@ class SpotTool(ToolBase):
             GenomicSetMember.participantId,
             GenomicSetMember.sampleId,
             GenomicSetMember.genomeType,
+            GenomicGCValidationMetrics.pipelineId,
             Participant.researchId,
             func.now().label('created_timestamp'),
         ]
@@ -665,6 +665,7 @@ class SpotTool(ToolBase):
                     'research_id': old_row.researchId,
                     'sample_id': old_row.sampleId,
                     'genome_type': old_row.genomeType.upper(),
+                    'pipeline_id': old_row.pipelineId,
                     'data_element_id': data_element.data_element_id,
                     'value_string': de_val,
                     'created_timestamp': old_row.created_timestamp.isoformat()


### PR DESCRIPTION
## Resolves *[DA-3488](https://precisionmedicineinitiative.atlassian.net/browse/DA-3488)*


## Description of changes/additions
This PR updates the `rdr_ods.sample_data_element` loader to include `pipeline_id`. Due to time pressures, the WGS export stored procedure was updated to have the hard-coded `pipeline_id` value of `dragen_3.4.12` . This will eventually be updated to the current pipeline when requested separately.

## Tests
- Tested locally and on cloud.




[DA-3488]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ