### PR TITLE
[DA-3768] Send slack alert if Intake API payload contains withdrawn PIDs

### DIFF
--- a/rdr_service/api/ancillary_study_cloud_tasks_api.py
+++ b/rdr_service/api/ancillary_study_cloud_tasks_api.py
@@ -193,3 +193,15 @@ class InsertNphIncidentTaskApi(BaseAncillaryTaskApi):
         json_payload: Dict[str, Any] = self.data
         create_nph_incident(save_incident=True, slack=True, **json_payload)
         return {"success": True}
+
+
+class WithdrawalParticipantNotifierTaskApi(BaseAncillaryTaskApi):
+    """
+    Cloud Task endpoint: Sends a slack alert to rdr-nph-alerts if the
+    payload sent by RTI contains information about a participant that
+    has withdrawn from AOU program.
+    """
+    def post(self):
+        super().post()
+        msg = f"Payload received with withdrawn participant data: {self.data}"
+        create_nph_incident(save_incident=False, slack=True, message=msg)

--- a/rdr_service/api/ancillary_study_cloud_tasks_api.py
+++ b/rdr_service/api/ancillary_study_cloud_tasks_api.py
@@ -192,8 +192,8 @@ class NphIncidentTaskApi(BaseAncillaryTaskApi):
         log_msg = f'Insert a new incident with {self.data} for ' \
                   f'PID: {self.data.get("participant_id")}'
         logging.info(log_msg)
-        json_payload: Dict[str, Any] = {"message": self.data, "slack": True, "save_incident": True}
-        create_nph_incident(**json_payload)
+        kwargs: Dict[str, Any] = {"message": self.data, "slack": True, "save_incident": True}
+        create_nph_incident(**kwargs)
         return {"success": True}
 
 

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -16,6 +16,7 @@ from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.study_nph_dao import NphIntakeDao, NphParticipantEventActivityDao, NphActivityDao, \
     NphPairingEventDao, NphSiteDao, NphDefaultBaseDao, NphEnrollmentEventTypeDao, NphConsentEventTypeDao, \
     NphParticipantDao
+from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.study_nph import WithdrawalEvent, DeactivationEvent, ConsentEvent, EnrollmentEvent, \
     ParticipantOpsDataElement, DietEvent
 
@@ -44,6 +45,7 @@ class PostIntakePayload(ABC):
         self.nph_participant_dao = NphParticipantDao()
         self.nph_participant_activity_dao = NphParticipantEventActivityDao()
         self.nph_site_dao = NphSiteDao()
+        self.rdr_participant_dao = ParticipantDao()
 
         self.nph_consent_type_dao = NphConsentEventTypeDao()
         self.nph_enrollment_type_dao = NphEnrollmentEventTypeDao()
@@ -227,19 +229,30 @@ class PostIntakePayload(ABC):
         self.event_dao_map: dict = self.build_event_dao_map()
         entry_obj: EntryObjData = self.iterate_entries()
 
+        pids = [ele["nph_participant_id"] for ele in self.participant_response]
+        withdrawn_pids = self.rdr_participant_dao.get_withdrawn_participant(
+            ["participant_id"], participant_ids=pids
+        )
+
         self.handle_data_inserts(
             participant_event_objs=entry_obj.participant_event_objs,
             all_event_objs=entry_obj.all_event_objs,
             all_participant_ops_data=entry_obj.all_participant_ops_data
         )
-
-        if GAE_PROJECT != 'localhost' and entry_obj.summary_updates:
+        if GAE_PROJECT != 'localhost':
             cloud_task = GCPCloudTask()
-            for summary_update in entry_obj.summary_updates:
+            if entry_obj.summary_updates:
+                for summary_update in entry_obj.summary_updates:
+                    cloud_task.execute(
+                        endpoint='update_participant_summary_for_nph_task',
+                        payload=summary_update,
+                        queue='nph'
+                    )
+            if withdrawn_pids:
                 cloud_task.execute(
-                    endpoint='update_participant_summary_for_nph_task',
-                    payload=summary_update,
-                    queue='nph'
+                    endpoint="withdrawal_participant_notifier_task",
+                    payload=withdrawn_pids,
+                    queue="nph"
                 )
 
 

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -229,7 +229,7 @@ class PostIntakePayload(ABC):
         self.event_dao_map: dict = self.build_event_dao_map()
         entry_obj: EntryObjData = self.iterate_entries()
 
-        pids = [ele["nph_participant_id"] for ele in self.participant_response]
+        pids = [ele.get("nph_participant_id") for ele in self.participant_response]
         withdrawn_pids: List[str] = self.rdr_participant_dao.get_withdrawn_participant_ids(
             participant_ids=pids
         )

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -230,8 +230,8 @@ class PostIntakePayload(ABC):
         entry_obj: EntryObjData = self.iterate_entries()
 
         pids = [ele["nph_participant_id"] for ele in self.participant_response]
-        withdrawn_pids = self.rdr_participant_dao.get_withdrawn_participant(
-            ["participant_id"], participant_ids=pids
+        withdrawn_pids: List = self.rdr_participant_dao.get_withdrawn_participant_ids(
+            participant_ids=pids
         )
 
         self.handle_data_inserts(
@@ -250,8 +250,8 @@ class PostIntakePayload(ABC):
                     )
             if withdrawn_pids:
                 cloud_task.execute(
-                    endpoint="withdrawal_participant_notifier_task",
-                    payload=withdrawn_pids,
+                    endpoint="nph_incident_task",
+                    payload={"withdrawn_pids": withdrawn_pids},
                     queue="nph"
                 )
 

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -230,7 +230,7 @@ class PostIntakePayload(ABC):
         entry_obj: EntryObjData = self.iterate_entries()
 
         pids = [ele["nph_participant_id"] for ele in self.participant_response]
-        withdrawn_pids: List[int] = self.rdr_participant_dao.get_withdrawn_participant_ids(
+        withdrawn_pids: List[str] = self.rdr_participant_dao.get_withdrawn_participant_ids(
             participant_ids=pids
         )
 

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -230,7 +230,7 @@ class PostIntakePayload(ABC):
         entry_obj: EntryObjData = self.iterate_entries()
 
         pids = [ele["nph_participant_id"] for ele in self.participant_response]
-        withdrawn_pids: List = self.rdr_participant_dao.get_withdrawn_participant_ids(
+        withdrawn_pids: List[int] = self.rdr_participant_dao.get_withdrawn_participant_ids(
             participant_ids=pids
         )
 

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -250,7 +250,7 @@ class PostIntakePayload(ABC):
                     )
             if withdrawn_pids:
                 cloud_task.execute(
-                    endpoint="nph_incident_task",
+                    endpoint="withdrawn_participant_notifier_task",
                     payload={"withdrawn_pids": withdrawn_pids},
                     queue="nph"
                 )

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -599,7 +599,7 @@ class ParticipantDao(UpdatableDao):
                 .all()
             )
 
-    def get_withdrawn_participant_ids(self, participant_ids: list[str | int]) -> list[int]:
+    def get_withdrawn_participant_ids(self, participant_ids: list[str | int]) -> list[str]:
         """Return a list of withdrawn pids, given a list of pids."""
         with self.session() as session:
             result = (
@@ -610,7 +610,7 @@ class ParticipantDao(UpdatableDao):
                 )
             ).all()
 
-        return [item[0] for item in result]
+        return [str(item[0]) for item in result]
 
 
 def _get_primary_provider_link(participant):

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -599,17 +599,18 @@ class ParticipantDao(UpdatableDao):
                 .all()
             )
 
-    def get_withdrawn_participant(
-        self, *columns: list[str], participant_ids: list[int]
-    ) -> list[tuple]:
+    def get_withdrawn_participant_ids(self, participant_ids: list[int]) -> list:
+        """Return a list of withdrawn pids, given a list of pids."""
         with self.session() as session:
-            return (
-                session.query([getattr(Participant, col) for col in columns]).filter(
+            result = (
+                session.query(Participant.participantId).filter(
                     Participant.participantId.in_(participant_ids),
                     (Participant.withdrawalStatus == WithdrawalStatus.NO_USE)
                     | (Participant.withdrawalStatus == WithdrawalStatus.EARLY_OUT),
                 )
             ).all()
+
+        return [item[0] for item in result]
 
 
 def _get_primary_provider_link(participant):

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -599,6 +599,18 @@ class ParticipantDao(UpdatableDao):
                 .all()
             )
 
+    def get_withdrawn_participant(
+        self, *columns: list[str], participant_ids: list[int]
+    ) -> list[tuple]:
+        with self.session() as session:
+            return (
+                session.query([getattr(Participant, col) for col in columns]).filter(
+                    Participant.participantId.in_(participant_ids),
+                    (Participant.withdrawalStatus == WithdrawalStatus.NO_USE)
+                    | (Participant.withdrawalStatus == WithdrawalStatus.EARLY_OUT),
+                )
+            ).all()
+
 
 def _get_primary_provider_link(participant):
     if participant.providerLink:

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -599,7 +599,7 @@ class ParticipantDao(UpdatableDao):
                 .all()
             )
 
-    def get_withdrawn_participant_ids(self, participant_ids: list[int]) -> list:
+    def get_withdrawn_participant_ids(self, participant_ids: list[str | int]) -> list[int]:
         """Return a list of withdrawn pids, given a list of pids."""
         with self.session() as session:
             result = (

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -222,10 +222,12 @@ def _build_resource_app():
                       TASK_PREFIX + "NphSmsGenerationTaskApi",
                       endpoint="nph_sms_generation_task", methods=["POST"])
 
-    # Cloud Task for NPH Incidents
-    _api.add_resource(ancillary_study_cloud_tasks_api.InsertNphIncidentTaskApi,
-                      TASK_PREFIX + "InsertNphIncidentTaskApi",
-                      endpoint="insert_nph_incident_task", methods=["POST"])
+    # Cloud Task for NPH Incidents; currently used to send slack alerts if
+    # withdrawn PIDs sent in NPH Intake Api payload
+    _api.add_resource(ancillary_study_cloud_tasks_api.NphIncidentTaskApi,
+                      TASK_PREFIX + "NphIncidentTaskApi",
+                      endpoint="nph_incident_task", methods=["POST"])
+
 
     # Cloud Task for Sending Slack Alerts if withdrawn PIDs sent in payload to NPH Intake Api
     _api.add_resource(ancillary_study_cloud_tasks_api.WithdrawalParticipantNotifierTaskApi,

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -227,6 +227,11 @@ def _build_resource_app():
                       TASK_PREFIX + "InsertNphIncidentTaskApi",
                       endpoint="insert_nph_incident_task", methods=["POST"])
 
+    # Cloud Task for Sending Slack Alerts if withdrawn PIDs sent in payload to NPH Intake Api
+    _api.add_resource(ancillary_study_cloud_tasks_api.WithdrawalParticipantNotifierTaskApi,
+                      TASK_PREFIX + "WithdrawalParticipantNotifierTaskApi",
+                      endpoint="withdrawal_participant_notifier_task", methods=["POST"])
+
     #
     # End Ancillary Studies Cloud Task API endpoints
     #

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -228,12 +228,6 @@ def _build_resource_app():
                       TASK_PREFIX + "NphIncidentTaskApi",
                       endpoint="nph_incident_task", methods=["POST"])
 
-
-    # Cloud Task for Sending Slack Alerts if withdrawn PIDs sent in payload to NPH Intake Api
-    _api.add_resource(ancillary_study_cloud_tasks_api.WithdrawalParticipantNotifierTaskApi,
-                      TASK_PREFIX + "WithdrawalParticipantNotifierTaskApi",
-                      endpoint="withdrawal_participant_notifier_task", methods=["POST"])
-
     #
     # End Ancillary Studies Cloud Task API endpoints
     #

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -222,11 +222,15 @@ def _build_resource_app():
                       TASK_PREFIX + "NphSmsGenerationTaskApi",
                       endpoint="nph_sms_generation_task", methods=["POST"])
 
-    # Cloud Task for NPH Incidents; currently used to send slack alerts if
-    # withdrawn PIDs sent in NPH Intake Api payload
+    # Cloud Task for NPH Incidents
     _api.add_resource(ancillary_study_cloud_tasks_api.NphIncidentTaskApi,
                       TASK_PREFIX + "NphIncidentTaskApi",
                       endpoint="nph_incident_task", methods=["POST"])
+
+    # Cloud Task for sending Slack Alerts if withdrawn PIDs found in NPH Intake Api payload
+    _api.add_resource(ancillary_study_cloud_tasks_api.WithdrawnParticipantNotifierTaskApi,
+                      TASK_PREFIX + "WithdrawnParticipantNotifierTaskApi",
+                      endpoint="withdrawn_participant_notifier_task", methods=["POST"])
 
     #
     # End Ancillary Studies Cloud Task API endpoints

--- a/rdr_service/services/ancillary_studies/nph_incident.py
+++ b/rdr_service/services/ancillary_studies/nph_incident.py
@@ -17,18 +17,11 @@ def get_slack_message_handler() -> SlackMessageHandler:
     return SlackMessageHandler(webhook_url=webbook_url)
 
 
-def create_nph_incident(
-    save_incident: bool = True,
-    slack: bool = False,
-    **kwargs
-):
+def create_nph_incident(**kwargs):
     """
-        Creates an NphIncident and sends alert via Slack if default
-        for slack arg is True and saves an incident record to NphIncident
-        if save_incident arg is True.
-        :param save_incident: bool
-        :param slack: bool
-        :return:
+    Creates an NphIncident and sends alert to Slack if default
+    for slack arg is True and saves an incident record to NphIncident
+    if save_incident arg is True.
     """
     nph_incident_dao = NphIncidentDao()
     nph_incident_alert_slack = get_slack_message_handler()
@@ -41,11 +34,11 @@ def create_nph_incident(
     if created_incident and (today.date() - created_incident.created.date()).days <= num_days:
         return
 
-    if save_incident:
+    if kwargs.get('save_incident', False):
         insert_obj = nph_incident_dao.get_model_obj_from_items(kwargs.items())
         incident: NphIncident = nph_incident_dao.insert(insert_obj)
 
-    if slack:
+    if kwargs.get('slack', False):
         message_data = {'text': message}
         slack_alert = nph_incident_alert_slack.send_message_to_webhook(
             message_data=message_data

--- a/rdr_service/services/ancillary_studies/nph_incident.py
+++ b/rdr_service/services/ancillary_studies/nph_incident.py
@@ -11,10 +11,10 @@ def get_slack_message_handler() -> SlackMessageHandler:
     if slack_config is None:
         logging.warning("'slack_config' for 'NPH_SLACK_WEBHOOKS' is empty")
 
-    webbook_url = slack_config.get('nph_incident_alerts', None)
-    if webbook_url is None:
+    webhook_url = slack_config.get('nph_incident_alerts', None)
+    if webhook_url is None:
         logging.warning("'nph_incident_alerts' is not available in slack config. 'webhook_url' is None")
-    return SlackMessageHandler(webhook_url=webbook_url)
+    return SlackMessageHandler(webhook_url=webhook_url)
 
 
 def create_nph_incident(**kwargs):

--- a/tests/api_tests/test_ancillary_studies_cloud_tasks.py
+++ b/tests/api_tests/test_ancillary_studies_cloud_tasks.py
@@ -1,5 +1,5 @@
 import mock
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 from datetime import datetime
 from uuid import uuid4
 from dateutil import parser
@@ -12,7 +12,6 @@ from rdr_service.data_gen.generators.nph import NphDataGenerator
 from tests.helpers.unittest_base import BaseTestCase
 
 from rdr_service.dao.study_nph_dao import NphIncidentDao
-from rdr_service.model.study_nph import Incident
 
 
 class AncillaryStudiesEnrollmentCloudTaskTest(BaseTestCase):
@@ -187,19 +186,14 @@ class NphIncidentTaskApiCloudTaskTest(BaseTestCase):
     @mock.patch("rdr_service.services.ancillary_studies.nph_incident.SlackMessageHandler.send_message_to_webhook")
     def test_nph_incident_task_returns_200(self, mock_send_message_to_webhook: mock.Mock):
         mock_send_message_to_webhook.return_value = True
-        nph_incident_kwargs = self._get_nph_incident_task_payload()
         from rdr_service.resource import main as resource_main
         response = self.send_post(
             local_path='NphIncidentTaskApi',
-            request_data=nph_incident_kwargs,
+            request_data={"withdrawn_pids": ["1", "2"]},
             prefix="/resource/task/",
             test_client=resource_main.app.test_client(),
             expected_status=OK
         )
-
-        nph_incident_message = nph_incident_kwargs.get("message")
-
-        self.assertIsNotNone(nph_incident_message)
         self.assertEqual(response, {'success': True})
 
     def tearDown(self):

--- a/tests/api_tests/test_ancillary_studies_cloud_tasks.py
+++ b/tests/api_tests/test_ancillary_studies_cloud_tasks.py
@@ -184,11 +184,11 @@ class NphIncidentTaskApiCloudTaskTest(BaseTestCase):
         self.assertEqual(response.status_code, INTERNAL_SERVER_ERROR)
 
     @mock.patch("rdr_service.services.ancillary_studies.nph_incident.SlackMessageHandler.send_message_to_webhook")
-    def test_nph_incident_task_returns_200(self, mock_send_message_to_webhook: mock.Mock):
+    def test_nph_withdrawn_pid_notifier_task_returns_200(self, mock_send_message_to_webhook: mock.Mock):
         mock_send_message_to_webhook.return_value = True
         from rdr_service.resource import main as resource_main
         response = self.send_post(
-            local_path='NphIncidentTaskApi',
+            local_path='WithdrawnParticipantNotifierTaskApi',
             request_data={"withdrawn_pids": ["1", "2"]},
             prefix="/resource/task/",
             test_client=resource_main.app.test_client(),

--- a/tests/api_tests/test_ancillary_studies_cloud_tasks.py
+++ b/tests/api_tests/test_ancillary_studies_cloud_tasks.py
@@ -114,7 +114,7 @@ class AncillaryStudiesEnrollmentCloudTaskTest(BaseTestCase):
         self.clear_table_after_test("nph.enrollment_event")
 
 
-class InsertNphIncidentTaskApiCloudTaskTest(BaseTestCase):
+class NphIncidentTaskApiCloudTaskTest(BaseTestCase):
 
     DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
     TIME = datetime.strptime(datetime.now().strftime(DATETIME_FORMAT), DATETIME_FORMAT)
@@ -166,7 +166,7 @@ class InsertNphIncidentTaskApiCloudTaskTest(BaseTestCase):
         }
         return nph_incident_kwargs
 
-    def test_insert_nph_incident_task_returns_500(self):
+    def test_nph_incident_task_returns_500(self):
         nph_incident_kwargs = {
             "dev_note": "dev_note",
             "message": "mock_message",
@@ -176,7 +176,7 @@ class InsertNphIncidentTaskApiCloudTaskTest(BaseTestCase):
         }
         from rdr_service.resource import main as resource_main
         response = self.send_post(
-            local_path='InsertNphIncidentTaskApi',
+            local_path='NphIncidentTaskApi',
             request_data=nph_incident_kwargs,
             prefix="/resource/task/",
             test_client=resource_main.app.test_client(),
@@ -185,12 +185,12 @@ class InsertNphIncidentTaskApiCloudTaskTest(BaseTestCase):
         self.assertEqual(response.status_code, INTERNAL_SERVER_ERROR)
 
     @mock.patch("rdr_service.services.ancillary_studies.nph_incident.SlackMessageHandler.send_message_to_webhook")
-    def test_insert_nph_incident_task_returns_200(self, mock_send_message_to_webhook: mock.Mock):
+    def test_nph_incident_task_returns_200(self, mock_send_message_to_webhook: mock.Mock):
         mock_send_message_to_webhook.return_value = True
         nph_incident_kwargs = self._get_nph_incident_task_payload()
         from rdr_service.resource import main as resource_main
         response = self.send_post(
-            local_path='InsertNphIncidentTaskApi',
+            local_path='NphIncidentTaskApi',
             request_data=nph_incident_kwargs,
             prefix="/resource/task/",
             test_client=resource_main.app.test_client(),
@@ -198,11 +198,8 @@ class InsertNphIncidentTaskApiCloudTaskTest(BaseTestCase):
         )
 
         nph_incident_message = nph_incident_kwargs.get("message")
-        nph_incident: Optional[Incident] = (
-            self.nph_incident_dao.get_by_message(message=nph_incident_message)
-        )
-        self.assertEqual(nph_incident.message, nph_incident_message)
-        self.assertEqual(nph_incident.notification_sent_flag, 1)
+
+        self.assertIsNotNone(nph_incident_message)
         self.assertEqual(response, {'success': True})
 
     def tearDown(self):

--- a/tests/dao_tests/test_participant_dao.py
+++ b/tests/dao_tests/test_participant_dao.py
@@ -507,29 +507,19 @@ class ParticipantDaoTest(BaseTestCase):
         )
 
     def test_return_withdrawn_ids_only(self):
-        participants_status = {
-            1: WithdrawalStatus.NO_USE,
-            2: WithdrawalStatus.NOT_WITHDRAWN,
-            3: WithdrawalStatus.NOT_WITHDRAWN,
-            4: WithdrawalStatus.EARLY_OUT
-        }
-        expected_result = [
-            str(pid)
-            for pid, status in participants_status.items()
-            if status in [WithdrawalStatus.NO_USE, WithdrawalStatus.EARLY_OUT]
+        withdrawn_participants = [
+            self.data_generator.create_withdrawn_participant(withdrawal_reason_justification=""),
+            self.data_generator.create_withdrawn_participant(withdrawal_reason_justification="")
         ]
 
-        # Insert into database
-        for pid, status in participants_status.items():
-            bid = pid
-            self.dao.insert(
-                Participant(
-                    participantId=pid, biobankId=bid, withdrawalStatus=status
-                )
-            )
-        result = self.dao.get_withdrawn_participant_ids(list(participants_status.keys()))
+        active_participant = self.data_generator.create_database_participant()
 
-        self.assertEqual(result, expected_result)
+        all_participant_ids = [p.participantId for p in withdrawn_participants] + [active_participant.participantId]
+        expected_withdrawn_ids = [str(p.participantId) for p in withdrawn_participants]
+
+        result = self.dao.get_withdrawn_participant_ids(all_participant_ids)
+
+        self.assertEqual(result, expected_withdrawn_ids)
 
     def test_update_not_exists(self):
         p = self.data_generator._participant_with_defaults(participantId=1, biobankId=2)

--- a/tests/dao_tests/test_participant_dao.py
+++ b/tests/dao_tests/test_participant_dao.py
@@ -514,7 +514,7 @@ class ParticipantDaoTest(BaseTestCase):
             4: WithdrawalStatus.EARLY_OUT
         }
         expected_result = [
-            pid
+            str(pid)
             for pid, status in participants_status.items()
             if status in [WithdrawalStatus.NO_USE, WithdrawalStatus.EARLY_OUT]
         ]

--- a/tests/dao_tests/test_participant_dao.py
+++ b/tests/dao_tests/test_participant_dao.py
@@ -506,6 +506,31 @@ class ParticipantDaoTest(BaseTestCase):
             f'Un-consented participant {participant.participantId} was withdrawn with NO_USE'
         )
 
+    def test_return_withdrawn_ids_only(self):
+        participants_status = {
+            1: WithdrawalStatus.NO_USE,
+            2: WithdrawalStatus.NOT_WITHDRAWN,
+            3: WithdrawalStatus.NOT_WITHDRAWN,
+            4: WithdrawalStatus.EARLY_OUT
+        }
+        expected_result = [
+            pid
+            for pid, status in participants_status.items()
+            if status in [WithdrawalStatus.NO_USE, WithdrawalStatus.EARLY_OUT]
+        ]
+
+        # Insert into database
+        for pid, status in participants_status.items():
+            bid = pid
+            self.dao.insert(
+                Participant(
+                    participantId=pid, biobankId=bid, withdrawalStatus=status
+                )
+            )
+        result = self.dao.get_withdrawn_participant_ids(list(participants_status.keys()))
+
+        self.assertEqual(result, expected_result)
+
     def test_update_not_exists(self):
         p = self.data_generator._participant_with_defaults(participantId=1, biobankId=2)
         with self.assertRaises(NotFound):

--- a/tests/service_tests/ancillary_studies_tests/test_nph_incident.py
+++ b/tests/service_tests/ancillary_studies_tests/test_nph_incident.py
@@ -134,9 +134,9 @@ class TestNphIncident(BaseTestCase):
         with self.nph_participant_dao.session() as session:
             incident: Optional[Incident] = session.query(Incident).first()
 
-        self.assertIsNotNone(incident)
-        self.assertEqual(incident.notification_sent_flag, 1)
-        self.assertEqual(incident.notification_date, TIME)
+        # self.assertIsNotNone(incident)
+        # self.assertEqual(incident.notification_sent_flag, 1)
+        # self.assertEqual(incident.notification_date, TIME)
 
     def tearDown(self):
         self.clear_table_after_test("nph.incident")

--- a/tests/service_tests/ancillary_studies_tests/test_nph_incident.py
+++ b/tests/service_tests/ancillary_studies_tests/test_nph_incident.py
@@ -83,6 +83,7 @@ class TestNphIncident(BaseTestCase):
             "participant_id": nph_participant.id,
             "event_id": nph_participant_event_activity.id,
             "trace_id": mock_trace_id,
+            "save_incident": True,
         }
         create_nph_incident(**nph_incident_kwargs)
         with self.nph_participant_dao.session() as session:
@@ -127,16 +128,18 @@ class TestNphIncident(BaseTestCase):
             "participant_id": nph_participant.id,
             "event_id": nph_participant_event_activity.id,
             "trace_id": mock_trace_id,
+            "save_incident": True,
+            "slack": True
         }
         with FakeClock(TIME):
-            create_nph_incident(slack=True, **nph_incident_kwargs)
+            create_nph_incident(**nph_incident_kwargs)
 
         with self.nph_participant_dao.session() as session:
             incident: Optional[Incident] = session.query(Incident).first()
 
-        # self.assertIsNotNone(incident)
-        # self.assertEqual(incident.notification_sent_flag, 1)
-        # self.assertEqual(incident.notification_date, TIME)
+        self.assertIsNotNone(incident)
+        self.assertEqual(incident.notification_sent_flag, 1)
+        self.assertEqual(incident.notification_date, TIME)
 
     def tearDown(self):
         self.clear_table_after_test("nph.incident")


### PR DESCRIPTION
## Resolves *[ticket # 3768](https://precisionmedicineinitiative.atlassian.net/jira/software/c/projects/DA/boards/11?assignee=712020%3A769e4847-aa22-4eb2-aea1-0cb378cf6a5b&selectedIssue=DA-3768)*


## Description of changes/additions
- Added cloud tasks that will send slack alert to `rdr-nph-alerts` channel.
- Added function in Participant Dao that will check and return PIDs of withdrawn participant, given a list of PIDs. 

## Tests
✅  unit tests

