### PR TITLE
[DA-3965] Surfacing pediatric consents in summary API for Hpro

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1261,10 +1261,12 @@ class ParticipantSummaryDao(UpdatableDao):
             return record.all()
 
     def get_hpro_consent_paths(self, result):
-        consents_map = {
+        type_to_field_name_map = {  # Maps types to the prefix of the field name they populate in the resulting JSON
             ConsentType.PRIMARY: 'consentForStudyEnrollment',
+            ConsentType.PEDIATRIC_PRIMARY: 'consentForStudyEnrollment',
             ConsentType.CABOR: 'consentForCABoR',
             ConsentType.EHR: 'consentForElectronicHealthRecords',
+            ConsentType.PEDIATRIC_EHR: 'consentForElectronicHealthRecords',
             ConsentType.GROR: 'consentForGenomicsROR',
             ConsentType.PRIMARY_RECONSENT: 'reconsentForStudyEnrollment',
             ConsentType.EHR_RECONSENT: 'reconsentForElectronicHealthRecords'
@@ -1272,12 +1274,12 @@ class ParticipantSummaryDao(UpdatableDao):
         participant_id = result['participantId']
         records = list(filter(lambda obj: obj.participant_id == participant_id, self.hpro_consents))
 
-        for consent_type, consent_name in consents_map.items():
-            value_path_key = f'{consent_name}FilePath'
-            has_consent_path = [obj for obj in records if consent_type == obj.consent_type]
+        for consent_type, field_name_prefix in type_to_field_name_map.items():
+            field_name = f'{field_name_prefix}FilePath'
+            matching_consent_list = [obj for obj in records if consent_type == obj.consent_type]
 
-            if has_consent_path:
-                result[value_path_key] = has_consent_path[0].file_path
+            if matching_consent_list:
+                result[field_name] = matching_consent_list[0].file_path
 
         return result
 

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -792,6 +792,35 @@ class ParticipantSummaryApiTest(BaseTestCase):
                 self.assertFalse(file_path in entry['resource'].keys())
                 self.assertIsNone(entry['resource'].get(file_path))
 
+    def test_pediatric_hpro_consent(self):
+        participant_summary = self.data_generator.create_database_participant_summary()
+        consent_record = self.data_generator.create_database_consent_file(
+            file_path='pediatric/primary',
+            type=ConsentType.PEDIATRIC_PRIMARY,
+            participant_id=participant_summary.participantId
+        )
+        self.data_generator.create_database_hpro_consent(
+            consent_file_id=consent_record.id,
+            file_path='transferred/pediatric/primary',
+            participant_id=participant_summary.participantId
+        )
+        consent_record = self.data_generator.create_database_consent_file(
+            file_path='pediatric/ehr',
+            type=ConsentType.PEDIATRIC_EHR,
+            participant_id=participant_summary.participantId
+        )
+        self.data_generator.create_database_hpro_consent(
+            consent_file_id=consent_record.id,
+            file_path='transferred/pediatric/ehr',
+            participant_id=participant_summary.participantId
+        )
+
+        self.overwrite_test_user_roles([HEALTHPRO])
+        summary_response = self.send_get(f"Participant/P{participant_summary.participantId}/Summary")
+
+        self.assertEqual('transferred/pediatric/primary', summary_response['consentForStudyEnrollmentFilePath'])
+        self.assertEqual('transferred/pediatric/ehr', summary_response['consentForElectronicHealthRecordsFilePath'])
+
     def test_hpro_participant_incentives(self):
         num_summary, first_pid, second_pid = 3, None, None
 


### PR DESCRIPTION
## Resolves *[DA-3965](https://precisionmedicineinitiative.atlassian.net/browse/DA-3965)*
This updates the participant summary API to surface the new pediatric consents for Hpro.


## Tests
- [x] unit tests




[DA-3965]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ