### PR TITLE
[DA-3564] Fix for receiving datetime values as extensions

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import BadRequest
 from rdr_service import singletons
 from rdr_service.api_util import dispatch_task
 from rdr_service.dao.database_utils import format_datetime, parse_datetime
-from rdr_service.lib_fhir.fhirclient_1_0_6.models import questionnaireresponse as fhir_questionnaireresponse
+from rdr_service.lib_fhir.fhirclient_1_0_6.models import fhirdate, questionnaireresponse as fhir_questionnaireresponse
 from rdr_service.participant_enums import QuestionnaireResponseStatus, PARTICIPANT_COHORT_2_START_TIME, \
     PARTICIPANT_COHORT_3_START_TIME, Race, get_all_races_from_codes
 from rdr_service.app_util import get_account_origin_id, is_self_request
@@ -1266,6 +1266,10 @@ class QuestionnaireResponseDao(BaseDao):
         fhir_fields = fhir_extension.__dict__
         filtered_values = {}
         for name, value in fhir_fields.items():
+            # Get date value from FHIRDate object
+            if isinstance(value, fhirdate.FHIRDate):
+                value = value.date
+
             if value is not None and (name == 'url' or name.startswith('value')):
                 filtered_values[name] = value
 

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -606,6 +606,11 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
             QuestionnaireResponseExtension.questionnaireResponseId == questionnaire_response_id
         ).one()
         self.assertEqual('code_value', code_extension.valueCode)
+        datetime_extension: QuestionnaireResponseExtension = self.session.query(QuestionnaireResponseExtension).filter(
+            QuestionnaireResponseExtension.url == 'datetime-extension',
+            QuestionnaireResponseExtension.questionnaireResponseId == questionnaire_response_id
+        ).one()
+        self.assertEqual(datetime.datetime(2023, 5, 10, 19, 0, 1), datetime_extension.valueDateTime)
 
         #  sending an update response with history reference
         with open(data_path('questionnaire_response4.json')) as fd:

--- a/tests/test-data/questionnaire_response3.json
+++ b/tests/test-data/questionnaire_response3.json
@@ -22,6 +22,10 @@
     {
       "url": "extension-url",
       "valueString": "test string"
+    },
+    {
+      "url": "datetime-extension",
+      "valueDateTime": "2023-05-10T10:00:01.123-09:00"
     }
   ],
   "group": {


### PR DESCRIPTION
## Resolves *[DA-3564](https://precisionmedicineinitiative.atlassian.net/browse/DA-3564)*
When we get a datetime value in a questionnaire response, we're seeing an error because other DB code is to treating it as a Datetime object rather than a FHIRDate object.

This updates the code to store extension datetime values as datetime objects.


## Tests
- [x] unit tests




[DA-3564]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ