### PR TITLE
Removing pediatric flag config check from biobank exports

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -252,10 +252,9 @@ def _query_and_write_received_report(exporter, report_path, query_params, report
             group_concat(ny_flag) ny_flag,
             group_concat(sex_at_birth_flag) sex_at_birth_flag
         """
-    if config.getSettingJson('enable_biobank_report_pediatric_flag', default=False):
-        received_report_select += """,
-            max(is_pediatric) ispediatric
-        """
+    received_report_select += """,
+        max(is_pediatric) ispediatric
+    """
     logging.info(f"Writing {report_path} report.")
     received_sql = replace_isodate(received_report_select + _RECONCILIATION_REPORT_SOURCE_SQL)
     exporter.run_export(

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -430,7 +430,6 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
 
     def test_demographic_flags_in_received_report(self):
         self.temporarily_override_config_setting(config.ENABLE_BIOBANK_MANIFEST_RECEIVED_FLAG, 1)
-        self.temporarily_override_config_setting('enable_biobank_report_pediatric_flag', 1)
 
         # Generate data for a New York sample to be in the report
         participant = self.data_generator.create_database_participant()

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -426,6 +426,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
                 None, None, None, None, None,  # cancelled_restored info: status_flag, name, name, time, reason
                 None,  # order origin
                 'example',  # Participant origin
+                0  # pediatric flag
             )])
 
     def test_demographic_flags_in_received_report(self):

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -619,7 +619,7 @@ class MySqlReconciliationTest(BaseTestCase):
         # not includes orders/samples from more than 10 days ago;
         # Includes 1 Salivary order
         exporter.assertRowCount(received, 11)
-        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES)
+        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES + ("ispediatric",))
         row = exporter.assertHasRow(
             received,
             {
@@ -1193,7 +1193,7 @@ class MySqlReconciliationTest(BaseTestCase):
         # sent-and-received: 4 on-time, 2 late, 2 edge, none of the missing/extra/repeated ones;
         # not includes orders/samples from more than 60 days ago
         exporter.assertRowCount(received, 12)
-        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES)
+        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES + ("ispediatric",))
         row = exporter.assertHasRow(
             received,
             {


### PR DESCRIPTION
We've switched over the flag for displaying the pediatric flag in the received reports sent to Biobank. Since we won't need it anymore, this removes the logic used to hide the flag until Biobank was ready.


## Tests
- [x] unit tests


