### PR TITLE
[DA-3784] Reading config for PM Core Data codes

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -281,6 +281,9 @@ RDR_GENOMICS_NOTIFICATION_EMAIL = "rdr_genomics_notification_email"
 
 SENSITIVE_EHR_RELEASE_DATE = 'sensitive_ehr_release_date'
 
+PM_HEIGHT_CODES = 'pm_height_codes'
+PM_WEIGHT_CODES = 'pm_weight_codes'
+
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}
 

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -198,5 +198,7 @@
       "organization",
       "site"
     ]
-  }
+  },
+  "pm_height_codes": ["height", "8302-2"],
+  "pm_weight_codes": ["weight", "29463-7", "pre-pregnancy-weight"]
 }

--- a/rdr_service/dao/physical_measurements_dao.py
+++ b/rdr_service/dao/physical_measurements_dao.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import subqueryload
 from sqlalchemy.orm.attributes import flag_modified
 from werkzeug.exceptions import BadRequest
 
-from rdr_service import clock
+from rdr_service import clock, config
 from rdr_service.api_util import parse_date
 from rdr_service.concepts import Concept
 from rdr_service.dao.base_dao import UpdatableDao
@@ -991,8 +991,8 @@ class PhysicalMeasurementsDao(UpdatableDao):
         """
         Analyzes the physical measurement data to determine if the Core Data flag should be set to True
         """
-        height_codes = ['height', '8302-2']
-        weight_codes = ['weight', '29463-7', 'pre-pregnancy-weight']
+        height_codes = config.getSettingJson(config.PM_HEIGHT_CODES)
+        weight_codes = config.getSettingJson(config.PM_WEIGHT_CODES)
 
         has_height = False
         has_weight = False


### PR DESCRIPTION
## Resolves *[DA-3784](https://precisionmedicineinitiative.atlassian.net/browse/DA-3784)*
Pediatrics will be using a different set of physical measurement codes, but we don't know yet which codes will be used of for specifying height and weight.

## Description of changes/additions
This changes the RDR so that the codes can be read from the config, letting us set them as soon as we have them and not needing to depend on a release.

## Tests
Current tests cover this code.




[DA-3784]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ