### PR TITLE
Fixes for PDR pipeline: EtM data and backfill tool

### DIFF
--- a/rdr_service/api/etm_api.py
+++ b/rdr_service/api/etm_api.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import List
 
+from rdr_service.cloud_utils.gcp_google_pubsub import submit_pipeline_pubsub_msg
 from rdr_service.lib_fhir.fhirclient_1_0_6.models.questionnaire import Questionnaire as FhirQuestionnaire
 from rdr_service.lib_fhir.fhirclient_1_0_6.models.questionnaireresponse import \
     QuestionnaireResponse as FhirQuestionnaireResponse
@@ -41,6 +42,11 @@ class EtmApi:
         repository = etm_repository.EtmQuestionnaireRepository()
         repository.store_questionnaire(questionnaire_obj)
 
+        # Support RDR to PDR pipeline.  All we need is just the pubsub message for the newly stored
+        # etm_questionnaire record (don't need submit_pipeline_pubsub_msg_from_model())
+        submit_pipeline_pubsub_msg(database='rdr', table='etm_questionnaire', action='insert',
+                                   pk_columns=['etm_questionnaire_id'], pk_values=[questionnaire_obj.id])
+
         return {
             **questionnaire_json
         }
@@ -61,6 +67,11 @@ class EtmApi:
         if validation_result.success:
             response_repository = etm_repository.EtmResponseRepository()
             response_repository.store_response(response_obj)
+
+            # Support RDR to PDR pipeline.  All we need is just the pubsub message for the newly stored
+            # etm_questionnaire_response record (don't need submit_pipeline_pubsub_msg_from_model())
+            submit_pipeline_pubsub_msg(database='rdr', table='etm_questionnaire_response', action='insert',
+                                       pk_columns=['etm_questionnaire_response_id'], pk_values=[response_obj.id])
 
             return {
                 'id': str(response_obj.id),

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -686,7 +686,8 @@ class ParticipantSummaryDao(UpdatableDao):
         if getattr(summary, field_name) is not None:
             setattr(summary, field_name, None)
 
-    def update_enrollment_status(self, summary: ParticipantSummary, session, allow_downgrade=False):
+    def update_enrollment_status(self, summary: ParticipantSummary, session,
+                                 allow_downgrade=False, pdr_pubsub=True):
         """
         Updates the enrollment status field on the provided participant summary to the correct value.
         If allow_downgrade flag is set (e.g., when called by backfill tool), V3.* statuses will be recalculated
@@ -956,8 +957,8 @@ class ParticipantSummaryDao(UpdatableDao):
         )
         summary.enrollmentStatusCoreOrderedSampleTime = self.calculate_core_ordered_sample_time(consent, summary)
 
-        # Support RDR to PDR pipeline
-        submit_pipeline_pubsub_msg_from_model(summary, self.get_connection_database_name())
+        if pdr_pubsub:
+            submit_pipeline_pubsub_msg_from_model(summary, self.get_connection_database_name())
 
     def calculate_enrollment_status(
         self, consent, num_completed_baseline_ppi_modules, physical_measurements_status,


### PR DESCRIPTION
## Resolves *(No ticket)*


## Description of changes/additions
When processing EtM Questionnaire[Response] payloads, the base `post` API handler was not being reached since the EtM data goes through its own handler.   Adds the calls to generate pubsub messages for PDR when records are inserted into `etm_questionnaire` or `etm_questionnaire_response` tables.   Currently, PDR only really needs the records/resource JSON for `etm_questionnaire_response` records to generate the target records for PDR.

Also updates the `backfill_enrollment` tool to make sure the `pubsub` events are not generated until the updated records are committed to the DB.   Note that we don't yet have a mechanism anywhere in the RDR code for generating pubsub messages for the `enrollment_status_history` records(still under investigation how best insert hooks for that, based on how the code that generates those new records is currently organized).

## Tests
- [x] unit tests


