### PR TITLE
[PDR-1827] Missing authored dates in lower environments

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1895,7 +1895,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                    result.sync_status in (int(ConsentSyncStatus.NEEDS_CORRECTING), int(ConsentSyncStatus.OBSOLETE))):
                 status = BQModuleStatusEnum.SUBMITTED_INVALID
 
-        elif consent_authored > pdf_validation_start_date:
+        elif consent_authored and consent_authored > pdf_validation_start_date:
             # No consent_file (consent_response) record yet to match to the questionnaire_response_id
             status = BQModuleStatusEnum.SUBMITTED_NOT_VALIDATED
 


### PR DESCRIPTION
## Resolves *[PDR-1827](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1827)*


## Description of changes/additions
Recent PDR generator changes to verify EHR consent validation status assumes `questionnaire_response` records always have a populated `authored` value.  Wasn't true in RDR stable data and it caused some exceptions to be thrown for some PDR rebuild operations in stable.

Production data does not have any missing `authored` values, so this should not be causing any issues with production data.

## Tests
- [x] unit tests




[PDR-1827]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ