### PR TITLE
[DA-3992] Updates to Biobank received report demographic flags

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -247,13 +247,10 @@ def _build_query_params(start_date: datetime):
 
 def _query_and_write_received_report(exporter, report_path, query_params, report_predicate):
     received_report_select = _RECONCILIATION_REPORT_SELECTS_SQL
-    if config.getSettingJson(config.ENABLE_BIOBANK_MANIFEST_RECEIVED_FLAG, default=False):
-        received_report_select += """,
-            group_concat(ny_flag) ny_flag,
-            group_concat(sex_at_birth_flag) sex_at_birth_flag
-        """
     received_report_select += """,
-        max(is_pediatric) ispediatric
+        max(is_pediatric) ispediatric,
+        group_concat(ny_flag) ny_flag,
+        group_concat(sex_at_birth_flag) sex_at_birth_flag
     """
     logging.info(f"Writing {report_path} report.")
     received_sql = replace_isodate(received_report_select + _RECONCILIATION_REPORT_SOURCE_SQL)
@@ -604,7 +601,7 @@ _RECONCILIATION_REPORT_SOURCE_SQL = (
     case when collected_site.site_id is not null then (case when collected_site.state = 'NY' then 'Y' else 'N' end)
        when mko_state_code.code_id is not null then
             (case when mko_state_code.value like 'state_ny' then 'Y' else 'N' end)
-       else 'NA'
+       else 'NULL'
     end ny_flag,
     case when sex_code.value like 'sexatbirth_male' then 'M'
        when sex_code.value like 'sexatbirth_female' then 'F'

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -601,7 +601,7 @@ _RECONCILIATION_REPORT_SOURCE_SQL = (
     case when collected_site.site_id is not null then (case when collected_site.state = 'NY' then 'Y' else 'N' end)
        when mko_state_code.code_id is not null then
             (case when mko_state_code.value like 'state_ny' then 'Y' else 'N' end)
-       else 'NULL'
+       else ''
     end ny_flag,
     case when sex_code.value like 'sexatbirth_male' then 'M'
        when sex_code.value like 'sexatbirth_female' then 'F'

--- a/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline_mysql.py
@@ -619,7 +619,7 @@ class MySqlReconciliationTest(BaseTestCase):
         # not includes orders/samples from more than 10 days ago;
         # Includes 1 Salivary order
         exporter.assertRowCount(received, 11)
-        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES + ("ispediatric",))
+        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES + ("ispediatric", "ny_flag", "sex_at_birth_flag"))
         row = exporter.assertHasRow(
             received,
             {
@@ -1193,7 +1193,7 @@ class MySqlReconciliationTest(BaseTestCase):
         # sent-and-received: 4 on-time, 2 late, 2 edge, none of the missing/extra/repeated ones;
         # not includes orders/samples from more than 60 days ago
         exporter.assertRowCount(received, 12)
-        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES + ("ispediatric",))
+        exporter.assertColumnNamesEqual(received, _CSV_COLUMN_NAMES + ("ispediatric", "ny_flag", "sex_at_birth_flag"))
         row = exporter.assertHasRow(
             received,
             {


### PR DESCRIPTION
## Resolves *[DA-3992](https://precisionmedicineinitiative.atlassian.net/browse/DA-3992)*
Biobank needs us to move the ny_flag and sex_at_birth_flag to the end of the received report's set of columns before we make them available. They've also asked that we leave the ny_flag value as an empty string if it's not going to be Y or N.


## Tests
- [x] unit tests




[DA-3992]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ