### PR TITLE
[PDR-2080] Send enrollment status history record pubsub messages

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1061,7 +1061,10 @@ class ParticipantSummaryDao(UpdatableDao):
         summary.enrollmentStatusCoreOrderedSampleTime = self.calculate_core_ordered_sample_time(consent, summary)
 
         if pdr_pubsub:
-            submit_pipeline_pubsub_msg_from_model(summary, self.get_connection_database_name())
+            # Capture any enrollment status history records that have been added to the session.
+            models_ = list(session.new)
+            models_.append(summary)
+            submit_pipeline_pubsub_msg_from_model(models_, self.get_connection_database_name())
 
     def calculate_enrollment_status(
         self, consent, num_completed_baseline_ppi_modules, physical_measurements_status,


### PR DESCRIPTION
## Resolves *[PDR-2080](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2080)*


## Description of changes/additions
This change captures the Enrollment Status History records that were added during the participant enrollment status calculation and submits Pub/Sub messages for them to the PDR.

## Tests
- [x] unit tests




[PDR-2080]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ