### PR TITLE
Parse bad headers when extracting data from manifests

### DIFF
--- a/rdr_service/genomic/genomic_job_components.py
+++ b/rdr_service/genomic/genomic_job_components.py
@@ -795,7 +795,8 @@ class GenomicFileIngester:
             for key in row.copy():
                 if not key:
                     del row[key]
-            data_to_ingest['rows'].append(row)
+            clean_row = {k.lower().replace('\ufeff', ''): v for k, v in row.copy().items()}
+            data_to_ingest['rows'].append(clean_row)
         return data_to_ingest
 
     def _process_aw1_attribute_data(self, aw1_data, member):

--- a/tests/genomics_tests/test_genomic_file_ingester.py
+++ b/tests/genomics_tests/test_genomic_file_ingester.py
@@ -55,7 +55,7 @@ class GenomicFileIngesterTest(BaseTestCase):
         data = file_ingester._retrieve_data_from_path(gen_processed_file.filePath)
 
         total_rows = len(data['rows'])
-        sample_ids = [obj['Sample ID'] for obj in data['rows']]
+        sample_ids = [obj['sample id'] for obj in data['rows']]
 
         iterations = file_ingester._set_data_ingest_iterations(data['rows'])
         self.assertEqual(len(iterations), 1)
@@ -68,7 +68,7 @@ class GenomicFileIngesterTest(BaseTestCase):
 
         distinct_sample_ids = set()
         for iteration in iterations:
-            current_sample_ids = set([obj['Sample ID'] for obj in iteration])
+            current_sample_ids = set([obj['sample id'] for obj in iteration])
             distinct_sample_ids.update(current_sample_ids)
 
         self.assertEqual(len(distinct_sample_ids), total_rows)


### PR DESCRIPTION
## Resolves *[NA]*


## Description of changes/additions
Preemptively clean the headers since GCs keep sending headers with bad characters

## Tests
- [x] unit tests


