### PR TITLE
[DA-3964] Store processing timestamp for stool samples in nightly biobank file export

### DIFF
--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -134,7 +134,11 @@ def _convert_ordered_samples_to_samples(
 ) -> List[Dict[str, Any]]:
     samples = []
     for ordered_sample in ordered_samples:
-        processing_timestamp = ordered_sample.collected if not ordered_sample.parent is None else None
+        processing_timestamp = (
+            ordered_sample.collected
+            if ordered_sample.parent is not None or ordered_sample.test.startswith("ST")
+            else None
+        )
         sample_cancelled = ordered_cancelled or ordered_sample.status == 'cancelled'
         sample = {
             "sampleID": (ordered_sample.aliquot_id or ordered_sample.nph_sample_id),


### PR DESCRIPTION
## Resolves *[ticket # 3964](https://precisionmedicineinitiative.atlassian.net/jira/software/c/projects/DA/boards/11?assignee=712020%3A769e4847-aa22-4eb2-aea1-0cb378cf6a5b&selectedIssue=DA-3964)*


## Description of changes/additions
- In the Nightly JSON ordered sample file sent to Biobank, stool samples do not have the `processingDateUTC` field populated. This PR will enable us to populate that field.


## Tests
- [] unit tests
**tested manually


