### PR TITLE
Updating response validation branching logic parser

### DIFF
--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -237,6 +237,11 @@ class TestConditionalFromBranchingLogic(BaseTestCase):
         result = Condition.from_branching_logic(branching_logic)
         self.assertEqual(branching_logic, str(result))
 
+    def test_equality_with_integer(self):
+        branching_logic = "[a] = 7"
+        result = Condition.from_branching_logic(branching_logic)
+        self.assertEqual("[a] = '7'", str(result))
+
     def test_answer_greater_than(self):
         branching_logic = "[a] > 7"
         result = Condition.from_branching_logic(branching_logic)


### PR DESCRIPTION
## Resolves *no ticket*
Response validation is hitting an error when trying to parse some branching logic. We usually see equality checks as something like `[ans_to_q] = '1'`. But the new survey has a branching logic string that looks `[ans_to_q] = 1`.

## Description of changes/additions
This updates the parsing code to allow for optional quotes around an answer. So now it expects to see a quote mark, but if it doesn't then it'll continue as if it was never expected.

## Tests
- [x] unit tests


