### PR TITLE
[DA-3054] add_invalid_response_classification_type

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -13,7 +13,7 @@ security: # configuration for the `safety check` command
             expires: '2022-10-21' # datetime string - date this ignore will expire, best practice to use this variable
         51668:
             reason: using SQLAlchemy versions >=1.4.0 is causing failures # optional, for internal note purposes to communicate with your team. This reason will be reported in the Safety reports
-            expires: '2023-09-30' # datetime string - date this ignore will expire, best practice to use this variable
+            expires: '2024-02-29' # datetime string - date this ignore will expire, best practice to use this variable
     continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
     security:

--- a/rdr_service/dao/bq_questionnaire_dao.py
+++ b/rdr_service/dao/bq_questionnaire_dao.py
@@ -63,7 +63,8 @@ class BQPDRQuestionnaireResponseGenerator(BigQueryGenerator):
             inner join participant p on p.participant_id = qr.participant_id
             left join hpo h on p.hpo_id = h.hpo_id
             -- Screen out classification DUPLICATE (1) responses from the PDR data [PDR-640]
-            where qr.participant_id = :p_id and qr.classification_type != 1 and qr.questionnaire_id IN (
+            where qr.participant_id = :p_id and qr.classification_type != 1 and qr.classification_type != 6
+                and qr.questionnaire_id IN (
                 select q.questionnaire_id from questionnaire q
                 inner join questionnaire_history qh on q.version = qh.version
                        and qh.questionnaire_id = q.questionnaire_id

--- a/rdr_service/participant_enums.py
+++ b/rdr_service/participant_enums.py
@@ -136,6 +136,7 @@ class QuestionnaireResponseClassificationType(messages.Enum):
     NO_ANSWER_VALUES = 3  # Isolated cases where payload had question data with no answer values
     AUTHORED_TIME_UPDATED = 4  # Known/expected retransmission of previous payloads, but with a corrected authored ts
     PARTIAL = 5  # Other cases (e.g., partial COPE surveys) where payload is not a completed survey
+    INVALID = 6  # Identify the invalid questionnaire responses
 
 
 class EnrollmentStatus(messages.Enum):

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -729,7 +729,8 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 QuestionnaireHistory.irbMapping). \
             join(QuestionnaireHistory). \
             filter(QuestionnaireResponse.participantId == p_id,
-                   QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE). \
+                   QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE,
+                   QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.INVALID). \
             order_by(QuestionnaireResponse.authored, QuestionnaireResponse.created.desc(),
                      QuestionnaireResponse.externalId.desc())
         # sql = self.ro_dao.query_to_text(query)

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1556,7 +1556,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                     INNER JOIN questionnaire_concept qc on qr.questionnaire_id = qc.questionnaire_id
                     INNER JOIN questionnaire q on q.questionnaire_id = qc.questionnaire_id
             WHERE qr.participant_id = :p_id and qc.code_id in (select c1.code_id from code c1 where c1.value = :mod)
-                AND qr.classification_type != 1
+                AND qr.classification_type != 1 AND qr.classification_type != 6
             ORDER BY qr.created;
         """
 

--- a/rdr_service/tools/tool_libs/curation.py
+++ b/rdr_service/tools/tool_libs/curation.py
@@ -396,6 +396,7 @@ class CurationExportClass(ToolBase):
         ).filter(
             QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
             QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE,
+            QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.INVALID,
             QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.PROFILE_UPDATE,
             QuestionnaireResponse.participantId.in_(pid_list)
         )
@@ -539,6 +540,7 @@ class CurationExportClass(ToolBase):
             ),
             QuestionnaireResponse.status != QuestionnaireResponseStatus.IN_PROGRESS,
             QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE,
+            QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.INVALID,
             QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.PROFILE_UPDATE,
 
             not_(QuestionnaireConcept.codeId.in_(

--- a/tests/tool_tests/test_curation_etl.py
+++ b/tests/tool_tests/test_curation_etl.py
@@ -401,6 +401,30 @@ class CurationEtlTest(ToolTestMixin, BaseTestCase):
             for answer_record in src_clean_answers
         ))
 
+    def test_invalid_record_in_temp_questionnaire_response_filtered_out(self):
+        """
+        Test that invalid record in cdm.tmp_questionnaire_response is not included in export
+        """
+
+        # Create a new questionnaire response
+        participant = self.data_generator.create_database_participant()
+        invalid_response = self._setup_questionnaire_response(
+            participant,
+            self.questionnaire,
+            classification_type=QuestionnaireResponseClassificationType.INVALID
+        )
+
+        self.run_cdm_data_generation()
+
+        # Make sure no answers from the response made it into SrcClean
+        src_clean_answers = self.session.query(SrcClean).filter(
+            SrcClean.participant_id == participant.participantId
+        ).all()
+        self.assertFalse(any(
+            answer_record.questionnaire_response_id == invalid_response.questionnaireResponseId
+            for answer_record in src_clean_answers
+        ))
+
     def test_zip_code_maps_to_string_field(self):
         """
         There are some questionnaire responses that have the zip code transmitted to us in the valueInteger


### PR DESCRIPTION
## Resolves *[DA-3054](https://precisionmedicineinitiative.atlassian.net/browse/DA-3054)*
Currently, we use the value DUPLICATE as a catch-all for other cases where PTSC informed us of data that was sent to RDR erroneously. This ticket added an additional enum value of INVALID to the QuestionnaireResponseClassificationType class and be able to use that moving forward for those invalid cases. It helps us to identify the “problem” payloads more quickly.

## Description of changes/additions
1. add new enum INVALID
2. update resource generator and curation ETL to filter out INVALID responses

## Tests
- [x] unit tests




[DA-3054]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ