### PR TITLE
[DA-4109] Update 500 Errors to be 400s Instead for PTSC 

### DIFF
--- a/rdr_service/api/questionnaire_response_api.py
+++ b/rdr_service/api/questionnaire_response_api.py
@@ -1,6 +1,6 @@
+import logging
 from flask_restful import Resource, request
 from werkzeug.exceptions import BadRequest, NotFound
-
 from rdr_service import app_util
 from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.bq_questionnaire_dao import bq_questionnaire_update_task
@@ -37,7 +37,15 @@ class QuestionnaireResponseApi(BaseApi):
 
         request_json = self.get_request_json()
         if EtmApi.is_etm_payload(request_json):
-            return EtmApi.post_questionnaire_response(request_json)
+            try:
+                response = EtmApi.post_questionnaire_response(request_json)
+            except Exception as e:
+                logging.error(
+                    f'ETM API BAD REQUEST: {e}'
+                )
+                raise BadRequest('BAD REQUEST, please ask the Raw Data Repository Support Team for more details as to '
+                                 'why this request is not processing')
+            return response
         else:
             resp = super(QuestionnaireResponseApi, self).post(participant_id=p_id)
             if resp and 'id' in resp:

--- a/tests/api_tests/test_etm_ingestion.py
+++ b/tests/api_tests/test_etm_ingestion.py
@@ -223,3 +223,35 @@ class EtmIngestionTest(BaseTestCase):
 
             if not found_match:
                 self.fail(f'No matching answer found for {expected_answer}')
+
+    def test_400_bad_request_exception(self):
+        """ Forcing a 400 Bad Request """
+        # loading a test QuestionnaireResponse (QR), creating a test participant, & updating the QR w/ participant info
+        with open(data_path("etm_questionnaire_response.json")) as file:
+            questionnaire_response_json = json.load(file)
+        participant = self.data_generator.create_database_participant_summary()
+        participant_id = participant.participantId
+        questionnaire_response_json["subject"][
+            "reference"
+        ] = f"Participant/P{participant_id}"
+
+        # deleting the authored field to force the 400 Bad Request
+        del questionnaire_response_json["authored"]
+
+        response = self.send_post(
+            f"Participant/P{participant_id}/QuestionnaireResponse",
+            questionnaire_response_json,
+            expected_status=400,
+        )
+
+        self.assertEqual(400, response.status_code)
+
+        # grabbing the error message from the response
+        message = json.loads(response.response[0])
+        error_message = message["message"]
+
+        self.assertEqual(
+            error_message,
+            "BAD REQUEST, please ask the Raw Data Repository Support Team for more details as to why this "
+            "request is not processing",
+        )


### PR DESCRIPTION
## Resolves *[DA-4109](https://precisionmedicineinitiative.atlassian.net/browse/DA-4109)*


## Description of changes/additions
Updating etm api 500 errors to 400
the original ticket is DA-4066


## Tests
- [] unit tests




[DA-4109]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ