### PR TITLE
Fixes for pediatric enrollment status

### DIFF
--- a/rdr_service/.configs/current_config.json
+++ b/rdr_service/.configs/current_config.json
@@ -38,7 +38,9 @@
     "2ED10",
     "1ED04",
     "1SAL",
-    "1SAL2"
+    "1SAL2",
+    "2ED02",
+    "2ED04"
   ],
   "native_american_race_codes": [
     "WhatRaceEthnicity_AIAN"

--- a/rdr_service/repository/questionnaire_response_repository.py
+++ b/rdr_service/repository/questionnaire_response_repository.py
@@ -176,7 +176,8 @@ class QuestionnaireResponseRepository:
             session=session,
             survey_codes=[
                 code_constants.CONSENT_FOR_DVEHR_MODULE,
-                code_constants.CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE
+                code_constants.CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE,
+                code_constants.PEDIATRIC_EHR_CONSENT
             ],
             participant_ids=[participant_id],
             classification_types=[


### PR DESCRIPTION
## Resolves *no ticket*
Pediatric enrollment calculations were checking for the ehr question, but weren't loading the EHR module. This updates the code to load their EHR module.

When running the calculation locally, the config needed to be updated to account for the new DNA test codes.

## Tests
- [ ] unit tests


