### PR TITLE
[DA-4038] Masking 3.2 PMB_ELIGIBLE status

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -171,9 +171,9 @@ CE_HEALTH_DATA_BUCKET_NAME = "ce_health_data_bucket_name"
 VA_WORKQUEUE_BUCKET_NAME = 'va_workqueue_bucket_name'
 VA_WORKQUEUE_SUBFOLDER = 'va_workqueue_subfolder'
 OPS_DATA_PAYLOAD_ROLES = 'ops_data_payload_roles'
-ENABLE_ENROLLMENT_STATUS_3 = 'enable_enrollment_status_3'
 ENABLE_HEALTH_SHARING_STATUS_3 = 'enable_health_sharing_status_3'
 ENABLE_PARTICIPANT_MEDIATED_EHR = 'enable_participant_mediated_ehr'
+ENABLED_STATUS_FIELD_LIST = 'enabled_status_field_list'
 NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP = 'nph_sample_data_biobank_bucket_name'
 CE_MEDIATED_HPO_ID='ce_mediated_hpo_id'
 

--- a/rdr_service/config/config_dev.json
+++ b/rdr_service/config/config_dev.json
@@ -180,7 +180,17 @@
     "stable-nph-sample-data-biobank"
   ],
   "sensitive_ehr_release_date": "2100-01-01",
-  "enable_enrollment_status_3": true,
+  "enabled_status_field_list": [
+    "enrollmentStatusV3_2",
+    "enrollmentStatusParticipantV3_2Time",
+    "enrollmentStatusParticipantPlusEhrV3_2Time",
+    "enrollmentStatusEnrolledParticipantV3_2Time",
+    "enrollmentStatusPmbEligibleV3_2Time",
+    "enrollmentStatusCoreMinusPmV3_2Time",
+    "enrollmentStatusCoreV3_2Time",
+    "hasCoreData",
+    "hasCoreDataTime"
+  ],
   "enable_health_sharing_status_3": true,
   "enable_participant_mediated_ehr": true
 }

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1430,21 +1430,29 @@ class ParticipantSummaryDao(UpdatableDao):
             result["physicalMeasurementsFinalizedSite"] = "UNSET"
             result["physicalMeasurementsCollectType"] = str(PhysicalMeasurementsCollectType.SELF_REPORTED)
 
-        # Check to see if we should hide 3.0 and 3.2 fields
-        if not config.getSettingJson(config.ENABLE_ENROLLMENT_STATUS_3, default=False):
-            del result['enrollmentStatusV3_2']
-            for field_name in [
-                'enrollmentStatusParticipantV3_2Time',
-                'enrollmentStatusParticipantPlusEhrV3_2Time',
-                'enrollmentStatusEnrolledParticipantV3_2Time',
-                'enrollmentStatusPmbEligibleV3_2Time',
-                'enrollmentStatusCoreMinusPmV3_2Time',
-                'enrollmentStatusCoreV3_2Time',
-                'hasCoreData',
-                'hasCoreDataTime'
-            ]:
-                if field_name in result:
-                    del result[field_name]
+        # Check to see if we should hide 3.2 fields
+        enabled_status_fields = config.getSettingJson(config.ENABLED_STATUS_FIELD_LIST, default=[])
+        for status_field_name in [
+            'enrollmentStatusV3_2',
+            'enrollmentStatusParticipantV3_2Time',
+            'enrollmentStatusParticipantPlusEhrV3_2Time',
+            'enrollmentStatusEnrolledParticipantV3_2Time',
+            'enrollmentStatusPmbEligibleV3_2Time',
+            'enrollmentStatusCoreMinusPmV3_2Time',
+            'enrollmentStatusCoreV3_2Time',
+            'hasCoreData',
+            'hasCoreDataTime'
+        ]:
+            if (
+                status_field_name in result
+                and status_field_name not in enabled_status_fields
+            ):
+                del result[status_field_name]
+                if (
+                    status_field_name == 'enrollmentStatusPmbEligibleV3_2Time'
+                    and result.get('enrollmentStatusV3_2') == str(EnrollmentStatusV32.PMB_ELIGIBLE)
+                ):
+                    result['enrollmentStatusV3_2'] = str(EnrollmentStatusV32.ENROLLED_PARTICIPANT)
 
         # Check to see if we should hide digital health sharing fields
         if not config.getSettingJson(config.ENABLE_HEALTH_SHARING_STATUS_3, default=False):

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -3868,7 +3868,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.session.commit()
 
         # Override the default config, disabling the fields on the API
-        self.temporarily_override_config_setting(config.ENABLE_ENROLLMENT_STATUS_3, False)
+        self.temporarily_override_config_setting(config.ENABLED_STATUS_FIELD_LIST, [])
         self.temporarily_override_config_setting(config.ENABLE_HEALTH_SHARING_STATUS_3, False)
 
         # Check that the new fields are hidden


### PR DESCRIPTION
## Resolves *[DA-4038](https://precisionmedicineinitiative.atlassian.net/browse/DA-4038)*
We need to be able to mask the PMB_ELIGIBLE status as it's still being defined in 3.2.

## Description of changes/additions
This removes a set of status fields that are blocked by the config, and if the PMB_ELIGIBLE time field is is removed then the enrollment status is displayed as the previous status.

## Tests
- [x] unit tests




[DA-4038]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ