### PR TITLE
[DA-3708] Adding origin filter to Scheduling API

### DIFF
--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -477,6 +477,8 @@ class GenomicSchedulingApi(BaseApi):
     def __init__(self):
         super().__init__(GenomicSchedulingDao())
         self.validate_scheduling_params()
+        _, user_info = get_validated_user_info()
+        self.user_info = user_info
 
     @auth_required(RDR_AND_PTC)
     def get(self):
@@ -500,12 +502,17 @@ class GenomicSchedulingApi(BaseApi):
         if not participant_id and not start_date:
             raise BadRequest('Participant ID or Start Date parameter is required for use with GenomicScheduling API.')
 
+        participant_origin = self.user_info.get('clientId')
+        if participant_origin not in GENOMIC_CLIENT_IDS:
+            raise BadRequest('Client Id cannot access GenomicScheduling lookup.')
+
         api_payload = GenomicGETPayload(
             method=self.dao.get_latest_scheduling_data,
             participant_id=participant_id,
             start_date=start_date,
             end_date=end_date,
-            module=module
+            module=module,
+            participant_origin=participant_origin
         )
         payload = api_payload.get_payload()
 

--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -2,7 +2,7 @@ import pytz
 from dateutil import parser
 
 from flask import request
-from werkzeug.exceptions import NotFound, BadRequest
+from werkzeug.exceptions import NotFound, BadRequest, Forbidden
 
 from rdr_service import clock, config
 from rdr_service.api.base_api import BaseApi, log_api_request, UpdatableApi
@@ -238,7 +238,8 @@ class GenomicOutreachApi(BaseApi):
         model = self.dao.from_client_json(resource, participant_id=p_id, mode='gem')
         participant_origin = self.user_info.get('clientId')
         if participant_origin not in GENOMIC_CLIENT_IDS:
-            raise BadRequest('Client Id cannot access GenomicOutreach update.')
+            raise Forbidden('Client Id cannot access GenomicOutreach update.')
+
         model.participantOrigin = participant_origin
         m = self._do_insert(model)
 
@@ -320,7 +321,7 @@ class GenomicOutreachApiV2(UpdatableApi):
 
         participant_origin = self.user_info.get('clientId')
         if participant_origin not in GENOMIC_CLIENT_IDS:
-            raise BadRequest('Client Id cannot access GenomicOutreach lookup.')
+            raise Forbidden('Client Id cannot access GenomicOutreach lookup.')
 
         api_payload = GenomicGETPayload(
             method=self.dao.get_outreach_data,
@@ -504,7 +505,7 @@ class GenomicSchedulingApi(BaseApi):
 
         participant_origin = self.user_info.get('clientId')
         if participant_origin not in GENOMIC_CLIENT_IDS:
-            raise BadRequest('Client Id cannot access GenomicScheduling lookup.')
+            raise Forbidden('Client Id cannot access GenomicScheduling lookup.')
 
         api_payload = GenomicGETPayload(
             method=self.dao.get_latest_scheduling_data,

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2423,7 +2423,17 @@ class GenomicSchedulingDao(BaseDao):
             "timestamp": timestamp
         }
 
-    def get_latest_scheduling_data(self, participant_id=None, start_date=None, end_date=None, module=None):
+    def get_latest_scheduling_data(
+        self,
+        participant_id=None,
+        start_date=None,
+        end_date=None,
+        module=None,
+        participant_origin=None
+    ):
+        if not participant_origin:
+            return []
+
         max_appointment_id_subquery = sqlalchemy.orm.Query(
             [functions.max(GenomicAppointmentEvent.appointment_id).label(
                 'max_appointment_id'
@@ -2487,7 +2497,8 @@ class GenomicSchedulingDao(BaseDao):
                     max_appointment_id_subquery.c.max_appointment_id,
                     GenomicAppointmentEvent.event_authored_time ==
                     max_event_authored_time_subquery.c.max_event_authored_time
-                )
+                ),
+                GenomicSetMember.participantOrigin == participant_origin
             )
 
             if module:

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -994,10 +994,10 @@ class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
         with clock.FakeClock(fake_now):
             resp = self.send_get(
                 f'GenomicOutreachV2?participant_id={second_participant.participantId}',
-                expected_status=http.client.BAD_REQUEST
+                expected_status=http.client.FORBIDDEN
             )
 
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 403)
         self.assertEqual(resp.json['message'], f"Client Id cannot access GenomicOutreach lookup.")
 
     def test_get_by_type(self):
@@ -2379,10 +2379,10 @@ class GenomicSchedulingApiTest(GenomicApiTestBase):
         # SHOULD NOT return data since client_id is invalid
         resp = self.send_get(
                 f'GenomicScheduling?participant_id={participant.participantId}',
-                expected_status=http.client.BAD_REQUEST
+                expected_status=http.client.FORBIDDEN
             )
 
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 403)
         self.assertEqual(resp.json['message'], f"Client Id cannot access GenomicScheduling lookup.")
 
     def test_validate_params(self):


### PR DESCRIPTION
## Resolves *[ticket DA-3708]
https://precisionmedicineinitiative.atlassian.net/browse/DA-3708


## Description of changes/additions
Need to add the origin filter to the Genomic Scheduling API

## Tests
- [x] unit tests


