### PR TITLE
Adding ignore flags to NPH Participant API query.

### DIFF
--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -108,10 +108,14 @@ class NphParticipantDao(BaseDao):
                     and_(
                         ConsentEvent.participant_id == consent_event_alias.participant_id,
                         ConsentEvent.event_type_id == consent_event_alias.event_type_id,
-                        ConsentEvent.id < consent_event_alias.id
+                        ConsentEvent.id < consent_event_alias.id,
+                        consent_event_alias.ignore_flag == 0
                     ),
                 )
-                .filter(consent_event_alias.id.is_(None))
+                .filter(
+                    consent_event_alias.id.is_(None),
+                    ConsentEvent.ignore_flag == 0
+                )
                 .group_by(Participant.id)
                 .subquery()
             )
@@ -137,7 +141,8 @@ class NphParticipantDao(BaseDao):
                 EnrollmentEventType.id == EnrollmentEvent.event_type_id,
             ).filter(
                 EnrollmentEventType.source_name.notlike('%_death'),
-                EnrollmentEventType.source_name.notlike('%_losttofollowup')
+                EnrollmentEventType.source_name.notlike('%_losttofollowup'),
+                EnrollmentEvent.ignore_flag == 0
             ).group_by(Participant.id).subquery()
 
     def get_diet_status_subquery(self):
@@ -167,10 +172,12 @@ class NphParticipantDao(BaseDao):
                 and_(
                     Participant.id == diet_alias.participant_id,
                     DietEvent.diet_name == diet_alias.diet_name,
-                    DietEvent.created < diet_alias.created
+                    DietEvent.created < diet_alias.created,
+                    diet_alias.ignore_flag == 0
                 )
             ).filter(
-              diet_alias.id.is_(None)
+                diet_alias.id.is_(None),
+                DietEvent.ignore_flag == 0
             ).group_by(
                 Participant.id
             ).subquery()
@@ -191,7 +198,7 @@ class NphParticipantDao(BaseDao):
             ).join(
                 DeactivationEvent,
                 DeactivationEvent.participant_id == Participant.id
-            ).group_by(Participant.id).subquery()
+            ).filter(DeactivationEvent.ignore_flag == 0).group_by(Participant.id).subquery()
 
     def get_withdrawal_subquery(self):
         with self.session() as session:
@@ -209,7 +216,7 @@ class NphParticipantDao(BaseDao):
             ).join(
                 WithdrawalEvent,
                 WithdrawalEvent.participant_id == Participant.id
-            ).group_by(Participant.id).subquery()
+            ).filter(WithdrawalEvent.ignore_flag == 0).group_by(Participant.id).subquery()
 
 
 class NphStudyCategoryDao(UpdatableDao):


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR adds filter conditions to the NPH Participant API query. These conditions are to remove records that have the ignore_flag set to `1`. 

## Tests
- [x] Current unit tests should pass


