### PR TITLE
Fixing bug when determining core data validity of physical measurements

### DIFF
--- a/rdr_service/dao/physical_measurements_dao.py
+++ b/rdr_service/dao/physical_measurements_dao.py
@@ -994,7 +994,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
         has_weight = False
         for measurement in measurement_collection.measurements:
             # Measurement should count if there is a value recorded, or if there are modifications/qualifiers
-            is_valid_value = measurement.valueDecimal is not None or measurement.qualifiers
+            is_valid_value = measurement.valueDecimal is not None or bool(measurement.qualifiers)
             if measurement.codeValue in height_codes:
                 has_height = is_valid_value
             elif measurement.codeValue in weight_codes:

--- a/tests/dao_tests/test_physical_measurements_dao.py
+++ b/tests/dao_tests/test_physical_measurements_dao.py
@@ -9,7 +9,7 @@ from rdr_service.dao.biobank_order_dao import BiobankOrderDao
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
-from rdr_service.model.measurements import PhysicalMeasurements
+from rdr_service.model.measurements import Measurement, PhysicalMeasurements
 from rdr_service.model.participant import Participant
 from rdr_service.participant_enums import PhysicalMeasurementsStatus, WithdrawalStatus, \
     PhysicalMeasurementsCollectType, OriginMeasurementUnit
@@ -413,3 +413,50 @@ class PhysicalMeasurementsDaoTest(BaseTestCase):
             record = session.query(PhysicalMeasurements).filter(PhysicalMeasurements.participantId==self.participant.participantId).first()
 
         self.assertEqual(type(measurements.resource), type(record.resource))
+
+    def _make_measurement(self, id_, code_value, pm_id, qualifiers=None):
+        if qualifiers is None:
+            qualifiers = []
+
+        return Measurement(
+            measurementId=id_,
+            physicalMeasurementsId=pm_id,
+            codeValue=code_value,
+            codeSystem='test',
+            qualifiers=qualifiers,
+            measurementTime=datetime.datetime.utcnow()
+        )
+
+    def test_core_data_qualifiers(self):
+        """
+        Make sure we can process qualifiers for height and weight
+        """
+
+        self._make_summary()
+        pm = self._make_physical_measurements()
+
+        pm.measurements = [
+            self._make_measurement(
+                id_=1,
+                pm_id=pm.physicalMeasurementsId,
+                code_value='height',
+                qualifiers=[
+                    self._make_measurement(id_=3, pm_id=pm.physicalMeasurementsId, code_value='height-qualifier')
+                ]
+            ),
+            self._make_measurement(
+                id_=2,
+                pm_id=pm.physicalMeasurementsId,
+                code_value='weight',
+                qualifiers=[
+                    self._make_measurement(id_=4, pm_id=pm.physicalMeasurementsId, code_value='weight-qualifier')
+                ]
+            )
+        ]
+
+        self.dao.insert(pm)
+
+        db_obj: PhysicalMeasurements = self.session.query(PhysicalMeasurements).filter(
+            PhysicalMeasurements.physicalMeasurementsId == pm.physicalMeasurementsId
+        ).one()
+        self.assertTrue(db_obj.meetsCoreDataRequirements)


### PR DESCRIPTION
## Resolves *no ticket*
When a physical measurement has height and/or weight qualifiers, the resulting value could unintentionally be a list rather than a boolean value.

This adds an explicit cast to give a boolean based on the list rather than the list itself.

## Tests
- [x] unit tests


