### PR TITLE
[DA-3606] Vibrent WEAR consent file validation

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Collection, Dict, List, Optional
 
-from sqlalchemy import and_, not_, or_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import aliased, joinedload, Session
 
 from rdr_service.code_constants import PRIMARY_CONSENT_UPDATE_QUESTION_CODE
@@ -60,15 +60,7 @@ class ConsentDao(BaseDao):
                     ConsentFile.participant_id == QuestionnaireResponse.participantId
                 )
             ).filter(
-                ConsentFile.id.is_(None),
-
-                # TODO: remove this when WEAR file parsing is done
-                not_(
-                    and_(
-                        ConsentResponse.type.in_([ConsentType.WEAR]),
-                        Participant.participantOrigin == 'vibrent'
-                    )
-                )
+                ConsentFile.id.is_(None)
             ).options(
                 joinedload(ConsentResponse.response)
             )

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -231,8 +231,6 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
         )
 
     def _is_wear_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
-        # TODO: When implementing WEAR validation for Vibrent, remove the filter currently blocking
-        #  them from being checked (in ConsentDao.get_consent_responses_to_validate)
         return basename(blob_wrapper.blob.name).startswith('wear_consent')
 
     def _is_etm_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:

--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -233,7 +233,7 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
     def _is_wear_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         # TODO: When implementing WEAR validation for Vibrent, remove the filter currently blocking
         #  them from being checked (in ConsentDao.get_consent_responses_to_validate)
-        raise NotImplementedError('Wear consent validation not implemented for Vibrent')
+        return basename(blob_wrapper.blob.name).startswith('wear_consent')
 
     def _is_etm_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> bool:
         return 'exploring_the_mind_consent_form' in basename(blob_wrapper.blob.name)
@@ -259,7 +259,10 @@ class VibrentConsentFactory(ConsentFileAbstractFactory):
         )
 
     def _build_wear_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'WearConsentFile':
-        raise NotImplementedError('Wear consent validation not implemented for Vibrent')
+        return VibrentWearConsentFile(
+            pdf=blob_wrapper.get_parsed_pdf(),
+            blob=blob_wrapper.blob
+        )
 
     def _build_etm_consent(self, blob_wrapper: '_ConsentBlobWrapper') -> 'EtmConsentFile':
         return VibrentEtmConsentFile(pdf=blob_wrapper.get_parsed_pdf(), blob=blob_wrapper.blob)
@@ -725,6 +728,28 @@ class VibrentPrimaryConsentUpdateFile(PrimaryConsentUpdateFile):
 
 
 class VibrentEtmConsentFile(EtmConsentFile):
+    _SIGNATURE_PAGE = 7
+
+    def _get_signature_elements(self):
+        return self.pdf.get_elements_intersecting_box(
+            Rect.from_edges(left=150, right=400, bottom=155, top=160),
+            page=self._SIGNATURE_PAGE
+        )
+
+    def _get_date_elements(self):
+        return self.pdf.get_elements_intersecting_box(
+            Rect.from_edges(left=130, right=400, bottom=110, top=115),
+            page=self._SIGNATURE_PAGE
+        )
+
+    def _get_printed_name_elements(self):
+        return self.pdf.get_elements_intersecting_box(
+            Rect.from_edges(left=350, right=500, bottom=45, top=50),
+            page=self._SIGNATURE_PAGE
+        )
+
+
+class VibrentWearConsentFile(WearConsentFile):
     _SIGNATURE_PAGE = 7
 
     def _get_signature_elements(self):

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -590,6 +590,8 @@ class ConsentValidationController:
             output_strategy.add_all(self._process_validation_results(validator.get_primary_update_validation_results()))
         if self._check_consent_type(ConsentType.ETM, types_to_validate):
             output_strategy.add_all(self._process_validation_results(validator.get_etm_validation_results()))
+        if self._check_consent_type(ConsentType.WEAR, types_to_validate):
+            output_strategy.add_all(self._process_validation_results(validator.get_wear_validation_results()))
 
         # DA-3423:  Populate the consent_response_id values for the ConsentFile validation results as needed
         output_strategy.set_consent_response_ids_for_results()

--- a/tests/tool_tests/test_consents.py
+++ b/tests/tool_tests/test_consents.py
@@ -166,7 +166,12 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
             pid_file_handle = open_mock.return_value.__enter__.return_value
             pid_file_handle.__iter__.return_value = iter(participant_id_list)
 
-            test_summaries = ['one', 'forty-five', 'two hundred eighty-nine', 'three thousand twenty']
+            test_summaries = [
+                mock.MagicMock(participantId='one'),
+                mock.MagicMock(participantId='forty-five'),
+                mock.MagicMock(participantId='two hundred eighty-nine'),
+                mock.MagicMock(participantId='three thousand twenty')
+            ]
             summary_dao_class_mock.get_by_ids_with_session.return_value = test_summaries
 
             # Verify that the script uses the participant ids from the file for validation
@@ -186,9 +191,9 @@ class ConsentsTest(ToolTestMixin, BaseTestCase):
             )
 
             # Make sure the validation was done for the loaded summaries and for the specific consent type
-            controller_mock.validate_participant_consents.assert_has_calls(
+            controller_mock.validate_consent_responses.assert_has_calls(
                 calls=[
-                    mock.call(summary=summary, output_strategy=mock.ANY, types_to_validate=[ConsentType.EHR])
+                    mock.call(summary=summary, output_strategy=mock.ANY, consent_responses=mock.ANY)
                     for summary in test_summaries
                 ],
                 any_order=True


### PR DESCRIPTION
## Resolves *[DA-3606](https://precisionmedicineinitiative.atlassian.net/browse/DA-3606)*
This implements the validation of Vibrent's WEAR consent file. The number of pages and layout matches the ETM consent, so the values were duplicated from that.

## Tests
- [] unit tests




[DA-3606]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ