### PR TITLE
fixing crash when ingesting pediatric consent

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -538,13 +538,6 @@ class QuestionnaireResponseDao(BaseDao):
             answer.endTime = questionnaire_response.created
             session.merge(answer)
 
-        summary = ParticipantSummaryDao.get_for_update_with_linked_data(
-            participant_id=questionnaire_response.participantId,
-            session=session
-        )
-        if summary:
-            ParticipantSummaryDao().update_enrollment_status(summary, session=session)
-
         # Create any account links based on extensions
         for extension in questionnaire_response.extensions:
             if extension.url == _GUARDIAN_EXTENSION:
@@ -555,6 +548,13 @@ class QuestionnaireResponseDao(BaseDao):
                     ),
                     session=session
                 )
+
+        summary = ParticipantSummaryDao.get_for_update_with_linked_data(
+            participant_id=questionnaire_response.participantId,
+            session=session
+        )
+        if summary:
+            ParticipantSummaryDao().update_enrollment_status(summary, session=session)
 
         return questionnaire_response
 


### PR DESCRIPTION
## Resolves *no ticket*
I mixed up the order of processes a bit and the code is trying to calculate the enrollment status for pediatric participants before we have their guardian information stored. This is causing a crash when trying to ingest primary permission for pediatric participants.

## Description of changes/additions
Parsing and storing guardian data first so it's ready for the enrollment status calc.

## Tests
- [ ] unit tests
Replicated and verified the fix with a unit test locally, but I had to modify irrelevant parts of the code to get it to function (like commenting out the PDF file check). Will create a future PR with a unit test, but should probably get this out quicker to keep from blocking Vibrent's testing.


