### PR TITLE
[DA-3967] Integrating retention calculation endpoint

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -428,8 +428,9 @@ class UpdateRetentionEligibleStatus(Resource):
                 participant_id=participant_id,
                 session=session
             )
-            RetentionEligibleMetricsDao.upsert_retention_data(
-                participant_id=participant_id,
-                retention_data=retention_data,
-                session=session
-            )
+            if retention_data:
+                RetentionEligibleMetricsDao.upsert_retention_data(
+                    participant_id=participant_id,
+                    retention_data=retention_data,
+                    session=session
+                )

--- a/rdr_service/api/etm_api.py
+++ b/rdr_service/api/etm_api.py
@@ -4,6 +4,7 @@ import logging
 import pytz
 from typing import List
 
+from rdr_service.api_util import dispatch_task
 from rdr_service.cloud_utils.gcp_google_pubsub import submit_pipeline_pubsub_msg
 from rdr_service.lib_fhir.fhirclient_1_0_6.models.questionnaire import Questionnaire as FhirQuestionnaire
 from rdr_service.lib_fhir.fhirclient_1_0_6.models.questionnaireresponse import \
@@ -92,6 +93,8 @@ class EtmApi:
             # etm_questionnaire_response record (don't need submit_pipeline_pubsub_msg_from_model())
             submit_pipeline_pubsub_msg(database='rdr', table='etm_questionnaire_response', action='insert',
                                        pk_columns=['etm_questionnaire_response_id'], pk_values=[response_obj.id])
+
+            dispatch_task(endpoint='update_retention_status', payload={'participant_id': response_obj.participantId})
 
             return {
                 'id': str(response_obj.id),

--- a/rdr_service/api/etm_api.py
+++ b/rdr_service/api/etm_api.py
@@ -94,7 +94,7 @@ class EtmApi:
             submit_pipeline_pubsub_msg(database='rdr', table='etm_questionnaire_response', action='insert',
                                        pk_columns=['etm_questionnaire_response_id'], pk_values=[response_obj.id])
 
-            dispatch_task(endpoint='update_retention_status', payload={'participant_id': response_obj.participantId})
+            dispatch_task(endpoint='update_retention_status', payload={'participant_id': response_obj.participant_id})
 
             return {
                 'id': str(response_obj.id),

--- a/rdr_service/dao/biobank_specimen_dao.py
+++ b/rdr_service/dao/biobank_specimen_dao.py
@@ -1,7 +1,7 @@
 
 from sqlalchemy import or_, and_
 
-from rdr_service.api_util import format_json_date
+from rdr_service.api_util import dispatch_task, format_json_date
 from rdr_service.model.config_utils import from_client_biobank_id, to_client_biobank_id
 from rdr_service.model.participant import Participant
 from rdr_service.api_util import parse_date
@@ -396,6 +396,7 @@ class BiobankSpecimenDao(BiobankDaoBase):
         dao.update_from_biobank_stored_samples(participant_id=participant_id, biobank_ids=[biobank_id], session=session)
 
         dispatch_participant_rebuild_tasks([participant_id])
+        dispatch_task(endpoint='update_retention_status', payload={'participant_id': participant_id})
 
 
 class BiobankSpecimenAttributeDao(BiobankDaoBase):

--- a/rdr_service/dao/deceased_report_dao.py
+++ b/rdr_service/dao/deceased_report_dao.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm.exc import DetachedInstanceError
 from werkzeug.exceptions import BadRequest, NotFound, Conflict, InternalServerError
 
 from rdr_service import config
+from rdr_service.api_util import dispatch_task
 from rdr_service.clock import CLOCK
 from rdr_service.dao.api_user_dao import ApiUserDao
 from rdr_service.dao.base_dao import UpdatableDao
@@ -586,6 +587,8 @@ class DeceasedReportDao(UpdatableDao):
 
             self._update_participant_summary(session, obj)
             insert_result = super(DeceasedReportDao, self).insert_with_session(session, obj)
+            dispatch_task(endpoint='update_retention_status', payload={'participant_id': obj.participantId})
+
             return insert_result
 
     def update_with_session(self, session, obj: DeceasedReport):

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -555,6 +555,10 @@ class QuestionnaireResponseDao(BaseDao):
         )
         if summary:
             ParticipantSummaryDao().update_enrollment_status(summary, session=session)
+            dispatch_task(
+                endpoint='update_retention_status',
+                payload={'participant_id': questionnaire_response.participantId}
+            )
 
         return questionnaire_response
 

--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql import func
 from werkzeug.exceptions import HTTPException, InternalServerError, BadGateway
 
 from rdr_service import config
+from rdr_service.api_util import dispatch_task
 from rdr_service.app_util import datetime_as_naive_utc
 from rdr_service.cloud_utils import bigquery
 from rdr_service.config import GAE_PROJECT
@@ -219,6 +220,9 @@ def update_participant_summaries_from_job(job, project_id=GAE_PROJECT):
                 create_rebuild_tasks_for_participants(
                     list(participant_ids_to_rebuild), batch_size, project_id, summary_dao
                 )
+
+            for participant_id in participant_ids_to_rebuild:
+                dispatch_task(endpoint='update_retention_status', payload={'participant_id': participant_id})
 
     # Rebuild any participants that had the "current" flag set before, but don't now
     # (because they didn't have a file today)


### PR DESCRIPTION
## Resolves *[DA-3967](https://precisionmedicineinitiative.atlassian.net/browse/DA-3967)*
This adds code to call the retention calculation task when it may be updated. Receiving the following data could update a retention status or type for a participant:
- a change to the deceased status
- a change to the withdrawal status
- responses to surveys
- new samples providing DNA
- ETM responses
- new EHR files provided for the participant

## Tests
- [ ] unit tests




[DA-3967]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ