### PR TITLE
Fix for pediatric consent parsing

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -476,6 +476,10 @@ class ConsentFile(ABC):
     def _parse_input_string(self, pdf_element_list) -> Optional[str]:
         for element in pdf_element_list:
             if isinstance(element, LTFigure) and len(element) > 0:
+                # skip image figures
+                if any(isinstance(child, LTImage) for child in element):
+                    continue
+
                 return ''.join([char_child.get_text() for char_child in element]).strip()
 
         return None


### PR DESCRIPTION
The consent validation code is hitting an error when trying to parse the date displayed on the pediatric PDFs. One of the elements captured in the search box is an image, and doesn't support the get_text call. This has the code skip any image elements that were also captured when looking for the date.

## Tests
- [ ] unit tests


