### PR TITLE
Fixing demographic flag aggregation in received reports

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -249,8 +249,8 @@ def _query_and_write_received_report(exporter, report_path, query_params, report
     received_report_select = _RECONCILIATION_REPORT_SELECTS_SQL
     received_report_select += """,
         max(is_pediatric) ispediatric,
-        group_concat(ny_flag) ny_flag,
-        group_concat(sex_at_birth_flag) sex_at_birth_flag
+        group_concat(distinct ny_flag) ny_flag,
+        group_concat(distinct sex_at_birth_flag) sex_at_birth_flag
     """
     logging.info(f"Writing {report_path} report.")
     received_sql = replace_isodate(received_report_select + _RECONCILIATION_REPORT_SOURCE_SQL)


### PR DESCRIPTION
## Resolves *no ticket*
Latest Biobank received report had a row that gave the ny_flag value as "N,N" (rather than just "N"). The other group_by functions on the report use distinct, so this PR updates the demographic flags to match.


## Tests
- [ ] unit tests


