### PR TITLE
Fix for finding consent data for retention calculation

### DIFF
--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -314,7 +314,10 @@ def _get_earliest_intent_for_ehr_datetime(session, participant_id) -> datetime:
     if not date_range_list:
         return None
 
-    return min(date_range.start for date_range in date_range_list)
+    return Consent(
+        is_consent_provided=True,
+        authored_timestamp=min(date_range.start for date_range in date_range_list)
+    )
 
 
 def _aggregate_response_timestamps(session, participant_id, survey_code_list, aggregate_function) -> datetime:
@@ -328,8 +331,8 @@ def _aggregate_response_timestamps(session, participant_id, survey_code_list, ag
     if participant_id in response_collection:
         program_update_response_list = response_collection[participant_id].responses.values()
         for response in program_update_response_list:
-            reconsent_answer = response.get_single_answer_for(PRIMARY_CONSENT_UPDATE_QUESTION_CODE).value.lower()
-            if reconsent_answer == COHORT_1_REVIEW_CONSENT_YES_CODE.lower():
+            reconsent_answer = response.get_single_answer_for(PRIMARY_CONSENT_UPDATE_QUESTION_CODE)
+            if reconsent_answer and reconsent_answer.value.lower() == COHORT_1_REVIEW_CONSENT_YES_CODE.lower():
                 revised_consent_time_list.append(response.authored_datetime)
 
     if not revised_consent_time_list:

--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -256,7 +256,7 @@ def _supplement_with_rdr_calculations(metrics_data: RetentionEligibleMetrics):
                 is_consent_provided=True,
                 authored_timestamp=summary.consentForStudyEnrollmentFirstYesAuthored
             ),
-            first_ehr_consent=_get_earliest_intent_for_ehr_datetime(
+            first_ehr_consent=_get_earliest_intent_for_ehr(
                 session=session,
                 participant_id=summary.participantId
             ),
@@ -306,7 +306,7 @@ def _supplement_with_rdr_calculations(metrics_data: RetentionEligibleMetrics):
         metrics_data.rdr_is_passively_retained = retention_data.is_passively_retained
 
 
-def _get_earliest_intent_for_ehr_datetime(session, participant_id) -> datetime:
+def _get_earliest_intent_for_ehr(session, participant_id) -> Consent:
     date_range_list = QuestionnaireResponseRepository.get_interest_in_sharing_ehr_ranges(
         participant_id=participant_id,
         session=session


### PR DESCRIPTION
## Resolves *no ticket*
The retention calculation import code is currently crashing when trying to get consent information for participants. This fixes bugs in the process so it can continue to work again.


## Tests
- [ ] unit tests


