### PR TITLE
Automating Query to Load Tactis Data to BigQuery

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -276,6 +276,6 @@ cron:
   target: offline
 - description: Sync Tactis participant data to Big Query
   url: /offline/TactisBigQuerySync
-  schedule: every day 02:30
+  schedule: 1 of jan 12:00
   timezone: America/New_York
   target: offline

--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -274,4 +274,8 @@ cron:
   schedule: every day 01:15
   timezone: America/New_York
   target: offline
-
+- description: Sync Tactis participant data to Big Query
+  url: /offline/TactisBigQuerySync
+  schedule: every day 02:30
+  timezone: America/New_York
+  target: offline

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -44,6 +44,7 @@ from rdr_service.offline.response_validation import ResponseValidationController
 from rdr_service.offline.service_accounts import ServiceAccountKeyManager
 from rdr_service.offline.sync_consent_files import ConsentSyncController
 from rdr_service.offline.table_exporter import TableExporter
+from rdr_service.offline.tactis_bq_sync import TactisBQDataSync
 from rdr_service.repository.obfuscation_repository import ObfuscationRepository
 from rdr_service.resource.tasks import dispatch_check_consent_errors_task
 from rdr_service.services.consent.validation import ConsentValidationController, ReplacementStoringStrategy,\
@@ -888,6 +889,22 @@ def nph_sms_n1_generation():
     return '{"success": "true"}'
 
 
+@app_util.auth_required_cron
+@check_genomic_cron_job('tactis_participants_to_bq')
+def sync_tactis_participants_to_bq():
+    a_day_ago = CLOCK.now() - timedelta(days=1)
+    since_date = datetime(year=a_day_ago.year, month=a_day_ago.month, day=a_day_ago.day)
+
+    data_sync = TactisBQDataSync(
+        dataset="drc_to_tactis_data",
+        table_name="participant_data_to_tactis",
+        since_date=since_date
+    )
+
+    data_sync.sync_data_to_bigquery()
+    return '{ "success": "true" }'
+
+
 def _build_pipeline_app():
     """Configure and return the app with non-resource pipeline-triggering endpoints."""
     offline_app = Flask(__name__)
@@ -904,6 +921,13 @@ def _build_pipeline_app():
         OFFLINE_PREFIX + "FlagResponseDuplication",
         endpoint="flagResponseDuplication",
         view_func=flag_response_duplication,
+        methods=["GET"],
+    )
+
+    offline_app.add_url_rule(
+        OFFLINE_PREFIX + "TactisBigQuerySync",
+        endpoint="tactisBigQuerySync",
+        view_func=sync_tactis_participants_to_bq,
         methods=["GET"],
     )
 

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -890,7 +890,6 @@ def nph_sms_n1_generation():
 
 
 @app_util.auth_required_cron
-@check_genomic_cron_job('tactis_participants_to_bq')
 def sync_tactis_participants_to_bq():
     a_day_ago = CLOCK.now() - timedelta(days=1)
     since_date = datetime(year=a_day_ago.year, month=a_day_ago.month, day=a_day_ago.day)

--- a/rdr_service/offline/tactis_bq_sync.py
+++ b/rdr_service/offline/tactis_bq_sync.py
@@ -1,0 +1,65 @@
+import logging
+import string
+from typing import Union
+
+from datetime import datetime
+
+import google.cloud.bigquery
+import google.api_core.exceptions
+from google.cloud import bigquery
+from google.cloud.exceptions import NotFound
+
+_logger = logging.getLogger("rdr_logger")
+
+
+class TactisBQDataSync:
+
+    EXTERNAL_CONNECTION = {
+        "all-of-us-rdr-sandbox": "all-of-us-rdr-sandbox.us-central1.aou_sandbox_rdrmaindb",
+        "all-of-us-rdr-stable": "all-of-us-rdr-stable.us-central1.all-of-us-rdr-stable-mysql",
+        "all-of-us-rdr-prod": "all-of-us-rdr-prod.us-central1.bq-rdr-preprod-curation"
+    }
+
+    QUERIES = {
+        "modified_participants": """
+                        SELECT * FROM
+                          EXTERNAL_QUERY("{external_connection}",
+                            "SELECT t.participant_id, ps.first_name, ps.middle_name, ps.last_name, ps.email, """
+                                 """ps.phone_number, ps.participant_origin FROM participant_data_to_tactis t """
+                                 """LEFT JOIN participant_summary ps ON ps.participant_id = t.participant_id """
+                                 """LEFT JOIN participant p ON p.participant_id = ps.participant_id """
+                                 """WHERE p.is_test_participant = 0 AND p.is_ghost_id is null """
+                                 """AND p.hpo_id not in (21) AND t.created >= '{since_date}'");"""
+    }
+
+    def __init__(self, dataset: string, table_name: string, since_date: datetime):
+        self.client = bigquery.Client()
+        self.dataset_id = f"{self.client.project}.{dataset}"
+        self.table_name = table_name
+        self.since_date = since_date
+        self.external_connection = self.EXTERNAL_CONNECTION[self.client.project]
+
+    def sync_data_to_bigquery(self):
+        table_id = f"{self.dataset_id}.{self.table_name}"
+        self.delete_table(table_id)
+        self.import_table(table_id)
+
+    def delete_table(self, table_id: string):
+        # Delete the existing BQ table if it exists
+        self.client.delete_table(table_id, not_found_ok=True)
+        _logger.debug("Deleted table '{}'.".format(table_id))
+
+    def run_query(self, sql: str, job_config: Union[None, google.cloud.bigquery.QueryJobConfig]):
+        try:
+            query_job = self.client.query(sql, job_config=job_config)
+            result = query_job.result()  # wait for query to finish
+            _logger.debug(f"Rows in result: {result.total_rows}")
+        except NotFound as error:
+            _logger.error("Dataset does not exist: %s", error)
+
+    def import_table(self, destination: string):
+        _logger.debug(f"Importing rdr.{self.table_name} to {destination}")
+        job_config = bigquery.QueryJobConfig(destination=destination)
+        sql = self.QUERIES['modified_participants'].format(external_connection=self.external_connection,
+                                                           since_date=self.since_date)
+        self.run_query(sql, job_config)

--- a/rdr_service/tools/tool_libs/tactis_bq_sync.py
+++ b/rdr_service/tools/tool_libs/tactis_bq_sync.py
@@ -1,0 +1,46 @@
+import argparse
+
+from dateutil.parser import parse
+from google.cloud import bigquery
+
+from rdr_service.offline.tactis_bq_sync import TactisBQDataSync
+from rdr_service.tools.tool_libs.tool_base import cli_run, ToolBase
+
+tool_cmd = 'tactis-bq-sync'
+tool_desc = 'Sync Tactis participant data that has been modified since a given date to BigQuery'
+
+
+class TactisBQSync(ToolBase):
+
+    def __init__(self, args, gcp_env=None, tool_name=None, replica=False):
+        super().__init__(args, gcp_env, tool_name, replica)
+        self.client = bigquery.Client()
+        self.dataset_id = f"{args.project}.{args.dataset}"
+
+    def run(self):
+        super(TactisBQSync, self).run()
+
+        dataset = self.args.dataset
+        table_name = self.args.table
+        since_date = parse(self.args.since)
+
+        data_sync = TactisBQDataSync(
+            dataset=dataset,
+            table_name=table_name,
+            since_date=since_date
+        )
+        data_sync.sync_data_to_bigquery()
+
+
+def add_additional_arguments(parser: argparse.ArgumentParser):
+    parser.add_argument("--dataset", help="BigQuery dataset where data should be synced", required=True)
+    parser.add_argument("--table", help="RDR table containing Tactis data", required=True)
+    parser.add_argument(
+        '--since',
+        help='Participants that have a modified Tactis field since this date string will be synced to BigQuery',
+        required=True
+    )
+
+
+def run():
+    cli_run(tool_cmd, tool_desc, TactisBQSync, add_additional_arguments)


### PR DESCRIPTION
## Resolves *[DA-3803](https://precisionmedicineinitiative.atlassian.net/browse/DA-3803)* 

## Description of changes/additions
In order to make data available to Tactis in BigQuery, we have created a table in the RDR called `participant_data_to_tactis` that will track all participants that have changes in Tactis relevant fields. The `participant_data_to_tactis` table is queried by the CRON job and all participants with changes in the last day are synced to Big Query.

This PR includes the following changes to set up the automatic BigQuery sync for Tactis:
* Creating a CRON job to run on a daily cadence and sync the 7 requested fields of participant data to BigQuery
  * The job will be disabled initially using the decorator `@check_genomic_cron_job()` until Tactis is ready on their end
  * The `participant_data_to_tactis` table will store all changes over time, while the BigQuery table will only provide Tactis with updated fields from the past 24 hours
* Creating a BigQuery Tactis tool to be able to manually sync Tactis data in the case of backfills or requests for specific data from Tactis

## Tests
- Tested in Sandbox & Stable




[DA-3803]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ