### PR TITLE
[DA-3944] Bug fix when setting pairing information from physical measurements

### DIFF
--- a/rdr_service/model/participant.py
+++ b/rdr_service/model/participant.py
@@ -153,7 +153,7 @@ class Participant(ParticipantBase, Base):
     )
     __table_args__ = (UniqueConstraint("external_id"), UniqueConstraint("research_id"),)
 
-    organization = relationship("Organization", foreign_keys='Participant.organizationId')
+    organization = relationship("Organization", foreign_keys='Participant.organizationId', viewonly=True)
     """
     Organ doc string on actual class
     """


### PR DESCRIPTION
## Resolves *[DA-3944](https://precisionmedicineinitiative.atlassian.net/browse/DA-3944)*
When physical measurements are received for a participant that doesn't have a biosample collected, then the participant's pairing information is updated with the hpo/org/site from the physical measurements. However, that was being reverted back in the participant table. When the enrollment status was recalculated for that participant, and the participant summary merged into a session, the summary's participant object was being used to reset the organization.

## Description of changes/additions
This updates the organization relationship to readonly, causing sqlalchemy to ignore it when considering changes for the organization data.

## Tests
- [x] unit tests




[DA-3944]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ