### PR TITLE
[DA-3508] code for calculating retention eligibility and status

### DIFF
--- a/rdr_service/services/retention_calculation.py
+++ b/rdr_service/services/retention_calculation.py
@@ -1,0 +1,146 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+
+from rdr_service.participant_enums import ParticipantCohort
+
+
+@dataclass
+class Consent:
+    is_consent_provided:    bool        # Indicates that we got a response that gives a "Yes" answer
+    authored_timestamp:     datetime
+
+
+@dataclass
+class RetentionEligibilityDependencies:
+    primary_consent:                        Consent
+    first_ehr_consent:                      Optional[Consent]   # First consent, or intent, to share EHR
+    is_deceased:                            bool                # Has an APPROVED deceased report
+    is_withdrawn:                           bool
+    dna_samples_timestamp:                  Optional[datetime]
+    consent_cohort:                         ParticipantCohort
+    has_uploaded_ehr_file:                  bool
+    latest_ehr_upload_timestamp:            Optional[datetime]  # Date RDR has for most recent upload of EHR file
+
+    basics_response_timestamp:              Optional[datetime]
+    overallhealth_response_timestamp:       Optional[datetime]
+    lifestyle_response_timestamp:           Optional[datetime]
+
+    healthcare_access_response_timestamp:   Optional[datetime]
+    family_health_response_timestamp:       Optional[datetime]
+    medical_history_response_timestamp:     Optional[datetime]
+    fam_med_history_response_timestamp:     Optional[datetime]
+    sdoh_response_timestamp:                Optional[datetime]
+    latest_cope_response_timestamp:         Optional[datetime]  # Most recent response to any of the cope/vax surveys
+    remote_pm_response_timestamp:           Optional[datetime]
+    life_func_response_timestamp:           Optional[datetime]
+    reconsent_response_timestamp:           Optional[datetime]  # Cohort 1 reconsent to primary consent
+    gror_response_timestamp:                Optional[datetime]
+
+
+class RetentionEligibility:
+    def __init__(self, participant_data: RetentionEligibilityDependencies):
+        self._participant = participant_data
+
+    @property
+    def is_eligible(self) -> bool:
+        return (
+            not self._participant.is_deceased
+            and not self._participant.is_withdrawn
+            and self._did_provide_consent(self._participant.primary_consent)
+            and self._did_provide_consent(self._participant.first_ehr_consent)
+            and self._participant.basics_response_timestamp is not None
+            and self._participant.overallhealth_response_timestamp is not None
+            and self._participant.lifestyle_response_timestamp is not None
+            and self._participant.dna_samples_timestamp is not None
+        )
+
+    @property
+    def retention_eligible_date(self) -> Optional[datetime]:
+        if not self.is_eligible:
+            return None
+
+        return max(
+            self._participant.primary_consent.authored_timestamp,
+            self._participant.first_ehr_consent.authored_timestamp,
+            self._participant.basics_response_timestamp,
+            self._participant.overallhealth_response_timestamp,
+            self._participant.lifestyle_response_timestamp,
+            self._participant.dna_samples_timestamp
+        )
+
+    @property
+    def is_actively_retained(self) -> bool:
+        if not self.is_eligible:
+            return False
+
+        return (
+            self._is_less_than_18_months_ago(self._participant.healthcare_access_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.family_health_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.medical_history_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.fam_med_history_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.sdoh_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.latest_cope_response_timestamp)
+
+            or self._is_less_than_18_months_ago(self._participant.remote_pm_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.life_func_response_timestamp)
+            or (
+                self._participant.consent_cohort in [ParticipantCohort.COHORT_1, ParticipantCohort.COHORT_2]
+                and self._is_less_than_18_months_ago(self._participant.gror_response_timestamp)
+            ) or (
+                self._participant.consent_cohort == ParticipantCohort.COHORT_1
+                and self._is_less_than_18_months_ago(self._participant.reconsent_response_timestamp)
+            )
+        )
+
+    @property
+    def last_active_retention_date(self) -> Optional[datetime]:
+        if not self.is_eligible:
+            return None
+
+        possible_dates = [
+            self._participant.healthcare_access_response_timestamp,
+            self._participant.family_health_response_timestamp,
+            self._participant.medical_history_response_timestamp,
+            self._participant.fam_med_history_response_timestamp,
+            self._participant.sdoh_response_timestamp,
+            self._participant.latest_cope_response_timestamp,
+            self._participant.remote_pm_response_timestamp,
+            self._participant.life_func_response_timestamp
+        ]
+
+        if self._participant.consent_cohort in [ParticipantCohort.COHORT_1, ParticipantCohort.COHORT_2]:
+            possible_dates.append(self._participant.gror_response_timestamp)
+
+        if self._participant.consent_cohort == ParticipantCohort.COHORT_1:
+            possible_dates.append(self._participant.reconsent_response_timestamp)
+
+        # Create a list of any gathered timestamps that are not None
+        none_null_timestamps = [timestamp for timestamp in possible_dates if timestamp]
+
+        # If all timestamps were None, then return None
+        if not none_null_timestamps:
+            return None
+
+        # Otherwise return the latest timestamp
+        return max(none_null_timestamps)
+
+    @property
+    def is_passively_retained(self):
+        return (
+            self.is_eligible
+            and self._is_less_than_18_months_ago(self._participant.latest_ehr_upload_timestamp)
+            and self._participant.has_uploaded_ehr_file
+        )
+
+    @classmethod
+    def _did_provide_consent(cls, consent: Consent) -> bool:
+        return False if consent is None else consent.is_consent_provided
+
+    @classmethod
+    def _is_less_than_18_months_ago(cls, timestamp: datetime) -> bool:
+        return None if timestamp is None else timestamp >= cls._get_datetime_18_months_ago()
+
+    @classmethod
+    def _get_datetime_18_months_ago(cls) -> datetime:
+        return datetime.today() - timedelta(days=547)

--- a/rdr_service/services/retention_calculation.py
+++ b/rdr_service/services/retention_calculation.py
@@ -81,7 +81,6 @@ class RetentionEligibility:
             or self._is_less_than_18_months_ago(self._participant.fam_med_history_response_timestamp)
             or self._is_less_than_18_months_ago(self._participant.sdoh_response_timestamp)
             or self._is_less_than_18_months_ago(self._participant.latest_cope_response_timestamp)
-
             or self._is_less_than_18_months_ago(self._participant.remote_pm_response_timestamp)
             or self._is_less_than_18_months_ago(self._participant.life_func_response_timestamp)
             or (

--- a/tests/service_tests/test_retention_status.py
+++ b/tests/service_tests/test_retention_status.py
@@ -1,0 +1,192 @@
+from datetime import datetime, timedelta
+
+from rdr_service.participant_enums import ParticipantCohort
+from rdr_service.services.retention_calculation import Consent, RetentionEligibility, RetentionEligibilityDependencies
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class RetentionCalculationTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+        self.participant_info = self._get_eligible_participant()
+
+    def test_participant_eligibility(self):
+        # Set up an eligible participant and make sure they show as eligible
+        self.assertTrue(
+            RetentionEligibility(self.participant_info).is_eligible
+        )
+
+    def test_deceased_not_eligible(self):
+        self.participant_info.is_deceased = True
+        self.assertFalse(
+            RetentionEligibility(self.participant_info).is_eligible
+        )
+
+    def test_withdrawn_not_eligible(self):
+        self.participant_info.is_withdrawn = True
+        self.assertFalse(
+            RetentionEligibility(self.participant_info).is_eligible
+        )
+
+    def test_missing_ehr_intent_not_eligible(self):
+        self.participant_info.first_ehr_consent = None
+        self.assertFalse(
+            RetentionEligibility(self.participant_info).is_eligible
+        )
+
+    def test_missing_basics_not_eligible(self):
+        self.participant_info.basics_response_timestamp = None
+        self.assertFalse(
+            RetentionEligibility(self.participant_info).is_eligible
+        )
+
+    def test_default_eligible_date(self):
+        self.assertEqual(
+            datetime(2021, 12, 1),
+            RetentionEligibility(self.participant_info).retention_eligible_date
+        )
+
+    def test_date_for_not_eligible(self):
+        # Make sure the eligibility date returns as None for a participant that is not eligible
+        self.participant_info.first_ehr_consent = None
+        self.assertIsNone(
+            RetentionEligibility(self.participant_info).retention_eligible_date
+        )
+
+    def test_for_latest(self):
+        self.participant_info.basics_response_timestamp = datetime(2023, 5, 12)
+        self.assertEqual(
+            self.participant_info.basics_response_timestamp,
+            RetentionEligibility(self.participant_info).retention_eligible_date
+        )
+
+    def test_default_not_active(self):
+        self.assertFalse(
+            RetentionEligibility(self.participant_info).is_actively_retained
+        )
+
+    def test_is_active_cope(self):
+        # Check that a recent survey sets them as actively retained
+        self.participant_info.latest_cope_response_timestamp = datetime.today()
+        self.assertTrue(
+            RetentionEligibility(self.participant_info).is_actively_retained
+        )
+
+    def test_recent_gror_cohort_3(self):
+        # Check that a cohort 3 participant with a recent GROR *is not* actively retained
+        self.participant_info.consent_cohort = ParticipantCohort.COHORT_3
+        self.participant_info.gror_response_timestamp = datetime.today()
+        self.assertFalse(
+            RetentionEligibility(self.participant_info).is_actively_retained
+        )
+
+    def test_recent_gror_cohort_1(self):
+        # ... but any earlier cohort with a recent GROR *is* actively retained
+        self.participant_info.consent_cohort = ParticipantCohort.COHORT_1
+        self.participant_info.gror_response_timestamp = datetime.today()
+        self.assertTrue(
+            RetentionEligibility(self.participant_info).is_actively_retained
+        )
+
+    def test_no_active_retention_date(self):
+        # Check that the default, non-active, information gives None for the active retention date
+        self.participant_info = self._get_eligible_participant()
+        self.assertIsNone(
+            RetentionEligibility(self.participant_info).last_active_retention_date
+        )
+
+    def test_latest_activity_date(self):
+        # Check that the latest activity date is used as the active retention date
+        self.participant_info.remote_pm_response_timestamp = datetime(2023, 1, 17)
+        self.participant_info.sdoh_response_timestamp = datetime(2023, 2, 4)
+        self.assertEqual(
+            self.participant_info.sdoh_response_timestamp,
+            RetentionEligibility(self.participant_info).last_active_retention_date
+        )
+
+    def test_default_not_passively_retained(self):
+        # Check that the default data for the tests is not passively retained
+        self.assertFalse(
+            RetentionEligibility(self.participant_info).is_passively_retained
+        )
+
+    def test_ehr_upload_is_passive(self):
+        # Check that an eligible participant with recent EHR data is passively retained
+        self.participant_info.has_uploaded_ehr_file = True
+        self.participant_info.latest_ehr_upload_timestamp = datetime.today() - timedelta(days=450)
+        self.assertTrue(
+            RetentionEligibility(self.participant_info).is_passively_retained
+        )
+
+    @classmethod
+    def _get_eligible_participant(cls):
+        return cls._build_retention_data(
+            first_ehr_authored=datetime(2021, 10, 10),
+            basics_authored=datetime(2021, 10, 10),
+            overallhealth_authored=datetime(2021, 10, 10),
+            lifestyle_authored=datetime(2021, 10, 10),
+            dna_samples_timestamp=datetime(2021, 12, 1)
+        )
+
+    @classmethod
+    def _build_retention_data(
+        cls,
+        primary_consent_authored: datetime = datetime(2021, 4, 1),
+        first_ehr_authored: datetime = None,
+        is_deceased: bool = False,
+        is_withdrawn: bool = False,
+        dna_samples_timestamp: datetime = None,
+        cohort: ParticipantCohort = ParticipantCohort.COHORT_3,
+        has_uploaded_ehr_file: bool = False,
+        latest_ehr_upload_timestamp: datetime = None,
+        basics_authored: datetime = None,
+        overallhealth_authored: datetime = None,
+        lifestyle_authored: datetime = None,
+        healthcare_authored: datetime = None,
+        family_health_authored: datetime = None,
+        medical_history_authored: datetime = None,
+        fam_med_history_authored: datetime = None,
+        sdoh_authored: datetime = None,
+        latest_cope_authored: datetime = None,
+        remote_pm_authored: datetime = None,
+        life_func_authored: datetime = None,
+        reconsent_authored: datetime = None,
+        gror_authored: datetime = None
+    ) -> RetentionEligibilityDependencies:
+        default_data = RetentionEligibilityDependencies(
+            primary_consent=Consent(
+                is_consent_provided=True,
+                authored_timestamp=primary_consent_authored
+            ),
+            first_ehr_consent=None,
+            is_deceased=is_deceased,
+            is_withdrawn=is_withdrawn,
+            dna_samples_timestamp=dna_samples_timestamp,
+            consent_cohort=cohort,
+            has_uploaded_ehr_file=has_uploaded_ehr_file,
+            latest_ehr_upload_timestamp=latest_ehr_upload_timestamp,
+            basics_response_timestamp=basics_authored,
+            overallhealth_response_timestamp=overallhealth_authored,
+            lifestyle_response_timestamp=lifestyle_authored,
+            healthcare_access_response_timestamp=healthcare_authored,
+            family_health_response_timestamp=family_health_authored,
+            medical_history_response_timestamp=medical_history_authored,
+            fam_med_history_response_timestamp=fam_med_history_authored,
+            sdoh_response_timestamp=sdoh_authored,
+            latest_cope_response_timestamp=latest_cope_authored,
+            remote_pm_response_timestamp=remote_pm_authored,
+            life_func_response_timestamp=life_func_authored,
+            reconsent_response_timestamp=reconsent_authored,
+            gror_response_timestamp=gror_authored
+        )
+        if first_ehr_authored is not None:
+            default_data.first_ehr_consent = Consent(
+                is_consent_provided=True,
+                authored_timestamp=first_ehr_authored
+            )
+
+        return default_data


### PR DESCRIPTION
## Partially Resolves *[DA-3508](https://precisionmedicineinitiative.atlassian.net/browse/DA-3508)*
RDR is going to be calculating the retention eligibility and statuses (active and/or passive) again. This sets up a class for performing that calculation. Another PR for this ticket will integrate the calculation code and store the results in the database.

## Tests
- [x] unit tests




[DA-3508]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ