### PR TITLE
[DA-4071] Bug fix for ny_flag on the Biobank received report

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -685,7 +685,7 @@ _RECONCILIATION_REPORT_SOURCE_SQL = (
       NULL edited_cancelled_restored_site_reason,
       NULL order_origin,
       participant.participant_origin,
-      'NA' ny_flag,
+      '' ny_flag,
       case when sex_code.value like 'sexatbirth_male' then 'M'
            when sex_code.value like 'sexatbirth_female' then 'F'
            else 'NA'


### PR DESCRIPTION
## Resolves *[DA-4071](https://precisionmedicineinitiative.atlassian.net/browse/DA-4071)*
In a previous ticket I missed another location that sets the default for the ny_flag on the Biobank received report. This updates that other default to show an empty string rather than the NA.


## Tests
- [ ] unit tests




[DA-4071]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ