### PR TITLE
[DA-3642] Updating rtd config and dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,6 @@
+-r ../requirements_base.txt
+
+sphinx-rtd-theme==1.2.2
+readthedocs-sphinx-ext==2.2.1
+sphinx==6.2.1
+docutils==0.18.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,5 +2,4 @@
 
 sphinx-rtd-theme==1.2.2
 readthedocs-sphinx-ext==2.2.1
-sphinx==6.2.1
 docutils==0.18.1

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -95,6 +95,7 @@ simple-geometry==0.1.4  # geometry
 simplejson==3.17.0        # via -r requirements.in
 six==1.15.0               # via astroid, cryptography, flask-restful, geventhttpclient, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-python-cloud-debugger, google-resumable-media, grpcio, isodate, jira, oauth2client, packaging, pip-tools, protobuf, protorpc, pyopenssl, python-dateutil
 snowballstemmer==2.0.0    # via sphinx
+sphinx==6.2.1
 sqlalchemy==1.3.17        # via -r requirements.in, alembic, dictalchemy
 sqlparse==0.4.4           # via -r requirements.in
 supervisor==4.2.0         # via -r requirements.in

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -16,7 +16,6 @@ cryptography==41.0.0       # via oauthlib, pyopenssl, requests
 defusedxml==0.6.0         # via jira
 dictalchemy3==1.0.0       # via -r requirements.in
 dnspython==1.16.0         # via -r requirements.in
-docutils==0.16            # via sphinx
 faker==4.1.0              # via -r requirements.in
 fhirclient==3.2.0         # via -r requirements.in
 flask-basicauth==0.2.0    # via locust
@@ -46,7 +45,6 @@ gspread==3.7.0
 gunicorn==20.0.4          # via -r requirements.in
 httplib2==0.19.1          # via google-api-python-client, google-auth-httplib2, oauth2client
 idna==2.9                 # via requests
-imagesize==1.2.0          # via sphinx
 isodate==0.6.0            # via fhirclient
 isort==4.3.21             # via pylint
 itsdangerous==2.1.2       # via flask
@@ -64,7 +62,6 @@ msgpack==1.0.0            # via locust
 netaddr==0.7.19           # via -r requirements.in
 oauth2client==4.1.3       # via -r requirements.in
 oauthlib[signedtoken]==3.1.0  # via jira, requests-oauthlib
-packaging==20.4           # via sphinx
 #pandas==1.3.1
 parameterized==0.7.4      # via -r requirements.in
 pbr==5.4.5                # via jira
@@ -77,7 +74,7 @@ psycopg2-binary==2.9.6
 pyasn1-modules==0.2.8     # via google-auth, oauth2client
 pyasn1==0.4.8             # via oauth2client, pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pygments==2.7.4           # via sphinx
+pygments==2.15.1           # via sphinx
 pyjwt==2.4.0              # via oauthlib
 pylint==2.17.4            # via -r requirements.in
 pyopenssl==23.2.0         # via requests
@@ -98,13 +95,6 @@ simple-geometry==0.1.4  # geometry
 simplejson==3.17.0        # via -r requirements.in
 six==1.15.0               # via astroid, cryptography, flask-restful, geventhttpclient, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-python-cloud-debugger, google-resumable-media, grpcio, isodate, jira, oauth2client, packaging, pip-tools, protobuf, protorpc, pyopenssl, python-dateutil
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.4             # via -r requirements.in
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlalchemy==1.3.17        # via -r requirements.in, alembic, dictalchemy
 sqlparse==0.4.4           # via -r requirements.in
 supervisor==4.2.0         # via -r requirements.in


### PR DESCRIPTION
## Resolves *[DA-3642](https://precisionmedicineinitiative.atlassian.net/browse/DA-3642)*
ReadTheDocs needs to be updated to use python 3.11 too. ReadTheDocs is also deprecation the current config system in favor of a yaml file in the repo, which coincidentally is also the way to set the python version.

## Description of changes/additions
This adds a ReadTheDocs config yaml, as well as updating related dependencies.

## Tests
- [ ] unit tests




[DA-3642]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ