### PR TITLE
N1 updates for tab-delimited

### DIFF
--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -104,7 +104,7 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
         if env_split in ['prod', 'stable', 'sandbox']:
             bucket = config.NPH_SMS_BUCKETS.get(env_split).get(recipient)
 
-        if "mcc" in bucket.lower():
+        if "ucsd" in recipient.lower():
             delimiter_str = '\t'
         else:
             delimiter_str = ','

--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -104,9 +104,15 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
         if env_split in ['prod', 'stable', 'sandbox']:
             bucket = config.NPH_SMS_BUCKETS.get(env_split).get(recipient)
 
+        if "mcc" in bucket.lower():
+            delimiter_str = '\t'
+        else:
+            delimiter_str = ','
+
         recipient_xfer_dict = {
             "bucket": bucket,
-            "file_name": f"n1_mcac_manifests/{recipient}_n1_{clock.CLOCK.now().isoformat()}.csv"
+            "file_name": f"n1_manifests/{recipient}_n1_{clock.CLOCK.now().isoformat()}.csv",
+            "delimiter": delimiter_str,
         }
 
         return recipient_xfer_dict

--- a/rdr_service/offline/sql_exporter.py
+++ b/rdr_service/offline/sql_exporter.py
@@ -15,8 +15,8 @@ _BATCH_SIZE = 1000
 class SqlExportFileWriter(object):
     """Writes rows to a CSV file, optionally filtering on a predicate."""
 
-    def __init__(self, dest, predicate=None):
-        self._writer = csv.writer(dest, delimiter=DELIMITER)
+    def __init__(self, dest, predicate=None, delimiter=DELIMITER):
+        self._writer = csv.writer(dest, delimiter=delimiter)
         self._predicate = predicate
 
     def write_header(self, keys):
@@ -115,13 +115,13 @@ class SqlExporter(object):
             cursor.close()
 
     @contextlib.contextmanager
-    def open_cloud_writer(self, file_name, predicate=None):
+    def open_cloud_writer(self, file_name, predicate=None, delimiter=DELIMITER):
         gcs_path = "/%s/%s" % (self._bucket_name, file_name)
         # Logging does not expand in GCloud, so I'm trying this out.
         message = f"Exporting data to {gcs_path}"
         logging.info(message)
         with open_cloud_file(gcs_path, mode='w') as dest:
-            writer = SqlExportFileWriter(dest, predicate)
+            writer = SqlExportFileWriter(dest, predicate, delimiter)
             yield writer
             message = f"Export to {gcs_path} complete."
             logging.info(message)

--- a/rdr_service/workflow_management/nph/sms_workflows.py
+++ b/rdr_service/workflow_management/nph/sms_workflows.py
@@ -88,7 +88,8 @@ class SmsWorkflow:
         exporter = SqlExporter(self.file_transfer_def['bucket'])
         self.file_path = f"{self.file_transfer_def['bucket']}/{self.file_transfer_def['file_name']}"
 
-        with exporter.open_cloud_writer(self.file_transfer_def['file_name']) as writer:
+        with exporter.open_cloud_writer(self.file_transfer_def['file_name'],
+                                        delimiter=self.file_transfer_def['delimiter']) as writer:
             writer.write_header(source_data[0].keys())
             writer.write_rows(source_data)
 

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -272,7 +272,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
                 test_client=resource_main.app.test_client(),
             )
 
-        expected_csv_path = "test-bucket-unc-meta/n1_mcac_manifests/UNC_META_n1_2023-04-25T15:13:00.csv"
+        expected_csv_path = "test-bucket-unc-meta/n1_manifests/UNC_META_n1_2023-04-25T15:13:00.csv"
 
         with open_cloud_file(expected_csv_path, mode='r') as cloud_file:
             csv_reader = csv.DictReader(cloud_file)

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -138,7 +138,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(ingested_record.age, "32")
 
     @staticmethod
-    def create_data_n1_mc1_generation():
+    def create_data_n1_mc1_generation(destination='UNC_META'):
         sms_datagen = NphSmsDataGenerator()
 
         # Urine Sample
@@ -164,7 +164,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sample_identifier="test",
             sample_id=10001,
             lims_sample_id="000200",
-            destination="UNC_META"
+            destination=destination
         )
         sms_datagen.create_database_sms_sample(
             ethnicity="test",
@@ -175,7 +175,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sample_identifier="test",
             sample_id=10002,
             lims_sample_id="000200",
-            destination="UNC_META"
+            destination=destination
         )
         sms_datagen.create_database_sms_sample(
             ethnicity="test",
@@ -186,7 +186,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sample_identifier="test",
             sample_id=10003,
             lims_sample_id="000200",
-            destination="UNC_META"
+            destination=destination
         )
 
         sms_datagen.create_database_sms_n0(
@@ -324,6 +324,35 @@ class NphSmsWorkflowsTest(BaseTestCase):
             )
         manifest_records = n1_mcac_dao.get_all()
         self.assertEqual(len(manifest_records), 3)
+
+    def test_n1_mcc_tab_delimited(self):
+        self.create_data_n1_mc1_generation(destination="UCSD")
+
+        generation_data = {
+            "job": "FILE_GENERATION",
+            "file_type": "N1_MC1",
+            "recipient": "UCSD"
+        }
+        with clock.FakeClock(self.TIME_1):
+            from rdr_service.resource import main as resource_main
+            self.send_post(
+                local_path='NphSmsGenerationTaskApi',
+                request_data=generation_data,
+                prefix="/resource/task/",
+                test_client=resource_main.app.test_client(),
+            )
+
+        expected_csv_path = "test-bucket-unc-meta/n1_manifests/UCSD_n1_2023-04-25T15:13:00.csv"
+
+        with open_cloud_file(expected_csv_path, mode='r') as cloud_file:
+            csv_reader = csv.DictReader(cloud_file, delimiter='\t')
+            csv_rows = list(csv_reader)
+
+        self.assertEqual(csv_rows[0]['sample_id'], '10001')
+        self.assertEqual(csv_rows[0]['matrix_id'], "1111")
+        self.assertEqual(csv_rows[0]['urine_color'], '"Color 4"')
+        self.assertEqual(csv_rows[0]['urine_clarity'], '"Clean"')
+        self.assertEqual(csv_rows[0]['manufacturer_lot'], '256837')
 
     @mock.patch('rdr_service.workflow_management.nph.sms_pipeline.GCPCloudTask.execute')
     def test_sms_pipeline_n1_function(self, task_mock):


### PR DESCRIPTION
## Resolves *[DA-3759](https://precisionmedicineinitiative.atlassian.net/browse/DA-3759)*


## Description of changes/additions
The UCSD MCC N1 manifest for the NPH sample management system is required to be tab-delimited. This PR makes changes to the SQL exporter to allow a custom delimiter. If the export bucket is for `UCSD`, the resulting file will be tab-delimited.

## Tests
- [x] unit tests




[DA-3759]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ