### PR TITLE
[PDR-2105] Participants under 18 are no longer counted as UBR

### DIFF
--- a/rdr_service/resource/calculators/participant_ubr.py
+++ b/rdr_service/resource/calculators/participant_ubr.py
@@ -270,8 +270,8 @@ class ParticipantUBRCalculator:
         # When calculating 'Age At Consent', ensure that leap years are accounted for. A date subtraction
         # function that is "leap year" aware must be used.
         rd = relativedelta(consent_time, answer)
-        # RBR if age is between 18 and 64, else UBR.
-        if 18 <= rd.years < 65:
+        # PDR-2105 - Due to Pediatric rollout, participants under 18 will no longer count as UBR.
+        if rd.years < 65:
             return UBRValueEnum.RBR
         return UBRValueEnum.UBR
 

--- a/tests/resource_tests/calculator_tests/test_ubr_calculator.py
+++ b/tests/resource_tests/calculator_tests/test_ubr_calculator.py
@@ -343,7 +343,7 @@ class UBRCalculatorTest(BaseTestCase):
 
         # Test UBR value
         dob = (consent_ts - relativedelta(years=17)).date()
-        self.assertEqual(self.ubr.ubr_age_at_consent(consent, dob), UBRValueEnum.UBR)
+        self.assertEqual(self.ubr.ubr_age_at_consent(consent, dob), UBRValueEnum.RBR)
         dob = (consent_ts - relativedelta(years=65)).date()
         self.assertEqual(self.ubr.ubr_age_at_consent(consent, dob), UBRValueEnum.UBR)
 


### PR DESCRIPTION
## Resolves *[PDR-2105](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2105)*


## Description of changes/additions
Due to the Pediatric participants rollout, participants under the age of 18 will no longer be counted as UBR.


## Tests
- [x] unit tests




[PDR-2105]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ