### PR TITLE
[DA-4026] Dynamic signature page detection for GROR

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -723,34 +723,37 @@ class VibrentEhrConsentFile(EhrConsentFile):
 
 
 class VibrentGrorConsentFile(GrorConsentFile):
-    _SIGNATURE_PAGE = 9
+    def _get_signature_page(self):
+        return self.pdf.get_page_number_of_text([
+            ('This document prepared for', 'Este documento está preparado para')
+        ])
 
     def _get_signature_elements(self):
         return self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=150, right=400, bottom=155, top=160),
-            page=self._SIGNATURE_PAGE
+            page=self._get_signature_page()
         )
 
     def _get_date_elements(self):
         return self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=130, right=400, bottom=110, top=115),
-            page=self._SIGNATURE_PAGE
+            page=self._get_signature_page()
         )
 
     def _get_confirmation_check_elements(self):
         spanish_signature_text = '¿Desea conocer alguno de sus resultados de ADN?'
         if self.pdf.get_page_number_of_text([spanish_signature_text]) is not None:
-            # Spanish versions of the the GROR have the checkmark a bit more to the left
+            # Spanish versions of the GROR have the checkmark a bit more to the left
             search_box = Rect.from_edges(left=33, right=36, bottom=480, top=485)
         else:
             search_box = Rect.from_edges(left=70, right=73, bottom=475, top=478)
 
-        return self.pdf.get_elements_intersecting_box(search_box, page=self._SIGNATURE_PAGE)
+        return self.pdf.get_elements_intersecting_box(search_box, page=self._get_signature_page())
 
     def _get_printed_name_elements(self):
         return self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=350, right=500, bottom=45, top=50),
-            page=self._SIGNATURE_PAGE
+            page=self._get_signature_page()
         )
 
 

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -525,7 +525,8 @@ class ConsentFileParsingTest(BaseTestCase):
                     bbox=(65, 470, 75, 480)
                 ),
                 self._build_form_element(text='Test gror', bbox=(140, 150, 450, 180)),
-                self._build_form_element(text='Jan 1st, 2021', bbox=(125, 100, 450, 130))
+                self._build_form_element(text='Jan 1st, 2021', bbox=(125, 100, 450, 130)),
+                self._build_pdf_element(cls=LTTextBoxHorizontal, text='This document prepared for')
             ]
         ])
         basic_gror_case = GrorConsentTestData(
@@ -539,7 +540,8 @@ class ConsentFileParsingTest(BaseTestCase):
             *nine_empty_pages,
             [
                 self._build_form_element(text='no confirmation', bbox=(140, 150, 450, 180)),
-                self._build_form_element(text='Feb 1st, 2021', bbox=(125, 100, 450, 130))
+                self._build_form_element(text='Feb 1st, 2021', bbox=(125, 100, 450, 130)),
+                self._build_pdf_element(cls=LTTextBoxHorizontal, text='This document prepared for')
             ]
         ])
         no_confirmation_case = GrorConsentTestData(
@@ -561,7 +563,8 @@ class ConsentFileParsingTest(BaseTestCase):
                     bbox=(30, 478, 40, 488)
                 ),
                 self._build_form_element(text='spanish gror', bbox=(140, 150, 450, 180)),
-                self._build_form_element(text='May 1st, 2018', bbox=(125, 100, 450, 130))
+                self._build_form_element(text='May 1st, 2018', bbox=(125, 100, 450, 130)),
+                self._build_pdf_element(cls=LTTextBoxHorizontal, text='Este documento está preparado para')
             ]
         ])
         spanish_gror_case = GrorConsentTestData(


### PR DESCRIPTION
## Resolves *[DA-4026](https://precisionmedicineinitiative.atlassian.net/browse/DA-4026)*
The content of the GROR consent PDF is being updated, and the changes are changing the page number of the signature.

## Description of changes/additions
This updates the validation code to figure out which page is the signature page (rather than a hardcoded value expecting it to always be a specific page).

## Tests
- [x] unit tests




[DA-4026]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ