### PR TITLE
[DA-3666] Biospecimen Collected date should be on the tube level

### DIFF
--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -585,7 +585,8 @@ class NphParticipantAPITest(BaseTestCase):
     def test_nph_biospecimen_for_participant(self):
         self.add_consents(nph_participant_ids=self.base_participant_ids)
         self._create_test_sample_updates()
-        field_to_test = "nphBiospecimens {orderID specimenCode studyID visitID timepointID biobankStatus { limsID biobankModified status } } "
+        field_to_test = "nphBiospecimens {orderID specimenCode studyID visitID collectionDateUTC processingDateUTC " \
+                        "timepointID biobankStatus { limsID biobankModified status } } "
         query = simple_query(field_to_test)
 
         executed = app.test_client().post('/rdr/v1/nph_participant', data=query)
@@ -596,9 +597,10 @@ class NphParticipantAPITest(BaseTestCase):
             biospecimens: Iterable[Dict[str, str]] = (
                 result.get("participant").get("edges")[i].get("node").get("nphBiospecimens")
             )
-            self.assertEqual(12, len(biospecimens))
+            self.assertEqual(8, len(biospecimens))
             for biospecimen in biospecimens:
                 self.assertIsNotNone(biospecimen.get("biobankStatus")[0].get("status"))
+                self.assertNotEqual(biospecimen.get("processingDateUTC"), biospecimen.get("collectionDateUTC"))
 
     def test_nph_biospecimen_duplicate_stored_samples(self):
         self.add_consents(nph_participant_ids=self.base_participant_ids)
@@ -675,7 +677,7 @@ class NphParticipantAPITest(BaseTestCase):
             biospecimens: Iterable[Dict[str, str]] = (
                 result.get("participant").get("edges")[0].get("node").get("nphBiospecimens")
             )
-            self.assertEqual(12, len(biospecimens))
+            self.assertEqual(8, len(biospecimens))
             for biospecimen in biospecimens:
                 self.assertIsNotNone(biospecimen.get("biobankStatus")[0].get("status"))
 


### PR DESCRIPTION
…g date should be on the aliquot level.

## Resolves *[DA-3666](https://precisionmedicineinitiative.atlassian.net/browse/DA-3666)*


## Description of changes/additions
This PR updates the NPH Participant API results to present the `nphBiospecimens.collectionDateUTC` as the collected date of a parent sample if it is an aliquot, i.e. the 'tube' level.

## Tests
- [x] unit tests




[DA-3666]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ