### PR TITLE
[DA-4145] Not requiring GROR for any pediatric participant statuses

### DIFF
--- a/tests/logic_tests/test_enrollment_info.py
+++ b/tests/logic_tests/test_enrollment_info.py
@@ -318,13 +318,13 @@ class TestEnrollmentInfo(BaseTestCase):
 
     def test_pediatric_pmb_eligible(self):
         """
-        Participants should get PM&B Eligible status when completing The Basics and consenting to share EHR
+        Participants should get PM&B Eligible status when completing The Basics and consenting to share EHR,
+        but not need GROR
         """
         participant_info = self._build_participant_info(
             primary_authored_time=datetime(2018, 1, 17),
             ehr_first_yes_timestamp=datetime(2018, 1, 17),
             ehr_consent_ranges=[DateRange(start=datetime(2018, 1, 17))],
-            gror_time=datetime(2018, 1, 17),
             is_pediatric=True,
             has_guardian=True
         )


### PR DESCRIPTION
## Resolves *[DA-4145](https://precisionmedicineinitiative.atlassian.net/browse/DA-4145)*
Pediatric participants don't complete a GROR consent currently, so shouldn't require it for any of the statuses. This remove GROR as a requirement for the rest of the pediatric participant statuses.

## Tests
- [x] unit tests




[DA-4145]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ