### PR TITLE
Bring is_pediatric flag to PDR

### DIFF
--- a/rdr_service/model/bq_base.py
+++ b/rdr_service/model/bq_base.py
@@ -407,7 +407,7 @@ class BQTable(object):
     __project_map__ = [
         ('all-of-us-rdr-prod', ('aou-pdr-data-prod', 'rdr_ops_data_view')),
         ('all-of-us-rdr-stable', ('aou-pdr-data-stable', 'rdr_ops_data_view')),
-        ('pmi-drc-api-test', ('aou-pdr-data-test', 'rdr_ops_data_view')),
+        ('pmi-drc-api-test', ('aou-pdr-data-dev', 'rdr_ops_data_view')),
     ]
 
     def get_name(self):

--- a/rdr_service/model/bq_participant_summary.py
+++ b/rdr_service/model/bq_participant_summary.py
@@ -444,6 +444,7 @@ class BQParticipantSummarySchema(BQSchema):
                                                        BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     health_datastream_sharing_status_v3_1_time = BQField('health_datastream_sharing_status_v3_1_time',
                                                          BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    is_pediatric = BQField('is_pediatric', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 class BQParticipantSummary(BQTable):
     """ Participant Summary BigQuery Table """

--- a/rdr_service/model/bq_pdr_participant_summary.py
+++ b/rdr_service/model/bq_pdr_participant_summary.py
@@ -251,6 +251,7 @@ class BQPDRParticipantSummarySchema(BQSchema):
                                                        BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
     health_datastream_sharing_status_v3_1_time = BQField('health_datastream_sharing_status_v3_1_time',
                                                          BQFieldTypeEnum.DATETIME, BQFieldModeEnum.NULLABLE)
+    is_pediatric = BQField('is_pediatric', BQFieldTypeEnum.INTEGER, BQFieldModeEnum.NULLABLE)
 
 
 class BQPDRParticipantSummary(BQTable):

--- a/rdr_service/resource/schemas/participant.py
+++ b/rdr_service/resource/schemas/participant.py
@@ -512,6 +512,7 @@ class ParticipantSchema(Schema):
     ubr_age_at_consent = fields.UInt8()
     ubr_disability = fields.UInt8()
     ubr_overall = fields.UInt8()
+    is_pediatric = fields.UInt8()
 
     class Meta:
         schema_id = SchemaID.participant


### PR DESCRIPTION
## Resolves *[PDR-2091 ](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2091)*


## Description of changes/additions
Add 'is_pediatric' flag to PDR participant data.  Pediatric flag is null until there is a RDR participant summary record created.

## Tests
- [x] unit tests


