### PR TITLE
Fixing Validation CRON Job 'ValueError'

### DIFF
--- a/rdr_service/offline/response_validation.py
+++ b/rdr_service/offline/response_validation.py
@@ -113,7 +113,7 @@ class ResponseValidationController:
         self._output_result(result_text)
 
     def _insert_data(self):
-        for key in self._error_list.items():
+        for key, error_list in self._error_list.items():  # pylint: disable=unused-variable
             survey_code, question_code, error_str, error_type, pid, answer_id = key
 
             data = PpiValidationErrors(
@@ -126,8 +126,9 @@ class ResponseValidationController:
                 questionnaire_response_answer_id=answer_id
             )
 
-            # Insert data into PPI validation table
-            self.validation_errors_dao.insert(data)
+            # Insert data into PPI validation table if offline job is running
+            if self._summarize_results:
+                self.validation_errors_dao.insert(data)
 
     def _output_result(self, result_str):
         if self._slack_webhook:


### PR DESCRIPTION
## Resolves *no ticket*


## Description of changes/additions
The offline/ResponseValidation CRON job failed recently with the following error:
`ValueError('not enough values to unpack (expected 6, got 2)')` because keys & values were not being unpacked properly when iterating through the error list. 

This PR resolves the error and updates the code to only update the RDR table when the job is run offline. This allows developers to run the tool locally without affecting data in the RDR.

## Tests
- [X] unit tests
- Successfully ran response validation tool locally


