### PR TITLE
[DA-4069] EHR validation fixes

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -51,9 +51,23 @@ class ConsentDao(BaseDao):
             .join(Participant)
             .outerjoin(
                 ConsentFile,
-                and_(
-                    ConsentFile.type == ConsentResponse.type,
-                    ConsentFile.participant_id == QuestionnaireResponse.participantId
+                or_(
+                    and_(
+                        or_(
+                            ConsentFile.type != ConsentType.EHR,
+                            and_(
+                                ConsentResponse.type == ConsentType.EHR,
+                                QuestionnaireResponse.authored <= '2022-04-01',
+                            )
+                        ),
+                        ConsentFile.type == ConsentResponse.type,
+                        ConsentFile.participant_id == QuestionnaireResponse.participantId
+                    ),
+                    and_(
+                        ConsentResponse.type == ConsentType.EHR,
+                        QuestionnaireResponse.authored > '2022-04-01',
+                        ConsentResponse.id == ConsentFile.consent_response_id
+                    )
                 )
             ).filter(
                 ConsentFile.id.is_(None),

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1078,7 +1078,13 @@ class QuestionnaireResponseDao(BaseDao):
                         code.value, [CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE, PEDIATRIC_EHR_CONSENT]
                     ):
                         # If we got a new EHR consent, mark that it needs to be validated
-                        if ehr_consent and authored > participant_summary.consentForElectronicHealthRecordsAuthored:
+                        if (
+                            ehr_consent
+                            and (
+                                participant_summary.consentForElectronicHealthRecordsAuthored is None
+                                or authored > participant_summary.consentForElectronicHealthRecordsAuthored
+                            )
+                        ):
                             new_status = QuestionnaireStatus.SUBMITTED_NOT_VALIDATED
                         else:
                             new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1077,7 +1077,8 @@ class QuestionnaireResponseDao(BaseDao):
                     if self._code_in_list(
                         code.value, [CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE, PEDIATRIC_EHR_CONSENT]
                     ):
-                        if ehr_consent:
+                        # If we got a new EHR consent, mark that it needs to be validated
+                        if ehr_consent and authored > participant_summary.consentForElectronicHealthRecordsAuthored:
                             new_status = QuestionnaireStatus.SUBMITTED_NOT_VALIDATED
                         else:
                             new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -455,7 +455,7 @@ class _ValidationOutputHelper:
         is_same_path = new_result.file_path == existing_result.file_path
         is_possible_match_valid = existing_result.sync_status in (
             ConsentSyncStatus.READY_FOR_SYNC, ConsentSyncStatus.SYNC_COMPLETE
-        )
+        ) and new_result.type != ConsentType.EHR
 
         # Determine if it's for the same consent response, regardless of the date actually on the file
         is_for_same_date = new_result.expected_sign_date == existing_result.expected_sign_date


### PR DESCRIPTION
## Resolves *[DA-4069](https://precisionmedicineinitiative.atlassian.net/browse/DA-4069)*
A couple of issues were getting participants into a state where EHR consent statuses were set as not_validated, but the code wouldn't actually try to validate anything for them.

The first case was when we already had a record that a single EHR consent payload was replayed to us multiple times. The code would set the status as needing to be validated, but wouldn't save a new consent_response (because we already had one for that same authored date).

Another case was when a participant would author a new EHR consent and we already had a valid EHR for them. A new consent_response object was generated, but the validation results (consent_file) wouldn't be saved because we already had a valid file.

## Description of changes/additions
To address the first case, we now will only update the EHR consent status if we're receiving a newer authored date (rather than a replay).

To address the second case we make a slightly different comparison for newer EHR files. Results won't be saved if they have the same file path. But for when we want to validate a new consent (with a new file path) we'll accept and store the result if they're for different consent responses.

## Tests
- [ ] unit tests




[DA-4069]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ