### PR TITLE
[DA-3585] Allow unstored blank columns in sample list file

### DIFF
--- a/rdr_service/workflow_management/nph/sms_workflows.py
+++ b/rdr_service/workflow_management/nph/sms_workflows.py
@@ -76,8 +76,10 @@ class SmsWorkflow:
 
     def validate_columns(self, fieldnames, dao):
         """ Simple check for column names in the model """
+        unstored_columns = ['blank']
+        expected_columns = dao.model_type.__table__.columns.keys() + unstored_columns
         for column_name in fieldnames:
-            if column_name not in dao.model_type.__table__.columns.keys():
+            if column_name not in expected_columns:
                 raise AttributeError(f"{self.file_path}: {column_name} column mismatch for "
                                      f"expected file type: {self.file_type.name}")
 

--- a/tests/workflow_tests/test_data/test_sample_list.csv
+++ b/tests/workflow_tests/test_data/test_sample_list.csv
@@ -1,4 +1,4 @@
-sample_id,lims_sample_id,plate_number,position,labware_type,sample_identifier,diet,sex_at_birth,bmi,age,race,ethnicity,destination
-10001,5847307831,1,A1,Matrix96_Blue,C_S_5847307831_M1_L_TP1,LMT,Intersex,38,21,"Native Hawaiian or other Pacific Islander","Black, African American or African",UNC_META
-10002,6470739164,1,B1,Matrix96_Blue,C_S_6470739164_M1_L_TP3,LMT,Intersex,38,21,"American Indian or Alaska Native","African",UNC_META
-10003,7013747926,1,C1,Matrix96_Blue,C_S_7013747926_M1_L_TP4,LMT,Intersex,38,21,"Black, African American or African","Asian",UNC_META
+sample_id,lims_sample_id,plate_number,position,labware_type,blank,sample_identifier,diet,sex_at_birth,bmi,age,race,ethnicity,destination
+10001,5847307831,1,A1,Matrix96_Blue,"",C_S_5847307831_M1_L_TP1,LMT,Intersex,38,21,"Native Hawaiian or other Pacific Islander","Black, African American or African",UNC_META
+10002,6470739164,1,B1,Matrix96_Blue,"",C_S_6470739164_M1_L_TP3,LMT,Intersex,38,21,"American Indian or Alaska Native","African",UNC_META
+10003,7013747926,1,C1,Matrix96_Blue,"",C_S_7013747926_M1_L_TP4,LMT,Intersex,38,21,"Black, African American or African","Asian",UNC_META


### PR DESCRIPTION
## Resolves *[DA-3585](https://precisionmedicineinitiative.atlassian.net/browse/DA-3585)*


## Description of changes/additions
RTI is sending a new column in the sample list called `blank`. We don't want to store this, but want to allow it in the file.

## Tests
- [x] unit tests




[DA-3585]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ