### PR TITLE
Updating frozen list of biobank test codes

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -261,8 +261,6 @@ AGREE_NO = "agree_no"
 
 BIOBANK_TESTS = [
     "1ED10",
-    "2ED02",
-    "2ED04",
     "2ED10",
     "1ED04",
     "1SST8",
@@ -279,6 +277,8 @@ BIOBANK_TESTS = [
     "1ED02",
     "1CFD9",
     "1PXR2",
+    "2ED02",
+    "2ED04"
 ]
 BIOBANK_TESTS_SET = frozenset(BIOBANK_TESTS)
 

--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -261,6 +261,8 @@ AGREE_NO = "agree_no"
 
 BIOBANK_TESTS = [
     "1ED10",
+    "2ED02",
+    "2ED04",
     "2ED10",
     "1ED04",
     "1SST8",


### PR DESCRIPTION
## Resolves *no ticket*
RDR is failing to ingest new pediatric biobank orders because the test codes are unrecognized.

## Description of changes/additions
This updates the frozen list of codes so that the API won't see them as invalid.

## Tests
- [] unit tests


