### PR TITLE
Updating W1IL manifest generation to pull from 3.4.12 and 3.7.8 pipelines

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -178,6 +178,11 @@ ENABLED_STATUS_FIELD_LIST = 'enabled_status_field_list'
 NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP = 'nph_sample_data_biobank_bucket_name'
 CE_MEDIATED_HPO_ID='ce_mediated_hpo_id'
 
+GENOMICS_SITES_DATA_BUCKETS = {
+    "bcm": "prod-genomics-data-baylor",
+    "co": "prod-genomics-data-color",
+    "uw": "prod-genomics-data-northwest"
+}
 # Buckets to listen for Pub/Sub notifications
 PUBSUB_NOTIFICATION_BUCKETS_PROD = [
     "prod-genomics-baylor",

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -181,6 +181,7 @@ CE_MEDIATED_HPO_ID='ce_mediated_hpo_id'
 GENOMICS_SITES_DATA_BUCKETS = {
     "bcm": "prod-genomics-data-baylor",
     "co": "prod-genomics-data-color",
+    "bi": "prod-genomics-data-color",
     "uw": "prod-genomics-data-northwest"
 }
 # Buckets to listen for Pub/Sub notifications

--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -178,7 +178,7 @@ ENABLED_STATUS_FIELD_LIST = 'enabled_status_field_list'
 NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP = 'nph_sample_data_biobank_bucket_name'
 CE_MEDIATED_HPO_ID='ce_mediated_hpo_id'
 
-GENOMICS_SITES_DATA_BUCKETS = {
+CVL_SITES_DATA_BUCKETS = {
     "bcm": "prod-genomics-data-baylor",
     "co": "prod-genomics-data-color",
     "bi": "prod-genomics-data-color",

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4324,6 +4324,7 @@ class GenomicQueriesDao(BaseDao):
         """
 
         gc_site_id = self.transform_cvl_site_id(cvl_id)
+        gc_site_data_bucket = config.GENOMICS_SITES_DATA_BUCKETS.get(cvl_id)
         previous_w1il_job_field = {
             'pgx': GenomicSetMember.cvlW1ilPgxJobRunId,
             'hdr': GenomicSetMember.cvlW1ilHdrJobRunId
@@ -4340,16 +4341,31 @@ class GenomicQueriesDao(BaseDao):
         informing_loop_subquery = aliased(GenomicInformingLoop, informing_loop_decision_query.subquery())
         pipeline_metrics = aliased(GenomicGCValidationMetrics)
 
+        def get_archive_path(*, file_path):
+            return func.replace(file_path, gc_site_data_bucket, gc_site_data_bucket + '-archive')
+
         with self.session() as session:
             query = session.query(
                 func.concat(get_biobank_id_prefix(), GenomicSetMember.biobankId),
                 GenomicSetMember.sampleId,
-                GenomicGCValidationMetrics.hfVcfPath.label('vcf_raw_path'),
-                GenomicGCValidationMetrics.hfVcfTbiPath.label('vcf_raw_index_path'),
-                GenomicGCValidationMetrics.hfVcfMd5Path.label('vcf_raw_md5_path'),
-                GenomicGCValidationMetrics.gvcfPath.label('gvcf_path'),
-                GenomicGCValidationMetrics.gvcfMd5Path.label('gvcf_md5_path'),
-                GenomicGCValidationMetrics.cramPath.label('cram_name'),
+                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                        get_archive_path(file_path=GenomicGCValidationMetrics.hfVcfPath),
+                        GenomicGCValidationMetrics.hfVcfPath).label('vcf_raw_path'),
+                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                        get_archive_path(file_path=GenomicGCValidationMetrics.hfVcfTbiPath),
+                        GenomicGCValidationMetrics.hfVcfTbiPath).label('vcf_raw_index_path'),
+                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                        get_archive_path(file_path=GenomicGCValidationMetrics.hfVcfMd5Path),
+                        GenomicGCValidationMetrics.hfVcfMd5Path).label('vcf_raw_md5_path'),
+                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                        get_archive_path(file_path=GenomicGCValidationMetrics.gvcfPath),
+                        GenomicGCValidationMetrics.gvcfPath).label('gvcf_path'),
+                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                        get_archive_path(file_path=GenomicGCValidationMetrics.gvcfMd5Path),
+                        GenomicGCValidationMetrics.gvcfMd5Path).label('gvcf_md5_path'),
+                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                        get_archive_path(file_path=GenomicGCValidationMetrics.cramPath),
+                        GenomicGCValidationMetrics.cramPath).label('cram_name'),
                 GenomicSetMember.sexAtBirth.label('sex_at_birth'),
                 func.IF(
                     GenomicSetMember.nyFlag == 1,
@@ -4378,16 +4394,22 @@ class GenomicQueriesDao(BaseDao):
                     GenomicGCValidationMetrics.genomicSetMemberId == GenomicSetMember.id,
                     GenomicGCValidationMetrics.ignoreFlag != 1
                 )
+            ).outerjoin(
+                GenomicAW4Raw,
+                and_(
+                    GenomicAW4Raw.sample_id == GenomicSetMember.sampleId,
+                    GenomicAW4Raw.ignore_flag != 1,
+                    or_(
+                        GenomicAW4Raw.pipeline_id == GenomicGCValidationMetrics.pipelineId,
+                        and_(
+                            GenomicAW4Raw.pipeline_id == None,
+                            GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_DEPRECATED_WGS_DRAGEN)
+                        )
+                    )
+                )
             ).join(
                 informing_loop_subquery,
                 informing_loop_subquery.participant_id == GenomicSetMember.participantId
-            ).outerjoin(
-                pipeline_metrics,
-                and_(
-                    pipeline_metrics.genomicSetMemberId == GenomicSetMember.id,
-                    pipeline_metrics.ignoreFlag != 1,
-                    pipeline_metrics.pipelineId < GenomicGCValidationMetrics.pipelineId
-                )
             ).filter(
                 GenomicGCValidationMetrics.processingStatus.ilike('pass'),
                 GenomicSetMember.genomeType == config.GENOME_TYPE_WGS,
@@ -4397,13 +4419,14 @@ class GenomicQueriesDao(BaseDao):
                 or_(
                     GenomicGCValidationMetrics.sexConcordance.ilike('true'),
                     GenomicGCValidationMetrics.sexConcordance.ilike('other')
-                ), # check AW2 gives sex concordance as true
-                GenomicGCValidationMetrics.drcSexConcordance.ilike('pass'),  # check AW4 gives sex concordance as true
+                ),  # check AW2 gives sex concordance as true
+                GenomicAW4Raw.drc_sex_concordance.ilike('pass'),
+                GenomicAW4Raw.qc_status.ilike('pass'),
                 GenomicSetMember.qcStatus == GenomicQcStatus.PASS,
                 GenomicSetMember.gcManifestSampleSource.ilike('whole blood'),
                 ParticipantSummary.consentForStudyEnrollment == QuestionnaireStatus.SUBMITTED,
                 ParticipantSummary.consentForGenomicsROR == QuestionnaireStatus.SUBMITTED,
-                GenomicGCValidationMetrics.drcFpConcordance.ilike('pass'),
+                GenomicAW4Raw.drc_fp_concordance.ilike('pass'),
                 GenomicSetMember.diversionPouchSiteFlag != 1,
                 GenomicSetMember.gcSiteId.ilike(gc_site_id),
                 ParticipantSummary.participantOrigin != 'careevolution',
@@ -4415,9 +4438,24 @@ class GenomicQueriesDao(BaseDao):
                 GenomicGCValidationMetrics.hfVcfMd5Path.isnot(None),
                 GenomicGCValidationMetrics.gvcfPath.isnot(None),
                 GenomicGCValidationMetrics.gvcfMd5Path.isnot(None),
-                GenomicGCValidationMetrics.cramPath.isnot(None),
-                pipeline_metrics.id.is_(None)
+                GenomicGCValidationMetrics.cramPath.isnot(None)
             )
+
+            if gc_site_id == 'uw':
+                query = query.outerjoin(
+                    pipeline_metrics,
+                    and_(
+                        pipeline_metrics.genomicSetMemberId == GenomicSetMember.id,
+                        pipeline_metrics.ignoreFlag != 1,
+                        pipeline_metrics.pipelineId < GenomicGCValidationMetrics.pipelineId
+                    )
+                ).filter(
+                    pipeline_metrics.id.is_(None)
+                )
+            else:
+                query = query.filter(
+                    GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_UPDATED_WGS_DRAGEN)
+                )
 
             if sample_ids:
                 query = query.filter(

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4324,7 +4324,7 @@ class GenomicQueriesDao(BaseDao):
         """
 
         gc_site_id = self.transform_cvl_site_id(cvl_id)
-        gc_site_data_bucket = config.GENOMICS_SITES_DATA_BUCKETS.get(cvl_id)
+        gc_site_data_bucket = config.CVL_SITES_DATA_BUCKETS.get(cvl_id)
         previous_w1il_job_field = {
             'pgx': GenomicSetMember.cvlW1ilPgxJobRunId,
             'hdr': GenomicSetMember.cvlW1ilHdrJobRunId

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4348,22 +4348,28 @@ class GenomicQueriesDao(BaseDao):
             query = session.query(
                 func.concat(get_biobank_id_prefix(), GenomicSetMember.biobankId),
                 GenomicSetMember.sampleId,
-                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                func.IF(and_(cvl_id == 'uw',
+                             GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_DEPRECATED_WGS_DRAGEN)),
                         get_archive_path(file_path=GenomicGCValidationMetrics.hfVcfPath),
                         GenomicGCValidationMetrics.hfVcfPath).label('vcf_raw_path'),
-                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                func.IF(and_(cvl_id == 'uw',
+                             GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_DEPRECATED_WGS_DRAGEN)),
                         get_archive_path(file_path=GenomicGCValidationMetrics.hfVcfTbiPath),
                         GenomicGCValidationMetrics.hfVcfTbiPath).label('vcf_raw_index_path'),
-                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                func.IF(and_(cvl_id == 'uw',
+                             GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_DEPRECATED_WGS_DRAGEN)),
                         get_archive_path(file_path=GenomicGCValidationMetrics.hfVcfMd5Path),
                         GenomicGCValidationMetrics.hfVcfMd5Path).label('vcf_raw_md5_path'),
-                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                func.IF(and_(cvl_id == 'uw',
+                             GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_DEPRECATED_WGS_DRAGEN)),
                         get_archive_path(file_path=GenomicGCValidationMetrics.gvcfPath),
                         GenomicGCValidationMetrics.gvcfPath).label('gvcf_path'),
-                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                func.IF(and_(cvl_id == 'uw',
+                             GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_DEPRECATED_WGS_DRAGEN)),
                         get_archive_path(file_path=GenomicGCValidationMetrics.gvcfMd5Path),
                         GenomicGCValidationMetrics.gvcfMd5Path).label('gvcf_md5_path'),
-                func.IF(and_(gc_site_id == 'uw', GenomicGCValidationMetrics.pipelineId.ilike('dragen_3.4.12')),
+                func.IF(and_(cvl_id == 'uw',
+                             GenomicGCValidationMetrics.pipelineId.ilike(config.GENOMIC_DEPRECATED_WGS_DRAGEN)),
                         get_archive_path(file_path=GenomicGCValidationMetrics.cramPath),
                         GenomicGCValidationMetrics.cramPath).label('cram_name'),
                 GenomicSetMember.sexAtBirth.label('sex_at_birth'),
@@ -4441,7 +4447,7 @@ class GenomicQueriesDao(BaseDao):
                 GenomicGCValidationMetrics.cramPath.isnot(None)
             )
 
-            if gc_site_id == 'uw':
+            if cvl_id == 'uw':
                 query = query.outerjoin(
                     pipeline_metrics,
                     and_(

--- a/tests/genomics_tests/test_genomic_cvl_pipeline.py
+++ b/tests/genomics_tests/test_genomic_cvl_pipeline.py
@@ -966,7 +966,7 @@ class GenomicW1ilGenerationTest(ManifestGenerationTestMixin, BaseTestCase):
         validation_metrics_params = validation_metrics_params or {}
         aw4_raw_params = aw4_raw_params or {}
 
-        gc_site_bucket = config.GENOMICS_SITES_DATA_BUCKETS.get(set_member_params.get('gcSiteId')) + '/'
+        gc_site_bucket = config.CVL_SITES_DATA_BUCKETS.get(set_member_params.get('gcSiteId')) + '/'
 
         participant_summary_params = {
             **{
@@ -1120,7 +1120,7 @@ class GenomicW1ilGenerationTest(ManifestGenerationTestMixin, BaseTestCase):
     def expected_w1il_row(cls, set_member: GenomicSetMember, validation_metrics: GenomicGCValidationMetrics,
                           summary: ParticipantSummary):
         if set_member.gcSiteId == 'uw':
-            gc_site_bucket = config.GENOMICS_SITES_DATA_BUCKETS.get(set_member.gcSiteId)
+            gc_site_bucket = config.CVL_SITES_DATA_BUCKETS.get(set_member.gcSiteId)
             return (
                 to_client_biobank_id(set_member.biobankId),
                 str(set_member.sampleId),


### PR DESCRIPTION
## Resolves *[DA-4067](https://precisionmedicineinitiative.atlassian.net/browse/DA-4067)*


## Description of changes/additions
The W1IL manifest workflow is currently set up to pull files from the old pipeline (3.4.12) if they exist and then the new pipeline (3.7.8).
These changes update the W1IL manifest generation to:
* Always pull files from the dragen_3.7.8 pipeline for Color and BCM sites
* Pull from the dragen_3.4.12 pipeline with the correct 'archive' file path first for Northwest site
* Use the AW4 raw table to filter for drc_fp_concordance, drc_sex_concordance, and qc statuses
  * I found that 25 participants have NULL values in the validation metrics table for these fields that do not match the AW4 raw table

## Tests
- [X] unit tests
- Spot-checked the query output




[DA-4067]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ