### PR TITLE
[DA-4017] Fix Slack alert when withdrawn PIDs received in NPH Intake API

### DIFF
--- a/rdr_service/api/ancillary_study_cloud_tasks_api.py
+++ b/rdr_service/api/ancillary_study_cloud_tasks_api.py
@@ -211,6 +211,7 @@ class WithdrawnParticipantNotifierTaskApi(BaseAncillaryTaskApi):
 
     def post(self):
         super().post()
+        bundle_id = self.data.get("bundle_id")
         nph_pids = self.data.get("nph_pids")
         aou_pids = self._convert_nph_pids_to_aou_pids(nph_pids=nph_pids)
         withdrawn_pids: list[str] = self.participant_dao.get_withdrawn_participant_ids(
@@ -222,8 +223,8 @@ class WithdrawnParticipantNotifierTaskApi(BaseAncillaryTaskApi):
         if withdrawn_pids:
             ts = CLOCK.now().strftime('%Y-%m-%d %H:%M:%S')
             msg = (
-                f"NPH Intake API Payload received on {ts} contains {len(withdrawn_pids)} withdrawn participant IDs:"
-                f" {', '.join(withdrawn_pids)}"
+                f"NPH Intake API Payload received on {ts} with bundle id {bundle_id} contains "
+                f"{len(withdrawn_pids)} withdrawn participant IDs: {', '.join(withdrawn_pids)}"
             )
             create_nph_incident(slack=True, message=msg)
         return {"success": True}

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -16,7 +16,6 @@ from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.study_nph_dao import NphIntakeDao, NphParticipantEventActivityDao, NphActivityDao, \
     NphPairingEventDao, NphSiteDao, NphDefaultBaseDao, NphEnrollmentEventTypeDao, NphConsentEventTypeDao, \
     NphParticipantDao
-from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.study_nph import WithdrawalEvent, DeactivationEvent, ConsentEvent, EnrollmentEvent, \
     ParticipantOpsDataElement, DietEvent
 
@@ -45,7 +44,6 @@ class PostIntakePayload(ABC):
         self.nph_participant_dao = NphParticipantDao()
         self.nph_participant_activity_dao = NphParticipantEventActivityDao()
         self.nph_site_dao = NphSiteDao()
-        self.rdr_participant_dao = ParticipantDao()
 
         self.nph_consent_type_dao = NphConsentEventTypeDao()
         self.nph_enrollment_type_dao = NphEnrollmentEventTypeDao()
@@ -229,11 +227,6 @@ class PostIntakePayload(ABC):
         self.event_dao_map: dict = self.build_event_dao_map()
         entry_obj: EntryObjData = self.iterate_entries()
 
-        pids = [ele.get("nph_participant_id") for ele in self.participant_response]
-        withdrawn_pids: List[str] = self.rdr_participant_dao.get_withdrawn_participant_ids(
-            participant_ids=pids
-        )
-
         self.handle_data_inserts(
             participant_event_objs=entry_obj.participant_event_objs,
             all_event_objs=entry_obj.all_event_objs,
@@ -241,6 +234,13 @@ class PostIntakePayload(ABC):
         )
         if GAE_PROJECT != 'localhost':
             cloud_task = GCPCloudTask()
+            received_nph_pids = [ele.get("nph_participant_id") for ele in self.participant_response]
+            cloud_task.execute(
+                endpoint="withdrawn_participant_notifier_task",
+                payload={"nph_pids": received_nph_pids},
+                queue="nph"
+            )
+
             if entry_obj.summary_updates:
                 for summary_update in entry_obj.summary_updates:
                     cloud_task.execute(
@@ -248,12 +248,6 @@ class PostIntakePayload(ABC):
                         payload=summary_update,
                         queue='nph'
                     )
-            if withdrawn_pids:
-                cloud_task.execute(
-                    endpoint="withdrawn_participant_notifier_task",
-                    payload={"withdrawn_pids": withdrawn_pids},
-                    queue="nph"
-                )
 
 
 # FHIR specific payloads

--- a/rdr_service/api/nph_intake_api.py
+++ b/rdr_service/api/nph_intake_api.py
@@ -237,7 +237,7 @@ class PostIntakePayload(ABC):
             received_nph_pids = [ele.get("nph_participant_id") for ele in self.participant_response]
             cloud_task.execute(
                 endpoint="withdrawn_participant_notifier_task",
-                payload={"nph_pids": received_nph_pids},
+                payload={"bundle_id": self.bundle_identifier, "nph_pids": received_nph_pids},
                 queue="nph"
             )
 

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -236,7 +236,7 @@ def _build_resource_app():
                       TASK_PREFIX + "NphIncidentTaskApi",
                       endpoint="nph_incident_task", methods=["POST"])
 
-    # Cloud Task for sending Slack Alerts if withdrawn PIDs found in NPH Intake Api payload
+    # Cloud Task for sending Slack alerts if withdrawn PIDs found in NPH Intake Api payload
     _api.add_resource(ancillary_study_cloud_tasks_api.WithdrawnParticipantNotifierTaskApi,
                       TASK_PREFIX + "WithdrawnParticipantNotifierTaskApi",
                       endpoint="withdrawn_participant_notifier_task", methods=["POST"])

--- a/tests/api_tests/test_ancillary_studies_cloud_tasks.py
+++ b/tests/api_tests/test_ancillary_studies_cloud_tasks.py
@@ -207,7 +207,7 @@ class NphIncidentTaskApiCloudTaskTest(BaseTestCase):
         with self.assertLogs(level="INFO") as cm:
             response = self.send_post(
                 local_path="WithdrawnParticipantNotifierTaskApi",
-                request_data={"nph_pids": ["1", "2"]},
+                request_data={"bundle_id": "abc", "nph_pids": ["1", "2"]},
                 prefix="/resource/task/",
                 test_client=resource_main.app.test_client(),
                 expected_status=OK,

--- a/tests/api_tests/test_ancillary_studies_cloud_tasks.py
+++ b/tests/api_tests/test_ancillary_studies_cloud_tasks.py
@@ -183,18 +183,39 @@ class NphIncidentTaskApiCloudTaskTest(BaseTestCase):
         )
         self.assertEqual(response.status_code, INTERNAL_SERVER_ERROR)
 
-    @mock.patch("rdr_service.services.ancillary_studies.nph_incident.SlackMessageHandler.send_message_to_webhook")
-    def test_nph_withdrawn_pid_notifier_task_returns_200(self, mock_send_message_to_webhook: mock.Mock):
+    @mock.patch(
+        "rdr_service.dao.participant_dao.ParticipantDao.get_withdrawn_participant_ids"
+    )
+    @mock.patch(
+        "rdr_service.api.ancillary_study_cloud_tasks_api.WithdrawnParticipantNotifierTaskApi._convert_nph_pids_to_aou_pids"
+    )
+    @mock.patch(
+        "rdr_service.services.ancillary_studies.nph_incident.SlackMessageHandler.send_message_to_webhook"
+    )
+    def test_nph_withdrawn_pid_notifier_task_returns_200(
+        self,
+        mock_send_message_to_webhook,
+        mock_convert_nph_pids_to_aou_pids,
+        mock_get_withdrawn_participant_ids,
+    ):
         mock_send_message_to_webhook.return_value = True
+        mock_convert_nph_pids_to_aou_pids.return_value = []
+        mock_get_withdrawn_participant_ids.return_value = ["1"]
+
         from rdr_service.resource import main as resource_main
-        response = self.send_post(
-            local_path='WithdrawnParticipantNotifierTaskApi',
-            request_data={"withdrawn_pids": ["1", "2"]},
-            prefix="/resource/task/",
-            test_client=resource_main.app.test_client(),
-            expected_status=OK
-        )
-        self.assertEqual(response, {'success': True})
+
+        with self.assertLogs(level="INFO") as cm:
+            response = self.send_post(
+                local_path="WithdrawnParticipantNotifierTaskApi",
+                request_data={"nph_pids": ["1", "2"]},
+                prefix="/resource/task/",
+                test_client=resource_main.app.test_client(),
+                expected_status=OK,
+            )
+            self.assertIn(
+                "INFO:root:1 withdrawn PIDs received in NPH intake payload.", cm.output
+            )
+            self.assertEqual(response, {"success": True})
 
     def tearDown(self):
         self.clear_table_after_test("nph.incident")


### PR DESCRIPTION
## Partially Resolves *[ticket # 4017](https://precisionmedicineinitiative.atlassian.net/jira/software/c/projects/DA/boards/11?assignee=712020%3A769e4847-aa22-4eb2-aea1-0cb378cf6a5b&selectedIssue=DA-4017)*


## Description of changes/additions
- There was a bug where we didn't convert NPH participant ids to AOU participant ids when searching for withdrawn ids used to send slack alert. This PR fixes that.
- Moved the logic for converting pids to cloud tasks instead of `handle_data_from_payload` in the NPH Intake API.


## Tests
✅  unit tests


