### PR TITLE
Make sample_id a string; source age from pull list

### DIFF
--- a/rdr_service/alembic/nph/versions/639a51a6ea25_change_sample_id_datatype.py
+++ b/rdr_service/alembic/nph/versions/639a51a6ea25_change_sample_id_datatype.py
@@ -1,0 +1,35 @@
+"""change sample_id datatype
+
+Revision ID: 639a51a6ea25
+Revises: cf4839a3b84a
+Create Date: 2023-09-12 15:47:00.055657
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '639a51a6ea25'
+down_revision = 'cf4839a3b84a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name):
+    globals()["upgrade_%s" % engine_name]()
+
+
+def downgrade(engine_name):
+    globals()["downgrade_%s" % engine_name]()
+
+
+def upgrade_nph():
+    op.execute('ALTER TABLE nph.sms_sample MODIFY COLUMN sample_id VARCHAR(32)')
+    op.execute('ALTER TABLE nph.sms_n0 MODIFY COLUMN sample_id VARCHAR(32)')
+    op.execute('ALTER TABLE nph.sms_n1_mc1 MODIFY COLUMN sample_id VARCHAR(32)')
+
+
+def downgrade_nph():
+    op.execute('ALTER TABLE nph.sms_sample MODIFY COLUMN sample_id BIGINT(20)')
+    op.execute('ALTER TABLE nph.sms_n0 MODIFY COLUMN sample_id BIGINT(20)')
+    op.execute('ALTER TABLE nph.sms_n1_mc1 MODIFY COLUMN sample_id BIGINT(20)')
+

--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -159,7 +159,7 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                 SmsN0.sample_type,
                 SmsN0.additive_treatment,
                 SmsN0.quantity_ml,
-                SmsN0.age,
+                SmsSample.age,
                 SmsSample.sex_at_birth,
                 SmsN0.package_id,
                 SmsN0.storage_unit_id,

--- a/rdr_service/model/study_nph_sms.py
+++ b/rdr_service/model/study_nph_sms.py
@@ -56,7 +56,7 @@ class SmsSample(NphBase):
     job_run_id = Column(BigInteger, ForeignKey("sms_job_run.id"))
 
     # File Fields
-    sample_id = Column(BigInteger, index=True)
+    sample_id = Column(String(32), index=True)
     lims_sample_id = Column(String(32), index=True)
     plate_number = Column(String(32))
     position = Column(String(16))
@@ -91,7 +91,7 @@ class SmsN0(NphBase):
     lims_sample_id = Column(String(32))
     matrix_id = Column(String(32))
     biobank_id = Column(String(32))
-    sample_id = Column(BigInteger, index=True)
+    sample_id = Column(String(32), index=True)
     study = Column(String(64))
     visit = Column(String(64))
     timepoint = Column(String(64))
@@ -127,7 +127,7 @@ class SmsN1Mc1(NphBase):
     job_run_id = Column(BigInteger, ForeignKey("sms_job_run.id"))
 
     # Manifest Fields
-    sample_id = Column(BigInteger, index=True)
+    sample_id = Column(String(32), index=True)
     matrix_id = Column(String(32))
     biobank_id = Column(String(32))
     sample_identifier = Column(String(32))

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -75,7 +75,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
 
         # Test Data inserted correctly
         self.assertEqual(ingested_record.job_run_id, 1)
-        self.assertEqual(ingested_record.sample_id, 10001)
+        self.assertEqual(ingested_record.sample_id, "10001")
         self.assertEqual(ingested_record.lims_sample_id, "5847307831")
         self.assertEqual(ingested_record.plate_number, "1")
         self.assertEqual(ingested_record.position, "A1")
@@ -120,7 +120,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(ingested_records[0].lims_sample_id, "00000000000")
         self.assertEqual(ingested_records[0].matrix_id, "MC8888888888")
         self.assertEqual(ingested_records[0].biobank_id, "N222222222")
-        self.assertEqual(ingested_records[0].sample_id, 2222222222)
+        self.assertEqual(ingested_records[0].sample_id, "2222222222")
         self.assertEqual(ingested_records[0].study, None)
         self.assertEqual(ingested_records[0].visit, None)
         self.assertEqual(ingested_records[0].timepoint, None)
@@ -301,7 +301,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         manifest_records = n1_mcac_dao.get_all()
         self.assertEqual(len(manifest_records), 3)
         self.assertEqual(manifest_records[0].file_path, expected_csv_path)
-        self.assertEqual(manifest_records[0].sample_id, 10001)
+        self.assertEqual(manifest_records[0].sample_id, "10001")
         self.assertEqual(manifest_records[0].matrix_id, "1111")
         self.assertEqual(manifest_records[0].bmi, "28")
         self.assertEqual(manifest_records[0].diet, "LMT")
@@ -312,7 +312,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(manifest_records[0].manufacturer_lot, '256837')
 
         self.assertEqual(manifest_records[1].file_path, expected_csv_path)
-        self.assertEqual(manifest_records[1].sample_id, 10002)
+        self.assertEqual(manifest_records[1].sample_id, "10002")
         self.assertEqual(manifest_records[1].matrix_id, "1112")
         self.assertEqual(manifest_records[1].bmi, "28")
         self.assertEqual(manifest_records[1].diet, "LMT")


### PR DESCRIPTION
## Resolves *[DA-3807](https://precisionmedicineinitiative.atlassian.net/browse/DA-3807)*


## Description of changes/additions
This PR updates the N1 generation process to incorporate requests from the DGCs. 
1. The N1 `age` field was updated to be sourced from the pull list rather than the N0.
2. The `sample_id` fields in `sms_sample`, `sms_n0`, and `sms_n1_mc1` were changed to a string to allow for leading “0” characters. 

## Tests
- [x] unit tests




[DA-3807]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ