### PR TITLE
[DA-3599] Adding less-than comparison for response validation

### DIFF
--- a/rdr_service/services/response_validation/validation.py
+++ b/rdr_service/services/response_validation/validation.py
@@ -115,6 +115,13 @@ class Question:
             answer_value=value
         )
 
+    def answer_less_than(self, value) -> Condition:
+        return _HasAnsweredQuestionWith(
+            question_code=self.question_code,
+            comparison=_Comparison.LESS_THAN,
+            answer_value=value
+        )
+
     def has_option_selected(self, option_value) -> Condition:
         return _HasSelectedOption(
             question_code=self.question_code,
@@ -127,6 +134,7 @@ class _Comparison(Enum):
 
     EQUALS = auto()
     GREATER_THAN = auto()
+    LESS_THAN = auto()
 
 
 class InAnySurvey(Condition):
@@ -270,10 +278,14 @@ class _HasAnsweredQuestionWith(Condition):
             self._passes = answer and answer.value == self.expected_answer_value
         elif self.comparison == _Comparison.GREATER_THAN:
             self._passes = answer and answer.value > self.expected_answer_value
+        elif self.comparison == _Comparison.LESS_THAN:
+            self._passes = answer and answer.value < self.expected_answer_value
 
     def __str__(self):
         if self.comparison == _Comparison.GREATER_THAN:
             return f"[{self.question_code}] > {self.expected_answer_value}"
+        elif self.comparison == _Comparison.LESS_THAN:
+            return f"[{self.question_code}] < {self.expected_answer_value}"
         else:
             return f"[{self.question_code}] = '{self.expected_answer_value}'"
 
@@ -439,7 +451,7 @@ class _ConstraintParser(_BaseParser):
     def _read_comparison(self, comparison_char):
         if comparison_char == '=':
             self._next_expected_chars = [' ', "'"]
-        elif comparison_char == '>':
+        elif comparison_char in ['<', '>']:
             self._next_expected_chars = [' ']
         else:
             raise Exception(f'unrecognized comparison char "{comparison_char}"')
@@ -469,6 +481,8 @@ class _ConstraintParser(_BaseParser):
 
         if self._comparison_operation == '>':
             condition = Question(question_code).answer_greater_than(answer_code)
+        elif self._comparison_operation == '<':
+            condition = Question(question_code).answer_less_than(answer_code)
         else:
             condition = Question(question_code).is_answered_with(answer_code)
 

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -242,6 +242,11 @@ class TestConditionalFromBranchingLogic(BaseTestCase):
         result = Condition.from_branching_logic(branching_logic)
         self.assertEqual(branching_logic, str(result))
 
+    def test_answer_less_than(self):
+        branching_logic = "[a] < 7"
+        result = Condition.from_branching_logic(branching_logic)
+        self.assertEqual(branching_logic, str(result))
+
     def test_number_comparison_with_quotes(self):
         branching_logic = "[a] > '7'"
         result = Condition.from_branching_logic(branching_logic)


### PR DESCRIPTION
## Resolves *[DA-3599](https://precisionmedicineinitiative.atlassian.net/browse/DA-3599)*
Somewhat recently, survey branching logic in redcap started including less-than comparisons. That wasn't in use when the validation code was originally written, so wasn't included as part of the implementation. This updates the code to be able to compare if an answer is less than a given value.


## Tests
- [x] unit tests




[DA-3599]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ