### PR TITLE
[DA-3640] NPH Modules 2 & 3 - Add new diet fields to Biobank Order API

### DIFF
--- a/rdr_service/data_gen/generators/nph.py
+++ b/rdr_service/data_gen/generators/nph.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from rdr_service.ancillary_study_resources.nph.enums import ModuleTypes
 from rdr_service.dao import database_factory
+from rdr_service.model.rex import ParticipantMapping
 from rdr_service.model.study_nph import Participant, Site, PairingEvent, ParticipantEventActivity, Activity, \
     PairingEventType, ConsentEvent, ConsentEventType, EnrollmentEventType, EnrollmentEvent, WithdrawalEvent, \
     DeactivationEvent, ParticipantOpsDataElement, OrderedSample, StoredSample, Order, StudyCategory, DietEvent
@@ -59,6 +60,24 @@ class NphDataGenerator(NphBaseGenerator):
         participant = self._participant(**fields)
         self._commit_to_database(participant)
         return participant
+
+    @staticmethod
+    def _rex_participant_mapping(**kwargs):
+        return ParticipantMapping(**kwargs)
+
+    def create_database_rex_participant_mapping(self, **kwargs):
+
+        fields = {
+            "primary_study_id": 1,
+            "ancillary_study_id": 2,
+            "primary_participant_id": kwargs.get("primary_participant_id"),
+            "ancillary_participant_id": kwargs.get("ancillary_participant_id"),
+        }
+        fields.update(kwargs)
+
+        participant_mapping = self._rex_participant_mapping(**fields)
+        self._commit_to_database(participant_mapping)
+        return participant_mapping
 
     @staticmethod
     def _site(**kwargs):

--- a/tests/api_tests/test_nph_participant_biobank_order_api.py
+++ b/tests/api_tests/test_nph_participant_biobank_order_api.py
@@ -513,3 +513,5 @@ class TestNPHParticipantOrderAPI(BaseTestCase):
         self.clear_table_after_test("nph.study_category")
         self.clear_table_after_test("nph.participant")
         self.clear_table_after_test("nph.sample_update")
+        self.clear_table_after_test("rex.participant_mapping")
+        self.clear_table_after_test("rex.study")

--- a/tests/api_tests/test_nph_participant_biobank_order_api.py
+++ b/tests/api_tests/test_nph_participant_biobank_order_api.py
@@ -4,13 +4,16 @@ import json
 from sqlalchemy.orm import Query
 from unittest.mock import MagicMock, patch
 
+from rdr_service.dao.rex_dao import RexStudyDao
+from rdr_service.dao.study_nph_dao import NphOrderedSampleDao
+from rdr_service.data_gen.generators.nph import NphDataGenerator, NphSmsDataGenerator
 from tests.helpers.unittest_base import BaseTestCase
 from rdr_service.dao import database_factory
 from rdr_service.main import app
 from rdr_service.model.study_nph import (
     StudyCategory, Order, OrderedSample, Participant, SampleUpdate, Site
 )
-
+from tests.workflow_tests.test_data.test_biobank_order_payloads import SALIVA_DIET_SAMPLE, URINE_DIET_SAMPLE
 
 BLOOD_SAMPLE = {
     "subject": "Patient/P124820391",
@@ -127,6 +130,52 @@ PATCH_CANCEL_SAMPLE = {
 
 
 class TestNPHParticipantOrderAPI(BaseTestCase):
+
+    def setUp(self, *args, **kwargs) -> None:
+        super().setUp(*args, **kwargs)
+        self.nph_datagen = NphDataGenerator()
+        self.sms_datagen = NphSmsDataGenerator()
+
+    @staticmethod
+    def _create_initial_study_data():
+        study_dao = RexStudyDao()
+        aou = study_dao.model_type(schema_name='rdr')
+        nph = study_dao.model_type(schema_name='nph')
+        study_dao.insert(aou)
+        study_dao.insert(nph)
+
+    def setup_backend_for_diet_orders(self):
+        self._create_initial_study_data()
+        self.nph_datagen.create_database_site(
+            external_id="test-site-1",
+            name="Test Site 1",
+            awardee_external_id="test-hpo-1",
+            organization_external_id="test-org-1"
+        )
+        self.sms_datagen.create_database_study_category(
+            name="3",
+            type_label="module"
+        )
+        self.sms_datagen.create_database_study_category(
+            name="Diet",
+            type_label="visitType",
+            parent_id=1,
+        )
+        self.sms_datagen.create_database_study_category(
+            name="Day 0",
+            type_label="timepoint",
+            parent_id=2,
+        )
+        self.nph_datagen.create_database_participant(
+            id=100001,
+            biobank_id=11110000101
+        )
+        aou_participant = self.data_generator.create_database_participant()
+        self.data_generator.create_database_participant_summary(participant=aou_participant)
+        self.nph_datagen.create_database_rex_participant_mapping(
+            primary_participant_id=aou_participant.participantId,
+            ancillary_participant_id=100001,
+        )
 
     @patch('rdr_service.dao.study_nph_dao.Query.filter')
     @patch('rdr_service.api.nph_participant_biobank_order_api.database_factory')
@@ -430,6 +479,31 @@ class TestNPHParticipantOrderAPI(BaseTestCase):
             result = query.all()
             for each in result:
                 self.assertIsNotNone(each.ordered_sample_json)
+
+    def test_diet_saliva_order(self):
+        self.setup_backend_for_diet_orders()
+        app.test_client().post('rdr/v1/api/v1/nph/Participant/100001/BiobankOrder', json=SALIVA_DIET_SAMPLE)
+        dao = NphOrderedSampleDao()
+        aliquot = dao.get_from_aliquot_id('456')[0]
+        expected_supplement = {"glycerolAdditiveVolume": {"units": "uL", "volume": 1000}}
+        self.assertEqual(expected_supplement, aliquot.supplemental_fields)
+
+    def test_diet_urine_order(self):
+        self.setup_backend_for_diet_orders()
+        app.test_client().post('rdr/v1/api/v1/nph/Participant/100001/BiobankOrder', json=URINE_DIET_SAMPLE)
+        dao = NphOrderedSampleDao()
+        sample = dao.get(1)
+        expected_supplement = {
+            "dlwdose":
+                {
+                    "dose": "84",
+                    "batchid": "NPHDLW9172397",
+                    "dosetime": "2022-11-03T08:45:49Z",
+                    "calculateddose": "84.57",
+                    "participantweight": "56.38"
+                }
+        }
+        self.assertEqual(expected_supplement, sample.supplemental_fields)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/dao_tests/test_study_nph_dao.py
+++ b/tests/dao_tests/test_study_nph_dao.py
@@ -1005,7 +1005,7 @@ class NphOrderedSampleDaoTest(BaseTestCase):
         request = json.loads(json.dumps(TEST_URINE_SAMPLE), object_hook=lambda d: Namespace(**d))
         order_sample_dao = NphOrderedSampleDao()
         os = order_sample_dao.from_client_json(request, 1, "10001")
-        supplemental_field = order_sample_dao._fetch_supplemental_fields(request)
+        supplemental_field = order_sample_dao._fetch_supplemental_fields_for_tube(request)
         self.assertEqual(os.supplemental_fields, supplemental_field)
 
     @patch('rdr_service.dao.study_nph_dao.Query.filter')

--- a/tests/workflow_tests/test_data/test_biobank_order_payloads.py
+++ b/tests/workflow_tests/test_data/test_biobank_order_payloads.py
@@ -1,0 +1,163 @@
+SALIVA_DIET_SAMPLE = {
+    "subject": "Patient/P100001",
+    "identifier": [{
+        "system": "http://www.pmi-ops.org/order-id",
+        "value": "nph-order-id-123"
+    }, {
+        "system": "http://www.pmi-ops.org/sample-id",
+        "value": "nph-sample-id-456"
+    }, {
+        "system": "http://www.pmi-ops.org/client-id",
+        "value": "123456789"
+    }],
+    "createdInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "collectedInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "finalizedInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "created": "2022-11-03T09:40:21Z",
+    "module": "3",
+    "visitType": "Diet",
+    "timepoint": "Day 0",
+    "sample": {
+        "test": "Saliva",
+        "description": "Saliva Sample",
+        "collected": "2022-11-03T09:45:49Z",
+        "finalized": "2022-11-03T10:55:41Z"
+    },
+    "aliquots": [
+        {
+            "id": "123",
+            "identifier": "SALIVAA1",
+            "container": "5mL Matrix tube (no glycerol)",
+            "volume": "3.8",
+            "description": "5mL Matrix tube",
+            "collected": "2022-11-03T09:45:49Z",
+            "units": "mL"
+        }, {
+            "id": "456",
+            "identifier": "SALIVAA2",
+            "container": "5mL Matrix tube (w/glycerol)",
+            "volume": "3",
+            "description": "5mL Matrix tube",
+            "collected": "2022-11-03T09:45:49Z",
+            "units": "mL",
+            "glycerolAdditiveVolume": {
+                "units": "uL",
+                "volume": 1000
+            }
+        }
+    ],
+    "notes": {
+        "collected": "Test notes 1",
+        "finalized": "Test notes 2"
+    }
+}
+
+URINE_DIET_SAMPLE = {
+    "subject": "Patient/P124820391",
+    "identifier": [{
+        "system": "http://www.pmi-ops.org/order-id",
+        "value": "nph-order-id-123"
+    }, {
+        "system": "http://www.pmi-ops.org/sample-id",
+        "value": "nph-sample-id-456"
+    }, {
+        "system": "http://www.pmi-ops.org/client-id",
+        "value": "123456789"
+    }],
+    "createdInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "collectedInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "finalizedInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "created": "2022-11-03T09:40:21Z",
+    "module": "3",
+    "visitType": "OrangeDLW",
+    "timepoint": "Day 0 Pre Dose A",
+    "sample": {
+        "test": "Urine",
+        "description": "Urine Sample",
+        "collected": "2022-11-03T09:45:49Z",
+        "finalized": "2022-11-03T10:55:41Z",
+        "dlwdose": {
+            "batchid": "NPHDLW9172397",
+            "participantweight": "56.38",
+            "dose": "84",
+            "calculateddose": "84.57",
+            "dosetime": "2022-11-03T08:45:49Z"
+
+        }
+    },
+    "aliquots": [{
+        "id": "123",
+        "identifier": "SALIVAA1",
+        "container": "5mL Matrix tube (no glycerol)",
+        "volume": "3.8",
+        "description": "5mL Matrix tube",
+        "collected": "2022-11-03T09:45:49Z",
+        "units": "mL"
+    }, {
+        "id": "456",
+        "identifier": "urineDlw",
+        "container": "5mL Matrix tube (w/glycerol)",
+        "volume": "3",
+        "description": "5mL Matrix tube",
+        "collected": "2022-11-03T09:45:49Z",
+        "units": "mL"
+    }],
+    "notes": {
+        "collected": "Test notes 1",
+        "finalized": "Test notes 2"
+    }
+}


### PR DESCRIPTION
## Resolves *[DA-3640](https://precisionmedicineinitiative.atlassian.net/browse/DA-3640)*


## Description of changes/additions
This PR allows the NPH Biobank Order API to ingest the new diet-related fields for modules 2 & 3. These new data elements are stored as "supplemental fields" in the `ordered_sample` table. The two new fields are on different levels---i.e. tube and aliquot. The new fields also include key-value pairs. In an effort to be minimally invasive due to the short turn-around, the population of supplemental fields on the tube and aliquot levels are handled in separate methods. The additional method `check_input_struct()` was created to check the structure of the input data. This avoids JSON serialization errors when data is returned as a `SimpleNamespace` instance.

Note: The ticket refers to the "File Drop," but we are not actually modifying the file delivered to the Biobank in any way.

## Tests
- [x] unit tests




[DA-3640]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ