### PR TITLE
[DA-3571] WEAR Consent Supplemental Table for Curation

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -187,6 +187,7 @@ COPE_FEB_MODULE = "cope_feb"
 GENETIC_ANCESTRY_MODULE = 'GeneticAncestry'
 LIFE_FUNCTIONING_SURVEY = 'lfs'
 PRIMARY_CONSENT_UPDATE_MODULE = 'PrimaryConsentUpdate'
+WEAR_CONSENT_MODULE = 'wear_consent'
 
 VA_EHR_RECONSENT = 'vaehrreconsent'
 

--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -729,3 +729,12 @@ class QuestionnaireResponseAdditionalInfo(CdmBase):
     type = Column(String(255))
     value = Column(String(255))
     src_id = Column(String(50))
+
+class WearConsent(CdmBase):
+    __tablename__ = "wear_consent"
+    id = Column(BigInteger, primary_key=True)
+    person_id = Column(BigInteger)
+    research_id = Column(BigInteger)
+    authored = Column(DateTime)
+    consent_status = Column(String(50))
+    src_id = Column(String(50))

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -17,7 +17,8 @@ from typing import Type, List, Callable, Union
 from rdr_service import config
 from rdr_service import api_util
 from rdr_service.code_constants import PPI_SYSTEM, CONSENT_FOR_STUDY_ENROLLMENT_MODULE, PMI_SKIP_CODE, \
-    EMPLOYMENT_ZIPCODE_QUESTION_CODE, STREET_ADDRESS_QUESTION_CODE, STREET_ADDRESS2_QUESTION_CODE, ZIPCODE_QUESTION_CODE
+    EMPLOYMENT_ZIPCODE_QUESTION_CODE, STREET_ADDRESS_QUESTION_CODE, STREET_ADDRESS2_QUESTION_CODE, \
+    ZIPCODE_QUESTION_CODE, WEAR_CONSENT_QUESTION_CODE, WEAR_CONSENT_MODULE
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.etl.model.src_clean import QuestionnaireAnswersByModule, SrcClean, Location, CareSite, Provider, \
     Person, Death, ObservationPeriod, PayerPlanPeriod, VisitOccurrence, ConditionOccurrence, ProcedureOccurrence, \
@@ -25,12 +26,13 @@ from rdr_service.etl.model.src_clean import QuestionnaireAnswersByModule, SrcCle
     DoseEra, Metadata, NoteNlp, VisitDetail, SrcParticipant, SrcMapped, SrcPersonLocation, SrcGender, SrcRace, \
     SrcEthnicity, SrcMeas, MeasurementCodeMap, MeasurementValueCodeMap, SrcMeasMapped, SrcVisits, TempObsTarget, \
     TempObsEndUnion, TempObsEndUnionPart, TempObsEnd, TempObs, TempFactRelSd, PidRidMapping, \
-    QuestionnaireResponseAdditionalInfo
+    QuestionnaireResponseAdditionalInfo, WearConsent
 from rdr_service.model.code import Code
 from rdr_service.model.hpo import HPO
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
-from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory, QuestionnaireQuestion
+from rdr_service.model.questionnaire import QuestionnaireConcept, QuestionnaireHistory, QuestionnaireQuestion, \
+    Questionnaire
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer, \
     QuestionnaireResponseClassificationType
 from rdr_service.model.curation_etl import CdrExcludedCode
@@ -64,7 +66,7 @@ class CurationExportClass(ToolBase):
               'device_exposure', 'dose_era', 'drug_era', 'drug_exposure', 'fact_relationship',
               'location', 'measurement', 'observation_period', 'payer_plan_period', 'visit_detail',
               'person', 'procedure_occurrence', 'provider', 'visit_occurrence', 'metadata', 'note_nlp',
-              'questionnaire_response_additional_info']
+              'questionnaire_response_additional_info', 'wear_consent']
 
     # Observation takes a while and ends up timing the client out. The server will continue to process and the client
     # will print out a message describing how to continue to track it, but for now it crashes the script so it has
@@ -728,6 +730,67 @@ class CurationExportClass(ToolBase):
         insert_query = insert(Death).from_select(column_map.keys(), deceased_select)
         session.execute(insert_query)
 
+    def _populate_wear_consent(self, session):
+        self._set_rdr_model_schema([Participant, Code, Questionnaire, QuestionnaireResponse,
+                                    QuestionnaireResponseAnswer, QuestionnaireQuestion,
+                                    QuestionnaireConcept])
+        question_code = aliased(Code)
+        answer_code = aliased(Code)
+        column_map = {
+            WearConsent.person_id: Participant.participantId,
+            WearConsent.research_id: Participant.researchId,
+            WearConsent.authored: QuestionnaireResponse.authored,
+            WearConsent.consent_status: answer_code.value,
+            WearConsent.src_id: Participant.participantOrigin
+        }
+
+        wear_consent_select = session.query(
+            *column_map.values()
+        ).select_from(
+            Participant
+        ).join(
+            QuestionnaireResponse,
+            QuestionnaireResponse.participantId == Participant.participantId
+        ).join(
+            QuestionnaireResponseAnswer,
+            QuestionnaireResponseAnswer.questionnaireResponseId == QuestionnaireResponse.questionnaireResponseId
+        ).join(
+            QuestionnaireQuestion,
+            QuestionnaireResponseAnswer.questionId == QuestionnaireQuestion.questionnaireQuestionId
+        ).join(
+            question_code,
+            QuestionnaireQuestion.codeId == question_code.codeId
+        ).outerjoin(
+            answer_code,
+            QuestionnaireResponseAnswer.valueCodeId == answer_code.codeId
+        ).join(
+            Questionnaire,
+            QuestionnaireResponse.questionnaireId == Questionnaire.questionnaireId
+        ).join(
+            QuestionnaireConcept,
+            and_(Questionnaire.questionnaireId == QuestionnaireConcept.questionnaireId,
+            Questionnaire.version == QuestionnaireConcept.questionnaireVersion)
+        ).join(
+            Code,
+            QuestionnaireConcept.codeId == Code.codeId
+        ).filter(
+            answer_code.value is not None,
+            Code.value == WEAR_CONSENT_MODULE,
+            question_code.value == WEAR_CONSENT_QUESTION_CODE,
+            Participant.participantId.in_(self.pid_list)
+        ).order_by(
+            Participant.participantId,
+            QuestionnaireResponse.authored
+        )
+
+        if self.cutoff_date:
+            wear_consent_select = wear_consent_select.filter(
+                QuestionnaireResponse.authored < self.cutoff_date
+            )
+
+        insert_query = insert(WearConsent).from_select(column_map.keys(), wear_consent_select)
+        session.execute(insert_query)
+
     def populate_cdm_database(self):
         """ Generates the src_clean table which is used to populate the rest of the ETL tables """
         surveys_file_name = None
@@ -847,6 +910,7 @@ class CurationExportClass(ToolBase):
                 self.run_function_on_pids(self._populate_observation_surveys, session, "observation survey data")
                 self._populate_questionnaire_response_additional_info(session)
             self._populate_death_table(session)
+            self._populate_wear_consent(session)
             _logger.debug("Finalizing ETL")
             self._finalize_cdm(session)
 
@@ -960,7 +1024,8 @@ class CurationExportClass(ToolBase):
                 TempObs,
                 TempFactRelSd,
                 PidRidMapping,
-                QuestionnaireResponseAdditionalInfo
+                QuestionnaireResponseAdditionalInfo,
+                WearConsent
             ])
 
     def _finalize_cdm(self, session, drop_tables: bool = False, drop_columns: bool = True):
@@ -1256,6 +1321,7 @@ class CurationExportClass(ToolBase):
                                 ALTER TABLE cdm.visit_occurrence DROP COLUMN unit_id, DROP COLUMN id;
                                 ALTER TABLE cdm.metadata DROP COLUMN id;
                                 ALTER TABLE cdm.death DROP COLUMN id;
+                                ALTER TABLE cdm.wear_consent DROP COLUMN id;
                                         """)
 
     @staticmethod

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -3,8 +3,10 @@ from typing import Collection, Any
 from decimal import Decimal
 
 from rdr_service.code_constants import CONSENT_FOR_STUDY_ENROLLMENT_MODULE, EMPLOYMENT_ZIPCODE_QUESTION_CODE, PMI_SKIP_CODE,\
-    STREET_ADDRESS_QUESTION_CODE, STREET_ADDRESS2_QUESTION_CODE, ZIPCODE_QUESTION_CODE, DATE_OF_BIRTH_QUESTION_CODE
-from rdr_service.etl.model.src_clean import SrcClean, Observation, PidRidMapping, Person, Measurement, Death
+    STREET_ADDRESS_QUESTION_CODE, STREET_ADDRESS2_QUESTION_CODE, ZIPCODE_QUESTION_CODE, DATE_OF_BIRTH_QUESTION_CODE,\
+    WEAR_CONSENT_QUESTION_CODE, WEAR_YES_ANSWER_CODE, WEAR_CONSENT_MODULE
+from rdr_service.etl.model.src_clean import SrcClean, Observation, PidRidMapping, Person, Measurement, Death, \
+    WearConsent
 from rdr_service.model.code import Code
 from rdr_service.model.measurements import PhysicalMeasurements
 from rdr_service.model.measurements import Measurement as RdrMeasurement
@@ -23,6 +25,9 @@ from rdr_service.clock import FakeClock
 
 TIME = datetime(2000, 1, 10)
 TIME_2 = datetime(2022, 5, 10)
+
+
+WEAR_NO_ANSWER_CODE = "wear_no"
 
 
 class CurationEtlTest(ToolTestMixin, BaseTestCase):
@@ -812,12 +817,17 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
         self.assertIn('test-data/test_curation_participant_list.txt',
                       run_history.filterOptions['participant_list_file'])
 
-    def _create_questionnaire(self, survey_name):
+    def _create_questionnaire(self, survey_name, question_code_list=None):
         module_code = self.data_generator.create_database_code(value=survey_name)
         question_codes = [
             self.data_generator.create_database_code(value=f'{survey_name}_q_code_{question_index}')
             for question_index in range(4)
         ]
+
+        if question_code_list:
+            question_codes += self.session.query(Code).filter(Code.value.in_([
+                question_code_list
+            ])).all()
 
         questionnaire = self.data_generator.create_database_questionnaire_history()
         for question_code in question_codes:
@@ -1225,3 +1235,69 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
         self.assertTrue(_exists_in_death_table(pids[0]))
         self.assertFalse(_exists_in_death_table(pids[1]))
         self.assertFalse(_exists_in_death_table(pids[2]))
+
+    def test_wear_consent_table(self):
+        wear_yes_code = self.data_generator.create_database_code(value=WEAR_YES_ANSWER_CODE)
+        wear_no_code = self.data_generator.create_database_code(value=WEAR_NO_ANSWER_CODE)
+        self.data_generator.create_database_code(value=WEAR_CONSENT_QUESTION_CODE)
+
+        participant = self.data_generator.create_database_participant(participantOrigin='test_portal')
+        self.data_generator.create_database_participant_summary(
+            participant=participant,
+            dateOfBirth=datetime(1982, 1, 9),
+            consentForStudyEnrollmentFirstYesAuthored=datetime(2000, 1, 10)
+        )
+
+        wear_questionnaire = self._create_questionnaire(WEAR_CONSENT_MODULE, [WEAR_CONSENT_QUESTION_CODE])
+
+        self._setup_questionnaire_response(
+            participant,
+            wear_questionnaire,
+            indexed_answers=[
+                (4, 'valueCodeId', wear_yes_code.codeId)
+            ],
+            authored=datetime(2020, 5, 1)
+        )
+        self._setup_questionnaire_response(
+            participant,
+            wear_questionnaire,
+            indexed_answers=[
+                (4, 'valueCodeId', wear_no_code.codeId)
+            ],
+            authored=datetime(2020, 6, 1)
+        )
+        self._setup_questionnaire_response(
+            participant,
+            wear_questionnaire,
+            indexed_answers=[
+                (4, 'valueCodeId', wear_yes_code.codeId)
+            ],
+            authored=datetime(2020, 7, 1)
+        )
+        self._setup_questionnaire_response(
+            participant,
+            wear_questionnaire,
+            indexed_answers=[
+                (4, 'valueCodeId', wear_no_code.codeId)
+            ],
+            authored=datetime(2020, 8, 1)
+        )
+
+        self.run_cdm_data_generation(
+            participant_origin='all',
+            cutoff='2020-07-15'
+        )
+
+        wear_table = self.session.query(
+            WearConsent.person_id,
+            WearConsent.authored,
+            WearConsent.consent_status
+        ).all()
+
+        self.assertIn((participant.participantId, datetime(2020, 5, 1), WEAR_YES_ANSWER_CODE), wear_table)
+        self.assertIn((participant.participantId, datetime(2020, 6, 1), WEAR_NO_ANSWER_CODE), wear_table)
+        self.assertIn((participant.participantId, datetime(2020, 7, 1), WEAR_YES_ANSWER_CODE), wear_table)
+        # Wear consent after cutoff date shouldn't be present.
+        self.assertNotIn((participant.participantId, datetime(2020, 8, 1), WEAR_NO_ANSWER_CODE), wear_table)
+
+


### PR DESCRIPTION
## Resolves *[DA-3571](https://precisionmedicineinitiative.atlassian.net/browse/DA-3571)*


## Description of changes/additions

The WEAR consent form is not being sent through the ETL. Creates a supplemental table with WEAR consent statuses for participants in the ETL run.

## Tests
- [x] unit tests




[DA-3571]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ