### PR TITLE
[DA-4065] displaying pediatric participants for guardians

### DIFF
--- a/rdr_service/model/account_link.py
+++ b/rdr_service/model/account_link.py
@@ -37,6 +37,7 @@ class AccountLink(Base):
     In a child-guardian relationship, this would be the guardian's participant id.
     """
 
+    participant = relationship('Participant', foreign_keys=participant_id)
     related = relationship('Participant', foreign_keys=related_id)
 
     @classmethod

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -4736,9 +4736,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
         )
         self.session.commit()
 
-        response = self.send_get(f'ParticipantSummary')
-        self.assertEqual([], response['entry'])
-        logging_mock.error.assert_called_with('Pediatric participant has unconsented guardian')
+        self.send_get(f'ParticipantSummary')
+        logging_mock.warning.assert_called_with('Found link to unconsented participant')
 
     def test_pmb_eligible_masking(self):
         """

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -4589,28 +4589,46 @@ class ParticipantSummaryApiTest(BaseTestCase):
     def test_displaying_linked_accounts(self):
         first_parent = self.data_generator.create_database_participant_summary()
         second_parent = self.data_generator.create_database_participant_summary()
-        child_id = self.data_generator.create_database_participant_summary().participantId
+        child = self.data_generator.create_database_participant_summary()
+        child_id = child.participantId
 
         PediatricDataLogDao.record_age_range(participant_id=child_id, age_range_str='TEEN')
         self.session.add(AccountLink(participant_id=child_id, related_id=first_parent.participantId))
         self.session.add(AccountLink(participant_id=child_id, related_id=second_parent.participantId))
         self.session.commit()
 
-        response = self.send_get(f'Participant/P{child_id}/Summary')
+        # Check that guardians show up for pediatric accounts
+        child_response = self.send_get(f'Participant/P{child_id}/Summary')
         self.assertEqual(
             [
                 {
                     'participantId': f'P{first_parent.participantId}',
                     'firstName': first_parent.firstName,
-                    'lastName': first_parent.lastName
+                    'lastName': first_parent.lastName,
+                    'relation': 'guardian'
                 },
                 {
                     'participantId': f'P{second_parent.participantId}',
                     'firstName': second_parent.firstName,
-                    'lastName': second_parent.lastName
+                    'lastName': second_parent.lastName,
+                    'relation': 'guardian'
                 }
             ],
-            response.get('relatedParticipants')
+            child_response.get('relatedParticipants')
+        )
+
+        # Check that pediatric accounts show up for guardians
+        adult_response = self.send_get(f'Participant/P{first_parent.participantId}/Summary')
+        self.assertEqual(
+            [
+                {
+                    'participantId': f'P{child_id}',
+                    'firstName': child.firstName,
+                    'lastName': child.lastName,
+                    'relation': 'pediatric'
+                }
+            ],
+            adult_response.get('relatedParticipants')
         )
 
     def test_pediatric_environmental_exposures(self):


### PR DESCRIPTION
## Resolves *[DA-4065](https://precisionmedicineinitiative.atlassian.net/browse/DA-4065)*
This updates the participant summary's `relatedParticipants` field to also show a guardian participant's list of pediatric participants.


## Tests
- [x] unit tests




[DA-4065]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ