### PR TITLE
[PDR-2210] Use NIH nomenclature for ped_environmental_health survey

### DIFF
--- a/rdr_service/dao/bq_participant_summary_dao.py
+++ b/rdr_service/dao/bq_participant_summary_dao.py
@@ -30,8 +30,10 @@ class BQParticipantSummaryGenerator(BigQueryGenerator):
     """
     ro_dao = None
     # Retrieve module and sample test lists from config.
+    # Need to add the peds mods since they don't have separate fields in participant_summary / aren't in the config item
     _baseline_modules = [mod.replace('questionnaireOn', '')
-                         for mod in config.getSettingList('baseline_ppi_questionnaire_fields')]
+                         for mod in config.getSettingList('baseline_ppi_questionnaire_fields')] + \
+                        ['ped_basics', 'ped_overall_health', 'ped_environmental_exposures']
     _baseline_sample_test_codes = config.getSettingList('baseline_sample_test_codes')
     _dna_sample_test_codes = config.getSettingList('dna_sample_test_codes')
 

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -201,8 +201,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
     """
     ro_dao = None
     # Retrieve module and sample test lists from config.
+    # Need to add the peds mods since they don't have separate fields in participant_summary / aren't in the config item
     _baseline_modules = [mod.replace('questionnaireOn', '')
-                         for mod in config.getSettingList('baseline_ppi_questionnaire_fields')]
+                         for mod in config.getSettingList('baseline_ppi_questionnaire_fields')] + \
+                        ['ped_basics', 'ped_overall_health', 'ped_environmental_exposures']
+
     _baseline_sample_test_codes = config.getSettingList('baseline_sample_test_codes')
     _dna_sample_test_codes = config.getSettingList('dna_sample_test_codes')
 
@@ -772,6 +775,9 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
                 if (module_name == 'EHRConsentPII'
                         and row.classificationType == QuestionnaireResponseClassificationType.PARTIAL):
                     continue
+                elif module_name == 'ped_environmental_health':
+                    # PDR-2210: NIH wants this nomenclature instead of the defined module name in codebook
+                    module_name = 'ped_environmental_exposures'
 
                 # Consent modules with a configured consent question start in UNSET status pending answer evaluation
                 if module_name in _consent_module_question_map and _consent_module_question_map[module_name]:

--- a/tests/api_tests/test_questionnaire_response_api.py
+++ b/tests/api_tests/test_questionnaire_response_api.py
@@ -2195,6 +2195,15 @@ class QuestionnaireResponseApiTest(BaseTestCase, BiobankTestMixin, PDRGeneratorT
         self.assertEqual(1, participant_summary.numCompletedPPIModules)
         self.assertEqual(1, participant_summary.numCompletedBaselinePPIModules)
 
+        # PDR-2210: Verify PDR BigQuery generator maps the mod name to NIH-requested value, and identifies it
+        # as baseline module
+        bqs_rsc = self.make_bq_participant_summary(participant_id)
+        mod_list = self.get_generated_items(bqs_rsc['modules'])
+        self.assertEqual(1, len(mod_list))
+        mod_data = mod_list[0]
+        self.assertEqual(mod_data['mod_module'], 'ped_environmental_exposures')
+        self.assertEqual(mod_data['mod_baseline_module'], 1)
+
     def test_pediatrics_permission(self):
         """
         Check that the pediatrics version of primary consent maps to the correct fields on participant summary


### PR DESCRIPTION
## Resolves *[PDR-2210](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2210)*


## Description of changes/additions
The PDR pipeline is still relying on the old generators/BQ pipeline to build the `participant_module` history of participant survey responses.  This updates those generators to match how RDR and the new PDR pipeline will map the `ped_environmental_health` module name to the NIH-required `ped_environmental_exposures` name.

Also adds necessary handling for detecting which peds modules are considered baseline.  The defined `_baseline_modules` lists will be referenced  in the generators after the `ped_environmental_health` module code has already been mapped to its `ped_environmental_exposures` module name.

## Tests
- [x] unit tests




[PDR-2210]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ