### PR TITLE
Handle multiselect responses in TheBasics analyzer tool

### DIFF
--- a/rdr_service/tools/tool_libs/thebasics_analyzer.py
+++ b/rdr_service/tools/tool_libs/thebasics_analyzer.py
@@ -193,7 +193,13 @@ class TheBasicsAnalyzerClass(object):
 
         # Build nested dict of question code keys/answer values
         for row in answer_list:
-            response_dict['answers'][row.question_code_value] = row.answer_value
+            ans = row.answer_value
+            if row.question_code_value in response_dict['answers']:
+                # Multi-select answer case; concatenate selections
+                prev_ans = response_dict['answers'][row.question_code_value]
+                ans = ','.join([prev_ans, ans])
+
+            response_dict['answers'][row.question_code_value] = ans
 
         response_dict['answer_count'] = len(response_dict['answers'].keys())
         response_dict['questionnaireResponseId'] = response_id


### PR DESCRIPTION
## Resolves *No ticket*


## Description of changes/additions
The tool to help inspect TheBasics data is still being used for some data quality investigations, and there was a bug when `verbose` mode is used to output the participant answers.  It would leave out multi-select answers to certain questions and only end up showing one of the selected answers.

This would not have impacted the correctness of identifying DUPLICATE / PROFILE_UPDATE / NO_ANSWER_VALUES `questionnaire_response` classifications (main reason the tool was originally written).  But this fixes the output when using it to inspect response data.

## Tests
N/A


