### PR TITLE
Fix for ETM classification migration file

### DIFF
--- a/rdr_service/alembic/versions/b7d11fd04fdc_classification_column_for_etm_responses.py
+++ b/rdr_service/alembic/versions/b7d11fd04fdc_classification_column_for_etm_responses.py
@@ -10,14 +10,7 @@ import sqlalchemy as sa
 import rdr_service.model.utils
 from sqlalchemy.dialects import mysql
 
-from rdr_service.participant_enums import PhysicalMeasurementsStatus, QuestionnaireStatus, OrderStatus
-from rdr_service.participant_enums import WithdrawalStatus, WithdrawalReason, SuspensionStatus, QuestionnaireDefinitionStatus
-from rdr_service.participant_enums import EnrollmentStatus, Race, SampleStatus, OrganizationType, BiobankOrderStatus
-from rdr_service.participant_enums import OrderShipmentTrackingStatus, OrderShipmentStatus
-from rdr_service.participant_enums import MetricSetType, MetricsKey, GenderIdentity
-from rdr_service.model.base import add_table_history_table, drop_table_history_table
-from rdr_service.model.code import CodeType
-from rdr_service.model.site_enums import SiteStatus, EnrollingStatus, DigitalSchedulingStatus, ObsoleteStatus
+from rdr_service.participant_enums import QuestionnaireResponseClassificationType
 
 # revision identifiers, used by Alembic.
 revision = 'b7d11fd04fdc'


### PR DESCRIPTION
This modifies the latest migration file to add an import statement for the missing enum.


