### PR TITLE
Avoiding participant summary check when creating new accounts

### DIFF
--- a/rdr_service/api/participant_api.py
+++ b/rdr_service/api/participant_api.py
@@ -26,7 +26,7 @@ class ParticipantApi(UpdatableApi):
         response, *_ = super(ParticipantApi, self).post()
 
         participant_id = from_client_participant_id(response['participantId'])
-        self._check_for_pediatric_update(participant_id)
+        self._check_for_pediatric_update(participant_id, check_for_summary=False)
         dispatch_task(endpoint='update_retention_status', payload={'participant_id': participant_id})
 
         return response, *_
@@ -39,13 +39,14 @@ class ParticipantApi(UpdatableApi):
 
         return response
 
-    def _check_for_pediatric_update(self, participant_id):
+    def _check_for_pediatric_update(self, participant_id, check_for_summary=True):
         pediatric_age_range_field = 'childAccountType'
         request_json = self.get_request_json()
         if pediatric_age_range_field in request_json:
             PediatricDataLogDao.record_age_range(
                 participant_id=participant_id,
-                age_range_str=request_json[pediatric_age_range_field]
+                age_range_str=request_json[pediatric_age_range_field],
+                check_for_summary=check_for_summary
             )
 
 

--- a/rdr_service/dao/pediatric_data_log_dao.py
+++ b/rdr_service/dao/pediatric_data_log_dao.py
@@ -13,7 +13,9 @@ from rdr_service.participant_enums import PediatricAgeRange
 class PediatricDataLogDao:
     @classmethod
     @with_session
-    def record_age_range(cls, participant_id: int, age_range_str: str, session: Session):
+    def record_age_range(
+        cls, participant_id: int, age_range_str: str, session: Session, check_for_summary: bool = True
+    ):
         if age_range_str == 'UNSET':
             # non-pediatric participants will get UNSET sent as their age range.
             # No need to record or log these as an error
@@ -29,7 +31,7 @@ class PediatricDataLogDao:
                 value=age_range_str
             ),
             session=session,
-            callback=cls._check_new_pediatric_participant
+            callback=cls._check_new_pediatric_participant if check_for_summary else None
         )
 
     @classmethod

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -815,7 +815,8 @@ class ParticipantApiTest(BaseTestCase, PDRGeneratorTestMixin):
         })
         pediatric_dao_mock.record_age_range.assert_called_with(
             participant_id=from_client_participant_id(response['participantId']),
-            age_range_str='TEEN'
+            age_range_str='TEEN',
+            check_for_summary=False
         )
 
     @mock.patch('rdr_service.api.participant_api.PediatricDataLogDao')
@@ -830,7 +831,8 @@ class ParticipantApiTest(BaseTestCase, PDRGeneratorTestMixin):
 
         pediatric_dao_mock.record_age_range.assert_called_with(
             participant_id=participant.participantId,
-            age_range_str='SIX_AND_BELOW'
+            age_range_str='SIX_AND_BELOW',
+            check_for_summary=True
         )
 
     @mock.patch('rdr_service.dao.pediatric_data_log_dao.PediatricDataLogDao._check_new_pediatric_participant')

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -833,6 +833,17 @@ class ParticipantApiTest(BaseTestCase, PDRGeneratorTestMixin):
             age_range_str='SIX_AND_BELOW'
         )
 
+    @mock.patch('rdr_service.dao.pediatric_data_log_dao.PediatricDataLogDao._check_new_pediatric_participant')
+    def test_participant_post_skips_summary_update(self, summary_update_mock):
+        """
+        POSTing new participant data wouldn't need to update a participant summary.
+        """
+        self.send_post('Participant', {
+            'childAccountType': 'SIX_AND_BELOW'
+        })
+        summary_update_mock.assert_not_called()
+
+
 def _add_code_answer(code_answers, link_id, code):
     if code:
         code_answers.append((link_id, Concept(PPI_SYSTEM, code)))


### PR DESCRIPTION
## Resolves *no ticket*
Yesterday night an issue was encountered when trying to generate a batch of test pediatric participants. When receiving that an account is a pediatric account, the code currently looks to the participant summary table to see if a modified date needs to be updated. Currently the EHR file data ingestion process makes its own long running batch updates to the participant summary table. So when these account creation requests were being processed, the check on the participant summary table timed out.

## Description of changes/additions
Since a POST to the Participant endpoint wouldn't need to update any participant summaries (because POSTs have to happen for accounts before they can be consented), the participant summary check can be skipped.

## Tests
- [x] unit tests


