### PR TITLE
Pediatric updates for last modified time

### DIFF
--- a/rdr_service/dao/account_link_dao.py
+++ b/rdr_service/dao/account_link_dao.py
@@ -2,8 +2,10 @@ from typing import Set
 
 from sqlalchemy.orm import Session
 
+from rdr_service.clock import CLOCK
 from rdr_service.dao.base_dao import with_session
 from rdr_service.model.account_link import AccountLink
+from rdr_service.model.participant_summary import ParticipantSummary
 
 
 class AccountLinkDao:
@@ -16,6 +18,12 @@ class AccountLinkDao:
         ).all()
         if not results:
             session.add(account_link)
+
+            summary: ParticipantSummary = session.query(ParticipantSummary).filter(
+                ParticipantSummary.participantId == account_link.participant_id
+            ).one_or_none()
+            if summary:
+                summary.lastModified = CLOCK.now()
 
     @classmethod
     @with_session

--- a/tests/dao_tests/test_account_link_dao.py
+++ b/tests/dao_tests/test_account_link_dao.py
@@ -60,3 +60,16 @@ class AccountLinkDaoTest(BaseTestCase):
         with FakeClock(datetime(2020, 12, 1)):
             results = AccountLinkDao.get_linked_ids(child_id, session=self.session)
             self.assertEqual({first_parent_id}, results)
+
+    def test_linking_sets_modified_time(self):
+        pediatric_summary = self.data_generator.create_database_participant_summary()
+        guardian_id = self.data_generator.create_database_participant().participantId
+
+        timestamp = datetime(2023, 4, 8)
+        with FakeClock(timestamp):
+            AccountLinkDao.save_account_link(
+                account_link=AccountLink(participant_id=pediatric_summary.participantId, related_id=guardian_id),
+                session=self.session
+            )
+
+        self.assertEqual(timestamp, pediatric_summary.lastModified)

--- a/tests/dao_tests/test_pediatric_data_log_dao.py
+++ b/tests/dao_tests/test_pediatric_data_log_dao.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from rdr_service.clock import FakeClock
 from rdr_service.dao.pediatric_data_log_dao import PediatricDataLogDao
 from rdr_service.model.pediatric_data_log import PediatricDataLog, PediatricDataType
 from tests.helpers.unittest_base import BaseTestCase
@@ -69,3 +70,20 @@ class PediatricDataLogDaoTest(BaseTestCase):
         ).all()
         self.assertEqual(1, len(pediatric_data))
         self.assertEqual(existing_record.id, pediatric_data[0].id)
+
+    def test_age_sets_last_modified(self):
+        """
+        Setting a new pediatric age range on a participant will set the summary's value of is_pediatric to True.
+        So we should update the lastModified time as well.
+        """
+        pediatric_summary = self.data_generator.create_database_participant_summary()
+
+        timestamp = datetime(2018, 7, 10)
+        with FakeClock(timestamp):
+            PediatricDataLogDao.record_age_range(
+                participant_id=pediatric_summary.participantId,
+                age_range_str='SIX_AND_BELOW',
+                session=self.session
+            )
+
+        self.assertEqual(timestamp, pediatric_summary.lastModified)


### PR DESCRIPTION
## Resolves *no ticket*
Some pediatric data is stored and loaded into a participant summary response in a slightly different way, so the `lastModified` would not get updated in these cases. But the summary would be providing new information, so the timestamp of the new information should be set in the `lastModified` field.

## Description of changes/additions
This updates the code to set the `lastModified` timestamp when something would change in the participant summary because of pediatric data.

## Tests
- [x] unit tests


