### PR TITLE
[PDR-1898] Add support for participant summary update Pub/Sub events.

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -26,6 +26,7 @@ from rdr_service.api_util import (
     parse_json_enum
 )
 from rdr_service.app_util import is_care_evo_and_not_prod
+from rdr_service.cloud_utils.gcp_google_pubsub import submit_pipeline_pubsub_msg_from_model
 from rdr_service.code_constants import BIOBANK_TESTS, COHORT_1_REVIEW_CONSENT_YES_CODE, ORIGINATING_SOURCES,\
     PMI_SKIP_CODE, PPI_SYSTEM, PRIMARY_CONSENT_UPDATE_MODULE, PRIMARY_CONSENT_UPDATE_QUESTION_CODE, UNSET
 from rdr_service.dao.base_dao import UpdatableDao
@@ -913,6 +914,9 @@ class ParticipantSummaryDao(UpdatableDao):
                       and summary.consentForDvElectronicHealthRecordsSharing == QuestionnaireStatus.SUBMITTED
         )
         summary.enrollmentStatusCoreOrderedSampleTime = self.calculate_core_ordered_sample_time(consent, summary)
+
+        # Support RDR to PDR pipeline
+        submit_pipeline_pubsub_msg_from_model(summary, self.get_connection_database_name())
 
     def calculate_enrollment_status(
         self, consent, num_completed_baseline_ppi_modules, physical_measurements_status,

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -119,7 +119,7 @@ class PubSubTest(BaseTestCase):
 
         # Test Pub/Sub messages successfully sent.
         self.assertTrue(mock_pub_func.called)
-        # We now get two extra calls due to participant enrollment re-calculations after biobank order is submitted.1898
+        # We now get two extra calls due to participant enrollment re-calculations after biobank order is submitted.
         self.assertEqual(mock_pub_func.call_count, 5)
 
     @mock.patch('rdr_service.cloud_utils.gcp_google_pubsub.publish_pubsub_message')
@@ -147,10 +147,11 @@ class PubSubTest(BaseTestCase):
         self.assertIn('measurement', parents)
 
         self.assertTrue(mock_pub_func.called)
-        self.assertEqual(mock_pub_func.call_count, 2)
+        # We now get two extra calls due to participant enrollment re-calculations after PM is submitted.
+        self.assertEqual(mock_pub_func.call_count, 4)
 
     @mock.patch('rdr_service.cloud_utils.gcp_google_pubsub.publish_pubsub_message')
-    def test_pubsub_from_model(self, mock_pub_func):
+    def test_participant_enrollment_update_pubsub(self, mock_pub_func):
         """ Test for Pub/Sub event messages when participant enrollment status is re-calculated. """
         mock_pub_func.return_value = {'messageIds': ['123']}
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -119,7 +119,8 @@ class PubSubTest(BaseTestCase):
 
         # Test Pub/Sub messages successfully sent.
         self.assertTrue(mock_pub_func.called)
-        self.assertEqual(mock_pub_func.call_count, 3)
+        # We now get two extra calls due to participant enrollment re-calculations after biobank order is submitted.1898
+        self.assertEqual(mock_pub_func.call_count, 5)
 
     @mock.patch('rdr_service.cloud_utils.gcp_google_pubsub.publish_pubsub_message')
     def test_pubsub_from_model(self, mock_pub_func):
@@ -147,3 +148,23 @@ class PubSubTest(BaseTestCase):
 
         self.assertTrue(mock_pub_func.called)
         self.assertEqual(mock_pub_func.call_count, 2)
+
+    @mock.patch('rdr_service.cloud_utils.gcp_google_pubsub.publish_pubsub_message')
+    def test_pubsub_from_model(self, mock_pub_func):
+        """ Test for Pub/Sub event messages when participant enrollment status is re-calculated. """
+        mock_pub_func.return_value = {'messageIds': ['123']}
+
+        dao = ParticipantSummaryDao()
+
+        participant_summary = self.participant_summary(self.participant)
+
+        self.summary_dao.insert(participant_summary)
+
+        self.assertFalse(mock_pub_func.called)
+        self.assertEqual(mock_pub_func.call_count, 0)
+
+        with dao.session() as session:
+            self.summary_dao.update_enrollment_status(participant_summary, session)
+
+        self.assertTrue(mock_pub_func.called)
+        self.assertEqual(mock_pub_func.call_count, 1)


### PR DESCRIPTION
## Resolves *[PDR-1898](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1898)*


## Description of changes/additions
Current Pub/Sub events are only being submitted for the Participant Summary table when the table record is initially created.  This update adds support for sending Pub/Sub messages when the enrollment status is re-calculated for a participant. 

Added new unittest for testing participant summary DAO enrollment status re-calculation code hook to submit Pub/Sub events.

## Tests
- [X] unit tests




[PDR-1898]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ