### PR TITLE
[PDR-1795] Fixes to legacy PDR enrollment status calculator

### DIFF
--- a/rdr_service/resource/calculators/participant_enrollment_status.py
+++ b/rdr_service/resource/calculators/participant_enrollment_status.py
@@ -3,7 +3,7 @@
 # file 'LICENSE', which is part of this source code package.
 #
 import datetime
-
+#pylint: disable=unused-import
 from rdr_service.code_constants import (
     CONSENT_PERMISSION_YES_CODE,
     CONSENT_PERMISSION_NO_CODE,
@@ -232,11 +232,13 @@ class EnrollmentStatusCalculator:
             if self._ehr_event_found is True and ev.event == ParticipantEventEnum.DVEHRSharing:
                 continue
             if ev.event in [ParticipantEventEnum.EHRConsentPII, ParticipantEventEnum.DVEHRSharing]:
+                # PDR-1795: RDR was updated to not downgrade on revocation/expiration of EHR consent.  Removing to match
                 # See if we need to reset the info object. Do not reset if 'DVEHRSHARING_CONSENT_CODE_NOT_SURE'.
-                if ev.answer in [CONSENT_PERMISSION_NO_CODE, DVEHRSHARING_CONSENT_CODE_NO, EHR_CONSENT_EXPIRED_YES]:
-                    self._ehr_consented = None  # Reset any saved info.
-                    info = EnrollmentStatusInfo()
-                    continue
+                # if (ev.answer in [CONSENT_PERMISSION_NO_CODE, DVEHRSHARING_CONSENT_CODE_NO, EHR_CONSENT_EXPIRED_YES]):
+                #    self._ehr_consented = None  # Reset any saved info.
+                #    info = EnrollmentStatusInfo()
+                #   continue
+
                 # See if we should set the consent info.
                 if info.calculated is False and \
                         ev.answer in [CONSENT_PERMISSION_YES_CODE, DVEHRSHARING_CONSENT_CODE_YES]:

--- a/rdr_service/tools/tool_libs/thebasics_analyzer.py
+++ b/rdr_service/tools/tool_libs/thebasics_analyzer.py
@@ -492,6 +492,8 @@ class TheBasicsAnalyzerClass(object):
 
                     if responses:
                         self.process_participant_responses(pid, responses, session)
+                    else:
+                        _logger.info(f'No TheBasics questionnaire_response records found for participant {pid}')
 
                     processed_pid_count += 1
                     if not self.args.verbose:

--- a/tests/dao_tests/test_bigquery_sync_dao.py
+++ b/tests/dao_tests/test_bigquery_sync_dao.py
@@ -302,8 +302,8 @@ class BigQuerySyncDaoTest(BaseTestCase, PDRGeneratorTestMixin):
         self._submit_ehrconsent_expired(p_id, response_time=self.TIME_2)
         ps_json = self.make_bq_participant_summary(p_id)
         self.assertIsNotNone(ps_json)
-        # downgrade FULLY_CONSENTED to PARTICIPANT
-        self.assertEqual(ps_json['enrollment_status'], 'PARTICIPANT')
+        # PDR-1795:  Need to match RDR and not downgrade.  FULLY_CONSENTED means "ever consented to EHR"
+        self.assertEqual(ps_json['enrollment_status'], 'FULLY_CONSENTED')
 
     def test_ehr_consent_expired_for_core_participant(self):
         self._set_up_participant_data(fake_time=self.TIME_1)


### PR DESCRIPTION
## Resolves *[PDR-1795](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1795)*


## Description of changes/additions
During a PDR investigation involving differences between the legacy enrollment status PDR and RDR calculations, several issues with the legacy PDR calculations were discovered:

1.  Some recently added EHR validation checks were returning SUBMITTED_NOT_VALIDATED incorrectly.  PDR filters out DUPLICATE questionnaire_responses,  but a DUPLICATE `questionnaire_response_id` can still be referenced in the `consent_file` / `consent_response` validation results.  Updating the generator to account for including DUPLICATE `questionnaire_response_id` values when querying for validation results.
2. PDR was using `confirmed` timestamps for biobank samples that were not DNA samples (but were part of the same order).  Revised logic to include check of test type.  This affects/resolves many mismatches between PDR calculator `enrl_core_participant_time` and RDR `enrollment_status_core_stored` timestamps.
3.  RDR has stopped downgrading from FULLY_CONSENTED (MEMBER) if an EHR consent is revoked or expired, but PDR would still prevent elevation to FULLY_CONSENTED (or above).  Updated PDR calculation to match RDR.  

## Tests
Generated a list of mismatched enrollment statuses from PDR with this query and ran hundreds of examples through the RDR `resource participant` tool with `--qc` option.  That acts as a dry run to be able to compare the PDR vs. RDR calculated values.
```
select participant_id from drc.pdr.mv_participant_all
where (enrollment_status_legacy_v2 != enrollment_status)
;
```





[PDR-1795]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ