### PR TITLE
[PDR-2148] Fetch DOB value from Participant Summary

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -531,6 +531,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
             ehr_status = EhrStatus.NOT_PRESENT if ps.ehrStatus is None else ps.ehrStatus
             ehr_receipts = []
             data = {
+                'date_of_birth': ps.dateOfBirth,
                 'ehr_status': str(ehr_status),
                 'ehr_status_id': int(ehr_status),
                 'ehr_receipt': ps.ehrReceiptTime,
@@ -660,20 +661,10 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # TODO: Update this to a JSONObject instead of BQRecord object.
         qnan = BQRecord(schema=None, data=qnans)  # use only most recent response.
 
-        # TODO: Should DOB be captured only from the first ConsentPII received?
-        try:
-            # Always use first ConsentPII submission when collecting DOB value. Get first key id from 'responses' dict.
-            first_resp = next(iter(responses))
-            # Value can be None, 'PMISkip' or date string.
-            dob = parser.parse(responses[first_resp].get('PIIBirthInformation_BirthDate')).date()
-        except (ParserError, TypeError):
-            dob = None
-
         data = {
             'first_name': qnan.get('PIIName_First'),
             'middle_name': qnan.get('PIIName_Middle'),
             'last_name': qnan.get('PIIName_Last'),
-            'date_of_birth': dob,
             'primary_language': qnan.get('language'),
             'addresses': [
                 {

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -662,8 +662,10 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
 
         # TODO: Should DOB be captured only from the first ConsentPII received?
         try:
+            # Always use first ConsentPII submission when collecting DOB value. Get first key id from 'responses' dict.
+            first_resp = next(iter(responses))
             # Value can be None, 'PMISkip' or date string.
-            dob = parser.parse(qnan.get('PIIBirthInformation_BirthDate')).date()
+            dob = parser.parse(responses[first_resp].get('PIIBirthInformation_BirthDate')).date()
         except (ParserError, TypeError):
             dob = None
 

--- a/tests/resource_tests/generator_tests/test_multiple_survey_responses.py
+++ b/tests/resource_tests/generator_tests/test_multiple_survey_responses.py
@@ -88,4 +88,7 @@ class MultipleQuestionnaireResponsesTest(BaseTestCase):
 
             # Verify data from second submission has been added.
             self.assertEqual(ps_data['login_phone_number'], '(555)-555-5555')
-            self.assertEqual(ps_data['date_of_birth'], datetime(year=1960, month=10, day=1).date())
+            # Date of birth is now pulled from the 'participant_summary' table in the generator. Since DOB
+            # was NULL in the first submission, we would expect DOB to stay NULL when an additional ConsentPII
+            # response are sent because 'participant_summary' is only updated on the first submission.
+            self.assertIsNone(ps_data['date_of_birth'])


### PR DESCRIPTION
## Resolves *[PDR-2148](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2148)*


## Description of changes/additions
Fetch the participant DOB value from the Participant Summary record instead of using ConsentPII responses.

## Tests
- [x] unit tests




[PDR-2148]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ