### PR TITLE
[DA-3793] Add Specimen Table to ETL Export

### DIFF
--- a/rdr_service/etl/bq/queries.py
+++ b/rdr_service/etl/bq/queries.py
@@ -1305,6 +1305,26 @@ queries = {
                       src_id STRING
                     )
                     DEFAULT COLLATE 'und:ci';
+                    CREATE TABLE `{dataset_id}.specimen`
+                    (
+                      specimen_id INT64,
+                      person_id INT64,
+                      specimen_concept_id INT64,
+                      specimen_type_concept_id INT64,
+                      specimen_date DATE,
+                      specimen_datetime TIMESTAMP,
+                      quantity NUMERIC,
+                      unit_concept_id INT64,
+                      anatomic_site_concept_id INT64,
+                      disease_status_concept_id INT64,
+                      specimen_source_id STRING,
+                      specimen_source_value STRING,
+                      unit_source_value STRING,
+                      anatomic_site_source_value STRING,
+                      disease_status_source_value STRING,
+                      src_id STRING,
+                    )
+                    DEFAULT COLLATE 'und:ci';
         """
     },
     "pid_rid_mapping": {

--- a/rdr_service/tools/tool_libs/curation_bq.py
+++ b/rdr_service/tools/tool_libs/curation_bq.py
@@ -105,7 +105,8 @@ class CurationBQ(ToolBase):
         'survey_conduct',
         'cope_survey_semantic_version_map',
         'note',
-        'procedure_occurrence'
+        'procedure_occurrence',
+        'specimen'
     ]
 
     def __init__(self, args, gcp_env=None, tool_name=None, replica=False):


### PR DESCRIPTION
## Resolves *[DA-3793](https://precisionmedicineinitiative.atlassian.net/browse/DA-3793)*


## Description of changes/additions
Curation's process expects all tables to present even if empty. This PR adds specimen as an empty table for export.

## Tests
Tested manually




[DA-3793]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ