### PR TITLE
[DA-3727] Filter out consent types for HPOs

### DIFF
--- a/tests/cron_job_tests/test_consent_sync_controller.py
+++ b/tests/cron_job_tests/test_consent_sync_controller.py
@@ -224,7 +224,7 @@ class ConsentSyncControllerTest(BaseTestCase):
             ], any_order=True
         )
 
-    def test_building_sync_filters(self):
+    def test_building_sync_filters(self, _):
         """Verify that the controller reads the config and sends consent types to exclude"""
         self.temporarily_override_config_setting(
             key=config.CONSENT_SYNC_BUCKETS,


### PR DESCRIPTION
## Resolves *[DA-3727](https://precisionmedicineinitiative.atlassian.net/browse/DA-3727)*
The VA has requested that we don't send them WEAR consent PDFs. This adds functionality for filtering consent types out of the files loaded for the a specific HPO when syncing files. The config will be updated to have WEAR consent filtered out for the VA.

## Tests
- [x] unit tests




[DA-3727]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ