### PR TITLE
[DA-3632] Update Outreach to Only return based on participant origin

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -312,7 +312,7 @@ class GenomicOutreachApiV2(UpdatableApi):
         if not participant_id and not start_date:
             raise BadRequest('Participant ID or Start Date is required for GenomicOutreach lookup.')
 
-        participant_origin = self.user_info[1].get('clientId')
+        participant_origin = self.user_info.get('clientId')
         if participant_origin not in GENOMIC_CLIENT_IDS:
             raise BadRequest('Client Id cannot access GenomicOutreach lookup.')
 

--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -7,7 +7,8 @@ from werkzeug.exceptions import NotFound, BadRequest
 from rdr_service import clock, config
 from rdr_service.api.base_api import BaseApi, log_api_request, UpdatableApi
 from rdr_service.api_util import GEM, RDR_AND_PTC, RDR
-from rdr_service.app_util import auth_required, restrict_to_gae_project
+from rdr_service.app_util import auth_required, restrict_to_gae_project, get_validated_user_info
+from rdr_service.config import GENOMIC_CLIENT_IDS
 from rdr_service.dao.genomics_dao import GenomicPiiDao, GenomicSetMemberDao, GenomicOutreachDao, GenomicOutreachDaoV2, \
     GenomicSchedulingDao, GenomicMemberReportStateDao
 from rdr_service.dao.participant_dao import ParticipantDao
@@ -135,7 +136,7 @@ class GenomicPiiApi(BaseApi):
             participant_id = None
 
         api_payload = GenomicGETPayload(
-            self.dao.get_pii,
+            method=self.dao.get_pii,
             participant_id=participant_id,
             biobank_id=biobank_id,
             mode=mode
@@ -268,6 +269,8 @@ class GenomicOutreachApiV2(UpdatableApi):
     def __init__(self):
         super().__init__(GenomicOutreachDaoV2())
         self.validate_outreach_params()
+        _, user_info = get_validated_user_info()
+        self.user_info = user_info
 
     @auth_required(RDR_AND_PTC)
     def get(self):
@@ -309,11 +312,16 @@ class GenomicOutreachApiV2(UpdatableApi):
         if not participant_id and not start_date:
             raise BadRequest('Participant ID or Start Date is required for GenomicOutreach lookup.')
 
+        participant_origin = self.user_info[1].get('clientId')
+        if participant_origin not in GENOMIC_CLIENT_IDS:
+            raise BadRequest('Client Id cannot access GenomicOutreach lookup.')
+
         api_payload = GenomicGETPayload(
-            self.dao.get_outreach_data,
+            method=self.dao.get_outreach_data,
             participant_id=participant_id,
             start_date=start_date,
-            end_date=end_date
+            end_date=end_date,
+            participant_origin=participant_origin
         )
         payload = api_payload.get_payload()
 
@@ -487,7 +495,7 @@ class GenomicSchedulingApi(BaseApi):
             raise BadRequest('Participant ID or Start Date parameter is required for use with GenomicScheduling API.')
 
         api_payload = GenomicGETPayload(
-            self.dao.get_latest_scheduling_data,
+            method=self.dao.get_latest_scheduling_data,
             participant_id=participant_id,
             start_date=start_date,
             end_date=end_date,

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -143,6 +143,7 @@ SENDGRID_FROM_EMAIL = "no-reply@pmi-ops.org"
 MAYOLINK_ENDPOINT = "mayolink_endpoint"
 GENOMIC_API_MODES = ('gem', 'rhp', 'pgx', 'hdr')
 GENOMIC_CVL_SITES = ('co', 'uw', 'bcm')
+GENOMIC_CLIENT_IDS = ('vibrent', 'careevolution')
 GENOMIC_CVL_SITE_BUCKET_MAP = 'cvl_site_bucket_map'
 GENOMIC_GC_SITE_BUCKET_MAP = 'gc_site_bucket_map'
 CONFIG_BUCKET = "all-of-us-rdr-sequestered-config-test"

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1071,7 +1071,6 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
                 ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED,
                 GenomicGCValidationMetrics.drcFpConcordance.ilike('pass'),
                 GenomicSetMember.diversionPouchSiteFlag != 1,
-                ParticipantSummary.participantOrigin != 'careevolution',
                 GenomicSetMember.ignoreFlag != 1,
                 GenomicSetMember.blockResults != 1,
             )
@@ -1837,7 +1836,12 @@ class GenomicPiiDao(BaseDao):
         participant_dict = participant_data._asdict()
         return {self.camel_to_snake(k): v for k, v in participant_dict.items()}
 
-    def get_pii(self, mode, participant_id=None, biobank_id=None):
+    def get_pii(
+        self,
+        mode,
+        participant_id=None,
+        biobank_id=None
+    ):
         """
         :param mode:
         :param participant_id:
@@ -2164,7 +2168,16 @@ class GenomicOutreachDaoV2(BaseDao):
             "timestamp": timestamp
         }
 
-    def get_outreach_data(self, participant_id=None, start_date=None, end_date=None):
+    def get_outreach_data(
+        self,
+        participant_id=None,
+        start_date=None,
+        end_date=None,
+        participant_origin=None
+    ):
+        if not participant_origin:
+            return []
+
         informing_loops, results = [], []
         end_date = clock.CLOCK.now() if not end_date else end_date
         informing_loop_ready = GenomicSetMemberDao.base_informing_loop_ready().subquery()
@@ -2221,7 +2234,8 @@ class GenomicOutreachDaoV2(BaseDao):
                         GenomicInformingLoop.decision_value.isnot(None),
                         GenomicInformingLoop.module_type.in_(self.module),
                         GenomicInformingLoop.event_authored_time.isnot(None),
-                        GenomicSetMember.ignoreFlag != 1
+                        GenomicSetMember.ignoreFlag != 1,
+                        GenomicSetMember.participantOrigin == participant_origin
                     )
                 )
                 ready_loop = (
@@ -2234,7 +2248,8 @@ class GenomicOutreachDaoV2(BaseDao):
                         informing_loop_ready.c.participant_id == GenomicSetMember.participantId
                     ).filter(
                         GenomicSetMember.informingLoopReadyFlag == 1,
-                        GenomicSetMember.informingLoopReadyFlagModified.isnot(None)
+                        GenomicSetMember.informingLoopReadyFlagModified.isnot(None),
+                        GenomicSetMember.participantOrigin == participant_origin
                     )
                 )
                 if participant_id:
@@ -2286,7 +2301,8 @@ class GenomicOutreachDaoV2(BaseDao):
                         ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
                         GenomicMemberReportState.genomic_report_state.in_(self.report_query_state),
                         GenomicMemberReportState.event_authored_time.isnot(None),
-                        GenomicSetMember.ignoreFlag != 1
+                        GenomicSetMember.ignoreFlag != 1,
+                        GenomicSetMember.participantOrigin == participant_origin
                     )
                 )
 
@@ -2313,7 +2329,8 @@ class GenomicOutreachDaoV2(BaseDao):
                         ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
                         GenomicMemberReportState.genomic_report_state.in_(self.report_query_state),
                         GenomicResultViewed.event_authored_time.isnot(None),
-                        GenomicSetMember.ignoreFlag != 1
+                        GenomicSetMember.ignoreFlag != 1,
+                        GenomicSetMember.participantOrigin == participant_origin
                     )
                 )
 

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -132,6 +132,11 @@ class GenomicApiTestBase(BaseTestCase):
         new_user_info['example@example.com']['roles'] = roles
         self.temporarily_override_config_setting(config.USER_INFO, new_user_info)
 
+    def overwrite_test_user_client_id(self, client_id: str) -> None:
+        new_user_info = deepcopy(config.getSettingJson(config.USER_INFO))
+        new_user_info['example@example.com']['clientId'] = client_id
+        self.temporarily_override_config_setting(config.USER_INFO, new_user_info)
+
 
 class GPGenomicPIIApiTest(GenomicApiTestBase):
     def setUp(self):
@@ -257,7 +262,8 @@ class GPGenomicPIIApiTest(GenomicApiTestBase):
             qcStatus=GenomicQcStatus.PASS,
             gcManifestSampleSource='Whole Blood',
             informingLoopReadyFlag=1,
-            informingLoopReadyFlagModified=clock.CLOCK.now()
+            informingLoopReadyFlagModified=clock.CLOCK.now(),
+            participantOrigin='vibrent'
         )
         self.data_generator.create_database_genomic_gc_validation_metrics(
             genomicSetMemberId=wgs_member.id,
@@ -287,13 +293,14 @@ class GPGenomicPIIApiTest(GenomicApiTestBase):
         self.assertIsNotNone(response)
         self.assertEqual(response.get('hgm_informing_loop'), True)
 
+        # base informimg loop ready changes allow all origins now
         update_summary = self.ps_dao.get_by_participant_id(p.participantId)
         update_summary.participantOrigin = 'careevolution'
         self.ps_dao.update(update_summary)
 
         response = self.send_get(f"GenomicPII/GP/P{p.participantId}")
         self.assertIsNotNone(response)
-        self.assertEqual(response.get('hgm_informing_loop'), False)
+        self.assertEqual(response.get('hgm_informing_loop'), True)
 
 
 class RhpGenomicPIIApiTest(GenomicApiTestBase):
@@ -635,6 +642,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
         self.member_dao = GenomicSetMemberDao()
         self.num_participants = 5
 
+        self.overwrite_test_user_client_id('vibrent')
+
     # GET
     def test_full_participant_validation_lookup(self):
 
@@ -675,7 +684,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
         gen_member = self.data_generator.create_database_genomic_set_member(
             genomicSetId=gen_set.id,
             participantId=participant.participantId,
-            genomeType='aou_array'
+            genomeType='aou_array',
+            participantOrigin='vibrent'
         )
 
         resp = self.send_get(
@@ -794,7 +804,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 sampleId="21042005280",
                 genomeType=genome_type,
                 genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
-                participantId=participant.participantId
+                participantId=participant.participantId,
+                participantOrigin='vibrent'
             )
 
             self.data_generator.create_database_genomic_member_report_state(
@@ -879,6 +890,110 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
         self.assertEqual(len(resp['data'][0]), 5)
         self.assertEqual(expected, resp)
 
+    def test_get_participant_lookup_filter_origin(self):
+        first_participant, second_participant = None, None
+        fake_date = parser.parse('2020-05-29T08:00:01-05:00')
+        fake_now = clock.CLOCK.now().replace(microsecond=0)
+
+        gen_set = self.data_generator.create_database_genomic_set(
+            genomicSetName=".",
+            genomicSetCriteria=".",
+            genomicSetVersion=1
+        )
+
+        for num in range(self.num_participants):
+            participant = self.data_generator.create_database_participant()
+
+            self.data_generator.create_database_participant_summary(
+                participant=participant,
+                consentForGenomicsRORAuthored=fake_date,
+                consentForStudyEnrollmentAuthored=fake_date
+            )
+
+            module = 'gem'
+            report_state = GenomicReportState.GEM_RPT_READY
+            genome_type = 'aou_array'
+            report_revision_number = 1
+            current_origin = None
+
+            if num == 0:
+                first_participant = participant
+                current_origin = 'vibrent'
+            elif num == 1:
+                second_participant = participant
+                current_origin = 'careevolution'
+
+            gen_member = self.data_generator.create_database_genomic_set_member(
+                genomicSetId=gen_set.id,
+                biobankId="100153482",
+                sampleId="21042005280",
+                genomeType=genome_type,
+                genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
+                participantId=participant.participantId,
+                participantOrigin=current_origin
+            )
+
+            self.data_generator.create_database_genomic_member_report_state(
+                genomic_set_member_id=gen_member.id,
+                participant_id=participant.participantId,
+                module=module,
+                genomic_report_state=report_state,
+                report_revision_number=report_revision_number,
+                event_authored_time=fake_date
+            )
+
+        # SHOULD return data since participant origin is vibrent
+        with clock.FakeClock(fake_now):
+            resp = self.send_get(f'GenomicOutreachV2?participant_id={first_participant.participantId}')
+
+        self.assertIsNotNone(resp)
+        self.assertIsNotNone(resp.get('timestamp'))
+        response_data = resp['data']
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0].get('module'), 'gem')
+        self.assertEqual(response_data[0].get('type'), 'result')
+        self.assertEqual(response_data[0].get('status'), 'ready')
+        self.assertEqual(response_data[0].get('participant_id'), f'P{first_participant.participantId}')
+
+        self.overwrite_test_user_client_id('careevolution')
+
+        # SHOULD NOT return since participant origin is vibrent
+        # and user client_id is careevoluton
+        with clock.FakeClock(fake_now):
+            resp = self.send_get(
+                f'GenomicOutreachV2?participant_id={first_participant.participantId}',
+                expected_status=http.client.NOT_FOUND
+            )
+
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json['message'], f"Participant with ID {first_participant.participantId}"
+                                               f" did not pass validation check")
+
+        # SHOULD return data since participant origin is careevolution
+        with clock.FakeClock(fake_now):
+            resp = self.send_get(f'GenomicOutreachV2?participant_id={second_participant.participantId}')
+
+        self.assertIsNotNone(resp)
+        self.assertIsNotNone(resp.get('timestamp'))
+        response_data = resp['data']
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0].get('module'), 'gem')
+        self.assertEqual(response_data[0].get('type'), 'result')
+        self.assertEqual(response_data[0].get('status'), 'ready')
+        self.assertEqual(response_data[0].get('participant_id'), f'P{second_participant.participantId}')
+
+        self.overwrite_test_user_client_id('example')
+
+        # SHOULD NOT return data since client_id is invalid
+        with clock.FakeClock(fake_now):
+            resp = self.send_get(
+                f'GenomicOutreachV2?participant_id={second_participant.participantId}',
+                expected_status=http.client.BAD_REQUEST
+            )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json['message'], f"Client Id cannot access GenomicOutreach lookup.")
+
     def test_get_by_type(self):
         self.num_participants = 10
         fake_date_one = parser.parse('2020-05-29T08:00:01-05:00')
@@ -912,7 +1027,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 sampleId="21042005280",
                 genomeType="aou_array",
                 genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
-                participantId=participant.participantId
+                participantId=participant.participantId,
+                participantOrigin='vibrent'
             )
 
             report_obj = self.data_generator.create_database_genomic_member_report_state(
@@ -1035,7 +1151,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 sampleId="21042005280",
                 genomeType=genome_type,
                 genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
-                participantId=participant.participantId
+                participantId=participant.participantId,
+                participantOrigin='vibrent'
             )
 
             self.data_generator.create_database_genomic_member_report_state(
@@ -1123,7 +1240,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             genomeType="aou_wgs",
             genomicWorkflowState=GenomicWorkflowState.CVL_READY,
             participantId=participant.participantId,
-            genomicWorkflowStateModifiedTime=clock.CLOCK.now()
+            genomicWorkflowStateModifiedTime=clock.CLOCK.now(),
+            participantOrigin='vibrent'
         )
 
         self.data_generator.create_database_genomic_member_report_state(
@@ -1176,6 +1294,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 genomeType="aou_array",
                 genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
                 participantId=participant.participantId,
+                participantOrigin='vibrent'
             )
 
             report_obj = self.data_generator.create_database_genomic_member_report_state(
@@ -1254,7 +1373,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             genomeType="aou_array",
             genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
             participantId=participant_one.participantId,
-            genomicWorkflowStateModifiedTime=fake_date_two
+            genomicWorkflowStateModifiedTime=fake_date_two,
+            participantOrigin='vibrent'
         )
 
         for i, _ in enumerate(decisions):
@@ -1283,7 +1403,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             genomeType="aou_array",
             genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
             participantId=participant_two.participantId,
-            genomicWorkflowStateModifiedTime=fake_date_two
+            genomicWorkflowStateModifiedTime=fake_date_two,
+            participantOrigin='vibrent'
         )
 
         for i, _ in enumerate(decisions):
@@ -1344,7 +1465,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 qcStatus=GenomicQcStatus.PASS,
                 gcManifestSampleSource='Whole Blood',
                 informingLoopReadyFlag=1,
-                informingLoopReadyFlagModified=loop_modified_date
+                informingLoopReadyFlagModified=loop_modified_date,
+                participantOrigin='vibrent'
             )
 
             self.data_generator.create_database_genomic_gc_validation_metrics(
@@ -1429,7 +1551,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             qcStatus=GenomicQcStatus.PASS,
             gcManifestSampleSource='Whole Blood',
             informingLoopReadyFlag=1,
-            informingLoopReadyFlagModified=fake_date_one
+            informingLoopReadyFlagModified=fake_date_one,
+            participantOrigin='vibrent'
         )
 
         self.data_generator.create_database_genomic_gc_validation_metrics(
@@ -1512,7 +1635,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
                 genomeType=genome_type,
                 genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
                 participantId=participant.participantId,
-                genomicWorkflowStateModifiedTime=fake_date_two
+                genomicWorkflowStateModifiedTime=fake_date_two,
+                participantOrigin='vibrent'
             )
 
             # gem decision
@@ -1640,7 +1764,8 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             genomeType=genome_type,
             genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
             participantId=participant.participantId,
-            genomicWorkflowStateModifiedTime=fake_date_one
+            genomicWorkflowStateModifiedTime=fake_date_one,
+            participantOrigin='vibrent'
         )
 
         self.data_generator.create_database_genomic_member_report_state(
@@ -1713,6 +1838,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             genomeType=config.GENOME_TYPE_ARRAY,
             genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY,
             participantId=participant.participantId,
+            participantOrigin='vibrent'
         )
 
         gem_member_report_state = self.data_generator.create_database_genomic_member_report_state(
@@ -1758,6 +1884,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
             genomeType=config.GENOME_TYPE_WGS,
             genomicWorkflowState=GenomicWorkflowState.CVL_READY,
             participantId=participant.participantId,
+            participantOrigin='vibrent'
         )
 
         hdr_report_state = self.data_generator.create_database_genomic_member_report_state(
@@ -1941,7 +2068,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
         ready_modules = ['hdr', 'pgx']
         self.build_ready_loop_template_data()
 
-        participant = self.data_generator.create_database_participant()
+        participant = self.data_generator.create_database_participant(participantOrigin='vibrent')
 
         resp = self.send_post(
             f'GenomicOutreachV2?participant_id=P{participant.participantId}',
@@ -1964,7 +2091,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
     def test_post_twice_same_pid_validation(self):
         self.build_ready_loop_template_data()
 
-        participant = self.data_generator.create_database_participant()
+        participant = self.data_generator.create_database_participant(participantOrigin='vibrent')
 
         resp = self.send_post(
             f'GenomicOutreachV2?participant_id=P{participant.participantId}',
@@ -1993,7 +2120,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
     def test_post_with_no_inserts_via_template_returns_correctly(self):
         self.build_ready_loop_template_data()
 
-        participant = self.data_generator.create_database_participant()
+        participant = self.data_generator.create_database_participant(participantOrigin='vibrent')
 
         resp = self.send_post(
             f'GenomicOutreachV2?participant_id=P{participant.participantId}',
@@ -2027,7 +2154,7 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
 
         self.build_ready_loop_template_data()
 
-        participant = self.data_generator.create_database_participant()
+        participant = self.data_generator.create_database_participant(participantOrigin='vibrent')
 
         # POST to create set member
         resp = self.send_post(
@@ -2093,7 +2220,8 @@ class GenomicSchedulingApiTest(GenomicApiTestBase):
         self.data_generator.create_database_genomic_set_member(
             genomicSetId=self.gen_set.id,
             participantId=participant.participantId,
-            genomeType='aou_array'
+            genomeType='aou_array',
+            participantOrigin='vibrent'
         )
 
         return participant
@@ -2138,7 +2266,8 @@ class GenomicSchedulingApiTest(GenomicApiTestBase):
         self.data_generator.create_database_genomic_set_member(
             genomicSetId=gen_set.id,
             participantId=participant.participantId,
-            genomeType='aou_array'
+            genomeType='aou_array',
+            participantOrigin='vibrent'
         )
 
         resp = self.send_get(
@@ -3359,7 +3488,8 @@ class GenomicCloudTasksApiTest(BaseTestCase):
             biobankId="100153482",
             sampleId="21042005280",
             genomeType="aou_array",
-            genomicWorkflowState=GenomicWorkflowState.AW0
+            genomicWorkflowState=GenomicWorkflowState.AW0,
+            participantOrigin='vibrent'
         )
 
         data = {}


### PR DESCRIPTION
## Resolves *[ticket DA-3632]*
https://precisionmedicineinitiative.atlassian.net/browse/DA-3632

## Description of changes/additions
Updating the outreach API to only return participants based on the client_id that is stored in the user configs that are linked to the service accounts

## Tests
- [x] unit tests


