### PR TITLE
[PDR-2031] PDR handling of ConsentPII "no" answer codes

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1685,13 +1685,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                   consent_status:  BQModuleStatusEnum
         """
         consent_question = _consent_module_question_map[module]
-        if consent_question:
-            # For any consents without an explicit consent question, default to implied ConsentPermission_Yes/SUBMITTED
-            # PDR-2031: "or" retains previous implied yes ConsentPII behavior if this response is based on old codebook
-            # that does not have the new explicit consent question
-            if not consent_question or (module == 'ConsentPII' and isinstance(consent_question, str) and
-                                        not hasattr(response_rec, consent_question)):
-                return 'ConsentPermission_Yes', BQModuleStatusEnum.SUBMITTED
+        # For any consents without an explicit consent question in their codebook, default to implied "yes"
+        # PDR-2031: "or" clause retains previous behavior if this response predates the update of
+        # the ConsentPII codebook, such that the response received is missing the consent question code
+        if not consent_question or (module == 'ConsentPII' and isinstance(consent_question, str) and
+                                    not hasattr(response_rec, consent_question)):
+            return 'ConsentPermission_Yes', BQModuleStatusEnum.SUBMITTED
 
         answer_code = None
 

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -1969,6 +1969,26 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
         ).one()
         self.assertEqual(response['id'], str(stored_response.questionnaireResponseId))
 
+        # Verify PDR data generation, including the mapping of new answer codes to be consistent with existing PDR data
+        pdr_rsc = self.make_participant_resource(consented_participant.participantId)
+        mod_data = self.get_generated_items(pdr_rsc['modules'])
+        self.assertEqual(len(mod_data), 1)
+        self.assertEqual(mod_data[0]['module'], 'ConsentPII')
+        # EXTRA_CONSENT_YES ==> CONSENT_PERMISSION_YES_CODE for PDR
+        self.assertEqual(mod_data[0]['consent_value'], CONSENT_PERMISSION_YES_CODE)
+        self.assertEqual(mod_data[0]['status'], 'SUBMITTED')
+        # This is based on legacy PDR enrollment_status (V2 status values)
+        self.assertEqual(pdr_rsc.get('enrollment_status', None), 'PARTICIPANT')
+
+        pdr_rsc = self.make_participant_resource(no_participant.participantId)
+        mod_data = self.get_generated_items(pdr_rsc['modules'])
+        self.assertEqual(len(mod_data), 1)
+        self.assertEqual(mod_data[0]['module'], 'ConsentPII')
+        # EXTRA_CONSENT_NO ==> CONSENT_PERMISSION_NO_CODE for PDR
+        self.assertEqual(mod_data[0]['consent_value'], CONSENT_PERMISSION_NO_CODE)
+        self.assertEqual(mod_data[0]['status'], 'SUBMITTED_NO_CONSENT')
+        self.assertEqual(pdr_rsc.get('enrollment_status', None), 'REGISTERED')
+
     @classmethod
     def _load_response_json(cls, template_file_name, questionnaire_id, participant_id_str):
         with open(data_path(template_file_name)) as fd:


### PR DESCRIPTION
## Resolves *[PDR-2031](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2031)*


## Description of changes/additions
PDR handling for "No" responses to ConsentPII:

- Do not attempt to use ConsentPII data for initial UBR calculations if  it is a "no" response (`_prep_consentpii_answers()`)
- Because PDR surfaces consent answer value strings in the participant module data (`_prep_modules()` processing) ,  previous ConsentPII responses were always assigned a default answer of `ConsentPermission_Yes`.  Decision was made to map the new `extraconsent_agreetoconsent/extraconsent_donotagreetoconsent` answer codes to `ConsentPermission_Yes/ConsentPermission_No` so all ConsentPII responses look consistent regardless of which version of the ConsentPII a participant responded to.
- Exclude ConsentPII responses from the participant activity timeline for "no" responses.  Ensures participant is only identified as REGISTERED.

## Tests
- [x] unit tests



[PDR-2031]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ