### PR TITLE
[PDR-2025] Update how PDR generators get email/phone creds for test pid identification

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -505,8 +505,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         if not ps:
             logging.debug(f'No participant_summary record found for {p_id}')
-            # PDR-2024: ParticipantSummary now source for current email/phone (could have changed to test values via
-            # profile_update), need to set those fields to None
+            # PDR-2024: Set default email/phone values if there is no participant_summary yet
             data['email'], data['email_available'] = None, 0
             data['phone_number'], data['login_phone_number'], data['phone_numer_available'] = None, None, 0
         else:
@@ -561,8 +560,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'health_datastream_sharing_status_v3_1_time': ps.healthDataStreamSharingStatusV3_1Time \
                     if has_enrollment_v3_1 else None,
 
-                # PDR-2024:  ParticipantSummary record now source for email and phone (which can indicate test pid),
-                # to make sure the info is current after any profile_update API requests
+                # PDR-2024:  ParticipantSummary record now source for current email and phone creds sent via
+                # profile_update API, need most recent creds in PDR record to identify potential test pids
                 'email': ps.email,
                 'email_available': 1 if ps.email else 0,
                 'phone_number': ps.phoneNumber,

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -507,7 +507,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             logging.debug(f'No participant_summary record found for {p_id}')
             # PDR-2024: Set default email/phone values if there is no participant_summary yet
             data['email'], data['email_available'] = None, 0
-            data['phone_number'], data['login_phone_number'], data['phone_numer_available'] = None, None, 0
+            data['phone_number'], data['login_phone_number'], data['phone_number_available'] = None, None, 0
         else:
             enrollment_v2 = EnrollmentStatusV2(int(ps.enrollmentStatus))
             # SqlAlchemy may return None for our zero-based NOT_PRESENT EhrStatus Enum, so map None to NOT_PRESENT

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -505,7 +505,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         if not ps:
             logging.debug(f'No participant_summary record found for {p_id}')
-            # PDR-2024: Set default email/phone values if there is no participant_summary yet
+            # PDR-2025: Set default email/phone values if there is no participant_summary yet
             data['email'], data['email_available'] = None, 0
             data['phone_number'], data['login_phone_number'], data['phone_number_available'] = None, None, 0
         else:
@@ -560,7 +560,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 'health_datastream_sharing_status_v3_1_time': ps.healthDataStreamSharingStatusV3_1Time \
                     if has_enrollment_v3_1 else None,
 
-                # PDR-2024:  ParticipantSummary record now source for current email and phone creds sent via
+                # PDR-2025:  ParticipantSummary record now source for current email and phone creds sent via
                 # profile_update API, need most recent creds in PDR record to identify potential test pids
                 'email': ps.email,
                 'email_available': 1 if ps.email else 0,


### PR DESCRIPTION
## Partially Resolves *[PDR-2025](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2025)*

## Description of changes/additions
PDR pipeline still produces most data like `participant_module` summary data using the old pipeline generators in RDR codebase, while implementing brand new data like MHWB module responses in the new pipeline generators.   The new pipeline is using `participant_summary` data from RDR to get current email/phone to look for test pid credentials, but the old pipeline was still using ConsentPII answer data.  Old pipeline may be inaccurate now that email/phone details can be updated via the profile update API.  One case of this was exposed in dashboard QC for the new MHWB surveys, where PTSC had used the API to change a pid's email to a test credential (`@example.com`), but had not otherwise flagged the pid as a test pid.  Net result was inconsistency in the old pipeline data vs. new pipeline data in identifying that pid as a test pid.

This updates the old pipeline generator to get the email/phone values from the `participant_summary` record in `_prep_participant_profile()` instead of in `_prep_consentpii_answers()`. 

The zip code and DOB values must still come from original ConsentPII because of current rules for UBR calculations being based on the original ConsentPII response only (may change in the future).  The other data collected in `_prep_consentpii_answers()` (name, other address elements) are PII that get mapped to boolean flags only  (present or not), so it's a don't care if the values have changed since the ConsentPII.

## Tests
- [x] unit tests






[PDR-2025]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ