### PR TITLE
[DA-3566] Populate Death Table from HealthPro Deceased Data

### DIFF
--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -125,10 +125,9 @@ class Death(CdmBase):
     death_date = Column(Date)
     death_datetime = Column(DateTime)
     death_type_concept_id = Column(BigInteger, )
-    cause_concept_id = Column(BigInteger, nullable=False)
+    cause_concept_id = Column(BigInteger, nullable=True)
     cause_source_value = Column(String(50))
-    cause_source_concept_id = Column(BigInteger, nullable=False)
-    unit_id = Column(String(50), nullable=False)
+    cause_source_concept_id = Column(BigInteger, nullable=True)
     src_id = Column(String(50))
 
 

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -707,11 +707,11 @@ class CurationExportClass(ToolBase):
         # Populates death table from deceased_report
         self._set_rdr_model_schema([DeceasedReport])
         column_map = {
-            Death.id: literal("0"),
+            Death.id: literal("0"),  # Auto-increment column, database will use next sequence number
             Death.person_id: DeceasedReport.participantId,
             Death.death_date: DeceasedReport.dateOfDeath,
             Death.death_datetime: DeceasedReport.dateOfDeath.label('date_of_death_datetime'),
-            Death.death_type_concept_id: literal("32809"),
+            Death.death_type_concept_id: literal("32809"),  # 32809 is the Case Report Form concept id
             Death.cause_concept_id: literal(None),
             Death.cause_source_value: literal(None),
             Death.cause_source_concept_id: literal(None),
@@ -720,8 +720,8 @@ class CurationExportClass(ToolBase):
         deceased_select = session.query(*column_map.values()).select_from(
             DeceasedReport
         ).join(
-         Person,
-         DeceasedReport.participantId == Person.person_id
+            Person,
+            DeceasedReport.participantId == Person.person_id
         ).filter(
             DeceasedReport.status == DeceasedReportStatus.APPROVED
         )

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 import pytz
 import sqlalchemy.orm.session
-from sqlalchemy import and_, case, insert, or_, text, not_
+from sqlalchemy import and_, case, insert, or_, text, not_, literal
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import literal_column
@@ -34,8 +34,9 @@ from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireH
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer, \
     QuestionnaireResponseClassificationType
 from rdr_service.model.curation_etl import CdrExcludedCode
+from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.participant_enums import QuestionnaireResponseStatus, WithdrawalStatus, CdrEtlCodeType,\
-    QuestionnaireStatus
+    QuestionnaireStatus, DeceasedReportStatus
 from rdr_service.services.gcp_utils import gcp_sql_export_csv
 from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
 from rdr_service.dao.curation_etl_dao import CdrEtlRunHistoryDao, CdrEtlSurveyHistoryDao, CdrExcludedCodeDao
@@ -700,6 +701,30 @@ class CurationExportClass(ToolBase):
         result = query.order_by(Participant.participantId).all()
         self.pid_list = [pid[0] for pid in result]
 
+    def _populate_death_table(self, session: sqlalchemy.orm.session):
+        # Populates death table from deceased_report
+        self._set_rdr_model_schema([DeceasedReport])
+        column_map = {
+            Death.id: literal("0"),
+            Death.person_id: DeceasedReport.participantId,
+            Death.death_date: DeceasedReport.dateOfDeath,
+            Death.death_datetime: DeceasedReport.dateOfDeath.label('date_of_death_datetime'),
+            Death.death_type_concept_id: literal("32809"),
+            Death.cause_concept_id: literal(None),
+            Death.cause_source_value: literal(None),
+            Death.cause_source_concept_id: literal(None),
+            Death.src_id: literal("healthpro")
+        }
+        deceased_select = session.query(*column_map.values()).select_from(
+            DeceasedReport
+        ).join(
+         Person,
+         DeceasedReport.participantId == Person.person_id
+        ).filter(
+            DeceasedReport.status == DeceasedReportStatus.APPROVED
+        )
+        insert_query = insert(Death).from_select(column_map.keys(), deceased_select)
+        session.execute(insert_query)
 
     def populate_cdm_database(self):
         """ Generates the src_clean table which is used to populate the rest of the ETL tables """
@@ -806,6 +831,7 @@ class CurationExportClass(ToolBase):
                 _logger.debug("Populating observation survey data")
                 self.run_function_on_pids(self._populate_observation_surveys, session, "observation survey data")
                 self._populate_questionnaire_response_additional_info(session)
+            self._populate_death_table(session)
             _logger.debug("Finalizing ETL")
             self._finalize_cdm(session)
 
@@ -1198,7 +1224,6 @@ class CurationExportClass(ToolBase):
                                 ALTER TABLE cdm.condition_era DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.condition_occurrence DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.cost DROP COLUMN unit_id, DROP COLUMN id;
-                                ALTER TABLE cdm.death DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.device_exposure DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.dose_era DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.drug_era DROP COLUMN unit_id, DROP COLUMN id;
@@ -1215,6 +1240,7 @@ class CurationExportClass(ToolBase):
                                 ALTER TABLE cdm.provider DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.visit_occurrence DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.metadata DROP COLUMN id;
+                                ALTER TABLE cdm.death DROP COLUMN id;
                                         """)
 
     @staticmethod

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -4,15 +4,17 @@ import json
 
 from rdr_service.code_constants import CONSENT_FOR_STUDY_ENROLLMENT_MODULE, EMPLOYMENT_ZIPCODE_QUESTION_CODE, PMI_SKIP_CODE,\
     STREET_ADDRESS_QUESTION_CODE, STREET_ADDRESS2_QUESTION_CODE, ZIPCODE_QUESTION_CODE, DATE_OF_BIRTH_QUESTION_CODE
-from rdr_service.etl.model.src_clean import SrcClean, Observation, PidRidMapping, Person, Measurement
+from rdr_service.etl.model.src_clean import SrcClean, Observation, PidRidMapping, Person, Measurement, Death
 from rdr_service.model.code import Code
 from rdr_service.model.measurements import PhysicalMeasurements
 from rdr_service.model.measurements import Measurement as RdrMeasurement
 from rdr_service.model.participant import Participant
+from rdr_service.model.deceased_report import DeceasedReport
+from rdr_service.model.api_user import ApiUser
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.dao.curation_etl_dao import CdrEtlRunHistoryDao, CdrEtlSurveyHistoryDao
 from rdr_service.participant_enums import QuestionnaireResponseStatus, QuestionnaireResponseClassificationType, \
-    PhysicalMeasurementsCollectType, OriginMeasurementUnit
+    PhysicalMeasurementsCollectType, OriginMeasurementUnit, DeceasedNotification, DeceasedReportStatus
 from rdr_service.tools.tool_libs.curation import CurationExportClass
 from tests.helpers.unittest_base import BaseTestCase
 from tests.helpers.tool_test_mixin import ToolTestMixin
@@ -104,6 +106,7 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
         ).distinct().scalar()
         return bool(value_exists
                     )
+
     @staticmethod
     def run_cdm_data_generation(cutoff=None, vocabulary='gs://curation-vocabulary/aou_vocab_20220201/',
                                 participant_origin='all', participant_list_file=None, include_surveys=None,
@@ -1010,3 +1013,76 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
         ).first()[0]
 
         self.assertEqual('hpro', meas_src_id)
+
+    def test_death_table(self):
+        # Create API User for DeceasedReport
+        api_user = ApiUser(id=1, username='test', system='test')
+        self.session.add(api_user)
+
+        pids = list(range(10000, 10010))
+        consent_questionnaire = self._create_consent_questionnaire()
+        for pid in pids:
+            participant = self.data_generator.create_database_participant(participantId=pid)
+            self.data_generator.create_database_participant_summary(
+                participant=participant,
+                dateOfBirth=datetime(1982, 1, 9),
+                consentForStudyEnrollmentFirstYesAuthored=datetime(2000, 1, 10)
+            )
+            self._setup_questionnaire_response(
+                participant,
+                consent_questionnaire,
+                indexed_answers=[
+                    (6, 'valueDate', datetime(1982, 1, 9))
+                    # Assuming the 6th question is the date of birth
+                ],
+                authored=datetime(2020, 5, 1)
+            )
+
+        # Only approved deceased reports should be in Death
+        deceased_reports = [
+            DeceasedReport(
+                participantId=pids[0],
+                dateOfDeath=date(2023, 2, 1),
+                status=DeceasedReportStatus.APPROVED,
+                notification=DeceasedNotification.EHR,
+                authorId=1,
+                authored=datetime(2023, 3, 1)
+            ),
+            DeceasedReport(
+                participantId=pids[1],
+                dateOfDeath=date(2023, 2, 1),
+                status=DeceasedReportStatus.PENDING,
+                notification=DeceasedNotification.EHR,
+                authorId=1,
+                authored=datetime(2023, 3, 1)
+            ),
+            DeceasedReport(
+                participantId=pids[2],
+                dateOfDeath=date(2023, 2, 1),
+                status=DeceasedReportStatus.DENIED,
+                notification=DeceasedNotification.EHR,
+                authorId=1,
+                authored=datetime(2023, 3, 1)
+            )
+        ]
+
+        for deceased_report in deceased_reports:
+            self.session.add(deceased_report)
+        self.session.commit()
+
+        self.run_cdm_data_generation(
+            participant_origin='all',
+        )
+
+        def _exists_in_death_table(participant_id: int) -> bool:
+            return bool(self.session.query(
+                Death.person_id
+            ).filter(
+                Death.person_id == participant_id
+            ).distinct().scalar())
+
+        self.assertTrue(_exists_in_death_table(pids[0]))
+        self.assertFalse(_exists_in_death_table(pids[1]))
+        self.assertFalse(_exists_in_death_table(pids[2]))
+
+

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -1155,7 +1155,6 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
         self.assertNotIn(remote_height, measurements)
         self.assertNotIn(remote_weight, measurements)
 
-
     def test_death_table(self):
         # Create API User for DeceasedReport
         api_user = ApiUser(id=1, username='test', system='test')
@@ -1226,5 +1225,3 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
         self.assertTrue(_exists_in_death_table(pids[0]))
         self.assertFalse(_exists_in_death_table(pids[1]))
         self.assertFalse(_exists_in_death_table(pids[2]))
-
-


### PR DESCRIPTION
## Resolves *[DA-3566](https://precisionmedicineinitiative.atlassian.net/browse/DA-3566)*


## Description of changes/additions

For CDR v8 deceased data captured in HealthPro needs to be sent through the ETL for CDR use in the research workbench.

Updates the ETL process to populate the cdm.death table from approved rdr.deceased_report records.

## Tests
- [x] unit tests




[DA-3566]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ