### PR TITLE
[PDR-2237] Case sensitivity fix for new ConsentPII consent answers

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -130,7 +130,10 @@ _consent_answer_status_map = {
     # Generic yes/no answer codes that apply to multiple consents (e.g., VA/non-VA reconsents and EtM consents)
     'agree_yes': BQModuleStatusEnum.SUBMITTED,
     'agree_no': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
-    # For the updated ConsentPII that allows yes or no reponses
+    # For the updated ConsentPII that allows yes or no reponses.
+    'ExtraConsent_AgreeToConsent': BQModuleStatusEnum.SUBMITTED,
+    'ExtraConsent_DoNotAgreeToConsent': BQModuleStatusEnum.SUBMITTED_NO_CONSENT,
+    # Need to support all lowercase values for unit test setups
     'extraconsent_agreetoconsent': BQModuleStatusEnum.SUBMITTED,
     'extraconsent_donotagreetoconsent': BQModuleStatusEnum.SUBMITTED_NO_CONSENT
 }
@@ -139,6 +142,9 @@ _consent_answer_status_map = {
 # in PDR (and that users are used to querying).  I.e., until now every ConsentPII response data record was given a
 # default ConsentPermission_Yes answer code value.
 _replace_answer_codes = {
+    'ExtraConsent_AgreeToConsent': 'ConsentPermission_Yes',
+    'ExtraConsent_DoNotAgreeToConsent': 'ConsentPermission_No',
+    # Need to support all lowercase values for unit test setups
     'extraconsent_agreetoconsent': 'ConsentPermission_Yes',
     'extraconsent_donotagreetoconsent': 'ConsentPermission_No'
 }


### PR DESCRIPTION

## Resolves *[PDR-2237](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2237)*

## Description of changes/additions
Addresses an issue with previous PR #3601 

Unit test setups are using the code constants defined for the new EXTRA_CONSENT_YES/NO ConsentPII answer values, but RDR's definitions/use cases for these were case insensitive and they were inserted into the unittest DB `code` table as all lowercase value strings.  The PDR generator code lookup maps have always been case sensitive, and the values that were added were based on those EXTRA_CONSENT_* constants instead of the actual codebook (mixed case values).  Unit tests passed, but the map lookups are failing when processing real payloads.

## Tests
- [x] unit tests




[PDR-2237]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ