### PR TITLE
[DA-3816] Remove EHR validation requirement from retention eligibility

### DIFF
--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -339,11 +339,11 @@ def _supplement_with_rdr_calculations(metrics_data: RetentionEligibleMetrics, se
     metrics_data.rdr_is_actively_retained = retention_data.is_actively_retained
     metrics_data.rdr_is_passively_retained = retention_data.is_passively_retained
 
-
 def _get_earliest_intent_for_ehr(session, participant_id) -> Optional[Consent]:
     date_range_list = QuestionnaireResponseRepository.get_interest_in_sharing_ehr_ranges(
         participant_id=participant_id,
-        session=session
+        session=session,
+        validation_not_required=True
     )
     if not date_range_list:
         return None

--- a/rdr_service/repository/questionnaire_response_repository.py
+++ b/rdr_service/repository/questionnaire_response_repository.py
@@ -159,7 +159,16 @@ class QuestionnaireResponseRepository:
         return [consent_response.questionnaire_response_id for consent_response in query.all()]
 
     @classmethod
-    def get_interest_in_sharing_ehr_ranges(cls, participant_id, session: Session, default_authored_datetime=None):
+    def get_interest_in_sharing_ehr_ranges(cls, participant_id, session: Session, default_authored_datetime=None,
+                                           validation_not_required=False):
+        """
+        :param participant_id:  Participant id (integer)
+        :param session:  A session object for querying data
+        :param default_authored_datetime: An authored timestamp to match to an EHR consent response, if provided
+        :param validation_not_required: A flag to disable enforcement of successful PDF validation.   When this
+                                        function is called during calculation of retention eligibility, is set to True
+
+        """
         # Load all EHR and DV_EHR responses
         sharing_response_list = cls.get_responses_to_surveys(
             session=session,
@@ -179,7 +188,8 @@ class QuestionnaireResponseRepository:
         # Find all ranges where interest in sharing EHR was expressed (DV_EHR) or consent to share was provided
         ehr_interest_date_ranges = []
 
-        skip_validation_check = config.getSettingJson('ENROLLMENT_STATUS_SKIP_VALIDATION', False)
+        skip_validation_check = (config.getSettingJson('ENROLLMENT_STATUS_SKIP_VALIDATION', False)
+                                 or validation_not_required)
         if sharing_response_list:
 
             current_date_range = None

--- a/rdr_service/tools/tool_libs/retention_qc.py
+++ b/rdr_service/tools/tool_libs/retention_qc.py
@@ -1,0 +1,69 @@
+import logging
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.retention_eligible_metrics import RetentionEligibleMetrics
+from rdr_service.offline.retention_eligible_import import _supplement_with_rdr_calculations
+from rdr_service.participant_enums import RetentionStatus
+from rdr_service.services.system_utils import list_chunks
+
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
+
+tool_cmd = 'retention-qc'
+tool_desc = 'QC tool comparing PTSC calculated retention_eligible_metrics data to the RDR supplemental calculations'
+
+class RetentionQC(ToolBase):
+    logger_name = None
+
+    def run(self):
+        super(RetentionQC, self).run()
+        with self.get_session() as session:
+            participant_id_list = None
+            query = session.query(ParticipantSummary)
+            # --id option takes precedence over --from-file option
+            if self.args.id:
+                participant_id_list = [int(i) for i in self.args.id.split(',')]
+            elif self.args.from_file:
+                participant_id_list = self.get_int_ids_from_file(self.args.from_file)
+
+            if participant_id_list:
+                query = query.filter(ParticipantSummary.participantId.in_(participant_id_list))
+
+            participants = query.order_by(ParticipantSummary.participantId).all()
+
+            if not participants:
+                logging.error('No participant summary results to process')
+                return 1
+
+            count = 0
+            chunk_size = 500
+            for summaries in list_chunks(lst=participants, chunk_size=chunk_size):
+                for ps in summaries:
+                    row = session.query(RetentionEligibleMetrics).filter(
+                        RetentionEligibleMetrics.participantId.in_(ps.participantId for ps in summaries)
+                    ).first()
+                    if row.retentionEligible:
+                        obj = RetentionEligibleMetrics(
+                            participantId=row.participantId,
+                            retentionEligible=row.retentionEligible,
+                            retentionEligibleTime=row.retentionEligibleTime,
+                            lastActiveRetentionActivityTime=row.lastActiveRetentionActivityTime,
+                            activelyRetained=row.activelyRetained,
+                            passivelyRetained=row.passivelyRetained,
+                            fileUploadDate=row.fileUploadDate,
+                            retentionEligibleStatus=RetentionStatus.ELIGIBLE\
+                                if row.retentionEligible else RetentionStatus.NOT_ELIGIBLE,
+                            retentionType=row.retentionType
+                        )
+                        _supplement_with_rdr_calculations(obj, session)
+                        if obj.rdr_retention_eligible != obj.retentionEligible:
+                            logging.error(f'P{ps.participantId}: undiagnosed eligibility mismatch')
+                count += 1
+                logging.info(f'Processed {min(count * chunk_size, len(participants))} of {len(participants)} pids...')
+
+
+def add_additional_arguments(parser):
+    parser.add_argument('--id', required=False,
+                        help="Single participant id or comma-separated list of id integer values to check")
+    parser.add_argument('--from-file', required=False,
+                        help="file of integer participant id values to check")
+def run():
+    return cli_run(tool_cmd, tool_desc, RetentionQC, add_additional_arguments)

--- a/rdr_service/tools/tool_libs/retention_qc.py
+++ b/rdr_service/tools/tool_libs/retention_qc.py
@@ -38,7 +38,7 @@ class RetentionQC(ToolBase):
             for summaries in list_chunks(lst=participants, chunk_size=chunk_size):
                 for ps in summaries:
                     row = session.query(RetentionEligibleMetrics).filter(
-                        RetentionEligibleMetrics.participantId.in_(ps.participantId for ps in summaries)
+                        RetentionEligibleMetrics.participantId == ps.participantId
                     ).first()
                     if row.retentionEligible:
                         obj = RetentionEligibleMetrics(
@@ -56,6 +56,8 @@ class RetentionQC(ToolBase):
                         _supplement_with_rdr_calculations(obj, session)
                         if obj.rdr_retention_eligible != obj.retentionEligible:
                             logging.error(f'P{ps.participantId}: undiagnosed eligibility mismatch')
+                        elif obj.activelyRetained != obj.rdr_is_actively_retained:
+                            logging.error(f'P{ps.participantId}: undiagnosed actively retained mismatch')
                 count += 1
                 logging.info(f'Processed {min(count * chunk_size, len(participants))} of {len(participants)} pids...')
 


### PR DESCRIPTION
## Partially resolves *[DA-3816](https://precisionmedicineinitiative.atlassian.net/browse/DA-3816)*


## Description of changes/additions
During QC comparing PTSC and RDR calculated retention metrics, there were approx. 13,700 participants considered retention eligible by PTSC but not by RDR.   

The cause was that the participants did not have a successful EHR consent PDF validation result (`consent_file` record where `sync_status` was READY_TO_SYNC or SYNC_COMPLETE).   This is a requirement for enrollment status, and the same RDR business logic was used to look for EHR consents during retention calculations.  Retention eligibility only requires that a "yes" response was received, regardless of PDF validation status.   Updated the logic to allow the PDF validation requirement to be skipped.

## Tests
- The  new `retention-qc` tool from this PR was used to run the ~13K participants back through the retention eligibility calculation with the new business logic.  Confirmed that this resolved the mismatches for all but about 100 of the participants.

The tool is likely to be updated in future PRs to perform additional QC checks and perhaps provide a way to backfill values that need correcting.




[DA-3816]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ