### PR TITLE
[ROC-1816] fixing bug in ehr consent processing

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1044,14 +1044,14 @@ class QuestionnaireResponseDao(BaseDao):
                     if self._code_in_list(
                         code.value, [CONSENT_FOR_ELECTRONIC_HEALTH_RECORDS_MODULE, PEDIATRIC_EHR_CONSENT]
                     ):
-                        # If we got a new EHR consent, mark that it needs to be validated
                         if (
-                            ehr_consent
-                            and (
-                                participant_summary.consentForElectronicHealthRecordsAuthored is None
-                                or authored > participant_summary.consentForElectronicHealthRecordsAuthored
-                            )
+                            participant_summary.consentForElectronicHealthRecords is not None
+                            and authored <= participant_summary.consentForElectronicHealthRecordsAuthored
                         ):
+                            # if we're getting a response that is the same or older than what we already have
+                            # then don't change the current status
+                            new_status = participant_summary.consentForElectronicHealthRecords
+                        elif ehr_consent:
                             new_status = QuestionnaireStatus.SUBMITTED_NOT_VALIDATED
                         else:
                             new_status = QuestionnaireStatus.SUBMITTED_NO_CONSENT


### PR DESCRIPTION
## Resolves *[ROC-1816](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1816)*
If we try to process the same EHR consent response multiple times for a participant, the conditional in place now will set their response to No inadvertently.

## Description of changes/additions
This updates the check to leave the status alone if we're processing the same authored date or an earlier one (rather than setting it to a No).

## Tests
- [x] unit tests




[ROC-1816]: https://precisionmedicineinitiative.atlassian.net/browse/ROC-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ