### PR TITLE
[DA-3673] Curation: Use cutoff date with deceased data

### DIFF
--- a/rdr_service/etl/bq/queries.py
+++ b/rdr_service/etl/bq/queries.py
@@ -941,7 +941,8 @@ queries = {
             ON
               dr.participant_id = per.person_id
             WHERE
-              dr.status = 2""",
+              dr.status = 2
+            AND dr.authored < {cutoff}""",
     },
     "ehr_consent_temp_table": {
         "destination": "tmp_ehr_consent",

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -736,6 +736,11 @@ class CurationExportClass(ToolBase):
         ).filter(
             DeceasedReport.status == DeceasedReportStatus.APPROVED
         )
+
+        if self.cutoff_date:
+            deceased_select = deceased_select.filter(
+                DeceasedReport.authored < self.cutoff_date
+            )
         insert_query = insert(Death).from_select(column_map.keys(), deceased_select)
         session.execute(insert_query)
 


### PR DESCRIPTION
## Resolves *[DA-3673](https://precisionmedicineinitiative.atlassian.net/browse/DA-3673)*


## Description of changes/additions
Use the cutoff date to exclude deceased reports authored after the date.

## Tests
- [x] unit tests




[DA-3673]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ