### PR TITLE
[PDR-2040] Add support for exluding secondary table records

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -266,6 +266,11 @@
     "excluded_table_list" : [
       "log_position",
       "questionnaire_response_answer"
+    ],
+    "secondary_excluded_table_list": [
+      "hpo",
+      "organization",
+      "site"
     ]
   }
 }

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -192,6 +192,11 @@
     "excluded_table_list" : [
       "log_position",
       "questionnaire_response_answer"
+    ],
+    "secondary_excluded_table_list": [
+      "hpo",
+      "organization",
+      "site"
     ]
   }
 }

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -198,7 +198,8 @@ class PubSubTest(BaseTestCase):
 
         # Fetch the Participant record and add an Organization record to it.
         with self.summary_dao.session() as session:
-            participant = session.query(Participant).filter(Participant.participantId == self.participant.participantId).first()
+            participant = session.query(Participant).\
+                filter(Participant.participantId == self.participant.participantId).first()
             organization = session.query(Organization).first()
             participant.organization = organization
 


### PR DESCRIPTION
## Resolves *[PDR-2040](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2040)*


## Description of changes/additions
In a lot of cases, SQLAlchemy is loading Relationship table records that are only being used for lookup and they are not being changed.  An example is the Participant record can load the 'Organization' relation record.  We do not want to  create Pub-Sub events for secondary relation records that we know are not being updated.

Added new unittests for checking exclusions.


## Tests
- [x] unit tests




[PDR-2040]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ