### PR TITLE
[DA-4077] Updating detection of checkmark for gror validation

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -531,7 +531,7 @@ class GrorConsentFile(ConsentFile, ABC):
     def is_confirmation_selected(self):
         for element in self._get_confirmation_check_elements():
             for child in element:
-                if isinstance(child, LTCurve):
+                if isinstance(child, LTCurve) or child.get_text() == '4':
                     return True
 
         return False


### PR DESCRIPTION
## Resolves *[DA-4077](https://precisionmedicineinitiative.atlassian.net/browse/DA-4077)*
Vibrent made an update to how they're embedding the checkmark on the GROR consent. This updates our validation process to recognize the new checkmark.


## Tests
- [ ] unit tests




[DA-4077]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ