### PR TITLE
[ROC-1763] Excluding pediatric participant summaries when data issues are encountered

### DIFF
--- a/rdr_service/api/awardee_api.py
+++ b/rdr_service/api/awardee_api.py
@@ -22,10 +22,11 @@ class AwardeeApi(BaseApi):
             return self._make_response(self.dao.get_with_children(hpo.hpoId))
         return super(AwardeeApi, self)._query(id_field="id")
 
-    def _make_resource_url(self, json, id_field, participant_id):  # pylint: disable=unused-argument
+    @classmethod
+    def _make_resource_url(cls, json, id_field, participant_id):  # pylint: disable=unused-argument
         from rdr_service import main
 
-        return main.api.url_for(self.__class__, a_id=json[id_field], _external=True)
+        return main.api.url_for(cls, a_id=json[id_field], _external=True)
 
     def _make_response(self, obj):
         inactive = request.args.get("_inactive")

--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -320,7 +320,7 @@ class BaseApi(Resource, ApiUtilMixin):
         entries = []
         for item in results.items:
             response_json = self._make_response(item)
-            self._append_response_to_bundle(entries, response_json, False, id_field, participant_id)
+            self._append_response_to_bundle(entries, response_json, True, id_field, participant_id)
         bundle_dict["entry"] = entries
         if results.total is not None:
             bundle_dict["total"] = results.total

--- a/rdr_service/api/nph_biospecimen_api.py
+++ b/rdr_service/api/nph_biospecimen_api.py
@@ -41,11 +41,8 @@ class NphBiospecimenAPI(BaseApi):
             payload_response.append(updated_payload)
         return self.dao.to_client_json(payload_response)
 
-    def _make_resource_url(self, response_json, id_field, participant_id):
+    @classmethod
+    def _make_resource_url(cls, response_json, id_field, participant_id):
         from rdr_service import main
-        return main.api.url_for(
-            self.__class__,
-            nph_participant_id=response_json[0][id_field],
-            _external=True
-        )
+        return main.api.url_for(cls, nph_participant_id=response_json[0][id_field], _external=True)
 

--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -5,7 +5,7 @@ from flask import request
 from werkzeug.exceptions import BadRequest, Forbidden, InternalServerError, NotFound
 
 from rdr_service import config
-from rdr_service.api.base_api import BaseApi, make_sync_results_for_request
+from rdr_service.api.base_api import BaseApi
 from rdr_service.api_util import AWARDEE, DEV_MAIL, RDR_AND_PTC, PTC_HEALTHPRO_AWARDEE_CURATION, SUPPORT
 from rdr_service.app_util import auth_required, get_validated_user_info, restrict_to_gae_project
 from rdr_service.dao.base_dao import _MIN_ID, _MAX_ID
@@ -113,8 +113,13 @@ class ParticipantSummaryApi(BaseApi):
 
     def _make_bundle(self, results, id_field, participant_id):
         if self._get_request_arg_bool("_sync"):
-            return make_sync_results_for_request(self.dao, results)
+            return self.make_sync_results_for_request(self.dao, results)
         return super(ParticipantSummaryApi, self)._make_bundle(results, id_field, participant_id)
+
+    @classmethod
+    def _append_response_to_bundle(cls, entries, response, include_url, id_field, participant_id):
+        if response:  # Skip any responses that are empty (like when pediatric participants are excluded)
+            super()._append_response_to_bundle(entries, response, include_url, id_field, participant_id)
 
     def _check_constraints(self):
         message = None

--- a/rdr_service/api/physical_measurements_api.py
+++ b/rdr_service/api/physical_measurements_api.py
@@ -1,7 +1,7 @@
 from flask import request
 
 from rdr_service import app_util, config
-from rdr_service.api.base_api import BaseApi, DEFAULT_MAX_RESULTS, get_sync_results_for_request, log_api_request
+from rdr_service.api.base_api import BaseApi, DEFAULT_MAX_RESULTS, log_api_request
 from rdr_service.api_util import HEALTHPRO, PTC, PTC_AND_HEALTHPRO
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.query import FieldFilter, Operator, Query
@@ -40,4 +40,4 @@ class PhysicalMeasurementsApi(BaseApi):
 @app_util.auth_required(PTC)
 def sync_physical_measurements():
     max_results = config.getSetting(config.MEASUREMENTS_ENTITIES_PER_SYNC, 100)
-    return get_sync_results_for_request(PhysicalMeasurementsDao(), max_results)
+    return BaseApi.get_sync_results_for_request(PhysicalMeasurementsDao(), max_results)

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -4590,6 +4590,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         second_parent = self.data_generator.create_database_participant_summary()
         child_id = self.data_generator.create_database_participant_summary().participantId
 
+        PediatricDataLogDao.record_age_range(participant_id=child_id, age_range_str='TEEN')
         self.session.add(AccountLink(participant_id=child_id, related_id=first_parent.participantId))
         self.session.add(AccountLink(participant_id=child_id, related_id=second_parent.participantId))
         self.session.commit()
@@ -4682,8 +4683,16 @@ class ParticipantSummaryApiTest(BaseTestCase):
 
     def test_pediatric_flag(self):
         regular_participant = self.data_generator.create_database_participant_summary()
+
         pediatric_participant = self.data_generator.create_database_participant_summary()
         PediatricDataLogDao.record_age_range(participant_id=pediatric_participant.participantId, age_range_str='TEEN')
+        self.session.add(
+            AccountLink(
+                participant_id=pediatric_participant.participantId,
+                related_id=regular_participant.participantId
+            )
+        )
+        self.session.commit()
 
         response = self.send_get(f'Participant/P{regular_participant.participantId}/Summary')
         self.assertEqual('UNSET', response['isPediatric'])


### PR DESCRIPTION
## Resolves *[ROC-1763](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1763)*
RDR is getting some data that indicates adult participants are guardians of other adults. When the 'guardian' accounts are unconsented, then the Participant Summary API crashes on trying to resolve the guardian's name.

## Description of changes/additions
This makes a few updates. First is that we only look for linked accounts if the participant is definitely a pediatric participant (currently defined by the pediatric data log). And in case something like this continues even for pediatric participants, we exclude the pediatric participants summary if they are missing guardians or a guardian is unconsented.

## Tests
- [x] unit tests




[ROC-1763]: https://precisionmedicineinitiative.atlassian.net/browse/ROC-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ