### PR TITLE
Updating response validation to parse not-equal in branching logic

### DIFF
--- a/rdr_service/offline/response_validation.py
+++ b/rdr_service/offline/response_validation.py
@@ -9,7 +9,7 @@ from rdr_service.domain_model.response import Response
 from rdr_service.model.code import Code
 from rdr_service.model.survey import Survey, SurveyQuestion, SurveyQuestionOption
 from rdr_service.repository.questionnaire_response_repository import QuestionnaireResponseRepository
-from rdr_service.services.response_validation.validation import ResponseValidator
+from rdr_service.services.response_validation.validation import BranchParsingError, ResponseValidator
 from rdr_service.services.slack_utils import SlackMessageHandler
 
 
@@ -30,7 +30,10 @@ class ResponseValidationController:
         )
         for participant_id, participant_responses in response_list.items():
             for response in participant_responses.responses.values():
-                self._check_response(response, participant_id=participant_id)
+                try:
+                    self._check_response(response, participant_id=participant_id)
+                except BranchParsingError:
+                    logging.error(f'Error parsing branching logic for {response.survey_code}', exc_info=True)
 
         self._send_error_message()
 

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -247,6 +247,24 @@ class TestConditionalFromBranchingLogic(BaseTestCase):
         result = Condition.from_branching_logic(branching_logic)
         self.assertEqual(branching_logic, str(result))
 
+    def test_answer_not_equal(self):
+        branching_logic = "[a] <> 7"
+        result = Condition.from_branching_logic(branching_logic)
+        self.assertEqual(branching_logic, str(result))
+
+        result.process_response(
+            self._build_response({
+                'a': (7, DataType.INTEGER)
+            }))
+        self.assertFalse(result.passes())
+
+        result.process_response(
+            self._build_response({
+                'a': (19, DataType.INTEGER)
+            })
+        )
+        self.assertTrue(result.passes())
+
     def test_number_comparison_with_quotes(self):
         branching_logic = "[a] > '7'"
         result = Condition.from_branching_logic(branching_logic)
@@ -271,3 +289,16 @@ class TestConditionalFromBranchingLogic(BaseTestCase):
         branching_logic = "[a] = 'a1' and ([b] > 0 or [c(option_1)] = '1' and [d] > 5)"
         result = Condition.from_branching_logic(branching_logic)
         self.assertEqual("([a] = 'a1' and (([b] > 0 or [c(option_1)] = '1') and [d] > 5))", str(result))
+
+    @classmethod
+    def _build_response(cls, answer_dict):
+        return Response(
+            answered_codes={
+                question_code: [Answer(id=1, value=str(answer_value), data_type=data_type)]
+                for question_code, (answer_value, data_type) in answer_dict.items()
+            },
+            authored_datetime=datetime.now(),
+            id=8,
+            status=QuestionnaireResponseStatus.COMPLETED,
+            survey_code='test'
+        )


### PR DESCRIPTION
## Resolves *no ticket*
The response validation cron job stopped working when a comparison operator I hadn't seen before appeared in the branching logic from Redcap. This updates the code to be able to process the not-equal (`<>`) operator.

This also adds a try-catch when processing each response. With this we'll be able to continue validation of other responses if some of them are failing.


## Tests
- [x] unit tests


