### PR TITLE
Setting login phone number on ProfileUpdate API

### DIFF
--- a/rdr_service/api/profile_update_api.py
+++ b/rdr_service/api/profile_update_api.py
@@ -130,7 +130,7 @@ class PatientPayload:
         """
         return any([
             'pmi-verified' in extension.url and getattr(extension, 'valueBoolean', False)
-            for extension in contact_point.extension
+            for extension in contact_point.extension or []
         ])
 
     @property

--- a/rdr_service/api/profile_update_api.py
+++ b/rdr_service/api/profile_update_api.py
@@ -6,6 +6,7 @@ from rdr_service.api_util import PTC
 from rdr_service.app_util import auth_required
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.utils import from_client_participant_id
+from rdr_service.lib_fhir.fhirclient_4_0_0.models.contactpoint import ContactPoint
 from rdr_service.lib_fhir.fhirclient_4_0_0.models.patient import Patient as FhirPatient
 from rdr_service.repository.profile_update_repository import ProfileUpdateRepository
 from rdr_service.services.ancillary_studies.study_enrollment import EnrollmentInterface
@@ -91,13 +92,46 @@ class PatientPayload:
         if not self._fhir_patient.telecom:
             return False
 
-        return any([telecom_object.system == 'phone' for telecom_object in self._fhir_patient.telecom])
+        return any([
+            telecom_object.system == 'phone' and not self._is_verified(telecom_object)
+            for telecom_object in self._fhir_patient.telecom
+        ])
 
     @property
     def phone_number(self):
         for telecom_object in self._fhir_patient.telecom:
-            if telecom_object.system == 'phone':
+            if telecom_object.system == 'phone' and not self._is_verified(telecom_object):
                 return telecom_object.value or None
+
+    @property
+    def has_login_phone_number_update(self):
+        """
+        Login phone number looks the same as a phone number, but it's verified.
+        """
+        if not self._fhir_patient.telecom:
+            return False
+
+        return any([
+            telecom_object.system == 'phone' and self._is_verified(telecom_object)
+            for telecom_object in self._fhir_patient.telecom
+        ])
+
+    @property
+    def login_phone_number(self):
+        for telecom_object in self._fhir_patient.telecom:
+            if telecom_object.system == 'phone' and self._is_verified(telecom_object):
+                return telecom_object.value or None
+
+    @classmethod
+    def _is_verified(cls, contact_point: ContactPoint):
+        """
+        Given a ContactPoint (such as an email address or phone number),
+        return whether it is verified (defaulting to False).
+        """
+        return any([
+            'pmi-verified' in extension.url and getattr(extension, 'valueBoolean', False)
+            for extension in contact_point.extension
+        ])
 
     @property
     def has_email_update(self):
@@ -295,6 +329,8 @@ class ProfileUpdateApi(Resource, ApiUtilMixin):
             update_field_list['last_name'] = update_payload.last_name
         if update_payload.has_phone_number_update:
             update_field_list['phone_number'] = update_payload.phone_number
+        if update_payload.has_login_phone_number_update:
+            update_field_list['login_phone_number'] = update_payload.login_phone_number
         if update_payload.has_email_update:
             update_field_list['email'] = update_payload.email
         if update_payload.has_birthdate_update:

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1440,6 +1440,7 @@ class ParticipantSummaryDao(UpdatableDao):
                 'middle_name': 'middleName',
                 'last_name': 'lastName',
                 'phone_number': 'phoneNumber',
+                'login_phone_number': 'loginPhoneNumber',
                 'email': 'email',
                 'birthdate': 'dateOfBirth',
                 'address_line1': 'streetAddress',

--- a/tests/api_tests/test_profile_update_api.py
+++ b/tests/api_tests/test_profile_update_api.py
@@ -489,3 +489,27 @@ class ProfileUpdateApiTest(BaseTestCase):
             ancillary_pid='1000578448930',
             event_authored_time="2015-02-07T13:28:17.239+02:00"
         )
+
+    def test_setting_login_phone(self):
+        self.send_post(
+            'Patient',
+            request_data={
+                'id': 'P123123123',
+                'telecom': [
+                    {
+                        'system': 'phone',
+                        'value': '1234567890',
+                        'extension': [
+                            {
+                                'url': 'https://pmi-fhir-ig.github.io/pmi-fhir-ig/StructureDefinition/pmi-verified',
+                                'valueBoolean': True
+                            }
+                        ]
+                    }
+                ]
+            }
+        )
+        self.update_mock.assert_called_with(
+            participant_id=123123123,
+            login_phone_number='1234567890'
+        )


### PR DESCRIPTION
## Resolves *no ticket*
We've discovered that Vibrent is letting users set a login phone number and is passing it to us as a verified phone number. This modifies the ProfileUpdate API so that we can set the login phone number as distinct from the regular phone number field.


## Tests
- [x] unit tests


