### PR TITLE
[DA-3976] Use AW4 RAW table to determine AW4 WGS PASS date.

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1347,7 +1347,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
         ).filter(
             GenomicAW4Raw.biobank_id == f'{get_biobank_id_prefix()}{biobank_id}',
             GenomicAW4Raw.genome_type == config.GENOME_TYPE_WGS,
-            GenomicAW4Raw.qc_status == "PASS"
+            GenomicAW4Raw.qc_status.ilike('pass')
         ).order_by(GenomicAW4Raw.created).first()
 
         if aw4_record:

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1345,7 +1345,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
         ).select_from(
             GenomicAW4Raw
         ).filter(
-            GenomicAW4Raw.biobank_id == biobank_id,
+            GenomicAW4Raw.biobank_id == f'{get_biobank_id_prefix()}{biobank_id}',
             GenomicAW4Raw.genome_type == config.GENOME_TYPE_WGS,
             GenomicAW4Raw.qc_status == "PASS"
         ).order_by(GenomicAW4Raw.created).first()

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -1345,7 +1345,7 @@ class GenomicSetMemberDao(UpdatableDao, GenomicDaoMixin):
         ).select_from(
             GenomicAW4Raw
         ).filter(
-            GenomicAW4Raw.biobank_id == f'{get_biobank_id_prefix()}{biobank_id}',
+            GenomicAW4Raw.biobank_id == biobank_id,
             GenomicAW4Raw.genome_type == config.GENOME_TYPE_WGS,
             GenomicAW4Raw.qc_status == "PASS"
         ).order_by(GenomicAW4Raw.created).first()

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -794,7 +794,7 @@ class ParticipantSummaryDao(UpdatableDao):
 
         wgs_sequencing_time = GenomicSetMemberDao.get_wgs_pass_date(
             session=session,
-            participant_id=summary.participantId
+            biobank_id=summary.biobankId
         )
         first_exposures_response_time = None
         for data in (summary.pediatricData or []):

--- a/rdr_service/data_gen/generators/data_generator.py
+++ b/rdr_service/data_gen/generators/data_generator.py
@@ -18,7 +18,7 @@ from rdr_service.model.genomics import GenomicManifestFeedback, GenomicManifestF
     GenomicMemberReportState, UserEventMetrics, GenomicInformingLoop, GenomicGcDataFile, GenomicGcDataFileMissing, \
     GenomicResultViewed, GenomicCVLSecondSample, GenomicSampleSwap, \
     GenomicSampleSwapMember, GenomicCVLResultPastDue, GenomicW4WRRaw, GenomicW3SCRaw, GenomicAppointmentEvent, \
-    GenomicAppointmentEventMetrics, GenomicLongRead, GenomicProteomics, GenomicRNA
+    GenomicAppointmentEventMetrics, GenomicLongRead, GenomicProteomics, GenomicRNA, GenomicAW4Raw
 from rdr_service.model.hpo import HPO
 from rdr_service.model.hpro_consent_files import HealthProConsentFile
 from rdr_service.model.log_position import LogPosition
@@ -709,6 +709,15 @@ class DataGenerator:
     @staticmethod
     def _genomic_aw2_raw(**kwargs):
         return GenomicAW2Raw(**kwargs)
+
+    def create_database_genomic_aw4_raw(self, **kwargs):
+        raw = self._genomic_aw4_raw(**kwargs)
+        self._commit_to_database(raw)
+        return raw
+
+    @staticmethod
+    def _genomic_aw4_raw(**kwargs):
+        return GenomicAW4Raw(**kwargs)
 
     def create_database_genomic_file_processed(self, **kwargs):
         file = self._genomic_file_processed(**kwargs)

--- a/tests/dao_tests/test_genomic_dao.py
+++ b/tests/dao_tests/test_genomic_dao.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from rdr_service import clock, code_constants
 from rdr_service.dao.genomics_dao import GenomicIncidentDao, GenomicQueriesDao, GenomicSetMemberDao
 from rdr_service.genomic_enums import GenomicJob, GenomicSubProcessResult, GenomicIncidentCode, GenomicIncidentStatus
-from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.model.genomics import GenomicIncident
 from rdr_service.participant_enums import QuestionnaireStatus
 from tests.helpers.unittest_base import BaseTestCase
@@ -183,7 +182,7 @@ class GenomicDaoTest(BaseTestCase):
                 pipeline_id='dragen_3.4.12',
                 qc_status='PASS',
                 genome_type='aou_wgs',
-                biobank_id=f'{get_biobank_id_prefix()}1234'
+                biobank_id=f'1234'
             )
 
         with clock.FakeClock(datetime(2023, 11, 2)):
@@ -191,7 +190,7 @@ class GenomicDaoTest(BaseTestCase):
                 pipeline_id='dragen_3.7.8',
                 qc_status='PASS',
                 genome_type='aou_wgs',
-                biobank_id=f'{get_biobank_id_prefix()}1234'
+                biobank_id=f'1234'
             )
 
         with self.member_dao.session() as session:

--- a/tests/dao_tests/test_genomic_dao.py
+++ b/tests/dao_tests/test_genomic_dao.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from rdr_service import clock, code_constants
 from rdr_service.dao.genomics_dao import GenomicIncidentDao, GenomicQueriesDao, GenomicSetMemberDao
 from rdr_service.genomic_enums import GenomicJob, GenomicSubProcessResult, GenomicIncidentCode, GenomicIncidentStatus
+from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.model.genomics import GenomicIncident
 from rdr_service.participant_enums import QuestionnaireStatus
 from tests.helpers.unittest_base import BaseTestCase
@@ -182,7 +183,7 @@ class GenomicDaoTest(BaseTestCase):
                 pipeline_id='dragen_3.4.12',
                 qc_status='PASS',
                 genome_type='aou_wgs',
-                biobank_id=f'1234'
+                biobank_id=f'{get_biobank_id_prefix()}1234'
             )
 
         with clock.FakeClock(datetime(2023, 11, 2)):
@@ -190,7 +191,7 @@ class GenomicDaoTest(BaseTestCase):
                 pipeline_id='dragen_3.7.8',
                 qc_status='PASS',
                 genome_type='aou_wgs',
-                biobank_id=f'1234'
+                biobank_id=f'{get_biobank_id_prefix()}1234'
             )
 
         with self.member_dao.session() as session:


### PR DESCRIPTION
## Resolves *[DA-3976](https://precisionmedicineinitiative.atlassian.net/browse/DA-3976)*


## Description of changes/additions
This PR changes the query behind the `get_wgs_pass_date()` method. 
The query uses the `genomic_aw4_raw` table to determine when the record was QC'd. 

## Tests
- [x] unit tests




[DA-3976]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ