### PR TITLE
reorganizing participant check to allow for indexing

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -51,23 +51,25 @@ class ConsentDao(BaseDao):
             .join(Participant)
             .outerjoin(
                 ConsentFile,
-                or_(
-                    and_(
-                        or_(
-                            ConsentFile.type != ConsentType.EHR,
-                            and_(
-                                ConsentResponse.type == ConsentType.EHR,
-                                QuestionnaireResponse.authored <= '2022-04-01',
-                            )
+                and_(
+                    or_(
+                        and_(
+                            or_(
+                                ConsentFile.type != ConsentType.EHR,
+                                and_(
+                                    ConsentResponse.type == ConsentType.EHR,
+                                    QuestionnaireResponse.authored <= '2022-04-01',
+                                )
+                            ),
+                            ConsentFile.type == ConsentResponse.type
                         ),
-                        ConsentFile.type == ConsentResponse.type,
-                        ConsentFile.participant_id == QuestionnaireResponse.participantId
+                        and_(
+                            ConsentResponse.type == ConsentType.EHR,
+                            QuestionnaireResponse.authored > '2022-04-01',
+                            ConsentResponse.id == ConsentFile.consent_response_id
+                        )
                     ),
-                    and_(
-                        ConsentResponse.type == ConsentType.EHR,
-                        QuestionnaireResponse.authored > '2022-04-01',
-                        ConsentResponse.id == ConsentFile.consent_response_id
-                    )
+                    ConsentFile.participant_id == QuestionnaireResponse.participantId
                 )
             ).filter(
                 ConsentFile.id.is_(None),


### PR DESCRIPTION
## Resolves *no ticket*
The consent validation process has been failing to run because of recent changes to the query for finding what needs validating. The query is taking too long to complete, and usually the cron job times out.

## Description of changes/additions
The way the join to `consent_file` happens doesn't allow for using the participant_id as an index (but the constraint is still there through the questionnaire response). So this makes it clear that the participant_id needs to be the same, letting mysql use the index.

## Tests
- [ ] unit tests


