### PR TITLE
[DA-3787] implementing pediatric flag

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -56,6 +56,7 @@ from rdr_service.model.participant_summary import (
 )
 from rdr_service.model.patient_status import PatientStatus
 from rdr_service.model.participant import Participant
+from rdr_service.model.pediatric_data_log import PediatricDataType
 from rdr_service.model.retention_eligible_metrics import RetentionEligibleMetrics
 from rdr_service.model.utils import get_property_type, to_client_participant_id
 from rdr_service.participant_enums import (
@@ -422,7 +423,8 @@ class ParticipantSummaryDao(UpdatableDao):
                 ParticipantSummary.participantId,
                 ParticipantSummary.firstName,
                 ParticipantSummary.lastName
-            )
+            ),
+            joinedload(ParticipantSummary.pediatricData)
         ]
 
     def get_by_hpo(self, hpo, session, yield_batch_size=1000):
@@ -1377,6 +1379,11 @@ class ParticipantSummaryDao(UpdatableDao):
                 }
                 for related_summary in related_summary_list
             ]
+
+        # set the pediatric data flag
+        result['isPediatric'] = UNSET
+        if any(data.data_type == PediatricDataType.AGE_RANGE for data in obj.pediatricData):
+            result['isPediatric'] = True
 
         # Format other responses to default to UNSET when none
         field_names = [

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql import expression
 
 from rdr_service.model.account_link import AccountLink
 from rdr_service.model.base import Base, InvalidDataState, model_insert_listener, model_update_listener
+from rdr_service.model.pediatric_data_log import PediatricDataLog
 from rdr_service.model.utils import Enum, EnumZeroBased, UTCDateTime, UTCDateTime6
 from rdr_service.participant_enums import (
     EhrStatus,
@@ -1675,6 +1676,22 @@ class ParticipantSummary(Base):
         uselist=True,
         lazy='noload'
     )
+
+    pediatricData: List[PediatricDataLog] = relationship(
+        'PediatricDataLog',
+        primaryjoin=and_(
+            foreign(participantId) == remote(PediatricDataLog.participant_id),
+            PediatricDataLog.replaced_by_id.is_(None)
+        ),
+        uselist=True,
+        lazy='noload'
+    )
+
+    isPediatric = None  # placeholder for docs, DAO sets on model
+    """
+    Field indicating whether this is a pediatric participant or not. The API will display as 'UNSET'
+    for adult participants, and will return a boolean value of true if it's a pediatric participant.
+    """
 
 
 Index("participant_summary_biobank_id", ParticipantSummary.biobankId)

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -178,7 +178,8 @@ participant_summary_default_values = {
     "hasCoreData": False,
     "questionnaireOnEmotionalHealthHistoryAndWellBeing": "UNSET",
     "questionnaireOnBehavioralHealthAndPersonality": "UNSET",
-    'relatedParticipants': 'UNSET'
+    'relatedParticipants': 'UNSET',
+    'isPediatric': 'UNSET'
 }
 
 participant_summary_default_values_no_basics = dict(participant_summary_default_values)

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -22,6 +22,7 @@ from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
+from rdr_service.dao.pediatric_data_log_dao import PediatricDataLogDao
 from rdr_service.dao.site_dao import SiteDao
 from rdr_service.model.account_link import AccountLink
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
@@ -4563,4 +4564,13 @@ class ParticipantSummaryApiTest(BaseTestCase):
             response.get('relatedParticipants')
         )
 
+    def test_pediatric_flag(self):
+        regular_participant = self.data_generator.create_database_participant_summary()
+        pediatric_participant = self.data_generator.create_database_participant_summary()
+        PediatricDataLogDao.record_age_range(participant_id=pediatric_participant.participantId, age_range_str='TEEN')
 
+        response = self.send_get(f'Participant/P{regular_participant.participantId}/Summary')
+        self.assertEqual('UNSET', response['isPediatric'])
+
+        response = self.send_get(f'Participant/P{pediatric_participant.participantId}/Summary')
+        self.assertEqual(True, response['isPediatric'])


### PR DESCRIPTION
## Resolves *[DA-3787](https://precisionmedicineinitiative.atlassian.net/browse/DA-3787)*
This sets up a pediatric flag on the participant summary, dynamically setting it to True if we have any pediatric age ranges for that participant.

## Tests
- [x] unit tests




[DA-3787]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ