### PR TITLE
DA-3520: Remediate NPH Participant API Issue

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -457,6 +457,8 @@ class ParticipantQuery(ObjectType):
                 ParticipantMapping.ancillary_study_id == NPH_STUDY_ID,
             ).options(
                 subqueryload(DbParticipant.orders).subqueryload(Order.samples)
+            ).options(
+                subqueryload(DbParticipant.stored_samples)
             ).distinct()
 
             current_class = Participant

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -1,13 +1,14 @@
 import logging
 from graphene import ObjectType, String, Int, DateTime, Field, List, Date, Schema, NonNull
 from graphene import relay
-from sqlalchemy.orm import Query, aliased
+from sqlalchemy.orm import Query, aliased, joinedload
 from sqlalchemy import and_, func
 from sqlalchemy.dialects.mysql import JSON
 from rdr_service.config import NPH_PROD_BIOBANK_PREFIX, NPH_TEST_BIOBANK_PREFIX, NPH_STUDY_ID
 from rdr_service.model.study_nph import (
     Participant as DbParticipant,
     Site as nphSite,
+    Order,
     PairingEvent,
     DeactivationEvent,
     WithdrawalEvent,
@@ -446,7 +447,7 @@ class ParticipantQuery(ObjectType):
                 ParticipantOpsDataElement,
                 ParticipantMapping.ancillary_participant_id == ParticipantOpsDataElement.participant_id
             ).outerjoin(
-                 DeactivationEvent,
+                DeactivationEvent,
                 ParticipantMapping.ancillary_participant_id == DeactivationEvent.participant_id
             ).outerjoin(
                 WithdrawalEvent,
@@ -454,6 +455,8 @@ class ParticipantQuery(ObjectType):
             ).filter(
                 pm2.id.is_(None),
                 ParticipantMapping.ancillary_study_id == NPH_STUDY_ID,
+            ).options(
+                joinedload(DbParticipant.orders).joinedload(Order.samples)
             ).distinct()
 
             current_class = Participant

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -1,7 +1,7 @@
 import logging
 from graphene import ObjectType, String, Int, DateTime, Field, List, Date, Schema, NonNull
 from graphene import relay
-from sqlalchemy.orm import Query, aliased, joinedload
+from sqlalchemy.orm import Query, aliased, subqueryload
 from sqlalchemy import and_, func
 from sqlalchemy.dialects.mysql import JSON
 from rdr_service.config import NPH_PROD_BIOBANK_PREFIX, NPH_TEST_BIOBANK_PREFIX, NPH_STUDY_ID
@@ -456,7 +456,7 @@ class ParticipantQuery(ObjectType):
                 pm2.id.is_(None),
                 ParticipantMapping.ancillary_study_id == NPH_STUDY_ID,
             ).options(
-                joinedload(DbParticipant.orders).joinedload(Order.samples)
+                subqueryload(DbParticipant.orders).subqueryload(Order.samples)
             ).distinct()
 
             current_class = Participant

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -536,14 +536,13 @@ class NphOrderDao(UpdatableDao):
 
     def get_nph_biospecimens_for_participant(self, nph_participant: Participant):
         with self.session() as session:
-            participant: Participant = session.query(Participant).filter(
-                    Order.participant_id == nph_participant.id
-                )\
-                .options(joinedload(Participant.orders).joinedload(Order.samples)).first()
-
+            # participant: Participant = session.query(Participant).filter(
+            #         Order.participant_id == nph_participant.id
+            #     )\
+            #     .options(joinedload(Participant.orders).joinedload(Order.samples)).first()
             biospecimens: Iterable[Dict[str, Any]] = []
-            if participant:
-                for order in participant.orders:
+            if nph_participant:
+                for order in nph_participant.orders:
                     _biospecimens = self._get_biospecimens_for_order(
                         nph_participant, order, list(order.samples)
                     )

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -495,7 +495,7 @@ class NphOrderDao(UpdatableDao):
         for ordered_sample in ordered_samples:
             parent_study_category = nph_study_category_dao.get_parent_study_category(order.category_id)
             nph_module_id = nph_study_category_dao.get_parent_study_category(parent_study_category.id)
-            sample_processing_ts = ordered_sample.collected if not ordered_sample.parent is None else None
+            sample_processing_ts = ordered_sample.collected if ordered_sample.parent is not None else None
             collection_date_utc = _format_timestamp((ordered_sample.parent or ordered_sample).collected)
             processing_date_utc = _format_timestamp(sample_processing_ts)
             finalized_date_utc = _format_timestamp(ordered_sample.finalized) if ordered_sample.finalized else None

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -910,22 +910,15 @@ class NphStoredSampleDao(BaseDao):
     def get_biobank_status_and_lims_id(
         self, nph_participant: Participant, ordered_sample: OrderedSample
     ) -> Iterable[Tuple[str]]:
-        participant_biobank_id = nph_participant.biobank_id
-        with self.session() as session:
-            stored_samples: Iterable[StoredSample] = session.query(StoredSample)\
-                .order_by(StoredSample.id.desc())\
-                .filter(
-                    StoredSample.biobank_id == participant_biobank_id,
-                    StoredSample.sample_id == ordered_sample.nph_sample_id,
-                )\
-                .all()
-
+        filtered_stored_samples = list(
+            filter(lambda ss: str(ss.sample_id) == ordered_sample.nph_sample_id, nph_participant.stored_samples)
+        )
         return [
             {
                 "limsID": stored_sample.lims_id,
                 "biobankModified": _format_timestamp(stored_sample.biobank_modified),
                 "status": stored_sample.status.name if stored_sample.status else None,
-            } for stored_sample in stored_samples
+            } for stored_sample in filtered_stored_samples
         ]
 
 

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -8,7 +8,7 @@ from typing import Optional
 from protorpc import messages
 from werkzeug.exceptions import BadRequest, NotFound
 
-from sqlalchemy.orm import Query, aliased, joinedload
+from sqlalchemy.orm import Query, aliased
 from sqlalchemy import exc
 
 from rdr_service.model.study_nph import (
@@ -535,20 +535,15 @@ class NphOrderDao(UpdatableDao):
             yield biospecimen_dict
 
     def get_nph_biospecimens_for_participant(self, nph_participant: Participant):
-        with self.session() as session:
-            # participant: Participant = session.query(Participant).filter(
-            #         Order.participant_id == nph_participant.id
-            #     )\
-            #     .options(joinedload(Participant.orders).joinedload(Order.samples)).first()
-            biospecimens: Iterable[Dict[str, Any]] = []
-            if nph_participant:
-                for order in nph_participant.orders:
-                    _biospecimens = self._get_biospecimens_for_order(
-                        nph_participant, order, list(order.samples)
-                    )
-                    for biospecimen in _biospecimens:
-                        biospecimens.append(biospecimen)
-            return biospecimens
+        biospecimens: Iterable[Dict[str, Any]] = []
+        if nph_participant:
+            for order in nph_participant.orders:
+                _biospecimens = self._get_biospecimens_for_order(
+                    nph_participant, order, list(order.samples)
+                )
+                for biospecimen in _biospecimens:
+                    biospecimens.append(biospecimen)
+        return biospecimens
 
 
 class NphOrderedSampleDao(UpdatableDao):

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -7,7 +7,7 @@ from typing import Optional
 from protorpc import messages
 from werkzeug.exceptions import BadRequest, NotFound
 
-from sqlalchemy.orm import Query, aliased
+from sqlalchemy.orm import Query, aliased, joinedload
 from sqlalchemy import exc
 
 from rdr_service.model.study_nph import (
@@ -17,6 +17,7 @@ from rdr_service.model.study_nph import (
     SampleUpdate, BiobankFileExport, SampleExport,
     StoredSample, EnrollmentEvent, Incident
 )
+from rdr_service.dao import database_factory
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
 from rdr_service.config import NPH_MIN_BIOBANK_ID, NPH_MAX_BIOBANK_ID
 
@@ -477,27 +478,6 @@ class NphOrderDao(UpdatableDao):
         session.refresh(order)
         return order
 
-    def get_nph_biospecimens_for_participant(self, nph_participant: Participant):
-        with self.session() as session:
-            orders_for_participant: Iterable[Order] = list(
-                session.query(Order).filter(Order.participant_id == nph_participant.id).all()
-            )
-
-        biospecimens: Iterable[Dict[str, Any]] = []
-        nph_ordered_sample_dao = NphOrderedSampleDao()
-        for order in orders_for_participant:
-            for biospecimen in nph_ordered_sample_dao.get_biospecimens_for_order(nph_participant, order):
-                biospecimens.append(biospecimen)
-        return biospecimens
-
-
-class NphOrderedSampleDao(UpdatableDao):
-    def __init__(self):
-        super(NphOrderedSampleDao, self).__init__(OrderedSample)
-
-    def get_id(self, obj: OrderedSample):
-        return obj.id
-
     @staticmethod
     def _is_order_cancelled(order: Order) -> bool:
         return order.status == "cancelled"
@@ -506,54 +486,76 @@ class NphOrderedSampleDao(UpdatableDao):
     def _is_ordered_sample_cancelled(ordered_sample: OrderedSample) -> bool:
         return str(ordered_sample.status).lower() == "cancelled"
 
-    def get_biospecimens_for_order(self, nph_participant: Participant, order: Order) -> Iterator[Dict[str, Any]]:
+    def _get_biospecimens_for_order(
+        self, nph_participant: Participant, order: Order, ordered_samples: Iterable[OrderedSample]
+    ) -> Iterator[Dict[str, Any]]:
         nph_stored_sample_session = NphStoredSampleDao()
         nph_study_category_dao = NphStudyCategoryDao()
-        with self.session() as session:
-            ordered_samples_for_participant: Iterable[OrderedSample] = list(
-                session.query(OrderedSample).filter(OrderedSample.order_id == order.id).all()
+        for ordered_sample in ordered_samples:
+            parent_study_category = nph_study_category_dao.get_parent_study_category(order.category_id)
+            nph_module_id = nph_study_category_dao.get_parent_study_category(parent_study_category.id)
+            sample_processing_ts = ordered_sample.collected if not ordered_sample.parent is None else None
+            collection_date_utc = _format_timestamp((ordered_sample.parent or ordered_sample).collected)
+            processing_date_utc = _format_timestamp(sample_processing_ts)
+            finalized_date_utc = _format_timestamp(ordered_sample.finalized) if ordered_sample.finalized else None
+            sample_is_cancelled = (
+                self._is_order_cancelled(order) or
+                self._is_ordered_sample_cancelled(ordered_sample)
             )
-            for ordered_sample in ordered_samples_for_participant:
-                parent_study_category = nph_study_category_dao.get_parent_study_category(order.category_id)
-                nph_module_id = nph_study_category_dao.get_parent_study_category(parent_study_category.id)
-                sample_processing_ts = ordered_sample.collected if not ordered_sample.parent is None else None
-                collection_date_utc = _format_timestamp((ordered_sample.parent or ordered_sample).collected)
-                processing_date_utc = _format_timestamp(sample_processing_ts)
-                finalized_date_utc = _format_timestamp(ordered_sample.finalized) if ordered_sample.finalized else None
-                sample_is_cancelled = (
-                    self._is_order_cancelled(order) or
-                    self._is_ordered_sample_cancelled(ordered_sample)
-                )
-                kit_id = None
-                if (ordered_sample.identifier or ordered_sample.test).startswith("ST"):
-                    kit_id = order.nph_order_id
+            kit_id = None
+            if (ordered_sample.identifier or ordered_sample.test).startswith("ST"):
+                kit_id = order.nph_order_id
 
-                sample_status = "Cancelled" if sample_is_cancelled else "Active"
-                biospecimen_dict = {
-                    "orderID": order.nph_order_id,
-                    "visitID": parent_study_category.name if parent_study_category else "",
-                    "studyID": f"NPH Module {nph_module_id.name}",
-                    "specimenCode": (ordered_sample.identifier or ordered_sample.test),
-                    "timepointID": nph_study_category_dao.get_study_category(order.category_id).name,
-                    "volume": ordered_sample.volume,
-                    "volumeUOM": ordered_sample.volumeUnits,
-                    "orderedSampleStatus": sample_status,
-                    "clientID": order.client_id,
-                    "collectionDateUTC": collection_date_utc,
-                    "processingDateUTC": processing_date_utc,
-                    "finalizedDateUTC": finalized_date_utc,
-                    "sampleID": (ordered_sample.aliquot_id or ordered_sample.nph_sample_id),
-                    "kitID": kit_id,
-                    "biobankStatus": None,
-                }
-                biobank_status_and_lims_id = (
-                    nph_stored_sample_session.get_biobank_status_and_lims_id(
-                        nph_participant, ordered_sample
-                    )
+            sample_status = "Cancelled" if sample_is_cancelled else "Active"
+            biospecimen_dict = {
+                "orderID": order.nph_order_id,
+                "visitID": parent_study_category.name if parent_study_category else "",
+                "studyID": f"NPH Module {nph_module_id.name}",
+                "specimenCode": (ordered_sample.identifier or ordered_sample.test),
+                "timepointID": nph_study_category_dao.get_study_category(order.category_id).name,
+                "volume": ordered_sample.volume,
+                "volumeUOM": ordered_sample.volumeUnits,
+                "orderedSampleStatus": sample_status,
+                "clientID": order.client_id,
+                "collectionDateUTC": collection_date_utc,
+                "processingDateUTC": processing_date_utc,
+                "finalizedDateUTC": finalized_date_utc,
+                "sampleID": (ordered_sample.aliquot_id or ordered_sample.nph_sample_id),
+                "kitID": kit_id,
+                "biobankStatus": None,
+            }
+            biobank_status_and_lims_id = (
+                nph_stored_sample_session.get_biobank_status_and_lims_id(
+                    nph_participant, ordered_sample
                 )
-                if biobank_status_and_lims_id:
-                    biospecimen_dict.update({"biobankStatus": biobank_status_and_lims_id})
-                yield biospecimen_dict
+            )
+            if biobank_status_and_lims_id:
+                biospecimen_dict.update({"biobankStatus": biobank_status_and_lims_id})
+            yield biospecimen_dict
+
+    def get_nph_biospecimens_for_participant(self, nph_participant: Participant):
+        with database_factory.get_database().session() as sessions:
+            participant: Participant = sessions.query(Participant).filter(
+                    Order.participant_id == nph_participant.id
+                )\
+                .options(joinedload(Participant.orders).joinedload(Order.samples)).first()
+
+            biospecimens: Iterable[Dict[str, Any]] = []
+            for order in participant.orders:
+                _biospecimens = self._get_biospecimens_for_order(
+                    nph_participant, order, list(order.samples)
+                )
+                for biospecimen in _biospecimens:
+                    biospecimens.append(biospecimen)
+            return biospecimens
+
+
+class NphOrderedSampleDao(UpdatableDao):
+    def __init__(self):
+        super(NphOrderedSampleDao, self).__init__(OrderedSample)
+
+    def get_id(self, obj: OrderedSample):
+        return obj.id
 
     @staticmethod
     def _get_parent_order_sample(order_id, session) -> OrderedSample:

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1,4 +1,5 @@
 import logging
+from functools import lru_cache
 from datetime import datetime
 from typing import Tuple, Dict, List, Any, Optional, Iterator, Iterable
 import json
@@ -156,11 +157,12 @@ class NphStudyCategoryDao(UpdatableDao):
             if result:
                 return True, result
         return False, None
-
+    @lru_cache(maxsize=128, typed=False)
     def get_study_category(self, study_category_id: int) -> StudyCategory:
         with self.session() as session:
             return session.query(StudyCategory).get(study_category_id)
 
+    @lru_cache(maxsize=128, typed=False)
     def get_parent_study_category(self, study_category_id: int) -> StudyCategory:
         with self.session() as session:
             study_category: StudyCategory = session.query(StudyCategory).get(study_category_id)

--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -25,6 +25,9 @@ class Participant(NphBase):
     research_id = Column(BigInteger, unique=True)
 
     orders: List['Order'] = relationship('Order', back_populates='participant')
+    stored_samples: List['StoredSample'] = relationship(
+        'StoredSample', back_populates="participant", order_by="desc(StoredSample.id)"
+    )
 
 
 Index("participant_biobank_id", Participant.biobank_id)
@@ -340,6 +343,7 @@ class StoredSample(NphBase):
     lims_id = Column(String(64))
     status = Column(Enum(StoredSampleStatus), default=StoredSampleStatus.SHIPPED)
     disposition = Column(String(256))
+    participant = relationship(Participant, back_populates="stored_samples")
 
 
 event.listen(StoredSample, "before_insert", model_insert_listener)

--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -24,6 +24,8 @@ class Participant(NphBase):
     biobank_id = Column(BigInteger, nullable=False, unique=True)
     research_id = Column(BigInteger, unique=True)
 
+    orders: List['Order'] = relationship('Order', back_populates='participant')
+
 
 Index("participant_biobank_id", Participant.biobank_id)
 
@@ -84,7 +86,7 @@ class Order(NphBase):
     amended_reason = Column(String(1024))
     notes = Column(JSON, nullable=False)
     status = Column(String(128))
-
+    participant = relationship(Participant, back_populates='orders')
     samples: List['OrderedSample'] = relationship('OrderedSample', back_populates='order')
 
 


### PR DESCRIPTION
## Resolves *[DA-3520](https://precisionmedicineinitiative.atlassian.net/browse/DA-3520)*

## Description of changes/additions
* Added `orders` relationship for `nph.Participant` model
* Added `participant` relationship for `nph.Order` model
* Moved `get_biospecimens_for_order` from NphOrderedSampleDao to NphOrderDao and modified the access to be private
* Updated `get_nph_biospecimens_for_participant` method in `NphOrderDao` to use `Participant.orders` & `Order.samples` relationships to `prefetch` the related orders and ordered samples for an nph participant
* Cache the return value of `NphStudyCategoryDao.get_study_category` & `NphStudyCategoryDao.get_parent_study_category` methods using LRU Cache

## Tests
Ran the tests on `localhost`
```python
$ python -m unittest -v tests.api_tests.test_nph_participant_api.TestQueryExecution
CPUs: 10.
test_client_biobank_id_prefix (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_filter_parameter (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_none_value_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_awardee_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_organization_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site_with_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_check_length (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_participant_summary (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_single_result (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_date_of_birth (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_deceased_status (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_field_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_syntax_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDateOfBirth_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDeactivationStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphEnrollmentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphModule1ConsentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphWithdrawalStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nph_biospecimen_for_participant (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok

----------------------------------------------------------------------
Ran 20 tests in 25.114s

OK
```




[DA-3520]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ