### PR TITLE
Fix case match on cvl_site_id

### DIFF
--- a/rdr_service/genomic/genomic_cvl_reconciliation.py
+++ b/rdr_service/genomic/genomic_cvl_reconciliation.py
@@ -27,7 +27,7 @@ class GenomicCVLReconcile:
 
         def _process_sample_data(*, dao, sample):
             sample = sample._asdict()
-            sample['cvlSiteId'] = 'co' if sample.get('cvlSiteId') == 'bi' else sample.get('cvlSiteId')
+            sample['cvlSiteId'] = 'co' if sample.get('cvlSiteId').lower() == 'bi' else sample.get('cvlSiteId')
             past_due_sample_obj = dao.get_model_obj_from_items(
                 {self.result_dao.camel_to_snake(k): v for k, v in sample.items()}.items()
             )


### PR DESCRIPTION
## Resolves *[ticket NA]*


## Description of changes/additions
Need to set case when checking/setting cvl_site_id in cvl reconcile records.
** This was causing an issue for BI samples to not be sent to Color on the subsequent scheduled alerts reporting.

## Tests
- [] unit tests
** all tests should still pass

