### PR TITLE
[DA-3686] Fixing errors when building deceased report api documentation

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@
 sphinx-rtd-theme==1.2.2
 readthedocs-sphinx-ext==2.2.1
 docutils==0.18.1
+mysqlclient==1.4.6

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -83,7 +83,7 @@ python-dateutil==2.8.1    # via alembic, faker
 python-editor==1.0.4      # via alembic
 python-http-client==3.2.7  # via sendgrid
 pytz==2020.1              # via babel, flask-restful, google-api-core, google-cloud-firestore
-pyyaml==5.4.1             # via google-python-cloud-debugger
+pyyaml==6.0             # via google-python-cloud-debugger
 pyzmq==25.1.0             # via locust
 redis==4.5.4              # via flask-limiter
 requests-oauthlib==1.3.0  # via jira


### PR DESCRIPTION
## Partially Resolves *[DA-3686](https://precisionmedicineinitiative.atlassian.net/browse/DA-3686)*
We need to provide CE with some documentation on endpoints, and one of them is the deceased report api. RTD has been having errors building those sections (a mysql module is a dependency of loading the dao), so this PR fixes the errors to make that documentation available again. 


## Tests
- [ ] unit tests




[DA-3686]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ