### PR TITLE
[DA-4100] Add parallelism for running unit tests, update image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 job_defaults: &job_defaults
   docker:
-    - image: cimg/base:2022.09
+    - image: cimg/base:2023.12
       environment:
         RDR_UNITTEST_SQL_SERVER_PORT: 3306
         CIRCLECI_FLAG: 1
@@ -78,6 +78,7 @@ commands:
 jobs:
   job_run_unittests:
     <<: *job_defaults
+    parallelism: 5
     steps:
       - unittest-app-steps
 

--- a/ci/run_unittests.sh
+++ b/ci/run_unittests.sh
@@ -3,4 +3,4 @@
 #
 source venv/bin/activate
 export PYTHONPATH=$PYTHONPATH:`pwd`
-UNITTEST_FLAG=1 coverage run -m unittest discover -v -s tests
+UNITTEST_FLAG=1 coverage run -m unittest -v $(circleci tests glob "tests/**/*.py" | circleci tests split --split-by=name)


### PR DESCRIPTION
## Resolves *[DA-4100](https://precisionmedicineinitiative.atlassian.net/browse/DA-4100)*


## Description of changes/additions
- Updates the base docker image
- Adds parallelism for running unit tests only. The test should now take 35-50 minutes to finish running.

## Tests
- [] unit tests
*** Tested manually by updating the config on a different branch and observing it in CircleCI. Here is an example of successful [run](https://app.circleci.com/pipelines/github/all-of-us/raw-data-repository/9402/workflows/ce01316e-0eb3-4d02-8331-643c386a6a17/jobs/19754)




[DA-4100]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ