### PR TITLE
[PDR-1479] Deprecate V3.1 enrollment status fields in PDR generator

### DIFF
--- a/rdr_service/cloud_utils/gcp_google_pubsub.py
+++ b/rdr_service/cloud_utils/gcp_google_pubsub.py
@@ -126,7 +126,7 @@ def submit_pipeline_pubsub_msg(database: str = 'rdr', table: str = None, action:
     validated_pk_values = _validate_pk_values(pk_values, expected_len=len(pk_columns)) or []
     if not len(validated_pk_values):
         log_pipeline_error(f'pipeline: {table} pk_values {pk_values} for pk_columns {pk_columns} failed validation',
-                           response_only=os.environ["UNITTEST_FLAG"] != "1")
+                           response_only=os.environ.get("UNITTEST_FLAG", '0') != "1")
     # If project is not allowed or is localhost, return error message
     if project not in allowed_projects:
         return log_pipeline_error(f'pipeline: project {project} not allowed.', True)

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -491,13 +491,17 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             Participant.participantId == p_id
         ).first()
 
-        # For PDR, start with REGISTERED as the default enrollment status (all versions).  This identifies participants
+        # For PDR, start with REGISTERED as the default enrollment status.  This identifies participants
         # who have not yet consented / should not have a participant_summary record
         data = {}
         # TODO:  add enrollment_status / enrollment_status_id after Goal 1 QC (move from _calculate_enrollment_status)
-        for key in ['enrollment_status_v2', 'enrollment_status_v3_0', 'enrollment_status_v3_1']:
+        for key in ['enrollment_status_v2', 'enrollment_status_v3_0']:
             data[key] = str(EnrollmentStatusV2.REGISTERED)
             data[key + '_id'] = int(EnrollmentStatusV2.REGISTERED)
+
+        # PDR-1479:  Deprecating V3.1; leave PDR values as None if columns no longer exist in participant_summary
+        data['enrollment_status_v3_1'] = str(EnrollmentStatusV2.REGISTERED) if has_enrollment_v3_1 else None
+        data['enrollment_status_v3_1_id'] = int(EnrollmentStatusV2.REGISTERED) if has_enrollment_v3_1 else None
 
         if not ps:
             logging.debug(f'No participant_summary record found for {p_id}')
@@ -532,8 +536,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'enrollment_status_v3_0_pmb_eligible_time': ps.enrollmentStatusPmbEligibleV3_0Time,
                 'enrollment_status_v3_0_core_minus_pm_time': ps.enrollmentStatusCoreMinusPmV3_0Time,
                 'enrollment_status_v3_0_core_time': ps.enrollmentStatusCoreV3_0Time,
-                # PDR-1479: Confirm if old columns still exist; if not assign null.  Not making updates to existing
-                # RDR-to-PDR pipeline schemas.  New fields/values will come through the new pipeline
+                # PDR-1479: Deprecating V3.1; leave PDR values as None if columns no longer exist in participant_summary
                 'enrollment_status_v3_1': str(ps.enrollmentStatusV3_1) if has_enrollment_v3_1 else None,
                 'enrollment_status_v3_1_id': int(ps.enrollmentStatusV3_1) if has_enrollment_v3_1 else None,
                 'enrollment_status_v3_1_participant_time': ps.enrollmentStatusParticipantV3_1Time \

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -541,7 +541,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'enrollment_status_v3_1_id': int(ps.enrollmentStatusV3_1) if has_enrollment_v3_1 else None,
                 'enrollment_status_v3_1_participant_time': ps.enrollmentStatusParticipantV3_1Time \
                     if has_enrollment_v3_1 else None,
-                'enrollment_status_v3_1_participant_plus_ehr_time': ps.enrollmentStatusParticipantPlusEhrV3_1Time
+                'enrollment_status_v3_1_participant_plus_ehr_time': ps.enrollmentStatusParticipantPlusEhrV3_1Time \
                     if has_enrollment_v3_1 else None,
                 'enrollment_status_v3_1_participant_plus_basics_time': ps.enrollmentStatusParticipantPlusBasicsV3_1Time\
                     if has_enrollment_v3_1 else None,
@@ -552,7 +552,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     ps.enrollmentStatusParticipantPlusBaselineV3_1Time if has_enrollment_v3_1 else None,
                 'health_datastream_sharing_status_v3_1': str(ps.healthDataStreamSharingStatusV3_1) \
                     if has_enrollment_v3_1 else None,
-                'health_datastream_sharing_status_v3_1_id': int(ps.healthDataStreamSharingStatusV3_1)
+                'health_datastream_sharing_status_v3_1_id': int(ps.healthDataStreamSharingStatusV3_1) \
                     if has_enrollment_v3_1 in ps_col_names else None,
                 'health_datastream_sharing_status_v3_1_time': ps.healthDataStreamSharingStatusV3_1Time \
                     if has_enrollment_v3_1 in ps_col_names else None

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -11,10 +11,23 @@ from rdr_service.participant_enums import (QuestionnaireStatus, ParticipantCohor
     SuspensionStatus, QuestionnaireResponseStatus, QuestionnaireResponseClassificationType,
     DeceasedStatus, ParticipantCohortPilotFlag, WithdrawalAIANCeremonyStatus, BiobankOrderStatus,
     SampleCollectionMethod, PhysicalMeasurementsCollectType, OriginMeasurementUnit,
-    EnrollmentStatusV30, EnrollmentStatusV31, DigitalHealthSharingStatusV31)
+    EnrollmentStatusV30, DigitalHealthSharingStatusV31)
 from rdr_service.resource import Schema, fields
 from rdr_service.resource.constants import SchemaID
 
+
+
+# Defining this enum class here so it can be safely removed from the RDR participant_enums file.  This schemas file
+# will eventually be superseded by the new RDR-to-PDR pipeline and removed from the RDR codebase
+class EnrollmentStatusV31(Enum):
+    """A status reflecting how fully enrolled a participant is according to the 3.1 data glossary"""
+
+    PARTICIPANT = 1
+    PARTICIPANT_PLUS_EHR = 2
+    PARTICIPANT_PLUS_BASICS = 3
+    CORE_MINUS_PM = 4
+    CORE_PARTICIPANT = 5
+    BASELINE_PARTICIPANT = 6
 
 class SexualOrientationEnum(Enum):
     SexualOrientation_None = 1
@@ -386,7 +399,8 @@ class ParticipantSchema(Schema):
     enrollment_status_v3_0_pmb_eligible_time = fields.DateTime()
     enrollment_status_v3_0_core_minus_pm_time = fields.DateTime()
     enrollment_status_v3_0_core_time = fields.DateTime()
-    # RDR v3.1 Enrollment Status Calculations
+    # Deprecated RDR v3.1 Enrollment Status Calculations.  Schema is not changing (new V3.2 data will be part of new
+    # # RDR-to-PDR pipeline only) but the existing pipeline will still generate records with these fields / null values
     enrollment_status_v3_1 = fields.EnumString(enum=EnrollmentStatusV31)
     enrollment_status_v3_1_id = fields.EnumInteger(enum=EnrollmentStatusV31)
     enrollment_status_v3_1_participant_time = fields.DateTime()

--- a/rdr_service/services/response_duplication_detector.py
+++ b/rdr_service/services/response_duplication_detector.py
@@ -83,7 +83,7 @@ class ResponseDuplicationDetector:
 
         # For new RDR-PDR pipeline:  generate PDR delete record events for the marked duplicates.  Allow calls
         # during unittests for mocks/param validation.  submit_pipeline_pubsub_msg() will enforce project restrictions
-        if project != 'localhost' or os.environ['UNITTEST_FLAG'] == "1":
+        if project != 'localhost' or os.environ.get('UNITTEST_FLAG', '0') == "1":
             submit_pipeline_pubsub_msg(table='questionnaire_response',
                                        action='delete', pk_columns=['questionnaire_response_id'],
                                        pk_values=duplicate_responses)


### PR DESCRIPTION
## Partially Resolves *[PDR-1479](https://precisionmedicineinitiative.atlassian.net/browse/PDR-1479)*


## Description of changes/additions
Allow old PDR data generators to run both before and after `participant_summary` alembic migrations to drop/rename the V3.1 enrollment status fields for V3.2 are deployed in RDR.   The new V3.2 enrollment status values calculated by RDR will be brought over as part of the new RDR-PDR pipeline (see PR #3502 , remaining changes will only be in PDR repository code), so no further changes to these generators are planned.

The SQLAlchemy query on ParticipantSummary will no longer target specific columns.  Instead it will query all columns and inspect the model to determine if the old V3.1 columns are still defined.  If not, the deprecated fields in the PDR record will be set to None values.

## Tests
Manual testing due to simulating `ParticipantSummary` model changes that are not part of this PR.  (See [DA-3546](https://precisionmedicineinitiative.atlassian.net/browse/DA-3546) and upcoming PR)


[PDR-1479]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DA-3546]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ