### PR TITLE
[DA-4178] core data requiring exposures survey instead of lifestyle for pediatric participants

### DIFF
--- a/rdr_service/logic/enrollment_info.py
+++ b/rdr_service/logic/enrollment_info.py
@@ -252,7 +252,6 @@ class EnrollmentCalculation:
             participant_info.first_ehr_consent_date,
             participant_info.basics_authored_time,
             participant_info.overall_health_authored_time,
-            participant_info.lifestyle_authored_time,
             participant_info.earliest_height_measurement_time,
             participant_info.earliest_weight_measurement_time,
             participant_info.wgs_sequencing_time,
@@ -260,6 +259,11 @@ class EnrollmentCalculation:
         ]
         if participant_info.consent_cohort == ParticipantCohort.COHORT_1:
             required_timestamp_list.append(participant_info.dna_update_time)
+
+        if participant_info.is_pediatric_participant:
+            required_timestamp_list.append(participant_info.exposures_authored_time)
+        else:
+            required_timestamp_list.append(participant_info.lifestyle_authored_time)
 
         if any(required_time is None for required_time in required_timestamp_list):
             return  # If any required timestamps are missing, leave Core Data flag as False

--- a/tests/logic_tests/test_enrollment_info.py
+++ b/tests/logic_tests/test_enrollment_info.py
@@ -364,6 +364,34 @@ class TestEnrollmentInfo(BaseTestCase):
         current_state = EnrollmentCalculation.get_enrollment_info(participant_info)
         self.assertEqual(EnrollmentStatusV32.CORE_PARTICIPANT, current_state.version_3_2_status)
 
+    def test_pediatric_achieving_core_data(self):
+        participant_info = self._build_participant_info(
+            primary_authored_time=datetime(2018, 1, 17),
+            ehr_consent_ranges=[
+                DateRange(start=datetime(2018, 1, 17), end=datetime(2018, 4, 13))
+            ],
+            basics_time=datetime(2018, 1, 17),
+            overall_health_time=datetime(2018, 1, 17),
+            exposures_time=datetime(2018, 1, 17),
+            biobank_received_dna_sample_time=datetime(2018, 2, 21),
+            physical_measurements_time=datetime(2018, 3, 1),
+            earliest_core_pm_time=datetime(2018, 3, 1),
+            is_pediatric=True,
+            has_guardian=True
+        )
+
+        enrollment_status = EnrollmentCalculation.get_enrollment_info(participant_info)
+        self.assertFalse(enrollment_status.has_core_data)
+
+        core_data_time = datetime(2018, 5, 6)
+        participant_info.wgs_sequencing_time = core_data_time
+        participant_info.earliest_ehr_file_received_time = core_data_time
+        participant_info.exposures_authored_time = core_data_time
+
+        enrollment_status = EnrollmentCalculation.get_enrollment_info(participant_info)
+        self.assertTrue(enrollment_status.has_core_data)
+        self.assertEqual(core_data_time, enrollment_status.core_data_time)
+
     @classmethod
     def _build_expected_enrollment_info(cls, legacy_data, v30_data, v32_data):
         enrollment = EnrollmentInfo()


### PR DESCRIPTION
## Resolves *[DA-4178](https://precisionmedicineinitiative.atlassian.net/browse/DA-4178)*
When calculating the core data flag for pediatric participants, we should use the environmental exposures survey in place of the lifestyle survey.

## Description of changes/additions
This updates the code to use the environmental exposures survey instead of the lifestyle survey for pediatric participants.

## Tests
- [x] unit tests




[DA-4178]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ