### PR TITLE
bumping openssl to fix cryptography issue

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 click==8.1.3              # via flask, pip-tools
 configargparse==1.2.3     # via locust
 coverage==6.0b1             # via -r requirements.in
-cryptography==41.0.6       # via oauthlib, pyopenssl, requests
+cryptography==42.0.0       # via oauthlib, pyopenssl, requests
 defusedxml==0.6.0         # via jira
 dictalchemy3==1.0.0       # via -r requirements.in
 dnspython==1.16.0         # via -r requirements.in
@@ -77,7 +77,7 @@ pycparser==2.20           # via cffi
 pygments==2.15.1           # via sphinx
 pyjwt==2.4.0              # via oauthlib
 pylint==2.17.4            # via -r requirements.in
-pyopenssl==23.3.0         # via requests
+pyopenssl==24.0.0         # via requests
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via alembic, faker
 python-editor==1.0.4      # via alembic


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
the automatic [cryptography bump](https://github.com/all-of-us/raw-data-repository/pull/3790) by dependabot [failed](https://app.circleci.com/pipelines/github/all-of-us/raw-data-repository/9390/workflows/fff856ca-c23a-4a66-b737-da5bfafbd280/jobs/19739) on the setup python environment because pyopenssl is not up to date. Updating pyopenssl and cryptography to the latest versions.

## Tests
- [] unit tests


