### PR TITLE
Gracefully skipping NotImplemented consent validation errors

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -529,9 +529,15 @@ class ConsentValidationController:
         for consent_response in consent_responses:
             get_validation_results_func = validation_method_map[consent_response.type]
             expected_signing_date = consent_response.expected_authored_date or consent_response.response.authored
-            validation_results = self._process_validation_results(
-                get_validation_results_func(expected_signing_date=expected_signing_date)
-            )
+
+            try:
+                validation_results = self._process_validation_results(
+                    get_validation_results_func(expected_signing_date=expected_signing_date)
+                )
+            except NotImplementedError:
+                logging.error(f'Unable to validate {consent_response.type} consent for P{summary.participantId}')
+                continue
+
             for result in validation_results:
                 result.consent_response = consent_response
             output_strategy.add_all(validation_results)


### PR DESCRIPTION
## Resolves *no ticket*
Vibrent recently released WEAR consents and RDR code isn't ready yet to validate them. This is causing an issue with the rest of the validation workflow. This puts in a check to skip over WEAR consents when we get the NotImplemented error while trying to load Vibrent WEAR PDFs


## Tests
- [ ] unit tests


