### PR TITLE
Gracefully handling unconsented guardian in consent validation

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -971,7 +971,7 @@ class ConsentValidator:
         if guardian_id_list:
             guardian_summary = self._session.query(
                 ParticipantSummary.firstName, ParticipantSummary.lastName
-            ).filter(ParticipantSummary.participantId == guardian_id_list.pop()).one()
+            ).filter(ParticipantSummary.participantId == guardian_id_list.pop()).one_or_none()
 
         # compare first and last name to parsed string
         if (


### PR DESCRIPTION
## Resolves *no ticket*
We're occasionally seeing a pediatric participant get assigned to a guardian that doesn't have a primary consent. This updates the consent validation process to be able to handle that scenario well.

## Tests
- [ ] unit tests


