### PR TITLE
[DA-3943] Update POST for /SupplyRequest endpoint to handle 5xx

### DIFF
--- a/rdr_service/api/mail_kit_order_api.py
+++ b/rdr_service/api/mail_kit_order_api.py
@@ -1,5 +1,6 @@
 from dateutil.parser import parse
 from flask import request
+from sqlalchemy.exc import IntegrityError
 from werkzeug.exceptions import BadRequest, Conflict, MethodNotAllowed
 
 from rdr_service.api.base_api import UpdatableApi
@@ -134,12 +135,32 @@ class MailKitOrderApi(UpdatableApi):
         return response
 
     def _post_supply_request(self, resource):
+        """
+        Return response when POSTed to /SupplyRequest, handling scenarios where partners POST again after receiving 502.
+
+        From October 2023, partner reported intermittent 502 errors when POSTing to /SupplyRequest.
+        Even though we saved their data in our DB on their receiving a 502, they weren't aware of this.
+        Due to their uncertainty about the first POST's success, they'd POST again with an updated payload,
+        to which we'd respond with a 500, since we expect them to send a PUT when updating. This includes a
+        workaround: if they POST again with the same order_id after they get 502, we treat the subsequent POST as a PUT,
+        updating the existing resource with their new payload. For more details, refer to ROC-1740.
+        """
         fhir_resource = SimpleFhirR4Reader(resource)
         patient = fhir_resource.contained.get(resourceType="Patient")
         pid = patient.identifier.get(system=DV_FHIR_URL + "participantId").value
         p_id = from_client_participant_id(pid)
-        response = super(MailKitOrderApi, self).post(participant_id=p_id)
         order_id = fhir_resource.identifier.get(system=DV_FHIR_URL + "orderId").value
+        try:
+            response = super(MailKitOrderApi, self).post(participant_id=p_id)
+        except IntegrityError as e:
+            constraint_name = "uidx_partic_id_order_id"
+            if constraint_name in str(e):
+                # Catch error due to repeated POSTs with the same order_id for a pid.
+                # Treat as a PUT, since 'supplier_status' in the payload is updated, as seen in logs.
+                response = self.put(bo_id=order_id)
+            else:
+                raise Conflict(e.orig)
+
         response[2]["Location"] = "/rdr/v1/SupplyRequest/{}".format(order_id)
         response[2]['auth_user'] = resource['auth_user']
         if response[1] == 200:

--- a/rdr_service/api/mail_kit_order_api.py
+++ b/rdr_service/api/mail_kit_order_api.py
@@ -141,9 +141,9 @@ class MailKitOrderApi(UpdatableApi):
         From October 2023, partner reported intermittent 502 errors when POSTing to /SupplyRequest.
         Even though we saved their data in our DB on their receiving a 502, they weren't aware of this.
         Due to their uncertainty about the first POST's success, they'd POST again with an updated payload,
-        to which we'd respond with a 500, since we expect them to send a PUT when updating. This includes a
-        workaround: if they POST again with the same order_id after they get 502, we treat the subsequent POST as a PUT,
-        updating the existing resource with their new payload. For more details, refer to ROC-1740.
+        to which we'd respond with a 500, since we expect them to send a PUT when updating. The try/except is
+        workaround: if they POST again with the same order_id after they get 502, we treat the subsequent POST
+        as a PUT, updating the existing resource with their new payload. For more details, refer to ROC-1740.
         """
         fhir_resource = SimpleFhirR4Reader(resource)
         patient = fhir_resource.contained.get(resourceType="Patient")

--- a/rdr_service/dao/mail_kit_order_dao.py
+++ b/rdr_service/dao/mail_kit_order_dao.py
@@ -239,7 +239,6 @@ class MailKitOrderDao(UpdatableDao):
                 order.order_date = parse_date(fhir_resource.authoredOn)
 
             order.supplier = fhir_resource.contained.get(resourceType="Organization").id
-            order.created = clock.CLOCK.now()
             order.supplierStatus = fhir_resource.extension.get(url=DV_FULFILLMENT_URL).valueString
 
             fhir_device = fhir_resource.contained.get(resourceType="Device")

--- a/tests/api_tests/test_mail_kit_order_api.py
+++ b/tests/api_tests/test_mail_kit_order_api.py
@@ -1,7 +1,9 @@
 import copy
+import datetime
 import http.client
 import mock
 
+from rdr_service import clock
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.mail_kit_order_dao import MailKitOrderDao
 from rdr_service.dao.hpo_dao import HPODao
@@ -108,6 +110,69 @@ class MailKitOrderApiTestPostSupplyRequest(MailKitOrderApiTestBase):
             BiobankMailKitOrder.participantId == paired_participant.participantId
         ).one()
         self.assertEqual(hpo.hpoId, order.associatedHpoId)
+
+    def test_subsequent_post_requests(self):
+        """
+        Test that two successive POSTs work as intended. The first POST creates data,
+        while the second, acting as a PUT, updates it. This scenario arises from partners
+        receiving a 502 on their initial POST and repeatedly sending updated POSTs.
+        """
+        # Initial POST
+        self.send_post(
+            "SupplyRequest",
+            request_data=self.get_payload("dv_order_api_post_supply_request.json"),
+            expected_status=http.client.CREATED,
+        )
+        initial_order = self.get_orders()[0]
+
+        # Second POST with a PUT payload
+        with clock.FakeClock(clock.CLOCK.now() + datetime.timedelta(minutes=1)):
+            response = self.send_post(
+                "SupplyRequest",
+                request_data=self.get_payload("dv_order_api_put_supply_request.json"),
+                expected_status=http.client.CREATED,
+            )
+
+        updated_order = self.get_orders()[0]
+
+        self.assertEqual(response.status_code, 201, msg="Subsequent POST should succeed")
+
+        # Compare values from the 1st and 2nd POST requests
+        self.assertEqual(
+            updated_order.created,
+            initial_order.created,
+            msg="Second POST should not update the 'created' timestamp",
+        )
+        self.assertEqual(
+            updated_order.order_id, initial_order.order_id, msg="OrderId should be the same"
+        )
+        self.assertGreater(
+            updated_order.modified,
+            initial_order.modified,
+            msg="'modified' timestamp should update and be greater after the second POST.",
+        )
+        self.assertGreater(
+            updated_order.version,
+            initial_order.version,
+            msg="The 'version' of the updated order should be greater than the initial order.",
+        )
+        self.assertNotEqual(updated_order.supplierStatus, initial_order.supplierStatus)
+
+    def test_subsequent_post_with_unknown_constraint_violations(self):
+        # Initial POST
+        self.send_post(
+            "SupplyRequest",
+            request_data=self.get_payload("dv_order_api_post_supply_request.json"),
+            expected_status=http.client.CREATED,
+        )
+        # Second POST with a PUT payload
+        with clock.FakeClock(clock.CLOCK.now() + datetime.timedelta(minutes=1)):
+            self.send_post(
+                "SupplyRequest",
+                request_data=self.get_payload("dv_order_api_put_supply_request.json"),
+                expected_status=http.client.CREATED,
+            )
+
 
 class MailKitOrderApiTestPutSupplyRequest(MailKitOrderApiTestBase):
     mayolink_response = {


### PR DESCRIPTION
## Resolves *[ticket # DA-3943](https://precisionmedicineinitiative.atlassian.net/jira/software/c/projects/DA/boards/11?assignee=712020%3A769e4847-aa22-4eb2-aea1-0cb378cf6a5b&selectedIssue=DA-3943)*


## Description of changes/additions
- Update POST for SupplyRequest to take in POST payload and treat it as a PUT. 

    -  Background:
         - Since October 2023, partners occasionally received 502 errors when POSTing to /SupplyRequest.
         - We saved their data upon their receiving a 502.
         - In response, they'd POST again with an updated payload, leading us to send a 500 response.
         - Our solution is to process these repeated POSTs (with unchanged order_id) as PUTs.
         - For more details, see ROC-1740.

- Remove `order.created = clock.CLOCK.now()` in `from_client_json` function, which was updating the created timestamp when SupplyRequest endpoint was called.

## Tests
✅  unit tests


