### PR TITLE
[DA-4098] Adding missing ETM fpk fields to the Request Log

### DIFF
--- a/rdr_service/repository/etm.py
+++ b/rdr_service/repository/etm.py
@@ -1,7 +1,8 @@
-
+from flask import request
 from sqlalchemy.orm import Query, Session
 from typing import List
 
+from rdr_service.api.base_api import log_api_request
 from rdr_service.dao import database_factory
 from rdr_service.domain_model import etm as domain_model
 from rdr_service.model import etm as schema_model
@@ -153,6 +154,8 @@ class EtmResponseRepository(BaseRepository):
                 )
 
         self._add_to_session(schema_response)
+
+        log_api_request(log=request.log_record, model_obj=schema_response)
         response_obj.id = schema_response.etm_questionnaire_response_id
 
     @classmethod

--- a/tests/api_tests/test_etm_ingestion.py
+++ b/tests/api_tests/test_etm_ingestion.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 
 from rdr_service.domain_model.etm import EtmResponseAnswer
 from rdr_service.model import etm
+from rdr_service.model.requests_log import RequestsLog
 from rdr_service.participant_enums import QuestionnaireStatus
 from tests.helpers.unittest_base import BaseTestCase
 from tests.test_data import data_path
@@ -173,6 +174,27 @@ class EtmIngestionTest(BaseTestCase):
 
         del response['id']
         self.assertEqual(questionnaire_response_json, response)
+
+        # checking for the log in the Requests Log and verifying the fpk info
+        log_entry = (
+            self.session.query(RequestsLog).order_by(RequestsLog.id.desc()).first()
+        )
+        self.assertIsNotNone(log_entry, "No log entry found in the requests log table")
+        self.assertEqual(
+            log_entry.fpk_id,
+            1,
+            "the fpk_id in the requests log entry does not match the expected value",
+        )
+        self.assertEqual(
+            log_entry.fpk_column,
+            "etm_questionnaire_response_id",
+            "the fpk_column in the requests log entry does not match the expected value",
+        )
+        self.assertEqual(
+            log_entry.fpk_table,
+            "etm_questionnaire_response",
+            "the fpk_table in the requests log entry does not match the expected value",
+        )
 
     def assert_has_extensions(
         self,


### PR DESCRIPTION
## Resolves *[DA-4098](https://precisionmedicineinitiative.atlassian.net/browse/DA-4098)*


## Description of changes/additions
logging to the RDR requests_log table the details about the related ETM record.
In the requests_log table, the fpk_id, fpk_table, and fpk_column fields are now displaying the associated record.

## Tests
- [] unit tests




[DA-4098]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ