### PR TITLE
[DA-3877] Implementing related person api for pediatric account linkage

### DIFF
--- a/rdr_service/api/related_person_api.py
+++ b/rdr_service/api/related_person_api.py
@@ -1,0 +1,36 @@
+
+from flask_restful import Resource
+
+from rdr_service.api.base_api import ApiUtilMixin
+from rdr_service.api_util import PTC
+from rdr_service.app_util import auth_required
+from rdr_service.clock import CLOCK
+from rdr_service.dao.account_link_dao import AccountLinkDao
+from rdr_service.lib_fhir.fhirclient_4_0_0.models.relatedperson import RelatedPerson
+from rdr_service.model.account_link import AccountLink
+from rdr_service.model.utils import from_client_participant_id
+
+
+class RelatedPersonApi(Resource, ApiUtilMixin):
+    @auth_required(PTC)
+    def post(self):
+        json = self.get_request_json()
+        related_person = RelatedPerson(json)
+
+        link_start = related_person.period.start.isostring if related_person.period.start else CLOCK.now()
+        link_end = related_person.period.end.isostring if related_person.period.end else None
+        child_pid = from_client_participant_id(related_person.patient.reference.split('/')[1])
+        guardian_pid = from_client_participant_id(related_person.identifier[0].value)
+
+        AccountLinkDao.save_account_link(
+            AccountLink(
+                created=CLOCK.now(),
+                modified=CLOCK.now(),
+                start=link_start,
+                end=link_end,
+                participant_id=child_pid,
+                related_id=guardian_pid
+            )
+        )
+
+        return json

--- a/rdr_service/dao/account_link_dao.py
+++ b/rdr_service/dao/account_link_dao.py
@@ -18,12 +18,18 @@ class AccountLinkDao:
         ).all()
         if not results:
             session.add(account_link)
+        else:
+            for result in results:
+                result.modified = CLOCK.now()
+                result.start = account_link.start
+                result.end = account_link.end
 
-            summary: ParticipantSummary = session.query(ParticipantSummary).filter(
-                ParticipantSummary.participantId == account_link.participant_id
-            ).one_or_none()
-            if summary:
-                summary.lastModified = CLOCK.now()
+        summary: ParticipantSummary = session.query(ParticipantSummary).filter(
+            ParticipantSummary.participantId == account_link.participant_id
+        ).one_or_none()
+        if summary:
+            summary.lastModified = CLOCK.now()
+
 
     @classmethod
     @with_session

--- a/rdr_service/main.py
+++ b/rdr_service/main.py
@@ -40,6 +40,7 @@ from rdr_service.api.questionnaire_api import QuestionnaireApi
 from rdr_service.api.questionnaire_response_api import ParticipantQuestionnaireAnswers, QuestionnaireResponseApi
 from rdr_service.api.organization_hierarchy_api import OrganizationHierarchyApi
 from rdr_service.api.workbench_api import WorkbenchWorkspaceApi, WorkbenchResearcherApi
+from rdr_service.api.related_person_api import RelatedPersonApi
 from rdr_service.api.research_projects_directory_api import ResearchProjectsDirectoryApi
 from rdr_service.api.redcap_workbench_audit_api import RedcapResearcherAuditApi, RedcapWorkbenchAuditApi
 from rdr_service.api.message_broker_api import MessageBrokerApi
@@ -347,6 +348,13 @@ api.add_resource(
     api_util.get_versioned_url_prefix(version=1) + 'Participant/ProfileUpdate',
     api_util.get_versioned_url_prefix(version=1) + 'Patient',
     endpoint='profile_update',
+    methods=['POST']
+)
+
+api.add_resource(
+    RelatedPersonApi,
+    api_util.get_versioned_url_prefix(version=1) + 'RelatedPerson',
+    endpoint='related_person',
     methods=['POST']
 )
 

--- a/tests/api_tests/test_related_person.py
+++ b/tests/api_tests/test_related_person.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+from rdr_service.clock import FakeClock
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class RelatedPersonApiTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs):
+        super().setUp(*args, **kwargs)
+        self.dao_mock = self.mock('rdr_service.api.related_person_api.AccountLinkDao')
+
+    def test_sending_link(self):
+        now_timestamp = datetime.now()
+        child_pid = 987654321
+        guardian_pid = 123456789
+
+        with FakeClock(now_timestamp):
+            self.send_post(
+                'RelatedPerson',
+                request_data={
+                    "resourceType": "RelatedPerson",
+                    "identifier": [
+                        {"value": f"P{guardian_pid}"}
+                    ],
+                    "period": {
+                        "start": "2023-08-01"
+                    },
+                    "patient": {
+                        "reference": f"Patient/P{child_pid}"
+                    }
+                }
+            )
+
+        saved_link = self.dao_mock.save_account_link.call_args[0][0]
+        self.assertEqual(now_timestamp, saved_link.created)
+        self.assertEqual(now_timestamp, saved_link.modified)
+        self.assertEqual('2023-08-01', saved_link.start)
+        self.assertIsNone(saved_link.end)
+        self.assertEqual(child_pid, saved_link.participant_id)
+        self.assertEqual(guardian_pid, saved_link.related_id)
+
+    def test_updating_with_end(self):
+        now_timestamp = datetime.now()
+        child_pid = 987654321
+        guardian_pid = 123456789
+
+        with FakeClock(now_timestamp):
+            self.send_post(
+                'RelatedPerson',
+                request_data={
+                    "resourceType": "RelatedPerson",
+                    "identifier": [
+                        {"value": f"P{guardian_pid}"}
+                    ],
+                    "period": {
+                        "start": "2023-08-01",
+                        "end": "2023-10-01"
+                    },
+                    "patient": {
+                        "reference": f"Patient/P{child_pid}"
+                    }
+                }
+            )
+
+        saved_link = self.dao_mock.save_account_link.call_args[0][0]
+        self.assertEqual('2023-10-01', saved_link.end)

--- a/tests/dao_tests/test_account_link_dao.py
+++ b/tests/dao_tests/test_account_link_dao.py
@@ -73,3 +73,32 @@ class AccountLinkDaoTest(BaseTestCase):
             )
 
         self.assertEqual(timestamp, pediatric_summary.lastModified)
+
+    def test_upsert(self):
+        """Saving a link should update the current data if one already exists"""
+        parent_id = self.data_generator.create_database_participant().participantId
+        child_id = self.data_generator.create_database_participant().participantId
+
+        # Create the initial link
+        AccountLinkDao.save_account_link(
+            account_link=AccountLink(
+                participant_id=child_id, related_id=parent_id,
+                start=datetime(2020, 10, 1)
+            )
+        )
+
+        # Make an update
+        saved_end_date = datetime(2021, 12, 1)
+        AccountLinkDao.save_account_link(
+            account_link=AccountLink(
+                participant_id=child_id, related_id=parent_id,
+                start=datetime(2020, 10, 1),
+                end=saved_end_date
+            )
+        )
+
+        account_link = self.session.query(AccountLink).filter(
+            AccountLink.participant_id == child_id,
+            AccountLink.related_id == parent_id
+        ).one()
+        self.assertEqual(saved_end_date, account_link.end)


### PR DESCRIPTION
## Resolves *[DA-3877](https://precisionmedicineinitiative.atlassian.net/browse/DA-3877)*
Vibrent will be sending pediatric guardian data using the RelatedPerson FHIR structure. This sets up an endpoint to read the linkage data and create or update records in the database based on what we get.


## Tests
- [x] unit tests




[DA-3877]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ