### PR TITLE
Updating flask and related dependencies

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -4,12 +4,12 @@ aniso8601==8.0.0          # via flask-restful
 astroid==2.15.5            # via pylint
 babel==2.9.1              # via sphinx
 backoff==1.10.0           # via -r requirements.in
-blinker==1.4              # via -r requirements.in
+blinker==1.6.2              # via -r requirements.in
 cachetools==4.1.0         # via google-auth
 certifi==2022.12.7       # via geventhttpclient, requests
 cffi==1.15.1              # via cryptography
 chardet==3.0.4            # via requests
-click==8.0.0              # via flask, pip-tools
+click==8.1.3              # via flask, pip-tools
 configargparse==1.2.3     # via locust
 coverage==6.0b1             # via -r requirements.in
 cryptography==39.0.1       # via oauthlib, pyopenssl, requests
@@ -21,7 +21,7 @@ faker==4.1.0              # via -r requirements.in
 fhirclient==3.2.0         # via -r requirements.in
 flask-basicauth==0.2.0    # via locust
 flask-restful==0.3.9      # via -r requirements.in
-flask==2.2.5              # via -r requirements.in, flask-basicauth, flask-restful, locust
+flask==2.3.2              # via -r requirements.in, flask-basicauth, flask-restful, locust
 flask-limiter==1.4
 gevent==22.10.2            # via geventhttpclient, locust
 geventhttpclient==2.0.2   # via locust
@@ -49,8 +49,8 @@ idna==2.9                 # via requests
 imagesize==1.2.0          # via sphinx
 isodate==0.6.0            # via fhirclient
 isort==4.3.21             # via pylint
-itsdangerous==2.0.1       # via flask
-jinja2==3.0.2             # via flask, sphinx
+itsdangerous==2.1.2       # via flask
+jinja2==3.1.2             # via flask, sphinx
 jira==2.0.0               # via -r requirements.in
 lazy-object-proxy==1.4.3  # via astroid
 locust==1.3.2             # via -r requirements.in
@@ -113,7 +113,7 @@ toml==0.10.1              # via pylint
 typed-ast==1.5.4          # via astroid
 uritemplate==3.0.1        # via google-api-python-client
 urllib3==1.26.5           # via requests
-werkzeug==2.2.3           # via flask
+werkzeug==2.3.6           # via flask
 wrapt==1.15.0             # via astroid
 xmltodict==0.12.0         # via -r requirements.in
 zope.event==4.4           # via gevent


### PR DESCRIPTION
Dependabot tried to update the flask version a bit ago (PR #3457). But we weren't able to merge it because newer versions of flask needed a more recent version of python (https://app.circleci.com/pipelines/github/all-of-us/raw-data-repository/8004/workflows/167cd7b4-e40a-4628-9ef4-e07faee4eec6/jobs/17707). Now that we're on python 3.11 we can go back and make this update.

This also updates some other libraries that the newer version of flask needed updated.