### PR TITLE
[DA-4099] Populate the missing participant_id in the requests_log from the ProfileUpdate API

### DIFF
--- a/tests/api_tests/test_profile_update_api.py
+++ b/tests/api_tests/test_profile_update_api.py
@@ -591,6 +591,16 @@ class ProfileUpdateApiTest(BaseTestCase):
         pediatric_data_insert_mock.assert_not_called()
         logging_mock.error.assert_not_called()
 
+    @mock.patch("rdr_service.api.base_api.log_api_request")
+    def test_participant_id_in_log_record(self, mock_log_api_request):
+        self.send_post(
+            "Patient", request_data={"id": "P123123123", "name": [{"given": ["Peter"]}]}
+        )
+        mock_log_api_request.assert_called_once()
+        self.assertEqual(mock_log_api_request.return_value.participantId, 123123123)
+
+
+
 
 class ProfileUpdateIntegrationTest(BaseTestCase):
     def test_error_when_removing_login(self):


### PR DESCRIPTION
## Resolves *[DA-4099](https://precisionmedicineinitiative.atlassian.net/browse/DA-4099)*

## Description of changes/additions
The ProfileUpdate API requests gets logged to the requests_log table, but the participant_id field is not populating. 
This updates the participant_id field in the request log. 

## Tests
- [] unit tests




[DA-4099]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ