### PR TITLE
Cleaning up ehr file upload logs

### DIFF
--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -211,9 +211,7 @@ def update_participant_summaries_from_job(job, project_id=GAE_PROJECT):
                     participant_id=participant_id,
                     session=session
                 )
-                if summary is None:
-                    LOG.error(f'No summary found for P{participant_id}')
-                else:
+                if summary:
                     summary_dao.update_enrollment_status(session=session, summary=summary)
                     participant_ids_to_rebuild.add(participant_id)
 


### PR DESCRIPTION
The BigQuery view we use to ingest whether participants have had EHR files uploaded for them is expected to have unclean data (particularly participant ids that don't exist, https://precisionmedicineinitiative.atlassian.net/browse/DC-2906).

This PR removes the error log that indicates a participant id was found in the view that doesn't have a participant summary.