### PR TITLE
Updating AW3 Ready Missing Data Files Alert Email

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from dateutil import parser
 
-from sqlalchemy import and_, or_, func
+from sqlalchemy import and_, or_, func, case
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import aliased, Query
 from sqlalchemy.sql import functions
@@ -3736,81 +3736,224 @@ class GenomicQueriesDao(BaseDao):
 
         return site_id_map[site_id]
 
-    def get_missing_data_files_for_aw3(self, genome_type):
-        missing_files_map = {
-            config.GENOME_TYPE_ARRAY: array_file_types_attributes,
-            config.GENOME_TYPE_WGS: wgs_file_types_attributes
-        }[genome_type]
-        required_file_types = [file_type['file_type'] for file_type in missing_files_map
-                               if file_type['required']]
+    def get_missing_array_data_files_for_aw3(self, genome_type):
+        t = genome_type
 
         with self.session() as session:
-            if genome_type == config.GENOME_TYPE_ARRAY:
-                subquery = session.query(
-                    GenomicSetMember.id,
-                    func.count(GenomicGcDataFile.file_type).label("file_count")
-                ).join(
-                    ParticipantSummary,
-                    ParticipantSummary.participantId == GenomicSetMember.participantId
-                ).join(
-                    GenomicGCValidationMetrics,
-                    GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
-                ).outerjoin(
-                    GenomicGcDataFile,
-                    GenomicGcDataFile.identifier_value == GenomicGCValidationMetrics.chipwellbarcode
-                ).filter(
-                    GenomicSetMember.genomeType == genome_type,
-                    GenomicSetMember.aw3ManifestJobRunID.is_(None),
-                    GenomicSetMember.ignoreFlag != 1,
-                    GenomicGCValidationMetrics.processingStatus.ilike('pass'),
-                    GenomicGCValidationMetrics.ignoreFlag != 1,
-                    GenomicGcDataFile.ignore_flag != 1,
-                    GenomicGcDataFile.file_type.in_(required_file_types),
-                    ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
-                    ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
-                ).group_by(GenomicSetMember.id).subquery()
-
-            elif genome_type == config.GENOME_TYPE_WGS:
-                subquery = session.query(
-                    GenomicSetMember.id,
-                    func.count(GenomicGcDataFile.file_type).label("file_count")
-                ).join(
-                    ParticipantSummary,
-                    ParticipantSummary.participantId == GenomicSetMember.participantId
-                ).join(
-                    GenomicGCValidationMetrics,
-                    GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
-                ).outerjoin(
-                    GenomicGcDataFile,
-                    GenomicGcDataFile.identifier_value == GenomicSetMember.sampleId
-                ).filter(
-                    GenomicSetMember.genomeType == genome_type,
-                    GenomicSetMember.aw3ManifestJobRunID.is_(None),
-                    GenomicSetMember.ignoreFlag != 1,
-                    GenomicGCValidationMetrics.processingStatus.ilike('pass'),
-                    GenomicGCValidationMetrics.ignoreFlag != 1,
-                    GenomicGcDataFile.ignore_flag != 1,
-                    GenomicGcDataFile.file_type.in_(required_file_types),
-                    ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
-                    ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
-                ).group_by(GenomicSetMember.id).subquery()
+            idat_red_path = aliased(GenomicGcDataFile)
+            idat_green_path = aliased(GenomicGcDataFile)
+            idat_red_md5_path = aliased(GenomicGcDataFile)
+            idat_green_md5_path = aliased(GenomicGcDataFile)
+            vcf_path = aliased(GenomicGcDataFile)
+            vcf_tbi_path = aliased(GenomicGcDataFile)
+            vcf_md5_path = aliased(GenomicGcDataFile)
 
             records = session.query(
-                GenomicSetMember.sampleId,
-                GenomicAW2Raw.created
+                GenomicAW2Raw.created.label('date_reported'),
+                GenomicSetMember.sampleId.label('sample_id'),
+                GenomicSetMember.gcSiteId.label('gc'),
+                GenomicAW2Raw.file_path.label('aw2_file_path'),
+                sqlalchemy.func.concat_ws(', ',
+                                          case([(idat_red_path.file_type.is_(None), 'Red.idat')]),
+                                          case([(idat_red_md5_path.file_type.is_(None), 'Red.idat.md5sum')]),
+                                          case([(idat_green_path.file_type.is_(None), 'Grn.idat')]),
+                                          case([(idat_green_md5_path.file_type.is_(None), 'Grn.idat.md5sum')]),
+                                          case([(vcf_path.file_type.is_(None), 'vcf.gz')]),
+                                          case([(vcf_tbi_path.file_type.is_(None), 'vcf.gz.tbi')]),
+                                          case([(vcf_md5_path.file_type.is_(None), 'vcf.gz.md5sum')])
+                                          ).label('missing_files')
             ).join(
-                subquery,
-                and_(
-                    subquery.c.id == GenomicSetMember.id
-                )
+                ParticipantSummary,
+                ParticipantSummary.participantId == GenomicSetMember.participantId
+            ).join(
+                GenomicGCValidationMetrics,
+                GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
             ).join(
                 GenomicAW2Raw,
                 GenomicSetMember.sampleId == GenomicAW2Raw.sample_id
+            ).outerjoin(
+                idat_red_path,
+                and_(
+                    idat_red_path.file_type == 'Red.idat',
+                    idat_red_path.identifier_value == GenomicGCValidationMetrics.chipwellbarcode,
+                    idat_red_path.ignore_flag != 1
+                )
+            ).outerjoin(
+                idat_green_path,
+                and_(
+                    idat_green_path.file_type == 'Grn.idat',
+                    idat_green_path.identifier_value == GenomicGCValidationMetrics.chipwellbarcode,
+                    idat_green_path.ignore_flag != 1
+                )
+            ).outerjoin(
+                idat_red_md5_path,
+                and_(
+                    idat_red_md5_path.file_type == 'Red.idat.md5sum',
+                    idat_red_md5_path.identifier_value == GenomicGCValidationMetrics.chipwellbarcode,
+                    idat_red_md5_path.ignore_flag != 1
+                )
+            ).outerjoin(
+                idat_green_md5_path,
+                and_(
+                    idat_green_md5_path.file_type == 'Grn.idat.md5sum',
+                    idat_green_md5_path.identifier_value == GenomicGCValidationMetrics.chipwellbarcode,
+                    idat_green_md5_path.ignore_flag != 1
+                )
+            ).outerjoin(
+                vcf_path,
+                and_(
+                    vcf_path.file_type == 'vcf.gz',
+                    vcf_path.identifier_value == GenomicGCValidationMetrics.chipwellbarcode,
+                    vcf_path.ignore_flag != 1
+                )
+            ).outerjoin(
+                vcf_tbi_path,
+                and_(
+                    vcf_tbi_path.file_type == 'vcf.gz.tbi',
+                    vcf_tbi_path.identifier_value == GenomicGCValidationMetrics.chipwellbarcode,
+                    vcf_tbi_path.ignore_flag != 1
+                )
+            ).outerjoin(
+                vcf_md5_path,
+                and_(
+                    vcf_md5_path.file_type == 'vcf.gz.md5sum',
+                    vcf_md5_path.identifier_value == GenomicGCValidationMetrics.chipwellbarcode,
+                    vcf_md5_path.ignore_flag != 1
+                )
             ).filter(
-                subquery.c.file_count !=
-                len(required_file_types)
+                GenomicSetMember.genomeType == genome_type,
+                GenomicSetMember.aw3ManifestJobRunID.is_(None),
+                GenomicSetMember.ignoreFlag != 1,
+                GenomicGCValidationMetrics.processingStatus.ilike('pass'),
+                GenomicGCValidationMetrics.ignoreFlag != 1,
+                ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
+                ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
+                or_(
+                    idat_red_path.file_type.is_(None),
+                    idat_red_md5_path.file_type.is_(None),
+                    idat_green_path.file_type.is_(None),
+                    idat_green_md5_path.file_type.is_(None),
+                    vcf_path.file_type.is_(None),
+                    vcf_tbi_path.file_type.is_(None),
+                    vcf_md5_path.file_type.is_(None)
+                )
             )
-            return records.distinct().all()
+        return records.distinct().all()
+
+    def get_missing_wgs_data_files_for_aw3(self, genome_type):
+        with self.session() as session:
+            hard_filtered_vcf_gz = aliased(GenomicGcDataFile)
+            hard_filtered_vcf_gz_tbi = aliased(GenomicGcDataFile)
+            hard_filtered_vcf_gz_md5_sum = aliased(GenomicGcDataFile)
+            cram = aliased(GenomicGcDataFile)
+            cram_md5_sum = aliased(GenomicGcDataFile)
+            cram_crai = aliased(GenomicGcDataFile)
+            hard_filtered_gvcf_gz = aliased(GenomicGcDataFile)
+            hard_filtered_gvcf_gz_md5_sum = aliased(GenomicGcDataFile)
+
+            records = session.query(
+                GenomicAW2Raw.created.label('date_reported'),
+                GenomicSetMember.sampleId.label('sample_id'),
+                GenomicSetMember.gcSiteId.label('gc'),
+                GenomicAW2Raw.file_path.label('aw2_file_path'),
+                sqlalchemy.func.concat_ws(', ',
+                                          case([(hard_filtered_vcf_gz.file_type.is_(None), 'hard-filtered.vcf.gz')]),
+                                          case([(hard_filtered_vcf_gz_tbi.file_type.is_(None),
+                                                 'hard-filtered.vcf.gz.tbi')]),
+                                          case([(hard_filtered_vcf_gz_md5_sum.file_type.is_(None),
+                                                 'hard-filtered.vcf.gz.md5sum')]),
+                                          case([(cram.file_type.is_(None), 'cram')]),
+                                          case([(cram_md5_sum.file_type.is_(None), 'cram.crai')]),
+                                          case([(cram_crai.file_type.is_(None), 'cram.md5sum')]),
+                                          case([(hard_filtered_gvcf_gz.file_type.is_(None), 'hard-filtered.gvcf.gz')]),
+                                          case([(hard_filtered_gvcf_gz_md5_sum.file_type.is_(None),
+                                                 'hard-filtered.gvcf.gz.md5sum')])
+                                          ).label('missing_files')
+            ).join(
+                ParticipantSummary,
+                ParticipantSummary.participantId == GenomicSetMember.participantId
+            ).join(
+                GenomicGCValidationMetrics,
+                GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id
+            ).join(
+                GenomicAW2Raw,
+                GenomicSetMember.sampleId == GenomicAW2Raw.sample_id
+            ).outerjoin(
+                hard_filtered_vcf_gz,
+                and_(
+                    hard_filtered_vcf_gz.file_type == 'hard-filtered.vcf.gz',
+                    hard_filtered_vcf_gz.identifier_value == GenomicSetMember.sampleId,
+                    hard_filtered_vcf_gz.ignore_flag != 1
+                )
+            ).outerjoin(
+                hard_filtered_vcf_gz_tbi,
+                and_(
+                    hard_filtered_vcf_gz_tbi.file_type == 'hard-filtered.vcf.gz.tbi',
+                    hard_filtered_vcf_gz_tbi.identifier_value == GenomicSetMember.sampleId,
+                    hard_filtered_vcf_gz_tbi.ignore_flag != 1
+                )
+            ).outerjoin(
+                hard_filtered_vcf_gz_md5_sum,
+                and_(
+                    hard_filtered_vcf_gz_md5_sum.file_type == 'hard-filtered.vcf.gz.md5sum',
+                    hard_filtered_vcf_gz_md5_sum.identifier_value == GenomicSetMember.sampleId,
+                    hard_filtered_vcf_gz_md5_sum.ignore_flag != 1
+                )
+            ).outerjoin(
+                cram,
+                and_(
+                    cram.file_type == 'cram',
+                    cram.identifier_value == GenomicSetMember.sampleId,
+                    cram.ignore_flag != 1
+                )
+            ).outerjoin(
+                cram_md5_sum,
+                and_(
+                    cram_md5_sum.file_type == 'cram.md5sum',
+                    cram_md5_sum.identifier_value == GenomicSetMember.sampleId,
+                    cram_md5_sum.ignore_flag != 1
+                )
+            ).outerjoin(
+                cram_crai,
+                and_(
+                    cram_crai.file_type == 'cram.crai',
+                    cram_crai.identifier_value == GenomicSetMember.sampleId,
+                    cram_crai.ignore_flag != 1
+                )
+            ).outerjoin(
+                hard_filtered_gvcf_gz,
+                and_(
+                    hard_filtered_gvcf_gz.file_type == 'hard-filtered.gvcf.gz',
+                    hard_filtered_gvcf_gz.identifier_value == GenomicSetMember.sampleId,
+                    hard_filtered_gvcf_gz.ignore_flag != 1
+                )
+            ).outerjoin(
+                hard_filtered_gvcf_gz_md5_sum,
+                and_(
+                    hard_filtered_gvcf_gz_md5_sum.file_type == 'hard-filtered.gvcf.gz.md5sum',
+                    hard_filtered_gvcf_gz_md5_sum.identifier_value == GenomicSetMember.sampleId,
+                    hard_filtered_gvcf_gz_md5_sum.ignore_flag != 1
+                )
+            ).filter(
+                GenomicSetMember.genomeType == genome_type,
+                GenomicSetMember.aw3ManifestJobRunID.is_(None),
+                GenomicSetMember.ignoreFlag != 1,
+                GenomicGCValidationMetrics.processingStatus.ilike('pass'),
+                GenomicGCValidationMetrics.ignoreFlag != 1,
+                ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
+                ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
+                or_(
+                    hard_filtered_vcf_gz.file_type.is_(None),
+                    hard_filtered_vcf_gz_tbi.file_type.is_(None),
+                    hard_filtered_vcf_gz_md5_sum.file_type.is_(None),
+                    cram.file_type.is_(None),
+                    cram_md5_sum.file_type.is_(None),
+                    cram_crai.file_type.is_(None),
+                    hard_filtered_gvcf_gz.file_type.is_(None),
+                    hard_filtered_gvcf_gz_md5_sum.file_type.is_(None)
+                )
+            )
+        return records.distinct().all()
 
     def get_aw3_array_records(self, **kwargs):
         # should be only array genome but query also

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -3737,8 +3737,6 @@ class GenomicQueriesDao(BaseDao):
         return site_id_map[site_id]
 
     def get_missing_array_data_files_for_aw3(self, genome_type):
-        t = genome_type
-
         with self.session() as session:
             idat_red_path = aliased(GenomicGcDataFile)
             idat_green_path = aliased(GenomicGcDataFile)

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1902,10 +1902,10 @@ class GenomicJobController:
         """ Runs report to email list of samples that are ready for AW3 manifest generation but missing data files"""
         notification_email_address = config.getSettingJson(config.RDR_GENOMICS_NOTIFICATION_EMAIL, default=None)
 
-        array_missing_data = self.query_dao.get_missing_array_data_files_for_aw3(
+        array_missing_data = self.query_dao.get_missing_data_files_for_aw3(
             genome_type=config.GENOME_TYPE_ARRAY
         )
-        wgs_missing_data = self.query_dao.get_missing_wgs_data_files_for_aw3(
+        wgs_missing_data = self.query_dao.get_missing_data_files_for_aw3(
             genome_type=config.GENOME_TYPE_WGS
         )
 

--- a/rdr_service/genomic/genomic_job_controller.py
+++ b/rdr_service/genomic/genomic_job_controller.py
@@ -1902,18 +1902,21 @@ class GenomicJobController:
         """ Runs report to email list of samples that are ready for AW3 manifest generation but missing data files"""
         notification_email_address = config.getSettingJson(config.RDR_GENOMICS_NOTIFICATION_EMAIL, default=None)
 
-        array_missing_data = self.query_dao.get_missing_data_files_for_aw3(
+        array_missing_data = self.query_dao.get_missing_array_data_files_for_aw3(
             genome_type=config.GENOME_TYPE_ARRAY
         )
-        wgs_missing_data = self.query_dao.get_missing_data_files_for_aw3(
+        wgs_missing_data = self.query_dao.get_missing_wgs_data_files_for_aw3(
             genome_type=config.GENOME_TYPE_WGS
         )
+
         if notification_email_address and any((array_missing_data, wgs_missing_data)):
-            message = 'The following samples matched AW3 manifest criteria except for the data file count:\n\n'
-            message += 'sample_id, aw2 manifest date, genome_type\n'
-            message += '\n'.join([f'{sample[0]}, {sample[1]}, aou_array' for sample in array_missing_data])
+            message = 'The following samples matched AW3 manifest criteria except for these data files:\n\n'
+            message += 'date_reported, sample_id, gc, aw2_file_path, missing_files\n'
+            message += '\n'.join([f'{sample[0]}, {sample[1]}, {sample[2]}, {sample[3]}, Missing {sample[4]} files for '
+                                  f'these samples' for sample in array_missing_data])
             message += '\n'
-            message += '\n'.join([f'{sample[0]}, {sample[1]}, aou_wgs' for sample in wgs_missing_data])
+            message += '\n'.join([f'{sample[0]}, {sample[1]}, {sample[2]}, {sample[3]}, Missing {sample[4]} files for '
+                                  f'these samples' for sample in wgs_missing_data])
             message += '\n'
             EmailService.send_email(
                 Email(

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -6887,38 +6887,59 @@ class GenomicPipelineTest(BaseTestCase):
                                               runStatus=GenomicSubProcessStatus.COMPLETED,
                                               runResult=GenomicSubProcessResult.SUCCESS))
 
-        self._create_fake_datasets_for_gc_tests(3, arr_override=False,
+        self._create_fake_datasets_for_gc_tests(2, arr_override=False,
                                                 recon_gc_man_id=1,
                                                 genome_center='rdr',
                                                 genomic_workflow_state=GenomicWorkflowState.AW1,
                                                 sample_source="Whole Blood",
                                                 ai_an='N')
 
+        self._create_fake_datasets_for_gc_tests(1, arr_override=True,
+                                                id_start_from=2,
+                                                array_participants=range(3, 4),
+                                                recon_gc_man_id=1,
+                                                genome_center='rdr',
+                                                genomic_workflow_state=GenomicWorkflowState.AW1)
+
         bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
 
-        test_file = create_ingestion_test_file(
+        wgs_test_file = create_ingestion_test_file(
             'RDR_AoU_SEQ_TestDataManifest.csv',
             bucket_name,
             folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[0])
         )
 
+        array_test_file = create_ingestion_test_file(
+            'RDR_AoU_GEN_TestDataManifest.csv',
+            bucket_name,
+            folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[1])
+        )
+
         self._update_test_sample_ids()
-        self._create_stored_samples([(3, 1003)])
+        self._create_stored_samples([(1, 1001)])
         self._create_stored_samples([(2, 1002)])
+        self._create_stored_samples([(3, 1003)])
 
         self.aw2_raw_dao.insert_bulk([{
             'id': 1,
             'created': parse('2022-11-01T14:13:12'),
             'modified': parse('2022-11-01T14:13:12'),
-            'sample_id': 1003,
-            'file_path': test_file
+            'sample_id': 1001,
+            'file_path': wgs_test_file
         },
         {
             'id': 2,
             'created': parse('2022-11-01T14:13:13'),
             'modified': parse('2022-11-01T14:13:13'),
             'sample_id': 1002,
-            'file_path': test_file
+            'file_path': wgs_test_file
+        },
+        {
+            'id': 3,
+            'created': parse('2022-11-01T14:13:14'),
+            'modified': parse('2022-11-01T14:13:14'),
+            'sample_id': 1003,
+            'file_path': array_test_file
         }
         ])
 
@@ -6937,9 +6958,9 @@ class GenomicPipelineTest(BaseTestCase):
         genomic_pipeline.ingest_genomic_centers_metrics_files()  # run_id = 2
 
         # metrics insert called via cloud task
-        self.assertEqual(metric_cloud_task.call_count, 2)
+        self.assertEqual(metric_cloud_task.call_count, 5)
         call_args = metric_cloud_task.call_args_list
-        self.assertEqual(len(call_args), 2)
+        self.assertEqual(len(call_args), 5)
 
         # assimilate cloud task ingestion via call args for tests
         for i, call_arg_data in enumerate(call_args):
@@ -6950,27 +6971,42 @@ class GenomicPipelineTest(BaseTestCase):
             )
 
         # Test sequencing file (required for AW3 WGS)
-        sequencing_test_files = (
+        wgs_sequencing_test_files = (
+            'test_data_folder/RDR_1_1001_10001_1.hard-filtered.vcf.gz',
+            'test_data_folder/RDR_1_1001_10001_1.hard-filtered.vcf.gz.tbi',
+            'test_data_folder/RDR_1_1001_10001_1.hard-filtered.vcf.gz.md5sum',
+            'test_data_folder/RDR_1_1001_10001_1.cram',
+            'test_data_folder/RDR_1_1001_10001_1.cram.md5sum',
+            'test_data_folder/RDR_1_1001_10001_1.cram.crai',
+            'test_data_folder/RDR_1_1001_10001_1.hard-filtered.gvcf.gz',
+            'test_data_folder/RDR_1_1001_10001_1.hard-filtered.gvcf.gz.md5sum',
             'test_data_folder/RDR_2_1002_10002_1.hard-filtered.vcf.gz',
-            'test_data_folder/RDR_2_1002_10002_1.hard-filtered.vcf.gz.tbi',
             'test_data_folder/RDR_2_1002_10002_1.hard-filtered.vcf.gz.md5sum',
             'test_data_folder/RDR_2_1002_10002_1.cram',
             'test_data_folder/RDR_2_1002_10002_1.cram.md5sum',
             'test_data_folder/RDR_2_1002_10002_1.cram.crai',
-            'test_data_folder/RDR_2_1002_10002_1.hard-filtered.gvcf.gz',
             'test_data_folder/RDR_2_1002_10002_1.hard-filtered.gvcf.gz.md5sum',
-            'test_data_folder/RDR_3_1003_10003_1.hard-filtered.vcf.gz',
-            'test_data_folder/RDR_3_1003_10003_1.hard-filtered.vcf.gz.md5sum',
-            'test_data_folder/RDR_3_1003_10003_1.cram',
-            'test_data_folder/RDR_3_1003_10003_1.cram.md5sum',
-            'test_data_folder/RDR_3_1003_10003_1.cram.crai',
-            'test_data_folder/RDR_3_1003_10003_1.hard-filtered.gvcf.gz.md5sum',
         )
+
+        # Test sequencing file (required for GEM)
+        array_sequencing_test_files = (
+            f'test_data_folder/10003_R01C03.vcf.gz',
+            f'test_data_folder/10003_R01C03.vcf.gz.tbi',
+            f'test_data_folder/10003_R01C03.vcf.gz.md5sum',
+            f'test_data_folder/10003_R01C03_Red.idat.md5sum',
+            f'test_data_folder/10003_R01C03_Grn.idat.md5sum',
+            f'test_data_folder/10004_R01C04.vcf.gz',
+            f'test_data_folder/10004_R01C04.vcf.gz.tbi',
+            f'test_data_folder/10004_R01C04.vcf.gz.md5sum',
+            f'test_data_folder/10004_R01C04_Red.idat',
+            f'test_data_folder/10004_R01C04_Grn.idat'
+        )
+
         test_date = datetime.datetime(2021, 7, 12, 0, 0, 0, 0)
 
         # create test records in GenomicGcDataFile
         with clock.FakeClock(test_date):
-            for f in sequencing_test_files:
+            for f in wgs_sequencing_test_files:
                 if "cram" in f:
                     file_prefix = "CRAMs_CRAIs"
                 else:
@@ -6989,103 +7025,9 @@ class GenomicPipelineTest(BaseTestCase):
 
                 self.data_generator.create_database_gc_data_file_record(**test_file_dict)
 
-        config.override_setting(config.RDR_GENOMICS_NOTIFICATION_EMAIL, ['email@test.com', 'email2@test.com'])
-        with GenomicJobController(GenomicJob.AW3_MISSING_DATA_FILE_REPORT) as controller:
-            controller.check_aw3_ready_missing_files()
-
-        # mock checks
-        self.assertEqual(email_mock.call_count, 1)
-        self.assertEqual(email_mock.call_args[0][0].recipients, ['email@test.com', 'email2@test.com'])
-        self.assertIn(f'2022-11-01 14:13:12, 1003, rdr, {test_file}, Missing hard-filtered.vcf.gz.tbi, '
-                      f'hard-filtered.gvcf.gz files for these samples', email_mock.call_args[0][0].plain_text_content)
-
-    @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
-    @mock.patch('rdr_service.services.email_service.EmailService.send_email')
-    def test_aw3_ready_missing_data_files_report_array(self, email_mock, metric_cloud_task):
-        self.job_run_dao.insert(GenomicJobRun(jobId=GenomicJob.AW1_MANIFEST,
-                                              startTime=clock.CLOCK.now(),
-                                              runStatus=GenomicSubProcessStatus.COMPLETED,
-                                              runResult=GenomicSubProcessResult.SUCCESS))
-
-        self._create_fake_datasets_for_gc_tests(2, arr_override=True,
-                                                array_participants=range(1, 3),
-                                                recon_gc_man_id=1,
-                                                genome_center='rdr',
-                                                genomic_workflow_state=GenomicWorkflowState.AW1)
-
-        bucket_name = _FAKE_GENOMIC_CENTER_BUCKET_A
-
-        test_file = create_ingestion_test_file(
-            'RDR_AoU_GEN_TestDataManifest.csv',
-            bucket_name,
-            folder=config.getSetting(config.GENOMIC_AW2_SUBFOLDERS[0])
-        )
-
-        self._update_test_sample_ids()
-        self._create_stored_samples([(1, 1001)])
-        self._create_stored_samples([(2, 1002)])
-
-        self.aw2_raw_dao.insert_bulk([{
-            'id': 1,
-            'created': parse('2022-11-01T14:13:12'),
-            'modified': parse('2022-11-01T14:13:12'),
-            'sample_id': 1001,
-            'file_path': test_file
-        },
-        {
-            'id': 2,
-            'created': parse('2022-11-01T14:13:13'),
-            'modified': parse('2022-11-01T14:13:13'),
-            'sample_id': 1002,
-            'file_path': test_file
-        }
-        ])
-
-        # Create corresponding array genomic_set_members
-        for i in range(1, 4):
-            self.data_generator.create_database_genomic_set_member(
-                participantId=i,
-                genomicSetId=1,
-                biobankId=i,
-                gcManifestParentSampleId=1000 + i,
-                genomeType="aou_array",
-                aw3ManifestJobRunID=1,
-                ai_an='N'
-            )
-
-        genomic_pipeline.ingest_genomic_centers_metrics_files()  # run_id = 2
-
-        # metrics insert called via cloud task
-        self.assertEqual(metric_cloud_task.call_count, 2)
-        call_args = metric_cloud_task.call_args_list
-        self.assertEqual(len(call_args), 2)
-
-        # assimilate cloud task ingestion via call args for tests
-        for i, call_arg_data in enumerate(call_args):
-            call_arg_data = call_arg_data.args[0]
-            self.metrics_dao.upsert_gc_validation_metrics_from_dict(
-                data_to_upsert=call_arg_data.get('payload_dict'),
-                existing_id=call_arg_data.get('metric_id')
-            )
-
-        # Test sequencing file (required for GEM)
-        sequencing_test_files = (
-            f'test_data_folder/10001_R01C01.vcf.gz',
-            f'test_data_folder/10001_R01C01.vcf.gz.tbi',
-            f'test_data_folder/10001_R01C01.vcf.gz.md5sum',
-            f'test_data_folder/10001_R01C01_Red.idat.md5sum',
-            f'test_data_folder/10001_R01C01_Grn.idat.md5sum',
-            f'test_data_folder/10002_R01C02.vcf.gz',
-            f'test_data_folder/10002_R01C02.vcf.gz.tbi',
-            f'test_data_folder/10002_R01C02.vcf.gz.md5sum',
-            f'test_data_folder/10002_R01C02_Red.idat',
-            f'test_data_folder/10002_R01C02_Grn.idat'
-        )
-        test_date = datetime.datetime(2021, 7, 12, 0, 0, 0, 0)
-
         # create test records in GenomicGcDataFile
         with clock.FakeClock(test_date):
-            for f in sequencing_test_files:
+            for f in array_sequencing_test_files:
                 # Set file type
                 if "idat" in f.lower():
                     file_type = f.split('/')[-1].split("_")[-1]
@@ -7113,7 +7055,7 @@ class GenomicPipelineTest(BaseTestCase):
         # mock checks
         self.assertEqual(email_mock.call_count, 1)
         self.assertEqual(email_mock.call_args[0][0].recipients, ['email@test.com', 'email2@test.com'])
-        self.assertIn(f'2022-11-01 14:13:12, 1001, rdr, {test_file}, Missing Red.idat, Grn.idat files for these '
-                      f'samples', email_mock.call_args[0][0].plain_text_content)
-        self.assertIn(f'2022-11-01 14:13:13, 1002, rdr, {test_file}, Missing Red.idat.md5sum, Grn.idat.md5sum '
-                      f'files for these samples', email_mock.call_args[0][0].plain_text_content)
+        self.assertIn(f'2022-11-01 14:13:13, 1002, rdr, {wgs_test_file}, Missing hard-filtered.vcf.gz.tbi, '
+                      f'hard-filtered.gvcf.gz files for these samples', email_mock.call_args[0][0].plain_text_content)
+        self.assertIn(f'2022-11-01 14:13:14, 1003, rdr, {array_test_file}, Missing Red.idat, Grn.idat files for '
+                      f'these samples', email_mock.call_args[0][0].plain_text_content)

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -7022,8 +7022,8 @@ class GenomicPipelineTest(BaseTestCase):
         )
 
         self._update_test_sample_ids()
-        self._create_stored_samples([(2, 1002)])
         self._create_stored_samples([(1, 1001)])
+        self._create_stored_samples([(2, 1002)])
 
         self.aw2_raw_dao.insert_bulk([{
             'id': 1,
@@ -7104,7 +7104,7 @@ class GenomicPipelineTest(BaseTestCase):
                     'ignore_flag': 0,
                 }
 
-                records = self.data_generator.create_database_gc_data_file_record(**test_file_dict)
+                self.data_generator.create_database_gc_data_file_record(**test_file_dict)
 
         config.override_setting(config.RDR_GENOMICS_NOTIFICATION_EMAIL, ['email@test.com', 'email2@test.com'])
         with GenomicJobController(GenomicJob.AW3_MISSING_DATA_FILE_REPORT) as controller:


### PR DESCRIPTION
## Resolves *[DA-3399](https://precisionmedicineinitiative.atlassian.net/browse/DA-3399)*

In the genomics pipeline, an alert email is sent out when there are AW3 Ready Samples that have missing data files. The email includes the sample_id, date, and genome_type of any samples that are missing one or more data files. 

To help with investigation into the missing files, the email will be updated to include more fields.

## Description of changes/additions

This PR updates the alert email to include the genome center, AW2 File Path, and a list of the missing files.
Specifically:
* Update dao to check if each data file is present and return any null values (missing files)
* Update unit tests to test multiple missing files for both array and wgs
* Update the alert email formatting to include the new fields

## Tests
- [X] unit tests




[DA-3399]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ