### PR TITLE
[DA-3785] Updating enrolled status to not require EHR or GROR

### DIFF
--- a/rdr_service/logic/enrollment_info.py
+++ b/rdr_service/logic/enrollment_info.py
@@ -195,23 +195,21 @@ class EnrollmentCalculation:
 
     @classmethod
     def _set_v32_status(cls, enrollment: EnrollmentInfo, participant_info: EnrollmentDependencies):
-        if not participant_info.ever_expressed_interest_in_sharing_ehr:
-            return  # stop here without ehr interest, any more upgrades to the enrollment status require it
-
-        enrollment.upgrade_3_2_status(EnrollmentStatusV32.PARTICIPANT_PLUS_EHR, participant_info.first_ehr_consent_date)
+        if participant_info.ever_expressed_interest_in_sharing_ehr:
+            enrollment.upgrade_3_2_status(
+                EnrollmentStatusV32.PARTICIPANT_PLUS_EHR,
+                participant_info.first_ehr_consent_date
+            )
 
         if not participant_info.has_completed_the_basics_survey:
             return  # stop here without TheBasics, any more upgrades to the enrollment status require it
 
-        # Upgrading 3.2 to ENROLLED_PARTICIPANT requires TheBasics and a GROR response
-        if participant_info.has_completed_gror_survey:
-            matching_date = cls._get_requirements_met_date([
-                participant_info.first_ehr_consent_date,
-                participant_info.basics_authored_time,
-                participant_info.gror_authored_time
-            ])
-            if matching_date:
-                enrollment.upgrade_3_2_status(EnrollmentStatusV32.ENROLLED_PARTICIPANT, matching_date)
+        # Upgrading 3.2 to ENROLLED_PARTICIPANT requires TheBasics
+        if participant_info.basics_authored_time:
+            enrollment.upgrade_3_2_status(
+                EnrollmentStatusV32.ENROLLED_PARTICIPANT,
+                participant_info.basics_authored_time
+            )
 
         if cls._meets_requirements_for_core_minus_pm(participant_info):
             enrollment.upgrade_3_2_status(

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -62,7 +62,7 @@ participant_summary_default_values = {
     "recontactMethod": "UNSET",
     "enrollmentStatus": "INTERESTED",
     "enrollmentStatusV3_0": "PARTICIPANT",
-    "enrollmentStatusV3_2": "PARTICIPANT",
+    "enrollmentStatusV3_2": "ENROLLED_PARTICIPANT",
     "samplesToIsolateDNA": "UNSET",
     "numBaselineSamplesArrived": 0,
     "numCompletedPPIModules": 1,
@@ -187,7 +187,8 @@ participant_summary_default_values_no_basics.update({
     "education": "UNSET",
     "income": "UNSET",
     "sex": "UNSET",
-    "sexualOrientation": "UNSET"
+    "sexualOrientation": "UNSET",
+    "enrollmentStatusV3_2": "PARTICIPANT"
 })
 
 
@@ -349,7 +350,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
                 "cohort2PilotFlag": "UNSET",
                 "patientStatus": patient_statuses or [],
                 "enrollmentStatusParticipantV3_0Time": "2016-01-01T00:00:00",
-                "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00",
+                "enrollmentStatusParticipantV3_2Time": TIME_1.isoformat(),
+                'enrollmentStatusEnrolledParticipantV3_2Time': TIME_1.isoformat(),
                 "isParticipantMediatedEhrDataAvailable": False
             }
         )
@@ -2815,7 +2817,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual("UNSET", ps_1["sampleStatus2ED10"])
         self.assertEqual("RECEIVED", ps_1["sampleStatus1SAL2"])
         self.assertEqual("RECEIVED", ps_1["samplesToIsolateDNA"])
-        self.assertEqual("PARTICIPANT", ps_1["enrollmentStatusV3_2"])
+        self.assertEqual("ENROLLED_PARTICIPANT", ps_1["enrollmentStatusV3_2"])
         self.assertEqual("UNSET", ps_1["clinicPhysicalMeasurementsStatus"])
         self.assertIsNone(ps_1.get("clinicPhysicalMeasurementsTime"))
         self.assertEqual("GenderIdentity_Man", ps_1["genderIdentity"])
@@ -2853,7 +2855,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual("UNSET", ps_2["sampleStatus1SAL"])
         self.assertEqual("UNSET", ps_2["sampleStatus2ED10"])
         self.assertEqual("UNSET", ps_2["samplesToIsolateDNA"])
-        self.assertEqual("PARTICIPANT_PLUS_EHR", ps_2["enrollmentStatusV3_2"])
+        self.assertEqual("ENROLLED_PARTICIPANT", ps_2["enrollmentStatusV3_2"])
         self.assertEqual("COMPLETED", ps_2["clinicPhysicalMeasurementsStatus"])
         self.assertEqual(TIME_2.isoformat(), ps_2["clinicPhysicalMeasurementsTime"])
         self.assertEqual("GenderIdentity_Woman", ps_2["genderIdentity"])
@@ -2956,8 +2958,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
             self.assertResponses("ParticipantSummary?_count=2&consentForCABoR=SUBMITTED", [[ps_1]])
             self.assertResponses("ParticipantSummary?_count=2&clinicPhysicalMeasurementsStatus=UNSET", [[ps_1]])
             self.assertResponses("ParticipantSummary?_count=2&clinicPhysicalMeasurementsStatus=COMPLETED", [[ps_2, ps_3]])
-            self.assertResponses("ParticipantSummary?_count=2&enrollmentStatusV3_2=PARTICIPANT", [[ps_1]])
-            self.assertResponses("ParticipantSummary?_count=2&enrollmentStatusV3_2=PARTICIPANT_PLUS_EHR", [[ps_2]])
+            self.assertResponses("ParticipantSummary?_count=2&enrollmentStatusV3_2=ENROLLED_PARTICIPANT", [[ps_1, ps_2]])
             self.assertResponses("ParticipantSummary?_count=2&enrollmentStatusV3_2=CORE_PARTICIPANT", [[ps_3]])
             self.assertResponses("ParticipantSummary?_count=2&withdrawalStatus=NOT_WITHDRAWN", [[ps_1, ps_3]])
             self.assertResponses("ParticipantSummary?_count=2&withdrawalStatus=NO_USE", [[ps_2]])
@@ -3022,7 +3023,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.assertEqual("UNSET", new_ps_2["sampleStatus1ED10"])
         self.assertEqual("UNSET", new_ps_2["sampleStatus1SAL"])
         self.assertEqual("UNSET", new_ps_2["samplesToIsolateDNA"])
-        self.assertEqual("PARTICIPANT_PLUS_EHR", new_ps_2["enrollmentStatusV3_2"])
+        self.assertEqual("ENROLLED_PARTICIPANT", new_ps_2["enrollmentStatusV3_2"])
         self.assertEqual("UNSET", new_ps_2["clinicPhysicalMeasurementsStatus"])
         self.assertEqual("SUBMITTED", new_ps_2["consentForStudyEnrollment"])
         self.assertIsNotNone(new_ps_2["consentForStudyEnrollmentAuthored"])

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -750,7 +750,8 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
             "consentCohort": str(ParticipantCohort.COHORT_1),
             "cohort2PilotFlag": str(ParticipantCohortPilotFlag.UNSET),
             "enrollmentStatusParticipantV3_0Time": "2016-01-01T00:00:00",
-            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00"
+            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00",
+            "enrollmentStatusEnrolledParticipantV3_2Time": TIME_2.isoformat()
         })
         self.assertJsonResponseMatches(expected, summary)
 
@@ -1181,7 +1182,8 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
             "consentCohort": str(ParticipantCohort.COHORT_1),
             "cohort2PilotFlag": str(ParticipantCohortPilotFlag.UNSET),
             "enrollmentStatusParticipantV3_0Time": "2016-01-01T00:00:00",
-            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00"
+            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00",
+            "enrollmentStatusEnrolledParticipantV3_2Time": TIME_2.isoformat()
         })
         self.assertJsonResponseMatches(expected, summary)
 
@@ -1358,7 +1360,8 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
             "consentCohort": str(ParticipantCohort.COHORT_1),
             "cohort2PilotFlag": str(ParticipantCohortPilotFlag.UNSET),
             "enrollmentStatusParticipantV3_0Time": "2016-01-01T00:00:00",
-            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00"
+            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00",
+            "enrollmentStatusEnrolledParticipantV3_2Time": TIME_2.isoformat()
         })
         self.assertJsonResponseMatches(expected, summary)
 
@@ -1402,7 +1405,8 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
             "consentCohort": str(ParticipantCohort.COHORT_1),
             "cohort2PilotFlag": str(ParticipantCohortPilotFlag.UNSET),
             "enrollmentStatusParticipantV3_0Time": "2016-01-01T00:00:00",
-            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00"
+            "enrollmentStatusParticipantV3_2Time": "2016-01-01T00:00:00",
+            "enrollmentStatusEnrolledParticipantV3_2Time": TIME_2.isoformat()
         })
         self.assertJsonResponseMatches(expected, summary)
 

--- a/tests/dao_tests/test_questionnaire_response_dao.py
+++ b/tests/dao_tests/test_questionnaire_response_dao.py
@@ -42,8 +42,10 @@ from rdr_service.model.questionnaire import Questionnaire, QuestionnaireConcept,
 from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer, \
     QuestionnaireResponseStatus
 from rdr_service.model.resource_data import ResourceData
-from rdr_service.participant_enums import GenderIdentity, QuestionnaireStatus, WithdrawalStatus, ParticipantCohort,\
+from rdr_service.participant_enums import (
+    EnrollmentStatusV32, GenderIdentity, QuestionnaireStatus, WithdrawalStatus, ParticipantCohort,
     DigitalHealthSharingStatus
+)
 from rdr_service.repository.questionnaire_response_repository import QuestionnaireResponseRepository
 from tests import test_data
 from tests.test_data import (
@@ -639,8 +641,10 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             consentCohort=ParticipantCohort.COHORT_1,
             retentionEligibleStatus=None,
             wasEhrDataAvailable=False,
+            enrollmentStatusV3_2=EnrollmentStatusV32.ENROLLED_PARTICIPANT,
             enrollmentStatusParticipantV3_0Time=datetime.datetime(2016, 1, 2),
             enrollmentStatusParticipantV3_2Time=datetime.datetime(2016, 1, 2),
+            enrollmentStatusEnrolledParticipantV3_2Time=TIME_2,
             healthDataStreamSharingStatus=DigitalHealthSharingStatus.NEVER_SHARED,
             aian=0
         )
@@ -1273,8 +1277,10 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             consentCohort=ParticipantCohort.COHORT_1,
             retentionEligibleStatus=None,
             wasEhrDataAvailable=False,
+            enrollmentStatusV3_2=EnrollmentStatusV32.ENROLLED_PARTICIPANT,
             enrollmentStatusParticipantV3_0Time=datetime.datetime(2016, 1, 2),
             enrollmentStatusParticipantV3_2Time=datetime.datetime(2016, 1, 2),
+            enrollmentStatusEnrolledParticipantV3_2Time=TIME_2,
             healthDataStreamSharingStatus=DigitalHealthSharingStatus.NEVER_SHARED,
             aian=0
         )
@@ -1353,8 +1359,10 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             consentCohort=ParticipantCohort.COHORT_1,
             retentionEligibleStatus=None,
             wasEhrDataAvailable=False,
+            enrollmentStatusV3_2=EnrollmentStatusV32.ENROLLED_PARTICIPANT,
             enrollmentStatusParticipantV3_0Time=datetime.datetime(2016, 1, 2),
             enrollmentStatusParticipantV3_2Time=datetime.datetime(2016, 1, 2),
+            enrollmentStatusEnrolledParticipantV3_2Time=TIME_2,
             healthDataStreamSharingStatus=DigitalHealthSharingStatus.NEVER_SHARED,
             aian=0
         )
@@ -1440,8 +1448,10 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             consentCohort=ParticipantCohort.COHORT_1,
             retentionEligibleStatus=None,
             wasEhrDataAvailable=False,
+            enrollmentStatusV3_2=EnrollmentStatusV32.ENROLLED_PARTICIPANT,
             enrollmentStatusParticipantV3_0Time=datetime.datetime(2016, 1, 2),
             enrollmentStatusParticipantV3_2Time=datetime.datetime(2016, 1, 2),
+            enrollmentStatusEnrolledParticipantV3_2Time=TIME_2,
             healthDataStreamSharingStatus=DigitalHealthSharingStatus.NEVER_SHARED,
             aian=0
         )
@@ -1517,8 +1527,10 @@ class QuestionnaireResponseDaoTest(PDRGeneratorTestMixin, BaseTestCase):
             consentCohort=ParticipantCohort.COHORT_1,
             retentionEligibleStatus=None,
             wasEhrDataAvailable=False,
+            enrollmentStatusV3_2=EnrollmentStatusV32.ENROLLED_PARTICIPANT,
             enrollmentStatusParticipantV3_0Time=datetime.datetime(2016, 1, 2),
             enrollmentStatusParticipantV3_2Time=datetime.datetime(2016, 1, 2),
+            enrollmentStatusEnrolledParticipantV3_2Time=TIME_2,
             healthDataStreamSharingStatus=DigitalHealthSharingStatus.NEVER_SHARED,
             aian=0
         )

--- a/tests/logic_tests/test_enrollment_info.py
+++ b/tests/logic_tests/test_enrollment_info.py
@@ -67,7 +67,7 @@ class TestEnrollmentInfo(BaseTestCase):
             EnrollmentCalculation.get_enrollment_info(participant_info)
         )
 
-    def test_basics_and_gror(self):
+    def test_enrolled_and_ehr(self):
         """
         3.0 should upgrade to PARTICIPANT_PMB_ELIGIBLE when TheBasics has been submitted, but also needs EHR
         3.2 should upgrade to needs TheBasics, but doesn't need EHR.
@@ -143,6 +143,7 @@ class TestEnrollmentInfo(BaseTestCase):
                 v32_data=[
                     (EnrollmentStatusV32.PARTICIPANT, participant_info.primary_consent_authored_time),
                     (EnrollmentStatusV32.PARTICIPANT_PLUS_EHR, participant_info.first_ehr_consent_date),
+                    (EnrollmentStatusV32.ENROLLED_PARTICIPANT, participant_info.basics_authored_time),
                     (EnrollmentStatusV32.CORE_MINUS_PM, participant_info.earliest_biobank_received_dna_time)
                 ]
             ),
@@ -191,6 +192,7 @@ class TestEnrollmentInfo(BaseTestCase):
                 v32_data=[
                     (EnrollmentStatusV32.PARTICIPANT, participant_info.primary_consent_authored_time),
                     (EnrollmentStatusV32.PARTICIPANT_PLUS_EHR, participant_info.first_ehr_consent_date),
+                    (EnrollmentStatusV32.ENROLLED_PARTICIPANT, participant_info.basics_authored_time),
                     (EnrollmentStatusV32.CORE_MINUS_PM, participant_info.earliest_biobank_received_dna_time),
                     (EnrollmentStatusV32.CORE_PARTICIPANT, participant_info.earliest_physical_measurements_time)
                 ]
@@ -233,6 +235,7 @@ class TestEnrollmentInfo(BaseTestCase):
                 v32_data=[
                     (EnrollmentStatusV32.PARTICIPANT, participant_info.primary_consent_authored_time),
                     (EnrollmentStatusV32.PARTICIPANT_PLUS_EHR, participant_info.first_ehr_consent_date),
+                    (EnrollmentStatusV32.ENROLLED_PARTICIPANT, participant_info.basics_authored_time),
                     (EnrollmentStatusV32.CORE_MINUS_PM, participant_info.earliest_biobank_received_dna_time),
                     (EnrollmentStatusV32.CORE_PARTICIPANT, participant_info.earliest_physical_measurements_time)
                 ]

--- a/tests/logic_tests/test_enrollment_info.py
+++ b/tests/logic_tests/test_enrollment_info.py
@@ -69,35 +69,31 @@ class TestEnrollmentInfo(BaseTestCase):
 
     def test_basics_and_gror(self):
         """
-        3.0 should upgrade to PARTICIPANT_PMB_ELIGIBLE when TheBasics has been submitted.
-        3.2 needs TheBasics, but shouldn't upgrade until GROR has been submitted as well.
+        3.0 should upgrade to PARTICIPANT_PMB_ELIGIBLE when TheBasics has been submitted, but also needs EHR
+        3.2 should upgrade to needs TheBasics, but doesn't need EHR.
         The legacy version of the calculation would still just show them as MEMBER.
         """
         participant_info = self._build_participant_info(
             primary_authored_time=datetime(2020, 7, 18),
-            ehr_consent_ranges=[DateRange(start=datetime(2020, 7, 18))],
             basics_time=datetime(2020, 7, 27)
         )
         self.assertEnrollmentInfoEqual(
             self._build_expected_enrollment_info(
                 legacy_data=[
-                    (EnrollmentStatus.INTERESTED, participant_info.primary_consent_authored_time),
-                    (EnrollmentStatus.MEMBER, participant_info.first_ehr_consent_date)
+                    (EnrollmentStatus.INTERESTED, participant_info.primary_consent_authored_time)
                 ],
                 v30_data=[
-                    (EnrollmentStatusV30.PARTICIPANT, participant_info.primary_consent_authored_time),
-                    (EnrollmentStatusV30.PARTICIPANT_PLUS_EHR, participant_info.first_ehr_consent_date),
-                    (EnrollmentStatusV30.PARTICIPANT_PMB_ELIGIBLE, participant_info.basics_authored_time)
+                    (EnrollmentStatusV30.PARTICIPANT, participant_info.primary_consent_authored_time)
                 ],
                 v32_data=[
                     (EnrollmentStatusV32.PARTICIPANT, participant_info.primary_consent_authored_time),
-                    (EnrollmentStatusV32.PARTICIPANT_PLUS_EHR, participant_info.first_ehr_consent_date)
+                    (EnrollmentStatusV32.ENROLLED_PARTICIPANT, participant_info.basics_authored_time)
                 ]
             ),
             EnrollmentCalculation.get_enrollment_info(participant_info)
         )
 
-        participant_info.gror_authored_time = datetime(2020, 8, 2)
+        participant_info.ehr_consent_date_range_list = [DateRange(start=datetime(2020, 7, 18))]
         self.assertEnrollmentInfoEqual(
             self._build_expected_enrollment_info(
                 legacy_data=[
@@ -112,7 +108,7 @@ class TestEnrollmentInfo(BaseTestCase):
                 v32_data=[
                     (EnrollmentStatusV32.PARTICIPANT, participant_info.primary_consent_authored_time),
                     (EnrollmentStatusV32.PARTICIPANT_PLUS_EHR, participant_info.first_ehr_consent_date),
-                    (EnrollmentStatusV32.ENROLLED_PARTICIPANT, participant_info.gror_authored_time)
+                    (EnrollmentStatusV32.ENROLLED_PARTICIPANT, participant_info.basics_authored_time)
                 ]
             ),
             EnrollmentCalculation.get_enrollment_info(participant_info)


### PR DESCRIPTION
## Resolves *[DA-3785](https://precisionmedicineinitiative.atlassian.net/browse/DA-3785)*
The Enrolled status should only need primary consent and a response to TheBasics.

## Description of changes/additions
This updates the enrollment status calculation to match what NIH is expecting.

## Tests
- [x] unit tests




[DA-3785]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ