### PR TITLE
Updating migration dependency for hotfix

### DIFF
--- a/rdr_service/alembic/versions/a404cc984acf_pilot_source_history.py
+++ b/rdr_service/alembic/versions/a404cc984acf_pilot_source_history.py
@@ -21,7 +21,7 @@ from rdr_service.model.site_enums import SiteStatus, EnrollingStatus, DigitalSch
 
 # revision identifiers, used by Alembic.
 revision = 'a404cc984acf'
-down_revision = 'a13126fcffb2'
+down_revision = '42071b7a8c88'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Resolves *no ticket*
I just noticed that the new migration for the hotfix will need to be independent of a migration created after the hotfix.

Updating the dependency of the migration file.


## Tests
- [] unit tests


