### PR TITLE
[DA-3511] Allow Remote Physical Measurements to Curation

### DIFF
--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -595,6 +595,7 @@ class SrcMeas(CdmBase):
     physical_measurements_id = Column(Integer, nullable=False)
     parent_id = Column(BigInteger)
     src_id = Column(String(50))
+    collect_type = Column(Integer)
 
 
 class MeasurementCodeMap(CdmBase):
@@ -638,6 +639,7 @@ class SrcMeasMapped(CdmBase):
     physical_measurements_id = Column(Integer, nullable=False)
     parent_id = Column(BigInteger)
     src_id = Column(String(50))
+    collect_type = Column(Integer)
 
 
 class SrcVisits(CdmBase):


### PR DESCRIPTION
## Resolves *[DA-3511](https://precisionmedicineinitiative.atlassian.net/browse/DA-3511)*


## Description of changes/additions

Allows remote physical measurements to be included in the Curation export. Adds new command line options to filter out remote or in-person measurements.

## Tests
- [x] unit tests




[DA-3511]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ