### PR TITLE
Fixing id reference when finding WGS sequencing date

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1343,7 +1343,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
             GenomicSetMember
         ).join(
             GenomicJobRun,
-            GenomicJobRun.jobId == GenomicSetMember.aw4ManifestJobRunID
+            GenomicJobRun.id == GenomicSetMember.aw4ManifestJobRunID
         ).filter(
             GenomicSetMember.participantId == participant_id,
             GenomicSetMember.genomeType == config.GENOME_TYPE_WGS,


### PR DESCRIPTION
## Resolves *no ticket*
There aren't currently any participants that have the Core Data flag set. That's because I mixed up column names when trying to find if the participant had the WGS data needed for Core Data.

## Description of changes/additions
This PR updates the id column in the join to correctly pull in the AW4 data.

## Tests
- [ ] unit tests


