### PR TITLE
[DA-3597] Overdue samples report upload for biobank

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -124,8 +124,8 @@ cron:
   target: offline
   timezone: America/New_York
   url: /offline/NphBiobankInventoryFileImport
-- description: Weekly Biobank missing sample check
-  url: /offline/BiobankMissingSamplesCheck
+- description: Weekly Biobank overdue DNA sample check
+  url: /offline/BiobankOverdueSamplesCheck
   schedule: every Monday 09:00
   timezone: America/New_York
   target: offline

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -21,7 +21,6 @@ from rdr_service.code_constants import PPI_SYSTEM, RACE_AIAN_CODE, RACE_QUESTION
 from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN, \
     BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN, RDR_SLACK_WEBHOOKS
 from rdr_service.dao.code_dao import CodeDao
-from rdr_service.dao.biobank_order_dao import BiobankOrderDao
 from rdr_service.dao.database_utils import MYSQL_ISO_DATE_FORMAT, parse_datetime, replace_isodate
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.code import Code

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -851,7 +851,7 @@ def overdue_samples_check(report_date=datetime.datetime.utcnow()):
     report_tmp_file = write_overdue_samples_report(report_date)
     # If a file was generated/uploaded, also post a slack alert with the details
     if report_tmp_file:
-        with open(report_tmp_file, 'r') as f:
+        with open(report_tmp_file, 'r', encoding='utf-8') as f:
             csv_reader = csv.DictReader(f)
             alert_msg = ''
             for row in csv_reader:

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -841,9 +841,9 @@ def write_overdue_samples_report(report_date):
                     "origin_filters": origin_filters}
 
     exporter = SqlExporter(bucket_name)
-    tmp_file, row_count = exporter.run_export(file_name, OVERDUE_DNA_SAMPLES_SQL, query_params, backup=True,
-                                              skip_upload_if_empty=True)
-    return tmp_file if row_count else None
+    tmp_file, has_data_rows = exporter.run_export(file_name, OVERDUE_DNA_SAMPLES_SQL, query_params, backup=True,
+                                                  skip_upload_if_empty=True)
+    return tmp_file if has_data_rows else None
 
 def overdue_samples_check(report_date=datetime.datetime.utcnow()):
     slack_config = config.getSettingJson(RDR_SLACK_WEBHOOKS, {})

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -151,8 +151,8 @@ def biobank_monthly_reconciliation_report():
     return json.dumps({"monthly-reconciliation-report": "generated"})
 
 @app_util.auth_required_cron
-def biobank_missing_samples_check():
-    biobank_samples_pipeline.missing_samples_check()
+def biobank_overdue_samples_check():
+    biobank_samples_pipeline.overdue_samples_check()
     return '{"success": "true"}'
 
 
@@ -931,9 +931,9 @@ def _build_pipeline_app():
     )
 
     offline_app.add_url_rule(
-        OFFLINE_PREFIX + "BiobankMissingSamplesCheck",
-        endpoint="biobankMissingSamplesCheck",
-        view_func=biobank_missing_samples_check,
+        OFFLINE_PREFIX + "BiobankOverdueSamplesCheck",
+        endpoint="biobankOverdueSamplesCheck",
+        view_func=biobank_overdue_samples_check,
         methods=["GET"],
     )
 

--- a/rdr_service/offline/sql_exporter.py
+++ b/rdr_service/offline/sql_exporter.py
@@ -42,7 +42,7 @@ class SqlExporter(object):
         """
         rows = 0
         with open(csv_tmp_file) as f:
-            for line in f:
+            for _ in f:
                 rows += 1
                 if rows > 1:
                     break

--- a/rdr_service/offline/sql_exporter.py
+++ b/rdr_service/offline/sql_exporter.py
@@ -41,7 +41,7 @@ class SqlExporter(object):
         :param tmp_file: The temporary CSV file created by write_temp_export_file()
         """
         rows = 0
-        with open(csv_tmp_file) as f:
+        with open(csv_tmp_file, encoding='utf-8') as f:
             for _ in f:
                 rows += 1
                 if rows > 1:

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -601,7 +601,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             biobank_samples_pipeline.overdue_samples_check(self.overdue_samples_report_dt)
             # Verify presence of expected bucket file
             blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
-            assert blob is not None
+            self.assertIsNotNone(blob)
 
             # Verify Slack message populated from bucket file rows
             error_log_call = mock_logging.error.call_args
@@ -638,7 +638,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
         )
         # Verify there was no file dropped to the bucket
         blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
-        assert blob is None
+        self.assertIsNone(blob)
 
         with mock.patch('rdr_service.offline.biobank_samples_pipeline.logging') as mock_logging:
             biobank_samples_pipeline.overdue_samples_check(self.overdue_samples_report_dt)
@@ -671,7 +671,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
 
         # Verify there was no file dropped to the bucket
         blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
-        assert blob is None
+        self.assertIsNone(blob)
 
         with mock.patch('rdr_service.offline.biobank_samples_pipeline.logging') as mock_logging:
             biobank_samples_pipeline.overdue_samples_check(self.overdue_samples_report_dt)

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -6,7 +6,7 @@ import random
 import os
 
 from rdr_service import clock, config
-from rdr_service.api_util import open_cloud_file
+from rdr_service.api_util import open_cloud_file, get_blob
 from rdr_service.code_constants import BIOBANK_TESTS
 from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN,\
     BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN
@@ -50,7 +50,15 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
 
         self.data_generator.initialize_common_codes()
 
-    mock_bucket_paths = [_FAKE_BUCKET, _FAKE_BUCKET + os.sep + biobank_samples_pipeline._REPORT_SUBDIR]
+    mock_bucket_paths = [_FAKE_BUCKET, _FAKE_BUCKET + os.sep + biobank_samples_pipeline._REPORT_SUBDIR,
+                         _FAKE_BUCKET + os.sep + biobank_samples_pipeline._OVERDUE_DNA_SAMPLES_SUBDIR]
+
+    # Set up values used by the overdue samples report test cases
+    overdue_samples_report_dt = datetime.utcnow().replace(microsecond=0)
+    overdue_samples_blobname = biobank_samples_pipeline._get_report_path(
+        overdue_samples_report_dt, 'overdue_dna_samples',
+        report_subdir=biobank_samples_pipeline._OVERDUE_DNA_SAMPLES_SUBDIR
+    )
 
     def _write_cloud_csv(self, file_name, contents_str):
         with open_cloud_file("/%s/%s" % (_FAKE_BUCKET, file_name), mode='wb') as cloud_file:
@@ -538,10 +546,13 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
         self.assertIsNotNone(cumulative_report_params)
         self.assertEqual(datetime(2021, 8, 1), cumulative_report_params['n_days_ago'])
 
-    def test_overdue_dna_sample(self):
+    def test_overdue_dna_sample_report(self):
         self.temporarily_override_config_setting(config.RDR_SLACK_WEBHOOKS, {
             'rdr_biobank_missing_samples_webhook': 'fakewh12345'
         })
+        self.clear_default_storage()
+        self.create_mock_buckets(self.mock_bucket_paths)
+
         participant = self.data_generator.create_database_participant()
         # Biobank order/samples finalized 7 or more days ago (since today's date)
         today = datetime.utcnow().replace(microsecond=0)
@@ -577,23 +588,33 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             test=non_dna_ordered_sample.test,
             status=SampleStatus.RECEIVED
         )
-        # Expect notification that the DNA sample is overdue/missing
+
+        # Expect Slack notification that the DNA sample is overdue
+        biobank_prefix = config.getSetting(config.BIOBANK_ID_PREFIX)
         expected_msg_substrings = [
-            f'Biobank ID: A{participant.biobankId}, order: {order.biobankOrderId}, ',
-            f'finalized: {dna_ordered_sample.finalized}, missing ordered DNA samples: {dna_ordered_sample.test}'
+            f'Biobank ID: {biobank_prefix}{participant.biobankId}, order: {order.biobankOrderId}, ',
+            f'finalized: {dna_ordered_sample.finalized}, overdue ordered DNA samples: {dna_ordered_sample.test}'
         ]
+
         with mock.patch('rdr_service.offline.biobank_samples_pipeline.logging') as mock_logging, \
              mock.patch('rdr_service.services.slack_utils.SlackMessageHandler.send_message_to_webhook') as mock_slack:
-            biobank_samples_pipeline.missing_samples_check()
+            biobank_samples_pipeline.overdue_samples_check(self.overdue_samples_report_dt)
+            # Verify presence of expected bucket file
+            blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
+            assert blob is not None
+
+            # Verify Slack message populated from bucket file rows
             error_log_call = mock_logging.error.call_args
             slack_webhook_args = mock_slack.call_args
-            self.assertIsNotNone(error_log_call, 'An error log should have been made')
+            self.assertIsNotNone(error_log_call, 'An error log call should have been made')
             self.assertIsNotNone(slack_webhook_args, 'A slack notification should have been made')
             for msg_str in expected_msg_substrings:
                 self.assertIn(msg_str, error_log_call.args[0])
                 self.assertIn(msg_str, slack_webhook_args.kwargs['message_data']['text'])
 
     def test_cancelled_order_sample_not_overdue(self):
+        self.clear_default_storage()
+        self.create_mock_buckets(self.mock_bucket_paths)
         participant = self.data_generator.create_database_participant()
         today = datetime.utcnow().replace(microsecond=0)
         order_ts = today - timedelta(days=9)
@@ -615,17 +636,21 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             processed=order_ts,
             finalized=order_ts
         )
+        # Verify there was no file dropped to the bucket
+        blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
+        assert blob is None
 
         with mock.patch('rdr_service.offline.biobank_samples_pipeline.logging') as mock_logging:
-            biobank_samples_pipeline.missing_samples_check()
+            biobank_samples_pipeline.overdue_samples_check(self.overdue_samples_report_dt)
             error_log_call = mock_logging.error.call_args
             self.assertIsNone(error_log_call, "Missing sample notification not expected for cancelled orders")
 
-    def test_missing_sample_not_yet_overdue(self):
+    def test_sample_not_yet_overdue(self):
+        self.clear_default_storage()
+        self.create_mock_buckets(self.mock_bucket_paths)
         participant = self.data_generator.create_database_participant()
-        today = datetime.utcnow().replace(microsecond=0)
-        order_ts = today - timedelta(days=6)
-        # Should not be notified of missing samples if less than 7 days since order was finalized
+        order_ts = self.overdue_samples_report_dt - timedelta(days=6)
+        # Should not be notified of overdue samples if less than 7 days since order was finalized
         order = self.data_generator.create_database_biobank_order(
             participantId=participant.participantId,
             orderOrigin='hpro',
@@ -644,7 +669,11 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             finalized=order_ts
         )
 
+        # Verify there was no file dropped to the bucket
+        blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
+        assert blob is None
+
         with mock.patch('rdr_service.offline.biobank_samples_pipeline.logging') as mock_logging:
-            biobank_samples_pipeline.missing_samples_check()
+            biobank_samples_pipeline.overdue_samples_check(self.overdue_samples_report_dt)
             error_log_call = mock_logging.error.call_args
-            self.assertIsNone(error_log_call, "Missing sample notification not expected for orders under a week old")
+            self.assertIsNone(error_log_call, "Overdue sample notification not expected for orders under a week old")

--- a/tests/cron_job_tests/test_offline_app_setup.py
+++ b/tests/cron_job_tests/test_offline_app_setup.py
@@ -76,9 +76,9 @@ class OfflineAppTest(BaseTestCase):
         self.send_cron_request('GenomicAW3ArrayWorkflow')
         pipeline_mock.aw3_array_manifest_workflow.assert_called()
 
-    @mock.patch('rdr_service.offline.main.biobank_samples_pipeline.missing_samples_check')
-    def test_biobank_missing_samples_check_route(self, mock_checker):
-        self.send_cron_request('BiobankMissingSamplesCheck')
+    @mock.patch('rdr_service.offline.main.biobank_samples_pipeline.overdue_samples_check')
+    def test_biobank_overdue_samples_check_route(self, mock_checker):
+        self.send_cron_request('BiobankOverdueSamplesCheck')
         mock_checker.assert_called()
 
     @mock.patch('rdr_service.offline.main.dispatch_check_consent_errors_task')


### PR DESCRIPTION
## Resolves *[DA-3597](https://precisionmedicineinitiative.atlassian.net/browse/DA-3597)*


## Description of changes/additions
Turning the previously implemented Slack alerts for missing (overdue) biobank samples into a report that gets uploaded to the biobank bucket.  A new folder has been added to the biobank bucket on prod (`overdue_dna_samples`)

Because there were other contexts that refer to "missing" samples in the biobank reconciliation process, I've renamed things (including the cron job endpoint) to "overdue" here.    Leveraging the existing `SqlExporter` class used in other biobank report generation, but added the ability to suppress bucket uploads if the SQL run by the exporter ends up with no data rows for the CSV (common for the weekly overdue samples report to have no data to report).

## Tests
- [x] unit tests




[DA-3597]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ