### PR TITLE
Misc. changes for PDR pipelines

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -553,9 +553,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'health_datastream_sharing_status_v3_1': str(ps.healthDataStreamSharingStatusV3_1) \
                     if has_enrollment_v3_1 else None,
                 'health_datastream_sharing_status_v3_1_id': int(ps.healthDataStreamSharingStatusV3_1) \
-                    if has_enrollment_v3_1 in ps_col_names else None,
+                    if has_enrollment_v3_1 else None,
                 'health_datastream_sharing_status_v3_1_time': ps.healthDataStreamSharingStatusV3_1Time \
-                    if has_enrollment_v3_1 in ps_col_names else None
+                    if has_enrollment_v3_1 else None
             }
             # Note:  None of the columns in the participant_ehr_receipt table are nullable
             pehr_results = ro_session.query(ParticipantEhrReceipt.id,

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -6,19 +6,18 @@ from datetime import date
 from enum import Enum
 from marshmallow import validate
 
-from rdr_service.participant_enums import (QuestionnaireStatus, ParticipantCohort, Race, GenderIdentity,
+from rdr_service.participant_enums import (
+    QuestionnaireStatus, ParticipantCohort, Race, GenderIdentity,
     PhysicalMeasurementsStatus, OrderStatus, EnrollmentStatusV2, EhrStatus, WithdrawalStatus, WithdrawalReason,
     SuspensionStatus, QuestionnaireResponseStatus, QuestionnaireResponseClassificationType,
     DeceasedStatus, ParticipantCohortPilotFlag, WithdrawalAIANCeremonyStatus, BiobankOrderStatus,
-    SampleCollectionMethod, PhysicalMeasurementsCollectType, OriginMeasurementUnit,
-    EnrollmentStatusV30, DigitalHealthSharingStatusV31)
+    SampleCollectionMethod, PhysicalMeasurementsCollectType, OriginMeasurementUnit, EnrollmentStatusV30
+)
 from rdr_service.resource import Schema, fields
 from rdr_service.resource.constants import SchemaID
 
-
-
-# Defining this enum class here so it can be safely removed from the RDR participant_enums file.  This schemas file
-# will eventually be superseded by the new RDR-to-PDR pipeline and removed from the RDR codebase
+# Defining these  enum classes here so they can be safely removed from the RDR participant_enums file.
+# This schemas file will eventually be superseded by the new RDR-to-PDR pipeline and removed from the RDR codebase
 class EnrollmentStatusV31(Enum):
     """A status reflecting how fully enrolled a participant is according to the 3.1 data glossary"""
 
@@ -28,6 +27,14 @@ class EnrollmentStatusV31(Enum):
     CORE_MINUS_PM = 4
     CORE_PARTICIPANT = 5
     BASELINE_PARTICIPANT = 6
+
+class DigitalHealthSharingStatusV31(Enum):
+    """Provides whether EHR files have been or currently are available for the participant"""
+
+    NEVER_SHARED = 1
+    EVER_SHARED = 2
+    CURRENTLY_SHARING = 3
+
 
 class SexualOrientationEnum(Enum):
     SexualOrientation_None = 1


### PR DESCRIPTION
## Resolves *No ticket*


## Description of changes/additions
Create a local `DigitalHealthStatusV31` enum in the old RDR-PDR pipeline generator to override the one in RDR that will be changing names for V3.2.   Note, the V31 values in the old generator are being deprecated (not being updated for V32).  This is a stopgap until we can delete the old generators from the RDR codebase.

Also,  allow `project ` value to be passed into the `ResponseDuplicationDetector `functions so the new PDR pipeline code that generates the `pubsub` `delete` event (called from `clean_pdr_data()`) will work from a tool running on localhost.

## Tests
- [x] unit tests


