### PR TITLE
Upgrading GCP CLI for CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ version: 2.1
 # To see the list of pre-built images that CircleCI provides for most common languages see
 # https://circleci.com/docs/2.0/circleci-images/
 
+orbs:
+  gcp-cli: circleci/gcp-cli@2.4.1
+
 job_defaults: &job_defaults
   docker:
     - image: cimg/base:2021.05-18.04
@@ -25,6 +28,7 @@ commands:
   unittest-app-steps:
     steps:
       - checkout
+      - gcp-cli/setup
       - run:
           name: Setup Python Environment
           command: ./ci/setup_python_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ version: 2.1
 # To see the list of pre-built images that CircleCI provides for most common languages see
 # https://circleci.com/docs/2.0/circleci-images/
 
-orbs:
-  gcp-cli: circleci/gcp-cli@2.4.1
-
 job_defaults: &job_defaults
   docker:
     - image: cimg/base:2021.05-18.04
@@ -82,7 +79,6 @@ jobs:
   job_run_unittests:
     <<: *job_defaults
     steps:
-      - gcp-cli/setup
       - unittest-app-steps
 
   job_deploy_to_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ commands:
   unittest-app-steps:
     steps:
       - checkout
-      - gcp-cli/setup
       - run:
           name: Setup Python Environment
           command: ./ci/setup_python_env.sh
@@ -83,6 +82,7 @@ jobs:
   job_run_unittests:
     <<: *job_defaults
     steps:
+      - gcp-cli/setup
       - unittest-app-steps
 
   job_deploy_to_test:

--- a/ci/install_google_sdk.sh
+++ b/ci/install_google_sdk.sh
@@ -3,7 +3,7 @@
 #
 # Install the Google Cloud SDK
 #
-curl -o /tmp/cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-367.0.0-linux-x86_64.tar.gz
+curl -o /tmp/cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-435.0.1-linux-x86_64.tar.gz
 mkdir /tmp/cloud-sdk
 tar -xf /tmp/cloud-sdk.tar.gz --directory /tmp/cloud-sdk
 cd /tmp/cloud-sdk/google-cloud-sdk


### PR DESCRIPTION
## Resolves *no ticket*
The version of GCP CLI that the CircleCI scripts download isn't compatible with python 3.11. So this updates the scripts to install a later version.

