### PR TITLE
[DA-3967] Task endpoint for retention calculation

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -87,6 +87,7 @@ from rdr_service.model.code import Code
 from rdr_service.query import FieldFilter, FieldJsonContainsFilter, Operator, OrderBy, PropertyType
 from rdr_service.repository.obfuscation_repository import ObfuscationRepository
 from rdr_service.repository.questionnaire_response_repository import QuestionnaireResponseRepository
+from rdr_service.services.retention_calculation import RetentionEligibility
 from rdr_service.services.system_utils import min_or_none
 
 
@@ -1682,6 +1683,18 @@ class ParticipantSummaryDao(UpdatableDao):
                 }
             )
             session.execute(query, {'file_upload_date': upload_date})
+
+    @classmethod
+    def update_with_retention_data(cls, participant_id, retention_data: RetentionEligibility, session):
+        participant_summary: ParticipantSummary = session.query(ParticipantSummary).filter(
+            ParticipantSummary.participantId == participant_id
+        ).one_or_none()
+
+        if participant_summary:
+            participant_summary.retentionEligibleStatus = retention_data.retention_status
+            participant_summary.retentionEligibleTime = retention_data.retention_eligible_date
+            participant_summary.retentionType = retention_data.retention_type
+            participant_summary.lastActiveRetentionActivityTime = retention_data.last_active_retention_date
 
     @classmethod
     def update_profile_data(cls, participant_id: int, **kwargs):

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -265,6 +265,13 @@ def _build_resource_app():
         methods=['POST']
     )
 
+    _api.add_resource(
+        cloud_tasks_api.UpdateRetentionEligibleStatus,
+        TASK_PREFIX + 'UpdateRetentionStatus',
+        endpoint='update_retention_status',
+        methods=['POST']
+    )
+
     _app.add_url_rule('/_ah/start', endpoint='start', view_func=flask_start, methods=["GET"])
     _app.add_url_rule('/_ah/stop', endpoint='stop', view_func=flask_stop, methods=["GET"])
 

--- a/rdr_service/services/retention_calculation.py
+++ b/rdr_service/services/retention_calculation.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Optional
 
-from rdr_service.participant_enums import ParticipantCohort
+from rdr_service.participant_enums import ParticipantCohort, RetentionStatus, RetentionType
 
 
 @dataclass
@@ -151,6 +151,21 @@ class RetentionEligibility:
             and self._is_less_than_18_months_ago(self._participant.latest_ehr_upload_timestamp)
             and self._participant.has_uploaded_ehr_file
         )
+
+    @property
+    def retention_status(self):
+        return RetentionStatus.ELIGIBLE if self.is_eligible else RetentionStatus.NOT_ELIGIBLE
+
+    @property
+    def retention_type(self):
+        if self.is_actively_retained and self.is_passively_retained:
+            return RetentionType.ACTIVE_AND_PASSIVE
+        elif self.is_actively_retained:
+            return RetentionType.ACTIVE
+        elif self.is_passively_retained:
+            return RetentionType.PASSIVE
+
+        return RetentionType.UNSET
 
     @classmethod
     def _did_provide_consent(cls, consent: Consent) -> bool:

--- a/tests/task_integration_tests/test_retention_task.py
+++ b/tests/task_integration_tests/test_retention_task.py
@@ -1,0 +1,154 @@
+from datetime import datetime
+
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.retention_eligible_metrics import RetentionEligibleMetrics
+from rdr_service.participant_enums import WithdrawalStatus
+from rdr_service.services.system_utils import DateRange
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class TestRetentionTask(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
+        self.test_client = None
+
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+
+        self._db_factory_mock = self.mock('rdr_service.dao.base_dao.database_factory')
+        self.session_mock = self._db_factory_mock.get_database().session().__enter__()
+
+        # When initialized a DAO automatically tries to connect to the database, and currently there's a task endpoint
+        # that initializes a DAO as part of the class definition. So need to mock the db factory before setting up the
+        # flask app.
+        if not self.test_client:
+            from rdr_service.resource.main import app
+            self.test_client = app.test_client()
+
+        self.existing_record_mock = self.mock(
+            'rdr_service.dao.retention_eligible_metrics_dao.'
+            'RetentionEligibleMetricsDao.get_existing_record'
+        )
+        self.existing_record_mock.return_value = None
+
+        self._ehr_consent_mock = self.mock(
+            'rdr_service.repository.questionnaire_response_repository.'
+            'QuestionnaireResponseRepository.get_interest_in_sharing_ehr_ranges'
+        )
+        self._dna_sample_mock = self.mock(
+            'rdr_service.dao.biobank_stored_sample_dao.'
+            'BiobankStoredSampleDao.get_earliest_confirmed_dna_sample_timestamp'
+        )
+        self.mock('rdr_service.dao.retention_eligible_metrics_dao.RetentionEligibleMetricsDao._submit_rebuild_task')
+        self.summary_update_mock = self.mock(
+            'rdr_service.dao.participant_summary_dao.'
+            'ParticipantSummaryDao.update_with_retention_data'
+        )
+
+        self.temporarily_override_config_setting('enable_retention_calc_task', True)
+
+    def test_basic_insert(self):
+        """
+        Trigger a retention task for a participant that doesn't have retention data yet.
+        """
+        generic_time = datetime.now()
+        summary = ParticipantSummary(
+            participantId=123123123,
+            withdrawalStatus=WithdrawalStatus.NOT_WITHDRAWN,
+            consentForStudyEnrollmentFirstYesAuthored=generic_time,
+            questionnaireOnTheBasicsAuthored=generic_time,
+            questionnaireOnOverallHealthAuthored=generic_time,
+            questionnaireOnLifestyleAuthored=generic_time,
+            wasEhrDataAvailable=True,
+            ehrUpdateTime=generic_time
+        )
+        self._set_mock_summary(summary)
+        self._set_ehr_consent_time(generic_time)
+        self._set_earliest_sample_time(generic_time)
+
+        self._create_retention_update_task(summary.participantId)
+        added_metrics: RetentionEligibleMetrics = self.session_mock.add.call_args[0][0]
+        self.assertTrue(added_metrics.rdr_retention_eligible)
+        self.assertEqual(generic_time, added_metrics.rdr_retention_eligible_time)
+        self.assertTrue(added_metrics.rdr_is_passively_retained)
+
+    def test_basic_update(self):
+        """
+        Trigger a retention task for a participant that has retention data that needs updated
+        """
+
+        self.existing_record_mock.return_value = RetentionEligibleMetrics(
+            rdr_retention_eligible=False
+        )
+
+        generic_time = datetime.now()
+        summary = ParticipantSummary(
+            participantId=123123123,
+            withdrawalStatus=WithdrawalStatus.NOT_WITHDRAWN,
+            consentForStudyEnrollmentFirstYesAuthored=generic_time,
+            questionnaireOnTheBasicsAuthored=generic_time,
+            questionnaireOnOverallHealthAuthored=generic_time,
+            questionnaireOnLifestyleAuthored=generic_time,
+            wasEhrDataAvailable=True,
+            ehrUpdateTime=generic_time
+        )
+        self._set_mock_summary(summary)
+        self._set_ehr_consent_time(generic_time)
+        self._set_earliest_sample_time(generic_time)
+
+        self._create_retention_update_task(summary.participantId)
+
+        self.session_mock.add.assert_not_called()  # New retention data should not be added
+        self.summary_update_mock.assert_called()  # But the participant summary should be updated
+
+    def test_skipping_update(self):
+        """
+        Make sure the process skips any updating of anything if we already have the retention set correctly
+        """
+        generic_time = datetime.now()
+        self.existing_record_mock.return_value = RetentionEligibleMetrics(
+            rdr_retention_eligible=True,
+            rdr_retention_eligible_time=generic_time,
+            rdr_is_actively_retained=False,
+            rdr_is_passively_retained=True
+        )
+
+        summary = ParticipantSummary(
+            participantId=123123123,
+            withdrawalStatus=WithdrawalStatus.NOT_WITHDRAWN,
+            consentForStudyEnrollmentFirstYesAuthored=generic_time,
+            questionnaireOnTheBasicsAuthored=generic_time,
+            questionnaireOnOverallHealthAuthored=generic_time,
+            questionnaireOnLifestyleAuthored=generic_time,
+            wasEhrDataAvailable=True,
+            ehrUpdateTime=generic_time
+        )
+        self._set_mock_summary(summary)
+        self._set_ehr_consent_time(generic_time)
+        self._set_earliest_sample_time(generic_time)
+
+        self._create_retention_update_task(summary.participantId)
+
+        self.session_mock.add.assert_not_called()  # New retention data should not be added
+        self.summary_update_mock.assert_not_called()  # The summary does not need updated if nothing changed
+
+    def _create_retention_update_task(self, participant_id):
+        self.send_post(
+            '/resource/task/UpdateRetentionStatus',
+            {
+                'participant_id': participant_id
+            },
+            test_client=self.test_client,
+            prefix=''
+        )
+
+    def _set_mock_summary(self, summary: ParticipantSummary):
+        self.session_mock.query().get.return_value = summary
+
+    def _set_ehr_consent_time(self, consent_time):
+        self._ehr_consent_mock.return_value = [DateRange(start=consent_time)]
+
+    def _set_earliest_sample_time(self, confirmed_time):
+        self._dna_sample_mock.return_value = confirmed_time


### PR DESCRIPTION
## Partially Resolves *[DA-3967](https://precisionmedicineinitiative.atlassian.net/browse/DA-3967)*
RDR will eventually be taking over the retention status calculations again. This creates a task endpoint that will be called whenever any events occur that would change retention status (such as questionnaire responses). The endpoint will only run once we're fully switched over from importing the retention data.

A follow up PR will be made to have the task endpoint called when needed.


## Tests
- [x] unit tests




[DA-3967]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ