### PR TITLE
Fix for NPH module/visit/timepoint creation

### DIFF
--- a/rdr_service/model/study_nph.py
+++ b/rdr_service/model/study_nph.py
@@ -40,7 +40,7 @@ class StudyCategory(NphBase):
     type_label = Column(String(128))
     parent_id = Column(BigInteger, ForeignKey("study_category.id"))
     parent = relation("StudyCategory", remote_side=[id])
-    children = relation("StudyCategory", remote_side=[parent_id], uselist=True)
+    children: List['StudyCategory'] = relation("StudyCategory", remote_side=[parent_id], uselist=True)
 
 
 event.listen(StudyCategory, "before_insert", model_insert_listener)

--- a/tests/dao_tests/test_study_nph_dao.py
+++ b/tests/dao_tests/test_study_nph_dao.py
@@ -279,6 +279,7 @@ class NphParticipantDaoTest(BaseTestCase):
 
     def tearDown(self):
         self.clear_table_after_test("nph.participant")
+        super().tearDown()
 
 
 class NphStudyCategoryTest(BaseTestCase):
@@ -392,6 +393,7 @@ class NphStudyCategoryTest(BaseTestCase):
 
     def tearDown(self):
         self.clear_table_after_test("nph.study_category")
+        super().tearDown()
 
 
 class NphSiteDaoTest(BaseTestCase):
@@ -467,6 +469,7 @@ class NphSiteDaoTest(BaseTestCase):
 
     def tearDown(self):
         self.clear_table_after_test("nph.site")
+        super().tearDown()
 
 
 class NphOrderDaoTest(BaseTestCase):
@@ -782,6 +785,7 @@ class NphOrderDaoTest(BaseTestCase):
         self.clear_table_after_test("nph.site")
         self.clear_table_after_test("nph.study_category")
         self.clear_table_after_test("nph.participant")
+        super().tearDown()
 
 
 class NphOrderedSampleDaoTest(BaseTestCase):
@@ -1096,6 +1100,7 @@ class NphOrderedSampleDaoTest(BaseTestCase):
         self.clear_table_after_test("nph.study_category")
         self.clear_table_after_test("nph.participant")
         self.clear_table_after_test("nph.sample_update")
+        super().tearDown()
 
 
 class NphSampleUpdateDaoTest(BaseTestCase):
@@ -1294,6 +1299,7 @@ class NphSampleUpdateDaoTest(BaseTestCase):
         self.clear_table_after_test("nph.site")
         self.clear_table_after_test("nph.study_category")
         self.clear_table_after_test("nph.participant")
+        super().tearDown()
 
 
 class NphBiobankFileExportDaoTest(BaseTestCase):
@@ -1331,6 +1337,7 @@ class NphBiobankFileExportDaoTest(BaseTestCase):
 
     def tearDown(self):
         self.clear_table_after_test("nph.biobank_file_export")
+        super().tearDown()
 
 
 class NphSampleExportDaoTest(BaseTestCase):
@@ -1555,6 +1562,7 @@ class NphSampleExportDaoTest(BaseTestCase):
         self.clear_table_after_test("nph.site")
         self.clear_table_after_test("nph.study_category")
         self.clear_table_after_test("nph.participant")
+        super().tearDown()
 
 
 class NphIncidentDaoTest(BaseTestCase):
@@ -1717,3 +1725,4 @@ class NphIncidentDaoTest(BaseTestCase):
         self.clear_table_after_test("nph.participant_event_activity")
         self.clear_table_after_test("nph.activity")
         self.clear_table_after_test("nph.participant")
+        super().tearDown()


### PR DESCRIPTION
## Resolves *no ticket*
When initializing the module, visit, and timepoint StudyCategory records for an NPH order the API was returning a 500 error code. The step for loading or creating the visit was finding that the visit didn't exist, and then initializing it into the `visit_type` variable. Later, when creating the timepoint and associating it with the visit, the empty `visit` variable was used rather than the initialized `visit_type` variable.

This PR reorganizes the code a bit for readability, and uses the same variable for loading and initializing the visit.

## Tests
- [x] unit tests


