### PR TITLE
Temporarily skipping wear consent validations

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -59,7 +59,8 @@ class ConsentDao(BaseDao):
                     ConsentFile.participant_id == QuestionnaireResponse.participantId
                 )
             ).filter(
-                ConsentFile.id.is_(None)
+                ConsentFile.id.is_(None),
+                ConsentResponse.type.notin_([ConsentType.WEAR])  # TODO: remove this when WEAR file parsing is done
             ).options(
                 joinedload(ConsentResponse.response)
             )

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Collection, Dict, List, Optional
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, not_
 from sqlalchemy.orm import aliased, joinedload, Session
 
 from rdr_service.code_constants import PRIMARY_CONSENT_UPDATE_QUESTION_CODE
@@ -47,11 +47,10 @@ class ConsentDao(BaseDao):
         """
         consent_batch_limit = 500
 
-        # A ConsentResponse will need to be validated if there are not yet any ConsentFile objects
-        # that are of the same type and for the same participant.
         consent_responses = (
             session.query(ConsentResponse)
             .join(QuestionnaireResponse)
+            .join(Participant)
             .outerjoin(
                 ConsentFile,
                 and_(
@@ -60,11 +59,51 @@ class ConsentDao(BaseDao):
                 )
             ).filter(
                 ConsentFile.id.is_(None),
-                ConsentResponse.type.notin_([ConsentType.WEAR])  # TODO: remove this when WEAR file parsing is done
+
+                # TODO: remove this when WEAR file parsing is done
+                not_(
+                    and_(
+                        ConsentResponse.type.in_([ConsentType.WEAR]),
+                        Participant.participantOrigin == 'vibrent'
+                    )
+                )
             ).options(
                 joinedload(ConsentResponse.response)
             )
-        ).limit(consent_batch_limit).all()
+        ).order_by(QuestionnaireResponse.authored.desc()).limit(consent_batch_limit)
+        consent_responses = consent_responses.all()
+
+        # match_by_id_date = '2023-01-01'  # Arbitrary date after ConsentFiles began referencing ConsentResponses directly
+        # old_files = aliased(ConsentFile)
+        # new_files = aliased(ConsentFile)
+        # consent_responses = (
+        #     session.query(ConsentResponse)
+        #     .join(QuestionnaireResponse)
+        #     .outerjoin(
+        #         old_files,
+        #         and_(
+        #             QuestionnaireResponse.authored < match_by_id_date,
+        #             old_files.type == ConsentResponse.type,
+        #             old_files.participant_id == QuestionnaireResponse.participantId
+        #         )
+        #     ).outerjoin(
+        #         new_files,
+        #         and_(  # Get newer ConsentFiles specifically meant for the ConsentResponse (rather than by type)
+        #             QuestionnaireResponse.authored >= match_by_id_date,
+        #             new_files.consent_response_id == ConsentResponse.id
+        #         )
+        #     ).filter(
+        #         old_files.id.is_(None),
+        #         new_files.id.is_(None),
+        #         ConsentResponse.type.in_([ConsentType.EHR]),
+        #         QuestionnaireResponse.participantId.in_([
+        #             897357328
+        #         ])
+        #     ).options(
+        #         joinedload(ConsentResponse.response)
+        #     )
+        # ).limit(consent_batch_limit)
+        # consent_responses = consent_responses.all()
 
         grouped_results = defaultdict(list)
         for consent_response in consent_responses:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -231,6 +231,8 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
         )
 
     def _is_wear_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
+        # TODO: When implementing WEAR validation for Vibrent, remove the filter currently blocking
+        #  them from being checked (in ConsentDao.get_consent_responses_to_validate)
         raise NotImplementedError('Wear consent validation not implemented for Vibrent')
 
     def _is_etm_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:


### PR DESCRIPTION
## Resolves *no ticket*
RDR doesn't yet have an implementation for parsing the WEAR consent PDFs from Vibrent. The consent validation process loads consents that need to be checked in batches, and a previous quick fix was put in place to ignore WEAR consents when they came up. But the process relies on each batch to clear, and the results to not come up again when loading the next batch. Eventually there were only WEAR consents coming up in a batch and no other consents were being validated.

This filters Vibrent's WEAR consents out of the validation batches so that the other files can continue to be validated.

## Tests
- [x] unit tests


