### PR TITLE
DA-3526: Add Pagination to the NPH Participant API

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -359,9 +359,6 @@ class ParticipantConnection(relay.Connection):
 
 
 class ParticipantQuery(ObjectType):
-
-    MAX_PARTICIPANTS_PER_RESPONSE = 1000
-
     class Meta:
         interfaces = (relay.Node,)
         connection_class = ParticipantConnection
@@ -377,12 +374,12 @@ class ParticipantQuery(ObjectType):
 
     @staticmethod
     def resolve_participant(root, info, nph_id=None, sort_by=None, limit=None, off_set=None, **filter_kwargs):
-        """
-        Set the value of pagination 'limit' between 10 (min), 1000 (max) & 100 (default)
-        Set the value of pagination 'off_set' between 0 (min), 1000 (max) & 0 (default)
-        """
+        # Set the value of pagination 'limit' between 1 (min), 1000 (max) & 100 (default)
         limit = min(max(limit, MIN_LIMIT), MAX_LIMIT)
+
+        # Set the value of pagination 'off_set' between 0 (min), 1000 (max) & 0 (default)
         off_set = min(max(off_set, MIN_OFFSET), MAX_OFFSET)
+
         with database_factory.get_database().session() as sessions:
             logging.info('root: %s, info: %s, kwargs: %s', root, info, filter_kwargs)
             pm2 = aliased(PairingEvent)

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -35,7 +35,6 @@ MAX_LIMIT = 1000
 
 DEFAULT_OFFSET = 0
 MIN_OFFSET = 0
-MAX_OFFSET = 1000
 
 
 class SortableField(Field):
@@ -378,7 +377,7 @@ class ParticipantQuery(ObjectType):
         limit = min(max(limit, MIN_LIMIT), MAX_LIMIT)
 
         # Set the value of pagination 'off_set' between 0 (min), 1000 (max) & 0 (default)
-        off_set = min(max(off_set, MIN_OFFSET), MAX_OFFSET)
+        off_set = max(off_set, MIN_OFFSET)
 
         with database_factory.get_database().session() as sessions:
             logging.info('root: %s, info: %s, kwargs: %s', root, info, filter_kwargs)

--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -28,6 +28,15 @@ from rdr_service import config
 
 NPH_BIOBANK_PREFIX = NPH_PROD_BIOBANK_PREFIX if config.GAE_PROJECT == "all-of-us-rdr-prod" else NPH_TEST_BIOBANK_PREFIX
 
+# 'limit' & 'off_set' values for paginating Nph Participant Api response
+DEFAULT_LIMIT = 100
+MIN_LIMIT = 1
+MAX_LIMIT = 1000
+
+DEFAULT_OFFSET = 0
+MIN_OFFSET = 0
+MAX_OFFSET = 1000
+
 
 class SortableField(Field):
     def __init__(self, *args, sort_modifier=None, filter_modifier=None, **kwargs):
@@ -350,18 +359,30 @@ class ParticipantConnection(relay.Connection):
 
 
 class ParticipantQuery(ObjectType):
+
+    MAX_PARTICIPANTS_PER_RESPONSE = 1000
+
     class Meta:
         interfaces = (relay.Node,)
         connection_class = ParticipantConnection
 
     participant = relay.ConnectionField(
-        ParticipantConnection, nph_id=String(required=False), sort_by=String(required=False), limit=Int(required=False),
-        off_set=Int(required=False),
+        ParticipantConnection,
+        nph_id=String(required=False),
+        sort_by=String(required=False),
+        limit=Int(required=False, default_value=DEFAULT_LIMIT),
+        off_set=Int(required=False, default_value=DEFAULT_OFFSET),
         **_build_filter_parameters(Participant)
     )
 
     @staticmethod
     def resolve_participant(root, info, nph_id=None, sort_by=None, limit=None, off_set=None, **filter_kwargs):
+        """
+        Set the value of pagination 'limit' between 10 (min), 1000 (max) & 100 (default)
+        Set the value of pagination 'off_set' between 0 (min), 1000 (max) & 0 (default)
+        """
+        limit = min(max(limit, MIN_LIMIT), MAX_LIMIT)
+        off_set = min(max(off_set, MIN_OFFSET), MAX_OFFSET)
         with database_factory.get_database().session() as sessions:
             logging.info('root: %s, info: %s, kwargs: %s', root, info, filter_kwargs)
             pm2 = aliased(PairingEvent)


### PR DESCRIPTION
## Resolves *[DA-3526](https://precisionmedicineinitiative.atlassian.net/browse/DA-3526)*

## Description of changes/additions
Added default values for `limit` & `offSet` filters to force paginate the response from Nph Participant API

## Tests
Ran Tests on `localhost`
```python
$ python -m unittest -v tests.api_tests.test_nph_participant_api.TestQueryExecution
CPUs: 10.
test_client_biobank_id_prefix (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_filter_parameter (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_none_value_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_awardee_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_organization_external_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_nph_pair_site_with_id (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_check_length (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_result_participant_summary (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_single_result (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_date_of_birth (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_client_sorting_deceased_status (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_field_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_graphql_syntax_error (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDateOfBirth_field (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphDeactivationStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphEnrollmentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphModule1ConsentStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nphWithdrawalStatus_fields (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nph_biospecimen_for_participant (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok
test_nph_biospecimen_for_participant_with_pagination (tests.api_tests.test_nph_participant_api.TestQueryExecution) ... ok

----------------------------------------------------------------------
Ran 20 tests in 24.877s

OK
```



[DA-3526]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ