### PR TITLE
[DA-3543] Cron job to check for missing/unacknowledged DNA samples

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -124,3 +124,8 @@ cron:
   target: offline
   timezone: America/New_York
   url: /offline/NphBiobankInventoryFileImport
+- description: Weekly Biobank missing sample check
+  url: /offline/BiobankMissingSamplesCheck
+  schedule: every Monday 09:00
+  timezone: America/New_York
+  target: offline

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -17,9 +17,10 @@ from rdr_service import config
 from rdr_service.api_util import list_blobs
 from rdr_service.code_constants import PPI_SYSTEM, RACE_AIAN_CODE, RACE_QUESTION_CODE, WITHDRAWAL_CEREMONY_YES,\
     WITHDRAWAL_CEREMONY_NO, WITHDRAWAL_CEREMONY_QUESTION_CODE
-from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN,\
-    BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN
+from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN, \
+    BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN, RDR_SLACK_WEBHOOKS
 from rdr_service.dao.code_dao import CodeDao
+from rdr_service.dao.biobank_order_dao import BiobankOrderDao
 from rdr_service.dao.database_utils import MYSQL_ISO_DATE_FORMAT, parse_datetime, replace_isodate
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import Code
@@ -34,6 +35,7 @@ from rdr_service.model.site import Site
 from rdr_service.offline.bigquery_sync import dispatch_participant_rebuild_tasks
 from rdr_service.offline.sql_exporter import SqlExporter
 from rdr_service.participant_enums import BiobankOrderStatus, OrganizationType, WithdrawalStatus
+from rdr_service.services.slack_utils import SlackMessageHandler
 
 # Format for dates in output filenames for the reconciliation report.
 _FILENAME_DATE_FORMAT = "%Y-%m-%d"
@@ -796,3 +798,52 @@ def in_past_n_days(result, now, n_days, ordered_before=None):
     if max_time:
         return (now - max_time).days <= n_days
     return False
+
+
+# DA-3543: Ordered DNA samples where order was finalized at least a week ago, but haven't been acknowledged by biobank
+# Intended for weekly check/alerts. Orders from more than 30 days ago will not be included in the alerts
+MISSING_STORED_SAMPLES_SQL = f"""
+                select p.participant_id, p.biobank_id, bo.biobank_order_id, bos.finalized,
+                     GROUP_CONCAT(bos.test) as missing_samples
+                from biobank_order bo
+                join participant p on bo.participant_id = p.participant_id
+                join biobank_ordered_sample bos on bo.biobank_order_id = bos.order_id
+                left join biobank_stored_sample bss on p.biobank_id = bss.biobank_id
+                     and bss.test = bos.test
+                     and bss.biobank_order_identifier IN (
+                           select `value` from biobank_order_identifier where biobank_order_id = bo.biobank_order_id
+                    )
+                where bo.order_status != :cancelled
+                      and bos.finalized is not null
+                      and DATE(bos.finalized)
+                           BETWEEN DATE(DATE_SUB(now(), INTERVAL 30 DAY)) AND DATE(DATE_SUB(now(), INTERVAL 7 DAY))
+                      and bo.order_origin IN :origin_filters
+                      and bos.test IN :dna_tests
+                      and bss.biobank_stored_sample_id is null
+                group by p.participant_id, p.biobank_id, bo.biobank_order_id, bos.finalized
+
+        """
+def missing_samples_check():
+    dna_tests = config.getSettingList(config.DNA_SAMPLE_TEST_CODES)
+    slack_config = config.getSettingJson(RDR_SLACK_WEBHOOKS, {})
+    webhook_url = slack_config.get('rdr_biobank_missing_samples_webhook', None)
+    # May expand what types of orders we monitor in the future, so use a list for WHERE IN clause
+    origin_filters = ['hpro']
+    dao = BiobankOrderDao()
+    with dao.session() as session:
+        results = session.execute(
+            MISSING_STORED_SAMPLES_SQL,
+            {"cancelled": int(BiobankOrderStatus.CANCELLED), "dna_tests": dna_tests, "origin_filters": origin_filters}
+        )
+
+        if results.rowcount > 0:
+            alert_msg = 'DNA samples ordered at least a week ago but still not reported by biobank:\n'
+            for rec in results:
+                alert_msg += f'Biobank ID: A{rec.biobank_id}, order: {rec.biobank_order_id}, ' + \
+                             f'finalized: {rec.finalized}, missing ordered DNA samples: {rec.missing_samples}\n'
+            # Send Slack notification if slack webhook configured, and log error as backup indication
+            if webhook_url:
+                slack_handler = SlackMessageHandler(webhook_url=webhook_url)
+                slack_handler.send_message_to_webhook(message_data={'text': alert_msg})
+
+            logging.error(alert_msg)

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -802,7 +802,7 @@ def in_past_n_days(result, now, n_days, ordered_before=None):
 
 # DA-3543: Ordered DNA samples where order was finalized at least a week ago, but haven't been acknowledged by biobank
 # Intended for weekly check/alerts. Orders from more than 30 days ago will not be included in the alerts
-MISSING_STORED_SAMPLES_SQL = f"""
+MISSING_STORED_SAMPLES_SQL = """
                 select p.participant_id, p.biobank_id, bo.biobank_order_id, bos.finalized,
                      GROUP_CONCAT(bos.test) as missing_samples
                 from biobank_order bo

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -147,6 +147,11 @@ def biobank_monthly_reconciliation_report():
     logging.info("Generated monthly reconciliation report.")
     return json.dumps({"monthly-reconciliation-report": "generated"})
 
+@app_util.auth_required_cron
+def biobank_missing_samples_check():
+    biobank_samples_pipeline.missing_samples_check()
+    return '{"success": "true"}'
+
 
 @app_util.auth_required_cron
 @_alert_on_exceptions
@@ -899,6 +904,13 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "MonthlyReconciliationReport",
         endpoint="monthlyReconciliationReport",
         view_func=biobank_monthly_reconciliation_report,
+        methods=["GET"],
+    )
+
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "BiobankMissingSamplesCheck",
+        endpoint="biobankMissingSamplesCheck",
+        view_func=biobank_missing_samples_check,
         methods=["GET"],
     )
 

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -578,7 +578,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             status=SampleStatus.RECEIVED
         )
         # Expect notification that the DNA sample is overdue/missing
-        expected_notification_substrings = [
+        expected_msg_substrings = [
             f'Biobank ID: A{participant.biobankId}, order: {order.biobankOrderId}, ',
             f'finalized: {dna_ordered_sample.finalized}, missing ordered DNA samples: {dna_ordered_sample.test}'
         ]
@@ -589,7 +589,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             slack_webhook_args = mock_slack.call_args
             self.assertIsNotNone(error_log_call, 'An error log should have been made')
             self.assertIsNotNone(slack_webhook_args, 'A slack notification should have been made')
-            for msg_str in expected_notification_substrings:
+            for msg_str in expected_msg_substrings:
                 self.assertIn(msg_str, error_log_call.args[0])
                 self.assertIn(msg_str, slack_webhook_args.kwargs['message_data']['text'])
 

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -75,3 +75,8 @@ class OfflineAppTest(BaseTestCase):
         self.send_cron_request('GenomicAW3ArrayWorkflow')
         pipeline_mock.aw3_array_manifest_workflow.assert_called()
 
+    @mock.patch('rdr_service.offline.main.biobank_samples_pipeline.missing_samples_check')
+    def test_biobank_missing_samples_check_route(self, mock_checker):
+        self.send_cron_request(f'BiobankMissingSamplesCheck')
+        mock_checker.assert_called()
+

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -77,6 +77,5 @@ class OfflineAppTest(BaseTestCase):
 
     @mock.patch('rdr_service.offline.main.biobank_samples_pipeline.missing_samples_check')
     def test_biobank_missing_samples_check_route(self, mock_checker):
-        self.send_cron_request(f'BiobankMissingSamplesCheck')
+        self.send_cron_request('BiobankMissingSamplesCheck')
         mock_checker.assert_called()
-


### PR DESCRIPTION
## Resolves *[DA-3543](https://precisionmedicineinitiative.atlassian.net/browse/DA-3543)*


## Description of changes/additions
Adds a cron job (production only) to alert if ordered DNA samples have not been acknowledged / had a `biobank_stored_sample` record created within a week since the order was finalized.   Will only look at orders finalized within the last month; does not continue to generate weekly alerts for older orders/missing samples.

Final determination of what internal/RDR-only slack channel to use for the slack alerts is still TBD, so the final step will be to make any slack changes and update the production configuration to add a `rdr_biobank_missing_samples_webhook` key/value to enable slack notifications.


## Tests
- [x] unit tests




[DA-3543]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ