### PR TITLE
[DA-3546] Updating enrollment status based on aw4

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -15,6 +15,7 @@ from rdr_service.dao.bq_participant_summary_dao import bq_participant_summary_up
 from rdr_service.dao.bq_questionnaire_dao import bq_questionnaire_update_task
 from rdr_service.dao.bq_workbench_dao import bq_workspace_batch_update, bq_workspace_user_batch_update, \
     bq_institutional_affiliations_batch_update, bq_researcher_batch_update, bq_audit_batch_update
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.offline import retention_eligible_import
 from rdr_service.offline.requests_log_migrator import RequestsLogMigrator
 from rdr_service.offline.sync_consent_files import cloudstorage_copy_objects_task
@@ -378,3 +379,19 @@ class ValidateDateOfBirthApi(Resource):
             participant_id=task_data['participant_id'],
             date_of_birth=date_of_birth
         )
+
+
+class UpdateEnrollmentStatus(Resource):
+    @task_auth_required
+    @returns_success
+    def post(self):
+        task_data = request.get_json(force=True)
+        participant_id = task_data['participant_id']
+
+        dao = ParticipantSummaryDao()
+        with dao.session() as session:
+            summary = dao.get_with_session(session=session, obj_id=participant_id)
+            dao.update_enrollment_status(
+                summary=summary,
+                session=session
+            )

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -31,7 +31,6 @@ from rdr_service.api_util import (
     open_cloud_file,
     copy_cloud_file,
     delete_cloud_file,
-    dispatch_task,
     list_blobs,
     get_blob
 )
@@ -550,7 +549,7 @@ class GenomicFileIngester:
 
                 self.member_dao.update(member)
 
-                dispatch_task(
+                self.controller.execute_cloud_task(
                     endpoint='update_enrollment_status',
                     payload={
                         'participant_id': member.participantId

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -553,7 +553,8 @@ class GenomicFileIngester:
                     endpoint='update_enrollment_status',
                     payload={
                         'participant_id': member.participantId
-                    }
+                    },
+                    task_queue='resource-tasks'
                 )
 
             return GenomicSubProcessResult.SUCCESS

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -31,8 +31,10 @@ from rdr_service.api_util import (
     open_cloud_file,
     copy_cloud_file,
     delete_cloud_file,
+    dispatch_task,
     list_blobs,
-    get_blob)
+    get_blob
+)
 from rdr_service.model.genomics import (
     GenomicSet,
     GenomicSetMember,
@@ -547,6 +549,13 @@ class GenomicFileIngester:
                     self.metrics_dao.upsert(metrics)
 
                 self.member_dao.update(member)
+
+                dispatch_task(
+                    endpoint='update_enrollment_status',
+                    payload={
+                        'participant_id': member.participantId
+                    }
+                )
 
             return GenomicSubProcessResult.SUCCESS
 

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -244,6 +244,13 @@ def _build_resource_app():
                       TASK_PREFIX + 'ValidateDateOfBirth',
                       endpoint='check_date_of_birth', methods=['POST'])
 
+    _api.add_resource(
+        cloud_tasks_api.UpdateEnrollmentStatus,
+        TASK_PREFIX + 'UpdateEnrollmentStatus',
+        endpoint='update_enrollment_status',
+        methods=['POST']
+    )
+
     _app.add_url_rule('/_ah/start', endpoint='start', view_func=flask_start, methods=["GET"])
     _app.add_url_rule('/_ah/stop', endpoint='stop', view_func=flask_stop, methods=["GET"])
 


### PR DESCRIPTION
## Resolves *[DA-3546](https://precisionmedicineinitiative.atlassian.net/browse/DA-3546)*
Changes in another PR are introducing a need to update the enrollment status (specifically the Core Data flag) when we receive an AW4 WGS for participants. This adds a dispatch to have the enrollment status updated when we receive an AW4.


## Tests
- [x] unit tests




[DA-3546]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ