### PR TITLE
[PDR-2277] Ensure Pub/Sub events for PUT requests

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -436,10 +436,10 @@ class UpdatableApi(BaseApi):
                 raise BadRequest("If-Match is missing for PUT request")
             expected_version = self.parse_etag(etag)
         m = self._get_model_to_update(resource, id_, expected_version, participant_id)
-        m_with_pk = self._do_update(m)
+        self._do_update(m)
 
         # Support RDR to PDR pipeline
-        submit_pipeline_pubsub_msg_from_model(m_with_pk, self.dao.get_connection_database_name())
+        submit_pipeline_pubsub_msg_from_model(m, self.dao.get_connection_database_name())
 
         # TODO: Delete this block after RDR to PDR pipeline is in production.
         if participant_id or (m and hasattr(m, 'participantId')):


### PR DESCRIPTION
## Resolves *[PDR-2277](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2277)*


## Description of changes/additions
* Ensure Pub/Sub messages are created for PUT requests
* Update PDR Participant Generator to correctly identify Pediatric participants when Participant Summary record does not exist. 

## Tests
- [X] unit tests




[PDR-2277]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ