### PR TITLE
Updating participant summary documentation for pediatric fields

### DIFF
--- a/doc/_ext/rdrhtml.py
+++ b/doc/_ext/rdrhtml.py
@@ -15,6 +15,13 @@ class RdrHtml5Translator(HTML5Translator):
         # class or function signature. Leaving them out to simplify the look and feel of the documentation.
         self._is_visiting_complex_signature = len(node.children) > 2
 
+        if node.attributes['fullname'] == 'ParticipantSummary.isPediatric':
+            # Need to modify the isPediatric output
+            self._is_visiting_complex_signature = False
+            node.children = [node.children[1]]  # remove "property" and "bool" tags
+        elif len(node.children) == 2:
+            node.children = [node.children[0]]  # remove data type if specified in the code
+
         if not self._is_visiting_complex_signature:
             super(RdrHtml5Translator, self).visit_desc_signature(node)
         else:

--- a/doc/api_workflows/field_reference/participant_summary_field_list.rst
+++ b/doc/api_workflows/field_reference/participant_summary_field_list.rst
@@ -11,4 +11,5 @@ Participant Summary Field List
                       biospecimenProcessedSiteId, biospecimenFinalizedSiteId, participant, enrollmentSiteId,
                       enrollmentStatusV3_2, enrollmentStatusParticipantV3_2Time,
                       enrollmentStatusParticipantPlusEhrV3_2Time, enrollmentStatusEnrolledParticipantV3_2Time,
-                      enrollmentStatusCoreMinusPmV3_2Time, enrollmentStatusCoreV3_2Time
+                      enrollmentStatusCoreMinusPmV3_2Time, enrollmentStatusCoreV3_2Time, pediatricData,
+                      did_submit_environmental_exposures

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -1793,6 +1793,21 @@ class ParticipantSummary(Base):
         uselist=True,
         lazy='noload'
     )
+    """
+    For a pediatric participant's summary, provides a list of guardians associated with the pediatric participant.
+
+    Will provide the following data for guardians linked to the pediatric participant:
+
+    .. code-block:: json
+
+        "relatedParticipants": [
+            {
+                "participantId": "P123456789",    // Participant ID of the guardian account
+                "firstName": "Jane",              // First name of the associated guardian
+                "lastName": "Smith"               // Last name of the associated guardian
+            }
+        ]
+    """
 
     pediatricData: List[PediatricDataLog] = relationship(
         'PediatricDataLog',


### PR DESCRIPTION
## Resolves *no ticket*
This updates the automated documentation for participant summary so some pediatric fields are reflected. I had missed adding the description for `relatedParticipants`, and the property for `isPediatric` wasn't rendering correctly.

And `pediatricData` and `did_submit_environmental_exposures` need to be ignored, as they don't appear on the API.

## Tests
- [ ] unit tests


