### PR TITLE
Fixing consent validation error in stable

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -60,7 +60,8 @@ class ConsentDao(BaseDao):
                     ConsentFile.participant_id == QuestionnaireResponse.participantId
                 )
             ).filter(
-                ConsentFile.id.is_(None)
+                ConsentFile.id.is_(None),
+                Participant.participantOrigin != 'configurator'
             ).options(
                 joinedload(ConsentResponse.response)
             )


### PR DESCRIPTION
## Resolves *no ticket*
Consent validation should be running in Stable, but it's hitting an error. Participant's with an origin of `configurator` don't have a PDF validation process set up, and they likely wouldn't have PDFs to validate anyway.

This PR filters out any participants with a `configurator` origin from the validation process.


## Tests
- [ ] unit tests


