### PR TITLE
[DA-3660] Curation: Set Death table column values to 'NULL'

### DIFF
--- a/rdr_service/etl/bq/queries.py
+++ b/rdr_service/etl/bq/queries.py
@@ -930,9 +930,9 @@ queries = {
               dr.date_of_death AS death_date,
               CAST(dr.date_of_death AS DATETIME) AS death_datetime,
               '32809' AS death_type_concept_id,
-              NULL AS cause_concept_id,
-              NULL AS cause_source_value,
-              NULL AS cause_source_concept_id,
+              'NULL' AS cause_concept_id, -- CDR requires these columns to have a value of 'NULL'
+              'NULL' AS cause_source_value,
+              'NULL' AS cause_source_concept_id,
               'healthpro' AS src_id
             FROM
               `{dataset_id}.deceased_report` dr

--- a/rdr_service/etl/model/src_clean.py
+++ b/rdr_service/etl/model/src_clean.py
@@ -125,9 +125,9 @@ class Death(CdmBase):
     death_date = Column(Date)
     death_datetime = Column(DateTime)
     death_type_concept_id = Column(BigInteger, )
-    cause_concept_id = Column(BigInteger, nullable=True)
+    cause_concept_id = Column(String(50))
     cause_source_value = Column(String(50))
-    cause_source_concept_id = Column(BigInteger, nullable=True)
+    cause_source_concept_id = Column(String(50))
     src_id = Column(String(50))
 
 

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -723,9 +723,9 @@ class CurationExportClass(ToolBase):
             Death.death_date: DeceasedReport.dateOfDeath,
             Death.death_datetime: DeceasedReport.dateOfDeath.label('date_of_death_datetime'),
             Death.death_type_concept_id: literal("32809"),  # 32809 is the Case Report Form concept id
-            Death.cause_concept_id: literal(None),
-            Death.cause_source_value: literal(None),
-            Death.cause_source_concept_id: literal(None),
+            Death.cause_concept_id: 'NULL',  # CDR requires the text value of these columns to be 'NULL'
+            Death.cause_source_value: 'NULL',
+            Death.cause_source_concept_id: 'NULL',
             Death.src_id: literal("healthpro")
         }
         deceased_select = session.query(*column_map.values()).select_from(


### PR DESCRIPTION
## Resolves *[DA-3660](https://precisionmedicineinitiative.atlassian.net/browse/DA-3660)*


## Description of changes/additions
The columns cause_concept_id, cause_source_value, and cause_source_concept_id in the Death table need to always have the value 'NULL'

## Tests
- [] unit tests




[DA-3660]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ