### PR TITLE
Allow pids with pre-existing SUBMITTED EHR consent to become CORE

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -702,9 +702,15 @@ class ParticipantSummaryDao(UpdatableDao):
                 sample.confirmed for sample in confirmed_dna_sample_list
             ])
 
+        # See ROC-1572/PDR-1699.  Provide a default date to get_interest_in_sharing_ehr_ranges() if participant
+        # has SUBMITTED status for their EHR consent.  Remediates data issues w/older consent validations
+        default_ehr_date = summary.consentForElectronicHealthRecordsFirstYesAuthored \
+            if summary.consentForElectronicHealthRecords == QuestionnaireStatus.SUBMITTED else None
+
         ehr_consent_ranges = QuestionnaireResponseRepository.get_interest_in_sharing_ehr_ranges(
             participant_id=summary.participantId,
-            session=session
+            session=session,
+            default_authored_datetime=default_ehr_date
         )
 
         revised_consent_time_list = []

--- a/rdr_service/repository/questionnaire_response_repository.py
+++ b/rdr_service/repository/questionnaire_response_repository.py
@@ -159,7 +159,7 @@ class QuestionnaireResponseRepository:
         return [consent_response.questionnaire_response_id for consent_response in query.all()]
 
     @classmethod
-    def get_interest_in_sharing_ehr_ranges(cls, participant_id, session: Session):
+    def get_interest_in_sharing_ehr_ranges(cls, participant_id, session: Session, default_authored_datetime=None):
         # Load all EHR and DV_EHR responses
         sharing_response_list = cls.get_responses_to_surveys(
             session=session,
@@ -204,9 +204,11 @@ class QuestionnaireResponseRepository:
                 if consent_answer:
                     # ignore any EHR responses that are not validated
                     # Note: only check for validated EHR if the consent was authored after the response->consent data
-                    #       started being generated (2022-02-18)
+                    #       started being generated (2022-02-18).  Also, if a default_authored_datetime was specified,
+                    #       consider a response with matching authored as validated.  (See ROC-1572/PDR-1699)
                     if (
                         response.id not in validated_ehr_id_list and not skip_validation_check
+                        and response.authored_datetime != default_authored_datetime
                         and response.authored_datetime > datetime(2022, 2, 18)
                     ):
                         continue


### PR DESCRIPTION
## Partially Resolves *[ROC-1573](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1573)* 


## Description of changes/additions
This is a follow-on to PR #3416 . Some participants with EHR consent authored times later than the filter date defined in that PR are still failing to elevate to CORE status because their older `consent_file` EHR validation record is still not linked to a `consent_response` record. 

This change will allow participants whose current EHR consent status is already SUBMITTED (i.e., they did not start in a SUBMITTED_NOT_VALIDATED state because they consented prior to the rollout of that new EHR validation status)  to elevate based on their `consentForElectronicHealthRecordsFirstYesAuthored` date.  If this PR is approved, suggest running an enrollment status backfill for these participants, to ensure they have not recently completed any remaining CORE activities but failed to elevate:

```
select ps.participant_id
from participant_summary ps
join participant p on p.participant_id = ps.participant_id
join consent_file cf on ps.participant_id = cf.participant_id and cf.type = 3
where ps.consent_for_electronic_health_records = 1 
     and ps.enrollment_status < 3 
     and ps.withdrawal_status = 1
     and p.is_test_participant = 0
     and cf.consent_response_id is null 
      -- Not remediated by the date filter from PR #3416
      and consent_for_electronic_health_records_first_yes_authored > '2022-02-18';
```


## Tests
- [x] unit tests (existing tests passing)
Used the new logic to run a `backfill-enrollment` tool update on the pid added to the ROC-1573 ticket on 4/17, and confirmed elevation to CORE (FULL_PARTICIPANT) status.




[ROC-1573]: https://precisionmedicineinitiative.atlassian.net/browse/ROC-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ