### PR TITLE
[DA-3866] Adding pediatric flag to received report

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -256,9 +256,12 @@ def _query_and_write_received_report(exporter, report_path, query_params, report
     received_report_select = _RECONCILIATION_REPORT_SELECTS_SQL
     if config.getSettingJson(config.ENABLE_BIOBANK_MANIFEST_RECEIVED_FLAG, default=False):
         received_report_select += """,
-                group_concat(ny_flag) ny_flag,
-                group_concat(sex_at_birth_flag) sex_at_birth_flag
-            """
+            group_concat(ny_flag) ny_flag,
+            group_concat(sex_at_birth_flag) sex_at_birth_flag
+        """
+    received_report_select += """,
+        max(is_pediatric) ispediatric
+    """
     logging.info(f"Writing {report_path} report.")
     received_sql = replace_isodate(received_report_select + _RECONCILIATION_REPORT_SOURCE_SQL)
     exporter.run_export(
@@ -536,6 +539,15 @@ def _participant_has_answer(question_code_value, answer_value):
     )
 
 
+_PEDIATRIC_SELECT_CLAUSE = 'pdl.id is not null is_pediatric'
+_PEDIATRIC_JOIN_CLAUSE = '''
+left join pediatric_data_log pdl
+    on pdl.participant_id = participant.participant_id
+    and pdl.replaced_by_id is null
+    and pdl.data_type = 1  -- is AGE_RANGE data
+'''
+
+
 # Joins orders and samples, and computes some derived values (elapsed_hours, counts).
 # MySQL does not support FULL OUTER JOIN, so instead we UNION ALL a LEFT OUTER JOIN
 # with a SELECT... WHERE NOT EXISTS (the latter for cases where we have a sample but no matching
@@ -631,9 +643,12 @@ _RECONCILIATION_REPORT_SOURCE_SQL = (
     case when sex_code.value like 'sexatbirth_male' then 'M'
        when sex_code.value like 'sexatbirth_female' then 'F'
        else 'NA'
-    end sex_at_birth_flag
-    FROM """
+    end sex_at_birth_flag,
+    """
+    + _PEDIATRIC_SELECT_CLAUSE
+    + """ FROM """
     + _ORDER_JOINS
+    + _PEDIATRIC_JOIN_CLAUSE
     + """
     LEFT OUTER JOIN
         participant_summary
@@ -711,16 +726,19 @@ _RECONCILIATION_REPORT_SOURCE_SQL = (
       case when sex_code.value like 'sexatbirth_male' then 'M'
            when sex_code.value like 'sexatbirth_female' then 'F'
            else 'NA'
-      end sex_at_birth_flag
-    FROM
+      end sex_at_birth_flag,
+    """
+    + _PEDIATRIC_SELECT_CLAUSE
+    + """ FROM
       biobank_stored_sample
       LEFT OUTER JOIN
         participant ON biobank_stored_sample.biobank_id = participant.biobank_id
       LEFT OUTER JOIN
         participant_summary ON participant_summary.participant_id = participant.participant_id
       LEFT OUTER JOIN
-        code sex_code ON participant_summary.sex_id = sex_code.code_id
-    WHERE biobank_stored_sample.confirmed IS NOT NULL AND NOT EXISTS (
+        code sex_code ON participant_summary.sex_id = sex_code.code_id """
+    + _PEDIATRIC_JOIN_CLAUSE
+    + """ WHERE biobank_stored_sample.confirmed IS NOT NULL AND NOT EXISTS (
       SELECT 0 FROM """
     + _ORDER_JOINS + """
       LEFT OUTER JOIN

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -22,6 +22,7 @@ from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.config_utils import from_client_biobank_id
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.pediatric_data_log import PediatricDataLog, PediatricDataType
 from rdr_service.offline import biobank_samples_pipeline
 from rdr_service.offline.sql_exporter import SqlExporter
 from rdr_service.participant_enums import EnrollmentStatus, SampleStatus, get_sample_status_enum_value,\
@@ -424,7 +425,8 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
                 None, None, None,  # notes info: collected, processed, finalized
                 None, None, None, None, None,  # cancelled_restored info: status_flag, name, name, time, reason
                 None,  # order origin
-                'example'  # Participant origin
+                'example',  # Participant origin
+                0  # is pediatric
             )])
 
     def test_demographic_flags_in_received_report(self):
@@ -448,6 +450,15 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             biobankOrderId=order.biobankOrderId,
             value='KIT-001',
             system=biobank_samples_pipeline._KIT_ID_SYSTEM
+        )
+
+        # set up data to show participant as pediatric
+        self.session.add(
+            PediatricDataLog(
+                participant_id=participant.participantId,
+                data_type=PediatricDataType.AGE_RANGE,
+                value='0_6'
+            )
         )
 
         ordered_sample = self.data_generator.create_database_biobank_ordered_sample(
@@ -495,7 +506,8 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
                 None,  # order origin
                 'example',  # Participant origin,
                 'Y',  # NY flag
-                'NA'  # sex at birth flag
+                'NA',  # sex at birth flag
+                1  # is pediatric flag
             )])
 
     def _generate_withdrawal_report(self):

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -619,7 +619,7 @@ class MySqlReconciliationTest(BaseTestCase):
         # not includes orders/samples from more than 10 days ago;
         # Includes 1 Salivary order
         exporter.assertRowCount(received, 11)
-        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES)
+        exporter.assertColumnNamesEqual(received, (*_CSV_COLUMN_NAMES, "ispediatric"))
         row = exporter.assertHasRow(
             received,
             {
@@ -1193,7 +1193,7 @@ class MySqlReconciliationTest(BaseTestCase):
         # sent-and-received: 4 on-time, 2 late, 2 edge, none of the missing/extra/repeated ones;
         # not includes orders/samples from more than 60 days ago
         exporter.assertRowCount(received, 12)
-        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES)
+        exporter.assertColumnNamesEqual(received, (*_CSV_COLUMN_NAMES, "ispediatric"))
         row = exporter.assertHasRow(
             received,
             {


### PR DESCRIPTION
## Partially Resolves *[DA-3866](https://precisionmedicineinitiative.atlassian.net/browse/DA-3866)*
Adding pediatric flag to the biobank received report.

## Tests
- [x] unit tests




[DA-3866]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ