### PR TITLE
[DA-3021] Updating mediated EHR check to look for a list of CE ids

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -272,5 +272,6 @@
       "organization",
       "site"
     ]
-  }
+  },
+  "ce_mediated_hpo_id": ["ce_id_1", "ce_id_2"]
 }

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -22,7 +22,7 @@ from rdr_service.participant_enums import EhrStatus
 from rdr_service.offline.bigquery_sync import dispatch_participant_rebuild_tasks
 
 LOG = logging.getLogger(__name__)
-ce_hpo_id = config.getSettingJson(config.CE_MEDIATED_HPO_ID, default=None)
+ce_hpo_id_list = config.getSettingJson(config.CE_MEDIATED_HPO_ID, default=None)
 
 
 class ParticipantEhrTracking:
@@ -66,11 +66,11 @@ class ParticipantEhrTracking:
 
     @classmethod
     def is_ce_mediated_file(cls, file: ParticipantEhrFile):
-        if ce_hpo_id is None:
+        if ce_hpo_id_list is None:
             # Continue assuming everything's HPO uploaded if CE's id isn't set
             return False
 
-        return file.hpo_id == ce_hpo_id
+        return file.hpo_id.lower() in ce_hpo_id_list
 
 
 def update_ehr_status_organization():

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -174,7 +174,7 @@ _enrollment_status_map = {
 }
 
 
-def get_ce_mediated_hpo_id():
+def get_ce_mediated_hpo_id_list():
     return config.getSettingJson(config.CE_MEDIATED_HPO_ID, default=None)
 
 
@@ -594,12 +594,12 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     ParticipantEhrReceipt.firstSeen,
                     ParticipantEhrReceipt.fileTimestamp
                 )
-            ce_hpo_id = get_ce_mediated_hpo_id()
-            if ce_hpo_id is not None:
+            ce_hpo_id_list = get_ce_mediated_hpo_id_list()
+            if ce_hpo_id_list is not None:
                 pehr_query = pehr_query.filter(
                     or_(
                         ParticipantEhrReceipt.hpo_id.is_(None),
-                        ParticipantEhrReceipt.hpo_id != ce_hpo_id
+                        ParticipantEhrReceipt.hpo_id.notin_(ce_hpo_id_list)
                     )
                 )
             pehr_results = pehr_query.all()


### PR DESCRIPTION
## Resolves *[DA-3021](https://precisionmedicineinitiative.atlassian.net/browse/DA-3021)*
The code was originally set up to only identify one hpo_id as CE for mediated EHR files. But it will need to be able to handle 2 different ids for now, and potentially 4 in the future.

## Description of changes/additions
This updates the check to look for ids in a list rather than a direct comparison.

## Tests
- [x] unit tests




[DA-3021]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ