### PR TITLE
[DA-4151] Updates to store validation results of multiple EHR consents

### DIFF
--- a/rdr_service/data_gen/generators/data_generator.py
+++ b/rdr_service/data_gen/generators/data_generator.py
@@ -20,6 +20,7 @@ from rdr_service.model.genomics import GenomicManifestFeedback, GenomicManifestF
     GenomicSampleSwapMember, GenomicCVLResultPastDue, GenomicW4WRRaw, GenomicW3SCRaw, GenomicAppointmentEvent, \
     GenomicAppointmentEventMetrics, GenomicLongRead, GenomicProteomics, GenomicRNA, GenomicPRRaw, GenomicP1Raw, \
     GenomicRRRaw, GenomicR1Raw, GenomicLRRaw, GenomicL1Raw, GenomicAW4Raw, GenomicL2ONTRaw, GenomicL2PBCCSRaw
+from rdr_service.model.consent_response import ConsentResponse
 from rdr_service.model.hpo import HPO
 from rdr_service.model.hpro_consent_files import HealthProConsentFile
 from rdr_service.model.log_position import LogPosition
@@ -408,6 +409,20 @@ class DataGenerator:
             defaults['participant_id'] = self.create_database_participant().participantId
 
         return ConsentFile(**defaults)
+
+    def create_database_consent_response(self, **kwargs):
+        consent_response = self._consent_response_with_defaults(**kwargs);
+        self._commit_to_database(consent_response)
+        return consent_response
+
+    def _consent_response_with_defaults(self, **kwargs):
+        defaults = {}
+        defaults.update(kwargs)
+
+        if defaults.get('response') is None:
+            defaults['response'] = self.create_database_questionnaire_response()
+
+        return ConsentResponse(**defaults)
 
     def create_database_biobank_specimen(self, **kwargs):
         specimen = self._biobank_specimen_with_defaults(**kwargs)

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -172,6 +172,9 @@ class StoreResultStrategy(ValidationOutputStrategy):
             existing_results=previous_results,
             results_to_filter=self._results
         )
+        new_results_to_store = _ValidationOutputHelper.filter_one_valid_result_per_response(
+            new_results_to_store
+        )
         self._consent_dao.batch_update_consent_files(new_results_to_store, self._session)
         self._session.commit()
         if new_results_to_store:
@@ -470,6 +473,23 @@ class _ValidationOutputHelper:
         else:
             return is_same_type and is_same_participant and is_for_same_date
 
+    @classmethod
+    def filter_one_valid_result_per_response(cls, file_collection: Collection[ParsingResult]):
+        response_result_map = defaultdict(list)
+        for file in file_collection:
+            response_result_map[file.consent_response.id].append(file)
+
+        result = []
+        for file_list in response_result_map.values():
+            if any(file.sync_status == ConsentSyncStatus.READY_FOR_SYNC for file in file_list):
+                for file in file_list:
+                    if file.sync_status == ConsentSyncStatus.READY_FOR_SYNC:
+                        result.append(file)
+                        break
+            else:
+                result.extend(file_list)
+        return result
+
 
 class ConsentValidationController:
     def __init__(self, consent_dao: ConsentDao, participant_summary_dao: ParticipantSummaryDao,
@@ -684,11 +704,8 @@ class ConsentValidationController:
 
     @classmethod
     def _process_validation_results(cls, results: List[ParsingResult]):
-        ready_file = cls._find_file_ready_for_sync(results)
-        if ready_file:
-            return [ready_file]
-        else:
-            return results
+        ready_file_list = cls._find_file_ready_for_sync(results)
+        return ready_file_list if ready_file_list else results
 
     @classmethod
     def _has_consent(cls, consent_status, authored=None, min_authored=None, max_authored=None):
@@ -741,11 +758,7 @@ class ConsentValidationController:
 
     @classmethod
     def _find_file_ready_for_sync(cls, results: List[ParsingResult]):
-        for result in results:
-            if result.sync_status == ConsentSyncStatus.READY_FOR_SYNC:
-                return result
-
-        return None
+        return [file for file in results if file.sync_status == ConsentSyncStatus.READY_FOR_SYNC]
 
     @classmethod
     def _find_matching_validation_result(cls, new_result: ParsingResult, previous_results: List[ParsingResult]):

--- a/tests/service_tests/consent_tests/test_consent_controller.py
+++ b/tests/service_tests/consent_tests/test_consent_controller.py
@@ -58,16 +58,19 @@ class ConsentControllerTest(BaseTestCase):
             {
                 primary_and_ehr_participant_id: [
                     ConsentResponse(
+                        id=1,
                         response=QuestionnaireResponse(participantId=primary_and_ehr_participant_id),
                         type=ConsentType.PRIMARY
                     ),
                     ConsentResponse(
+                        id=2,
                         response=QuestionnaireResponse(participantId=primary_and_ehr_participant_id),
                         type=ConsentType.EHR
                     )
                 ],
                 cabor_participant_id: [
                     ConsentResponse(
+                        id=3,
                         response=QuestionnaireResponse(participantId=cabor_participant_id),
                         type=ConsentType.CABOR
                     ),
@@ -121,9 +124,21 @@ class ConsentControllerTest(BaseTestCase):
         primary_file = ConsentFile(id=1, sync_status=ConsentSyncStatus.READY_FOR_SYNC,
                                    file_path='/primary', file_exists=True)
         self.consent_validator_mock.get_primary_validation_results.return_value = [primary_file]
-        ehr_file = ConsentFile(id=2, sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/ehr', file_exists=True)
+        ehr_file = ConsentFile(
+            id=2,
+            sync_status=ConsentSyncStatus.READY_FOR_SYNC,
+            file_path='/ehr',
+            file_exists=True,
+            consent_response=ConsentResponse(id=1)
+        )
         self.consent_validator_mock.get_ehr_validation_results.return_value = [ehr_file]
-        gror_file = ConsentFile(id=3, sync_status=ConsentSyncStatus.READY_FOR_SYNC, file_path='/gror', file_exists=True)
+        gror_file = ConsentFile(
+            id=3,
+            sync_status=ConsentSyncStatus.READY_FOR_SYNC,
+            file_path='/gror',
+            file_exists=True,
+            consent_response=ConsentResponse(id=2)
+        )
         self.consent_validator_mock.get_gror_validation_results.return_value = [gror_file]
 
         # Make sure that only specific consent types are validated

--- a/tests/service_tests/consent_tests/test_consent_validation.py
+++ b/tests/service_tests/consent_tests/test_consent_validation.py
@@ -6,6 +6,7 @@ from typing import List, Type
 from rdr_service import config
 from rdr_service.code_constants import SENSITIVE_EHR_STATES
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType, ConsentOtherErrors
+from rdr_service.model.consent_response import ConsentResponse
 from rdr_service.model.hpo import HPO
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.services.consent import files
@@ -305,19 +306,22 @@ class ConsentValidationTesting(BaseTestCase):
             id=3,
             participant_id=new_primary_participant_id,
             type=ConsentType.PRIMARY,
-            file_exists=False
+            file_exists=False,
+            consent_response=ConsentResponse(id=1)
         )
         previous_ehr_result = ConsentFile(
             id=2,
             participant_id=new_primary_participant_id,
             type=ConsentType.EHR,
-            file_exists=False
+            file_exists=False,
+            consent_response=ConsentResponse(id=2)
         )
         new_gror_result = ConsentFile(
             id=4,
             participant_id=new_gror_participant_id,
             type=ConsentType.GROR,
-            file_exists=False
+            file_exists=False,
+            consent_response=ConsentResponse(id=3)
         )
 
         # Create a new storage validation strategy and provide the new validation results for each participant
@@ -355,14 +359,16 @@ class ConsentValidationTesting(BaseTestCase):
                 type=ConsentType.PRIMARY,
                 expected_sign_date=date(2021, 10, 17),
                 file_path='duplicate_primary',
-                sync_status=ConsentSyncStatus.SYNC_COMPLETE
+                sync_status=ConsentSyncStatus.SYNC_COMPLETE,
+                consent_response=ConsentResponse(id=1)
             ),
             ConsentFile(
                 participant_id=participant_id,
                 type=ConsentType.EHR,
                 expected_sign_date=date(2022, 2, 4),
                 file_path='older_ehr',
-                sync_status=ConsentSyncStatus.SYNC_COMPLETE
+                sync_status=ConsentSyncStatus.SYNC_COMPLETE,
+                consent_response=ConsentResponse(id=2)
             )
         ]
 
@@ -373,7 +379,8 @@ class ConsentValidationTesting(BaseTestCase):
             expected_sign_date=date(2021, 10, 17),
             file_exists=True,
             file_path='replay_primary',
-            sync_status=ConsentSyncStatus.READY_FOR_SYNC
+            sync_status=ConsentSyncStatus.READY_FOR_SYNC,
+            consent_response=ConsentResponse(id=3)
         )
         new_ehr_result = ConsentFile(  # Another EHR file, but signed later than the one we've already seen
             participant_id=participant_id,
@@ -381,7 +388,8 @@ class ConsentValidationTesting(BaseTestCase):
             expected_sign_date=date(2023, 1, 23),
             file_exists=True,
             file_path='newer_ehr',
-            sync_status=ConsentSyncStatus.READY_FOR_SYNC
+            sync_status=ConsentSyncStatus.READY_FOR_SYNC,
+            consent_response=ConsentResponse(id=4)
         )
 
         # Create a new storage validation strategy and provide the new validation results for each participant


### PR DESCRIPTION
## Partially Resolves *[DA-4151](https://precisionmedicineinitiative.atlassian.net/browse/DA-4151)*
The consent validation process was running into issues validating recent consents. Investigation found that there were many consent_response objects that were found as needing to be validated, but any validation results for them matched with existing data so nothing was stored. Then the next time a validation job started, these same consent_response objects were put through the validation process. This eventually leads to an endless loop in the validation job: trying to validate consent_responses but never actually storing the result.

## Description of changes/additions
For any time a participant provides consent, we store a consent_response and run a validation. We find the file and store a valid result and that consent_response isn't checked again. If the participant provides consent again (such as for EHR), we create another consent_response. When we try to validate for that consent_response, we sometimes find the same file that we validated for the first response. When we try to store that, we see that we already have one.

This updates the code to run storage for any valid files we have for a given consent response. This will still avoid storing results for a file that has already been checked, but other files that are valid for a given consent_response will be stored (keeping the consent_response from showing up in future validation checks).

## Tests
- [x] unit tests




[DA-4151]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ