### PR TITLE
[DA-4070] Add explicit select and join to appointment query.

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -2500,11 +2500,18 @@ class GenomicSchedulingDao(BaseDao):
                     ],
                     else_=False
                 ).label('note_available'),
+            ).select_from(
+                GenomicAppointmentEvent
             ).join(
                 max_appointment_id_subquery,
                 and_(
                     GenomicAppointmentEvent.participant_id == max_appointment_id_subquery.c.participant_id,
                     GenomicAppointmentEvent.module_type == max_appointment_id_subquery.c.module_type,
+                )
+            ).join(
+                GenomicSetMember,
+                and_(
+                    GenomicSetMember.participantId == GenomicAppointmentEvent.participant_id,
                 )
             ).outerjoin(
                 note_alias,


### PR DESCRIPTION
## Resolves *[DA-4070](https://precisionmedicineinitiative.atlassian.net/browse/DA-4070)*


## Description of changes/additions
This PR updates the genomic appointment query to explicitly SELECT from `genomic_appointment_event` and explicitly JOIN to `genomic_set_member`. 
SQLAlchemy compiled the previous query to use an implicit join, effectively cross-joining these two tables. This update reduces the amount of overhead for this query and should resolve the slow-query errors alerts.

## Tests
- [x] current unit tests should pass





[DA-4070]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ