### PR TITLE
[DA-3705] Add new elements to retention calculations

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -127,6 +127,7 @@ COHORT_1_REVIEW_CONSENT_YES_CODE = "ReviewConsentAgree_Yes"
 COHORT_1_REVIEW_CONSENT_NO_CODE = "ReviewConsentAgree_No"
 
 WEAR_YES_ANSWER_CODE = "wear_yes"
+WEAR_NO_ANSWER_CODE = "wear_no"
 
 # Cohort Group Code
 CONSENT_COHORT_GROUP_CODE = "ConsentPII_CohortGroup"
@@ -226,7 +227,7 @@ APPLE_HEALTH_KIT_STOP_SHARING_MODULE = "participantintendstostopsharingappleheal
 FITBIT_SHARING_MODULE = "participantintendstosharefitbit"
 FITBIT_STOP_SHARING_MODULE = "participantintendstostopsharingfitbit"
 
-# General response answer codes
+# General response answer codes (used for EtM consent yes/no responses)
 AGREE_YES = "agree_yes"
 AGREE_NO = "agree_no"
 

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1571,7 +1571,7 @@ class QuestionnaireResponseDao(BaseDao):
             participant_id=participant_id,
             question_code_value=code_constants.STATE_QUESTION_CODE
         )
-        return answer.value
+        return answer.value if answer else None
 
     @classmethod
     def get_latest_answer_for_state_receiving_care(cls, session: Session, participant_id) -> str:
@@ -1583,7 +1583,7 @@ class QuestionnaireResponseDao(BaseDao):
             participant_id=participant_id,
             question_code_value=code_constants.RECEIVE_CARE_STATE
         )
-        return answer.value
+        return answer.value if answer else None
 
     @classmethod
     def _code_in_list(cls, code_value: str, code_list: List[str]):

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1548,7 +1548,7 @@ class QuestionnaireResponseDao(BaseDao):
 
         if latest_only:
             query = query.limit(1)
-            return query.one()
+            return query.one_or_none()
 
         else:
             return query.all()

--- a/rdr_service/repository/etm.py
+++ b/rdr_service/repository/etm.py
@@ -169,4 +169,6 @@ class EtmResponseRepository(BaseRepository):
                 schema_model.EtmQuestionnaireResponse.questionnaire_type.in_(task_types)
             )
 
+        etm_response_query = etm_response_query.order_by(schema_model.EtmQuestionnaireResponse.authored)
+
         return etm_response_query.all()

--- a/rdr_service/repository/etm.py
+++ b/rdr_service/repository/etm.py
@@ -1,5 +1,6 @@
 
-from sqlalchemy.orm import Query
+from sqlalchemy.orm import Query, Session
+from typing import List
 
 from rdr_service.dao import database_factory
 from rdr_service.domain_model import etm as domain_model
@@ -153,3 +154,19 @@ class EtmResponseRepository(BaseRepository):
 
         self._add_to_session(schema_response)
         response_obj.id = schema_response.etm_questionnaire_response_id
+
+    @classmethod
+    def get_etm_responses(cls, session: Session, participant_id: int = None, task_types: List = None):
+
+        etm_response_query = Query(schema_model.EtmQuestionnaireResponse)
+        etm_response_query.session = session
+        if participant_id:
+            etm_response_query = etm_response_query.filter(
+                schema_model.EtmQuestionnaireResponse.participant_id == participant_id
+            )
+        if task_types:
+            etm_response_query = etm_response_query.filter(
+                schema_model.EtmQuestionnaireResponse.questionnaire_type.in_(task_types)
+            )
+
+        return etm_response_query.all()

--- a/rdr_service/services/retention_calculation.py
+++ b/rdr_service/services/retention_calculation.py
@@ -37,7 +37,7 @@ class RetentionEligibilityDependencies:
     reconsent_response_timestamp:           Optional[datetime]  # Cohort 1 reconsent to primary consent
     gror_response_timestamp:                Optional[datetime]
 
-    # Additional elements from DA-3507
+    # Additional elements from DA-3705
     nph_consent_timestamp:                  Optional[datetime]
     etm_consent_timestamp:                  Optional[datetime]
     wear_consent_timestamp:                 Optional[datetime]

--- a/rdr_service/services/retention_calculation.py
+++ b/rdr_service/services/retention_calculation.py
@@ -91,6 +91,12 @@ class RetentionEligibility:
             or self._is_less_than_18_months_ago(self._participant.latest_cope_response_timestamp)
             or self._is_less_than_18_months_ago(self._participant.remote_pm_response_timestamp)
             or self._is_less_than_18_months_ago(self._participant.life_func_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.bhp_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.ehhwb_response_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.nph_consent_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.wear_consent_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.etm_consent_timestamp)
+            or self._is_less_than_18_months_ago(self._participant.latest_etm_response_timestamp)
             or (
                 self._participant.consent_cohort in [ParticipantCohort.COHORT_1, ParticipantCohort.COHORT_2]
                 and self._is_less_than_18_months_ago(self._participant.gror_response_timestamp)
@@ -113,7 +119,13 @@ class RetentionEligibility:
             self._participant.sdoh_response_timestamp,
             self._participant.latest_cope_response_timestamp,
             self._participant.remote_pm_response_timestamp,
-            self._participant.life_func_response_timestamp
+            self._participant.life_func_response_timestamp,
+            self._participant.bhp_response_timestamp,
+            self._participant.ehhwb_response_timestamp,
+            self._participant.nph_consent_timestamp,
+            self._participant.wear_consent_timestamp,
+            self._participant.etm_consent_timestamp,
+            self._participant.latest_etm_response_timestamp
         ]
 
         if self._participant.consent_cohort in [ParticipantCohort.COHORT_1, ParticipantCohort.COHORT_2]:

--- a/rdr_service/services/retention_calculation.py
+++ b/rdr_service/services/retention_calculation.py
@@ -37,6 +37,14 @@ class RetentionEligibilityDependencies:
     reconsent_response_timestamp:           Optional[datetime]  # Cohort 1 reconsent to primary consent
     gror_response_timestamp:                Optional[datetime]
 
+    # Additional elements from DA-3507
+    nph_consent_timestamp:                  Optional[datetime]
+    etm_consent_timestamp:                  Optional[datetime]
+    wear_consent_timestamp:                 Optional[datetime]
+    ehhwb_response_timestamp:               Optional[datetime]
+    bhp_response_timestamp:                 Optional[datetime]
+    latest_etm_response_timestamp:          Optional[datetime]  # Repeatable EtM task responses, find most recent
+
 
 class RetentionEligibility:
     def __init__(self, participant_data: RetentionEligibilityDependencies):

--- a/tests/service_tests/test_retention_status.py
+++ b/tests/service_tests/test_retention_status.py
@@ -155,7 +155,13 @@ class RetentionCalculationTest(BaseTestCase):
         remote_pm_authored: datetime = None,
         life_func_authored: datetime = None,
         reconsent_authored: datetime = None,
-        gror_authored: datetime = None
+        gror_authored: datetime = None,
+        etm_consent_yes_authored: datetime = None,
+        wear_consent_yes_authored: datetime = None,
+        nph_consent_yes_authored: datetime = None,
+        ehhwb_authored: datetime = None,
+        bhp_authored: datetime = None,
+        latest_etm_task_authored: datetime = None
     ) -> RetentionEligibilityDependencies:
         default_data = RetentionEligibilityDependencies(
             primary_consent=Consent(
@@ -181,7 +187,13 @@ class RetentionCalculationTest(BaseTestCase):
             remote_pm_response_timestamp=remote_pm_authored,
             life_func_response_timestamp=life_func_authored,
             reconsent_response_timestamp=reconsent_authored,
-            gror_response_timestamp=gror_authored
+            gror_response_timestamp=gror_authored,
+            nph_consent_timestamp=nph_consent_yes_authored,
+            etm_consent_timestamp=etm_consent_yes_authored,
+            wear_consent_timestamp=wear_consent_yes_authored,
+            ehhwb_response_timestamp=ehhwb_authored,
+            bhp_response_timestamp=bhp_authored,
+            latest_etm_response_timestamp=latest_etm_task_authored
         )
         if first_ehr_authored is not None:
             default_data.first_ehr_consent = Consent(

--- a/tests/test_retention_calculation.py
+++ b/tests/test_retention_calculation.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 import mock
 
-from rdr_service import config
+from rdr_service import config, code_constants
 from rdr_service.model.retention_eligible_metrics import RetentionEligibleMetrics
 from rdr_service.offline.retention_eligible_import import _supplement_with_rdr_calculations
+from rdr_service.participant_enums import QuestionnaireResponseStatus, QuestionnaireResponseClassificationType
 from rdr_service.services.retention_calculation import RetentionEligibilityDependencies
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -11,12 +12,77 @@ from tests.helpers.unittest_base import BaseTestCase
 class RetentionCalculationIntegrationTest(BaseTestCase):
     def setUp(self, *args, **kwargs):
         super().setUp(*args, **kwargs)
-        self.summary = self.data_generator.create_database_participant_summary()
+        participant = self.data_generator.create_database_participant(participantOrigin='test_portal')
+        self.summary = self.data_generator.create_database_participant_summary(
+            participant=participant,
+            dateOfBirth=datetime(1982, 1, 9),
+            consentForStudyEnrollmentFirstYesAuthored=datetime(2000, 1, 10),
+            questionnaireOnEmotionalHealthHistoryAndWellBeingAuthored=datetime(2023, 5, 15),
+            questionnaireOnBehavioralHealthAndPersonalityAuthored=datetime(2023, 6, 1)
+        )
+
+        self.wear_consent_question = self.data_generator.create_database_code(
+            value=code_constants.WEAR_CONSENT_QUESTION_CODE
+        )
+        self.wear_yes = self.data_generator.create_database_code(value=code_constants.WEAR_YES_ANSWER_CODE)
+        self.wear_no = self.data_generator.create_database_code(value=code_constants.WEAR_NO_ANSWER_CODE)
+
+        self.etm_consent_question = self.data_generator.create_database_code(
+            value=code_constants.ETM_CONSENT_QUESTION_CODE
+        )
+        self.etm_yes = self.data_generator.create_database_code(value=code_constants.AGREE_YES)
+        self.etm_no = self.data_generator.create_database_code(value=code_constants.AGREE_NO)
+
+        self.etm_consent = self._create_consent_questionnaire('etm_consent_ut', self.etm_consent_question.codeId)
+        self.wear_consent = self._create_consent_questionnaire('wear_consent_ut', self.wear_consent_question.codeId)
 
         # mock the retention calculation to see what it got passed
         retention_calc_patch = mock.patch('rdr_service.offline.retention_eligible_import.RetentionEligibility')
         self.retention_calc_mock = retention_calc_patch.start()
         self.addCleanup(retention_calc_patch.stop)
+
+    def _create_consent_questionnaire(self, module: str, consent_question_code: int):
+        module_code = self.data_generator.create_database_code(value=module)
+
+        questionnaire = self.data_generator.create_database_questionnaire_history()
+        self.data_generator.create_database_questionnaire_question(
+                questionnaireId=questionnaire.questionnaireId,
+                questionnaireVersion=questionnaire.version,
+                codeId=consent_question_code
+            )
+
+        self.data_generator.create_database_questionnaire_concept(
+            questionnaireId=questionnaire.questionnaireId,
+            questionnaireVersion=questionnaire.version,
+            codeId=module_code.codeId
+        )
+
+        return questionnaire
+
+    def _setup_consent_questionnaire_response(self, participant, questionnaire, answer_code,
+                                              authored=datetime(2023, 5, 15),
+                                              created=datetime(2023, 3, 15),
+                                              status=QuestionnaireResponseStatus.COMPLETED,
+                                              classification_type=QuestionnaireResponseClassificationType.COMPLETE):
+
+        questionnaire_response = self.data_generator.create_database_questionnaire_response(
+            participantId=participant,
+            questionnaireId=questionnaire.questionnaireId,
+            questionnaireVersion=questionnaire.version,
+            authored=authored,
+            created=created,
+            status=status,
+            classificationType=classification_type
+        )
+
+        question = questionnaire.questions[0]
+        self.data_generator.create_database_questionnaire_response_answer(
+                questionnaireResponseId=questionnaire_response.questionnaireResponseId,
+                questionId=question.questionnaireQuestionId,
+                **{'valueCodeId': answer_code.codeId}
+            )
+
+        return questionnaire_response
 
     def test_get_earliest_dna_sample(self):
         self.temporarily_override_config_setting(
@@ -39,13 +105,144 @@ class RetentionCalculationIntegrationTest(BaseTestCase):
         retention_parameters = self._get_retention_dependencies_found()
         self.assertEqual(first_dna_sample_timestamp, retention_parameters.dna_samples_timestamp)
 
-    def _get_retention_dependencies_found(self) -> RetentionEligibilityDependencies:
+    def test_mhwb_surveys_detected(self):
+        # DA-3705:  Confirm the RetentionMetricsEligibility picks up new values for MHWB surveys
+        # Check for the default participant_summary setup authored times
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(self.summary.questionnaireOnBehavioralHealthAndPersonalityAuthored,
+                         retention_parameters.bhp_response_timestamp)
+        self.assertEqual(self.summary.questionnaireOnEmotionalHealthHistoryAndWellBeingAuthored,
+                         retention_parameters.ehhwb_response_timestamp)
+
+    def test_nph1_consent_status(self):
+        # Test participant without an NPH1 authored time - use default paritcipant from test setup
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertIsNone(retention_parameters.nph_consent_timestamp)
+        # Create/test participant with NPH1 consent authored
+        nph_participant = self.data_generator.create_database_participant(participantOrigin='test_portal')
+        nph_pid_summary = self.data_generator.create_database_participant_summary(
+            participant=nph_participant,
+            dateOfBirth=datetime(1982, 1, 9),
+            consentForStudyEnrollmentFirstYesAuthored=datetime(2000, 1, 10),
+            questionnaireOnEmotionalHealthHistoryAndWellBeingAuthored=datetime(2023, 5, 15),
+            questionnaireOnBehavioralHealthAndPersonalityAuthored=datetime(2023, 6, 1),
+            consentForNphModule1Authored=datetime(2023, 6, 30),
+            consentForNphModule1=True
+        )
+        retention_parameters = self._get_retention_dependencies_found(participant=nph_participant)
+        self.assertEqual(nph_pid_summary.consentForNphModule1Authored, retention_parameters.nph_consent_timestamp)
+
+    def test_wear_yes_timestamp(self):
+        # DA-3705: Confirm logic to find the WEAR consent response data
+        qr = self._setup_consent_questionnaire_response(self.summary.participantId,
+                                                        self.wear_consent, self.wear_yes)
+        self.assertIsNotNone(qr)
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(qr.authored, retention_parameters.wear_consent_timestamp)
+
+    def test_wear_no_response_no_timestamp(self):
+        # DA-3705:  Confirm WEAR consent "no" response is ignored
+        qr = self._setup_consent_questionnaire_response(self.summary.participantId,
+                                                        self.wear_consent, self.wear_no)
+        self.assertIsNotNone(qr)
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(None, retention_parameters.wear_consent_timestamp)
+
+    def test_multiple_wear_responses_latest_yes(self):
+        # DA-3705: Confirm if there are multiple WEAR consent responses, the latest "yes" is used
+        self._setup_consent_questionnaire_response(self.summary.participantId,
+                                                   self.wear_consent, self.wear_no)
+        qr_no_1 = self._setup_consent_questionnaire_response(self.summary.participantId, self.wear_consent,
+                                                             self.wear_no, authored=datetime(2023, 6, 1))
+        qr_yes_2 = self._setup_consent_questionnaire_response(self.summary.participantId,  self.wear_consent,
+                                                              self.wear_yes, authored=datetime(2023, 3, 1))
+        self.assertTrue(None not in [qr_no_1, qr_yes_2])
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(qr_yes_2.authored, retention_parameters.wear_consent_timestamp)
+
+    def test_etm_consent_yes(self):
+        # DA-3705: Confirm logic to find EtM consent response data
+        qr_yes = self._setup_consent_questionnaire_response(self.summary.participantId, self.etm_consent, self.etm_yes,
+                                                            authored=datetime(2023, 1, 1))
+        self.assertIsNotNone(qr_yes)
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(qr_yes.authored, retention_parameters.etm_consent_timestamp)
+
+    def test_etm_consent_no_response_no_timestamp(self):
+        # DA-3705: Confirm if EtM consent is "no" response, it's ignored
+        no_rsp = self._setup_consent_questionnaire_response(self.summary.participantId, self.etm_consent, self.etm_no,
+                                                            authored=datetime(2023, 1, 1))
+        self.assertIsNotNone(no_rsp)
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(None, retention_parameters.etm_consent_timestamp)
+
+    def test_multiple_etm_consent_yes_latest(self):
+        # DA-3705: Confirm if multiple EtM consent "yes" responses, latest authored is used
+        qr_first_yes = self._setup_consent_questionnaire_response(self.summary.participantId, self.etm_consent,
+                                                                  self.etm_yes, authored=datetime(2023, 1, 1))
+        qr_later_yes = self._setup_consent_questionnaire_response(self.summary.participantId, self.etm_consent,
+                                                                  self.etm_yes, authored=datetime(2023, 3, 1))
+        self.assertTrue(None not in [qr_first_yes, qr_later_yes])
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(qr_later_yes.authored, retention_parameters.etm_consent_timestamp)
+
+    def test_etm_task_timestamp(self):
+        # DA-3705: Confirm logic to find latest EtM task response authored.  Need EtM consent to process task
+        self._setup_consent_questionnaire_response(self.summary.participantId, self.etm_consent, self.etm_yes,
+                                                   authored=datetime(2023, 1, 1))
+        # Default EtM questionnaire created is emorecog
+        etm_rsp_1 = self.data_generator.create_etm_questionnaire_response(
+            authored=datetime(2023, 3, 1),
+            participant_id=self.summary.participantId
+        )
+        self.assertIsNotNone(etm_rsp_1)
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(etm_rsp_1.authored, retention_parameters.latest_etm_response_timestamp)
+
+    def test_etm_multiple_tasks_latest(self):
+        self._setup_consent_questionnaire_response(self.summary.participantId, self.etm_consent, self.etm_yes,
+                                                   authored=datetime(2023, 1, 1))
+        q_emorecog = self.data_generator.create_database_etm_questionnaire(questionnaire_type='emorecog')
+        q_flanker = self.data_generator.create_database_etm_questionnaire(questionnaire_type='flanker')
+        emorecog_rsp = self.data_generator.create_etm_questionnaire_response(
+            participant_id=self.summary.participantId,
+            questionnaire_type='emorecog',
+            etm_questionnaire_id=q_emorecog.etm_questionnaire_id,
+            authored=datetime(2023, 5, 15)
+        )
+        flanker_rsp = self.data_generator.create_etm_questionnaire_response(
+            participant_id=self.summary.participantId,
+            questionnaire_type='flanker',
+            etm_questionnaire_id=q_flanker.etm_questionnaire_id,
+            authored=datetime(2023, 6, 30)
+        )
+        self.assertTrue(None not in [emorecog_rsp, flanker_rsp])
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(flanker_rsp.authored, retention_parameters.latest_etm_response_timestamp)
+
+    def test_etm_prt_excluded(self):
+        # DA-3705: Ignore prt response data for retention since it exists unexpectedly in RDR production
+        self._setup_consent_questionnaire_response(self.summary.participantId, self.etm_consent, self.etm_yes,
+                                                   authored=datetime(2023, 1, 1))
+        q_prt = self.data_generator.create_database_etm_questionnaire(questionnaire_type='prt')
+        prt_rsp = self.data_generator.create_etm_questionnaire_response(
+            participant_id=self.summary.participantId,
+            questionnaire_type='prt',
+            etm_questionnaire_id=q_prt.etm_questionnaire_id,
+            authored=datetime(2023, 6, 30)
+        )
+        self.assertEqual(prt_rsp.authored, datetime(2023, 6, 30))
+        retention_parameters = self._get_retention_dependencies_found()
+        self.assertEqual(None,  retention_parameters.latest_etm_response_timestamp)
+
+    def _get_retention_dependencies_found(self, participant=None) -> RetentionEligibilityDependencies:
         """
         Call the code responsible for collecting the retention calculation data.
         Return the data in provided to the calculation code.
         """
+        pid = participant.participantId if participant else self.summary.participantId
         _supplement_with_rdr_calculations(
-            RetentionEligibleMetrics(participantId=self.summary.participantId),
+            RetentionEligibleMetrics(participantId=pid),
             session=self.session
         )
         return self.retention_calc_mock.call_args[0][0]


### PR DESCRIPTION
## Resolves *[DA-3705](https://precisionmedicineinitiative.atlassian.net/browse/DA-3705)*


## Description of changes/additions
Adds Mental Health and Well-Being surveys, NPH consent, WEAR consent, EtM consent, and EtM task completions to the retention calculations

Refactors some existing `QuestionnaireResponseDao` utility methods that look up answer code values by question code so they can be used for finding (multiple) WEAR/EtM consent question responses.

Adds unit test data generators for `EtmQuestionnaire` and `EtmQuestionnaireResponse` models 

## Tests
- [x] unit tests




[DA-3705]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ