### PR TITLE
[DA-3689] Upload overdue samples report even if empty

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -842,15 +842,15 @@ def write_overdue_samples_report(report_date):
 
     exporter = SqlExporter(bucket_name)
     tmp_file, has_data_rows = exporter.run_export(file_name, OVERDUE_DNA_SAMPLES_SQL, query_params, backup=True,
-                                                  skip_upload_if_empty=True)
-    return tmp_file if has_data_rows else None
+                                                  skip_upload_if_empty=False)
+    return tmp_file, has_data_rows
 
 def overdue_samples_check(report_date=datetime.datetime.utcnow()):
     slack_config = config.getSettingJson(RDR_SLACK_WEBHOOKS, {})
     webhook_url = slack_config.get('rdr_biobank_missing_samples_webhook', None)
-    report_tmp_file = write_overdue_samples_report(report_date)
-    # If a file was generated/uploaded, also post a slack alert with the details
-    if report_tmp_file:
+    report_tmp_file, has_data_rows = write_overdue_samples_report(report_date)
+    # If a file with data was generated/uploaded, also post a slack alert with the details
+    if report_tmp_file and has_data_rows:
         with open(report_tmp_file, 'r', encoding='utf-8') as f:
             csv_reader = csv.DictReader(f)
             alert_msg = ''

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -64,16 +64,16 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
                                        finalized=None, overdue_samples=None):
         blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
         self.assertIsNotNone(blob)
-        with open_cloud_file("/%s/%s" % (_FAKE_BUCKET, self.overdue_samples_blobname), mode='rb') as cloud_file:
+        with open_cloud_file("/%s/%s" % (_FAKE_BUCKET, self.overdue_samples_blobname)) as cloud_file:
             lines = cloud_file.readlines()
             if not overdue_samples:
                 # No overdue samples expected in this report; verify it's a header row only
                 self.assertEqual(1, len(lines))
-                self.assertEqual(lines[0].decode().rstrip(),
+                self.assertEqual(lines[0].rstrip(),
                                  'biobank_id,biobank_order_id,order_finalized_date,overdue_dna_samples')
             else:
                 # Verify the data row expected by the test case
-                self.assertEqual(lines[1].decode().rstrip(),
+                self.assertEqual(lines[1].rstrip(),
                                  f'{biobank_id},{biobank_order},{finalized},{overdue_samples}')
     def _write_cloud_csv(self, file_name, contents_str):
         with open_cloud_file("/%s/%s" % (_FAKE_BUCKET, file_name), mode='wb') as cloud_file:

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -64,7 +64,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
                                        finalized=None, overdue_samples=None):
         blob = get_blob(_FAKE_BUCKET, blob_name=self.overdue_samples_blobname)
         self.assertIsNotNone(blob)
-        with open_cloud_file("/%s/%s" % (_FAKE_BUCKET, self.overdue_samples_blobname)) as cloud_file:
+        with open_cloud_file(f'/{_FAKE_BUCKET}/{self.overdue_samples_blobname}') as cloud_file:
             lines = cloud_file.readlines()
             if not overdue_samples:
                 # No overdue samples expected in this report; verify it's a header row only
@@ -76,7 +76,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
                 self.assertEqual(lines[1].rstrip(),
                                  f'{biobank_id},{biobank_order},{finalized},{overdue_samples}')
     def _write_cloud_csv(self, file_name, contents_str):
-        with open_cloud_file("/%s/%s" % (_FAKE_BUCKET, file_name), mode='wb') as cloud_file:
+        with open_cloud_file(f'/{_FAKE_BUCKET}/{file_name}', mode='wb') as cloud_file:
             cloud_file.write(contents_str.encode("utf-8"))
 
     def _make_biobank_order(self, **kwargs):


### PR DESCRIPTION
## Resolves *[DA-3689](https://precisionmedicineinitiative.atlassian.net/browse/DA-3689)*


## Description of changes/additions
Biobank has requested that an overdue samples report CSV file be uploaded every week, regardless of whether any samples are overdue.  Slack alerts still only generated when there are overdue samples.  Unit tests were refactored to verify both empty CSV file and CSV file w/expected data cases.

## Tests
- [x] unit tests




[DA-3689]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ