### PR TITLE
[DA-3670] Move consent error reporting to its own cron job

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -129,3 +129,8 @@ cron:
   schedule: every Monday 09:00
   timezone: America/New_York
   target: offline
+- description: Daily Consent Error Report checks
+  url: /offline/ConsentErrorReport
+  schedule: every day 08:30
+  target: offline
+  timezone: America/New_York

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -21,9 +21,8 @@ from rdr_service.model.consent_file import ConsentFile as ParsingResult, Consent
 from rdr_service.model.consent_response import ConsentResponse
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.participant_enums import ParticipantCohort, QuestionnaireStatus
-from rdr_service.resource.tasks import dispatch_rebuild_consent_metrics_tasks, dispatch_check_consent_errors_task
+from rdr_service.resource.tasks import dispatch_rebuild_consent_metrics_tasks
 from rdr_service.services.consent import files
-from rdr_service.services.gcp_config import RdrEnvironment
 from rdr_service.storage import GoogleCloudStorageProvider
 
 
@@ -599,15 +598,6 @@ class ConsentValidationController:
         """
         Find all the expected consents (filtering by dates if provided) and check the files that have been uploaded
         """
-
-        # Workaround for this job frequently failing (OOM killer) before it can launch these tasks on a normal exit:
-        # Pre-schedule the error reporting tasks to run in 8 hours.  Ensures the error report check occurs once each
-        # time the validation runs.
-        if self._report_validation_errors():
-            # Only dispatch error reports for prod
-            dispatch_check_consent_errors_task(origin='vibrent', in_seconds=1800)
-            dispatch_check_consent_errors_task(origin='careevolution', in_seconds=1800)
-
         # Retrieve consent response objects that need to be validated
         is_last_batch = False
         while not is_last_batch:
@@ -770,11 +760,6 @@ class ConsentValidationController:
 
         logging.warning(f"Unable to find suitable original file for P{participant_id}'s {reconsent_type}")
         return None
-
-    @classmethod
-    def _report_validation_errors(cls) -> bool:
-        return config.GAE_PROJECT == RdrEnvironment.PROD.value
-
 
 class ConsentValidator:
     def __init__(self, consent_factory: files.ConsentFileAbstractFactory,

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -1,6 +1,6 @@
 import http.client
 import mock
-
+from unittest.mock import call
 from rdr_service.services.gcp_config import RdrEnvironment
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -83,7 +83,6 @@ class OfflineAppTest(BaseTestCase):
 
     @mock.patch('rdr_service.offline.main.dispatch_check_consent_errors_task')
     def test_consent_error_report_route(self, mock_checker):
-        from unittest.mock import call
         # Do not expect the reporting tasks to be dispatched except when on PROD
         self.send_cron_request('ConsentErrorReport')
         mock_checker.assert_not_called()

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -1,6 +1,7 @@
 import http.client
 import mock
 
+from rdr_service.services.gcp_config import RdrEnvironment
 from tests.helpers.unittest_base import BaseTestCase
 
 from rdr_service import config
@@ -79,3 +80,18 @@ class OfflineAppTest(BaseTestCase):
     def test_biobank_missing_samples_check_route(self, mock_checker):
         self.send_cron_request('BiobankMissingSamplesCheck')
         mock_checker.assert_called()
+
+    @mock.patch('rdr_service.offline.main.dispatch_check_consent_errors_task')
+    def test_consent_error_report_route(self, mock_checker):
+        from unittest.mock import call
+        # Do not expect the reporting tasks to be dispatched except when on PROD
+        self.send_cron_request('ConsentErrorReport')
+        mock_checker.assert_not_called()
+
+        # To override project, cannot use the settings dict temporary override -- need to set directly?
+        saved_config_project = config.GAE_PROJECT
+        config.GAE_PROJECT = RdrEnvironment.PROD.value
+        self.send_cron_request('ConsentErrorReport')
+        mock_checker.assert_has_calls([call(origin='vibrent', in_seconds=30),
+                                       call(origin='careevolution', in_seconds=180)])
+        config.GAE_PROJECT = saved_config_project

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -40,7 +40,6 @@ class ConsentControllerTest(BaseTestCase):
         consent_metrics_dispatch_check_errors_patch = mock.patch(
             'rdr_service.services.consent.validation.dispatch_check_consent_errors_task'
         )
-        self.dispatch_check_consent_errors_mock = consent_metrics_dispatch_check_errors_patch.start()
         self.addCleanup(consent_metrics_dispatch_check_errors_patch.stop)
         self.consent_controller = ConsentValidationController(
             consent_dao=self.consent_dao_mock,
@@ -51,11 +50,7 @@ class ConsentControllerTest(BaseTestCase):
         )
         self.store_strategy = StoreResultStrategy(session=mock.MagicMock(), consent_dao=self.consent_dao_mock)
 
-    @mock.patch(
-        'rdr_service.services.consent.validation.ConsentValidationController._report_validation_errors',
-        return_value=True
-    )
-    def test_new_consent_validation(self, _):
+    def test_new_consent_validation(self):
         """The controller should find all recent participant summary consents authored and validate files for them"""
         primary_and_ehr_participant_id = 123
         cabor_participant_id = 456
@@ -109,10 +104,6 @@ class ConsentControllerTest(BaseTestCase):
                 ConsentFile(id=4, file_path='/valid_cabor_1', sync_status=ConsentSyncStatus.READY_FOR_SYNC),
             ]
         )
-        # Confirm calls to dispatcher for task that checks for newly detected validation errors.   A separate task
-        # is dispatched for each participant origin.
-        self.assertEqual(2, self.dispatch_check_consent_errors_mock.call_count)
-
         # Confirm a call to the dispatcher to rebuild the consent metrics resource data, with the ConsentFile.id
         # values from the expected_updates list
         self.assertDispatchRebuildConsentMetricsCalled([2, 5, 6, 4], call_count=2)


### PR DESCRIPTION
## Resolves *[DA-3670](https://precisionmedicineinitiative.atlassian.net/browse/DA-3670)*


## Description of changes/additions
Now that the consent validation cron job is running hourly, the consent error reporting tasks will be split out into their own cron job that only runs once a day.  It is only intended to run in production.

## Tests
- [x] unit tests




[DA-3670]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ