### PR TITLE
Change logging level for retention import condition

### DIFF
--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -262,7 +262,9 @@ def _supplement_with_rdr_calculations(metrics_data: RetentionEligibleMetrics, se
     )
 
     if not summary:
-        logging.error(f'no summary for P{metrics_data.participantId}')
+        # PTSC currently included  REGISTERED participants without primary consent yet, so only emit warning if there
+        # is no participant_summary record found
+        logging.warning(f'no summary for P{metrics_data.participantId}')
         return
 
     dependencies = RetentionEligibilityDependencies(


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Currently, PTSC is including all `participant_id` values from their system in the daily retention metrics file drop ingested by RDR, even if the participants are only registered/not yet primary consented.

To better isolate unexpected error conditions in the GCP logs and help streamline QC/validation work,  lowering the message about missing `participant_summary` record to a warning since those are somewhat expected.  Discussing whether it would be better to have PTSC only include participants with a primary consent in their daily retention metrics file drop.

## Tests
- [x] unit tests



