### PR TITLE
Updating AW Manifest Naming Conventions to Accept "_v2"

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1952,7 +1952,7 @@ class GenomicFileValidator:
         def gem_a2_manifest_name_rule():
             """GEM A2 manifest name rule: i.e. AoU_GEM_A2_manifest_2020-07-11-00-00-00.csv"""
             return (
-                len(filename_components) <= 6 and
+                len(filename_components) == 5 and
                 filename_components[0] == 'aou' and
                 filename_components[1] == 'gem' and
                 filename_components[2] == 'a2' and

--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -1939,20 +1939,20 @@ class GenomicFileValidator:
         def aw1f_manifest_name_rule():
             """Biobank to GCs Failure (AW1F) manifest name rule"""
             return (
-                len(filename_components) == 5 and
+                len(filename_components) <= 6 and
                 filename_components[0] in self.VALID_GENOME_CENTERS and
                 filename_components[1] == 'aou' and
                 filename_components[2] in ('seq', 'gen') and
                 re.search(r"pkg-[0-9]{4}-[0-9]{5,}$",
                           filename_components[3]) is not None and
-                filename_components[4] == 'failure.csv' and
+                filename_components[4] in ('failure', 'failure.csv') and
                 filename.lower().endswith('csv')
             )
 
         def gem_a2_manifest_name_rule():
             """GEM A2 manifest name rule: i.e. AoU_GEM_A2_manifest_2020-07-11-00-00-00.csv"""
             return (
-                len(filename_components) == 5 and
+                len(filename_components) <= 6 and
                 filename_components[0] == 'aou' and
                 filename_components[1] == 'gem' and
                 filename_components[2] == 'a2' and

--- a/tests/genomics_tests/test_genomic_file_ingester.py
+++ b/tests/genomics_tests/test_genomic_file_ingester.py
@@ -117,36 +117,48 @@ class GenomicFileIngesterTest(BaseTestCase):
         self.assertEqual(copy_member.blockResearch, 1)
 
     def test_validate_filenames(self):
-        job_controller = GenomicJobController(job_id=GenomicJob.AW1F_MANIFEST)
+        job_controller = GenomicJobController(job_id=0)
 
         file_validator = GenomicFileValidator(
             job_id=job_controller.job_id,
             controller=job_controller
         )
 
-        short_read_job_ids = [GenomicJob.AW1F_MANIFEST,
-                              GenomicJob.AW1_MANIFEST,
-                              GenomicJob.METRICS_INGESTION,
-                              GenomicJob.AW4_ARRAY_WORKFLOW,
-                              GenomicJob.AW4_WGS_WORKFLOW]
-
-        file_list = {
-            GenomicJob.AW1F_MANIFEST: ['UW_AoU_GEN_PKG-1234-567890_FAILURE.csv',
-                                       'UW_AoU_SEQ_PKG-1234-567890_FAILURE_v2.csv'],
-            GenomicJob.AW1_MANIFEST: ['UW_AoU_SEQ_PKG-1234-567890.csv',
-                                      'UW_AoU_GEN_PKG-1234-567890_v2.csv'],
-            GenomicJob.METRICS_INGESTION: ['UW_AoU_GEN_DataManifest_01234567_890.csv',
-                                           'UW_AoU_SEQ_DataManifest_01234567_890_v2.csv'],
-            GenomicJob.AW4_ARRAY_WORKFLOW: ['AoU_DRCB_GEN_2020-07-11-00-00-00.csv',
-                                            'AoU_DRCB_GEN_2020-07-11-00-00-00_v2.csv'],
-            GenomicJob.AW4_WGS_WORKFLOW: ['AoU_DRCB_SEQ_2020-07-11-00-00-00.csv',
-                                          'AoU_DRCB_SEQ_2020-07-11-00-00-00_v2.csv']
+        short_read_map = {
+            GenomicJob.AW1F_MANIFEST: {
+                'valid': ['UW_AoU_GEN_PKG-1234-567890_FAILURE.csv', 'UW_AoU_SEQ_PKG-1234-567890_FAILURE_v2.csv'],
+                'invalid': ['UW_AoU_GEN_PKG-1234-567890_FAILURE-v2.csv', 'UW_AoU_SEQ_PKG-1234-567890_FAILURE.v2.csv']
+            },
+            GenomicJob.AW1_MANIFEST: {
+                'valid': ['UW_AoU_SEQ_PKG-1234-567890.csv', 'UW_AoU_GEN_PKG-1234-567890_v2.csv'],
+                'invalid': ['UW_AoU_SEQ_PKG-1234-567890.pdf', 'UW_AoU_ABC_PKG-1234-567890_v2.csv']
+            },
+            GenomicJob.METRICS_INGESTION: {
+                'valid': ['UW_AoU_GEN_DataManifest_01234567_890.csv', 'UW_AoU_SEQ_DataManifest_01234567_890_v2.csv'],
+                'invalid': ['AB_AoU_GEN_DataManifest_01234567_890.csv', 'UW_SEQ_DataManifest_01234567_890_v2.csv']
+            },
+            GenomicJob.AW4_ARRAY_WORKFLOW: {
+                'valid': ['AoU_DRCB_GEN_2020-07-11-00-00-00.csv', 'AoU_DRCB_GEN_2020-07-11-00-00-00_v2.csv'],
+                'invalid': ['AU_DRCB_GEN_2020-07-11-00-00-00.csv', 'AoU_DRAB_GEN_2020-07-11-00-00-00_v2.csv']
+            },
+            GenomicJob.AW4_WGS_WORKFLOW: {
+                'valid': ['AoU_DRCB_SEQ_2020-07-11-00-00-00.csv', 'AoU_DRCB_SEQ_2020-07-11-00-00-00_v2.csv'],
+                'invalid': ['AoU_DRCB_GEN_2020-07-11-00-00-00.csv', 'AoU_DRCB_SEQ_2020-07-11-00-00-00_v2.pdf']
+            },
+            GenomicJob.AW5_ARRAY_MANIFEST: {
+                'valid': ['AoU_DRCB_GEN_0000-00-00-00-00-00.csv', 'AoU_DRCB_GEN_0000-00-00-00-00-00_v2.csv'],
+                'invalid': ['AoU_DRCB_GEN_0000-00-00-00-00-00.json']
+            },
+            GenomicJob.AW5_WGS_MANIFEST: {
+                'valid': ['AoU_DRCB_SEQ_0000-00-00-00-00-00.csv', 'AoU_DRCB_SEQ_0000-00-00-00-00-00_v2.csv'],
+                'invalid': ['AoU_DRCB_SEQ_0000-00-00-00-00-00.txt']
+            }
         }
 
-        self.assertFalse(file_validator.validate_filename('UW_AoU_GEN_PKG-1234-567890_FAILURE-v2.csv'))
-        self.assertFalse(file_validator.validate_filename('UW_AoU_SEQ_PKG-1234-567890_FAILURE.v2.csv'))
-
-        for job_id in short_read_job_ids:
+        for job_id in short_read_map:
             file_validator.job_id = job_id
-            for file in file_list[job_id]:
-                self.assertTrue(file_validator.validate_filename(file))
+            for valid_file in short_read_map[job_id]['valid']:
+                self.assertTrue(file_validator.validate_filename(valid_file))
+
+            for invalid_file in short_read_map[job_id]['invalid']:
+                self.assertFalse(file_validator.validate_filename(invalid_file))

--- a/tests/genomics_tests/test_genomic_file_ingester.py
+++ b/tests/genomics_tests/test_genomic_file_ingester.py
@@ -134,7 +134,7 @@ class GenomicFileIngesterTest(BaseTestCase):
             GenomicJob.AW1F_MANIFEST: ['UW_AoU_GEN_PKG-1234-567890_FAILURE.csv',
                                        'UW_AoU_SEQ_PKG-1234-567890_FAILURE_v2.csv'],
             GenomicJob.AW1_MANIFEST: ['UW_AoU_SEQ_PKG-1234-567890.csv',
-                                      'UW_AoU_GEN_PKG-1234-567890_2.csv'],
+                                      'UW_AoU_GEN_PKG-1234-567890_v2.csv'],
             GenomicJob.METRICS_INGESTION: ['UW_AoU_GEN_DataManifest_01234567_890.csv',
                                            'UW_AoU_SEQ_DataManifest_01234567_890_v2.csv'],
             GenomicJob.AW4_ARRAY_WORKFLOW: ['AoU_DRCB_GEN_2020-07-11-00-00-00.csv',

--- a/tests/genomics_tests/test_genomic_file_ingester.py
+++ b/tests/genomics_tests/test_genomic_file_ingester.py
@@ -124,36 +124,29 @@ class GenomicFileIngesterTest(BaseTestCase):
             controller=job_controller
         )
 
-        aw1f_files = ['UW_AoU_GEN_PKG-1234-567890_FAILURE.csv',
-                      'UW_AoU_GEN_PKG-1234-567890_FAILURE_v2.csv',
-                      'UW_AoU_GEN_PKG-1234-567890_FAILURE-v2.csv',
-                      'UW_AoU_GEN_PKG-1234-567890_FAILURE.v2.csv']
-        aw2_files = ['AoU_GEM_A2_manifest_2020-07-11.csv',
-                     'AoU_GEM_A2_manifest_2020-07-11_v2.csv']
-        aw4_arr_files = ['AoU_DRCB_GEN_2020-07-11-00-00-00.csv',
-                         'AoU_DRCB_GEN_2020-07-11-00-00-00_v2.csv']
-        aw4_wgs_files = ['AoU_DRCB_SEQ_2020-07-11-00-00-00.csv',
-                         'AoU_DRCB_SEQ_2020-07-11-00-00-00_v2.csv']
+        short_read_job_ids = [GenomicJob.AW1F_MANIFEST,
+                              GenomicJob.AW1_MANIFEST,
+                              GenomicJob.METRICS_INGESTION,
+                              GenomicJob.AW4_ARRAY_WORKFLOW,
+                              GenomicJob.AW4_WGS_WORKFLOW]
 
-        expected = [True, True, False, False,
-                    True, True,
-                    True, True,
-                    True, True]
-        actual = []
+        file_list = {
+            GenomicJob.AW1F_MANIFEST: ['UW_AoU_GEN_PKG-1234-567890_FAILURE.csv',
+                                       'UW_AoU_SEQ_PKG-1234-567890_FAILURE_v2.csv'],
+            GenomicJob.AW1_MANIFEST: ['UW_AoU_SEQ_PKG-1234-567890.csv',
+                                      'UW_AoU_GEN_PKG-1234-567890_2.csv'],
+            GenomicJob.METRICS_INGESTION: ['UW_AoU_GEN_DataManifest_01234567_890.csv',
+                                           'UW_AoU_SEQ_DataManifest_01234567_890_v2.csv'],
+            GenomicJob.AW4_ARRAY_WORKFLOW: ['AoU_DRCB_GEN_2020-07-11-00-00-00.csv',
+                                            'AoU_DRCB_GEN_2020-07-11-00-00-00_v2.csv'],
+            GenomicJob.AW4_WGS_WORKFLOW: ['AoU_DRCB_SEQ_2020-07-11-00-00-00.csv',
+                                          'AoU_DRCB_SEQ_2020-07-11-00-00-00_v2.csv']
+        }
 
-        for f in aw1f_files:
-            actual.append(file_validator.validate_filename(f))
+        self.assertFalse(file_validator.validate_filename('UW_AoU_GEN_PKG-1234-567890_FAILURE-v2.csv'))
+        self.assertFalse(file_validator.validate_filename('UW_AoU_SEQ_PKG-1234-567890_FAILURE.v2.csv'))
 
-        file_validator.job_id = GenomicJob.GEM_A2_MANIFEST
-        for f in aw2_files:
-            actual.append(file_validator.validate_filename(f))
-
-        file_validator.job_id = GenomicJob.AW4_ARRAY_WORKFLOW
-        for f in aw4_arr_files:
-            actual.append(file_validator.validate_filename(f))
-
-        file_validator.job_id = GenomicJob.AW4_WGS_WORKFLOW
-        for f in aw4_wgs_files:
-            actual.append(file_validator.validate_filename(f))
-
-        self.assertEqual(expected, actual)
+        for job_id in short_read_job_ids:
+            file_validator.job_id = job_id
+            for file in file_list[job_id]:
+                self.assertTrue(file_validator.validate_filename(file))


### PR DESCRIPTION
## Resolves *[DA-3996](https://precisionmedicineinitiative.atlassian.net/browse/DA-3996)*


## Description of changes/additions
* Updated the AW1F and AW2 manifests to accept "_v2". All other AW manifests that are validated can accept "_v2" in the naming conventions with no changes.
* Added unit tests to verify that manifests with and without "_v2" will be accepted

## Tests
- [X] unit tests




[DA-3996]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ