### PR TITLE
[DA-4141] Automatically detecting duplicate accounts

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -134,3 +134,8 @@ cron:
   schedule: every day 08:30
   target: offline
   timezone: America/New_York
+- description: Daily Duplicate Account Check
+  url: /offline/DetectDuplicateAccounts
+  schedule: every day 20:00
+  target: offline
+  timezone: America/New_York

--- a/rdr_service/dao/duplicate_account_dao.py
+++ b/rdr_service/dao/duplicate_account_dao.py
@@ -1,9 +1,11 @@
 from datetime import datetime
+from typing import Iterable
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from rdr_service.model.duplicate_account import DuplicateAccount, DuplicationSource, DuplicationStatus
+from rdr_service.model.participant_summary import ParticipantSummary
 
 
 class DuplicateExistsException(Exception):
@@ -41,3 +43,29 @@ class DuplicateAccountDao:
                 source=source
             )
         )
+
+    @classmethod
+    def query_participant_duplication_data(cls, session) -> Iterable[ParticipantSummary]:
+        """Load participant summary data used for finding duplicate accounts"""
+        return session.query(
+            ParticipantSummary.participantId,
+            ParticipantSummary.firstName,
+            ParticipantSummary.lastName,
+            ParticipantSummary.dateOfBirth,
+            ParticipantSummary.email,
+            ParticipantSummary.loginPhoneNumber
+        ).yield_per(1000)
+
+    @classmethod
+    def query_participants_to_check(cls, since: datetime, session: Session) -> Iterable[ParticipantSummary]:
+        """Load participant summary data for accounts that should be checked for duplication"""
+        return session.query(
+            ParticipantSummary.participantId,
+            ParticipantSummary.firstName,
+            ParticipantSummary.lastName,
+            ParticipantSummary.dateOfBirth,
+            ParticipantSummary.email,
+            ParticipantSummary.loginPhoneNumber
+        ).filter(
+            ParticipantSummary.lastModified > since
+        ).all()

--- a/rdr_service/model/database.py
+++ b/rdr_service/model/database.py
@@ -28,6 +28,7 @@ from rdr_service.model.code import CodeBook, Code, CodeHistory
 from rdr_service.model.calendar import Calendar
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.deceased_report_import_record import DeceasedReportImportRecord
+from rdr_service.model.duplicate_account import DuplicateAccount
 from rdr_service.model.ehr import EhrReceipt, ParticipantEhrReceipt
 from rdr_service.model.enrollment_status_history import EnrollmentStatusHistory
 from rdr_service.model.ghost_api_check import GhostApiCheck

--- a/rdr_service/services/duplicate_detection.py
+++ b/rdr_service/services/duplicate_detection.py
@@ -1,0 +1,80 @@
+from collections import defaultdict
+from datetime import datetime
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from rdr_service.dao.base_dao import with_session
+from rdr_service.dao.duplicate_account_dao import DuplicateAccountDao, DuplicationSource, DuplicateExistsException
+from rdr_service.model.participant_summary import ParticipantSummary
+
+
+class _SummaryCache:
+    def __init__(self, session: Session):
+        self._session = session
+        self._name_dob_cache = defaultdict(         # top level dict for keying by first name
+            lambda: defaultdict(                    # next level dict for keying by last name
+                lambda: defaultdict(                # next level dict for keying by dob
+                    list                            # list to hold any participant ids that have the above data
+                )
+            )
+        )
+        self._email_cache = defaultdict(list)
+        self._phone_cache = defaultdict(list)
+        self._load_data()
+
+    def _load_data(self):
+        for summary in DuplicateAccountDao.query_participant_duplication_data(self._session):
+            self._name_dob_cache[summary.firstName][summary.lastName][summary.dateOfBirth].append(summary.participantId)
+            if summary.email:
+                self._email_cache[summary.email].append(summary.participantId)
+            if summary.loginPhoneNumber:
+                self._phone_cache[summary.loginPhoneNumber].append(summary.participantId)
+
+    def get_matching_participant_ids(self, summary: ParticipantSummary) -> List[int]:
+        result = set()
+        name_dob_matches = (
+            self._name_dob_cache
+            .get(summary.firstName, {})
+            .get(summary.lastName, {})
+            .get(summary.dateOfBirth, [])
+        )
+        result.update(name_dob_matches)
+        result.update(self._email_cache[summary.email])
+        result.update(self._phone_cache[summary.loginPhoneNumber])
+        return [participant_id for participant_id in result if participant_id != summary.participantId]
+
+
+class DuplicateDetection:
+    @classmethod
+    @with_session
+    def find_duplicates(cls, since: datetime, session: Session):
+        """
+        Find and record duplicate accounts since the provided timestamp.
+        Will load any participants modified since the timestamp and compare
+        them to all other participants to find and record any new duplicates.
+        """
+
+        cache = _SummaryCache(session)
+        recently_modified_summaries = DuplicateAccountDao.query_participants_to_check(session=session, since=since)
+        for summary in recently_modified_summaries:
+            duplicate_id_list = cache.get_matching_participant_ids(summary)
+            for duplicate_id in duplicate_id_list:
+                cls._record_as_duplicate(
+                    participant_a_id=summary.participantId,
+                    participant_b_id=duplicate_id,
+                    session=session
+                )
+
+    @classmethod
+    def _record_as_duplicate(cls, participant_a_id: int, participant_b_id: int, session: Session):
+        try:
+            DuplicateAccountDao.store_duplication(
+                participant_a_id=participant_a_id,
+                participant_b_id=participant_b_id,
+                authored=datetime.utcnow(),
+                source=DuplicationSource.RDR,
+                session=session
+            )
+        except DuplicateExistsException:
+            pass  # ignore any that are already flagged as duplicates

--- a/tests/service_tests/test_duplicate_account_detection.py
+++ b/tests/service_tests/test_duplicate_account_detection.py
@@ -1,0 +1,147 @@
+from datetime import date, datetime
+import mock
+
+from rdr_service.dao.duplicate_account_dao import DuplicateExistsException
+from rdr_service.model.duplicate_account import DuplicationSource
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.services.duplicate_detection import DuplicateDetection
+from tests.helpers.unittest_base import BaseTestCase
+
+
+class DuplicateDetectionTest(BaseTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uses_database = False
+
+    def setUp(self, *args, **kwargs) -> None:
+        super().setUp(*args, **kwargs)
+        self.all_participants_mock = self.mock(
+            'rdr_service.dao.duplicate_account_dao.DuplicateAccountDao.query_participant_duplication_data'
+        )
+        self.participants_to_check_mock = self.mock(
+            'rdr_service.dao.duplicate_account_dao.DuplicateAccountDao.query_participants_to_check'
+        )
+        self.save_duplicate_mock = self.mock(
+            'rdr_service.dao.duplicate_account_dao.DuplicateAccountDao.store_duplication'
+        )
+
+    def test_detecting_name_and_dob(self):
+        first_sam = ParticipantSummary(
+            firstName='Sam', lastName='Smith', dateOfBirth=date(2020, 3, 2),
+            email="firstsam@msn.com", participantId=1
+        )
+        second_sam = ParticipantSummary(
+            firstName='Sam', lastName='Smith', dateOfBirth=date(2020, 3, 2),
+            email="secondsam@gmail.com", participantId=2
+        )
+
+        self.all_participants_mock.return_value = [
+            first_sam,
+            second_sam,
+            # more that shouldn't match
+            ParticipantSummary(
+                firstName='Sam', lastName='Smith', dateOfBirth=date(1991, 3, 2), participantId=3
+            ),
+            ParticipantSummary(
+                firstName='Alice', lastName='Smith', dateOfBirth=date(2020, 3, 2), participantId=4
+            ),
+            ParticipantSummary(
+                firstName='Sam', lastName='Smyth', dateOfBirth=date(1991, 3, 2), participantId=5
+            )
+        ]
+        self.participants_to_check_mock.return_value = [second_sam]
+
+        DuplicateDetection.find_duplicates(datetime.now(), session=mock.MagicMock())
+        self.assertEqual(1, self.save_duplicate_mock.call_count)
+
+        saved_record = self.save_duplicate_mock.call_args_list[0].kwargs
+        self.assertEqual(second_sam.participantId, saved_record['participant_a_id'])
+        self.assertEqual(first_sam.participantId, saved_record['participant_b_id'])
+        self.assertEqual(DuplicationSource.RDR, saved_record['source'])
+
+    def test_detecting_email(self):
+        johnson_account = ParticipantSummary(
+            firstName='Fred', lastName='Johnson', dateOfBirth=date(2020, 3, 2),
+            email="tycho@belt.net", participantId=1
+        )
+        drummer_account = ParticipantSummary(
+            firstName='Karina', lastName='Drummer', dateOfBirth=date(2020, 3, 2),
+            email="tycho@belt.net", participantId=2
+        )
+        sam_account = ParticipantSummary(
+            firstName='Sam', lastName='Test', dateOfBirth=date(2020, 3, 2),
+            email="another@email.org", participantId=3
+        )
+        foo_account = ParticipantSummary(
+            firstName='Foo', lastName='Bar', dateOfBirth=date(2020, 3, 2),
+            email="another@email.org", participantId=4
+        )
+
+        self.all_participants_mock.return_value = [
+            johnson_account, drummer_account, sam_account, foo_account
+        ]
+        self.participants_to_check_mock.return_value = [johnson_account, foo_account]
+
+        DuplicateDetection.find_duplicates(datetime.now(), session=mock.MagicMock())
+        self.assertEqual(2, self.save_duplicate_mock.call_count)
+
+        saved_record = self.save_duplicate_mock.call_args_list[0].kwargs
+        self.assertEqual(johnson_account.participantId, saved_record['participant_a_id'])
+        self.assertEqual(drummer_account.participantId, saved_record['participant_b_id'])
+
+        saved_record = self.save_duplicate_mock.call_args_list[1].kwargs
+        self.assertEqual(foo_account.participantId, saved_record['participant_a_id'])
+        self.assertEqual(sam_account.participantId, saved_record['participant_b_id'])
+
+    def test_detecting_login_phone(self):
+        johnson_account = ParticipantSummary(
+            firstName='Fred', lastName='Johnson', dateOfBirth=date(2020, 3, 2),
+            loginPhoneNumber='(123) 456-7890', participantId=1
+        )
+        drummer_account = ParticipantSummary(
+            firstName='Karina', lastName='Drummer', dateOfBirth=date(2020, 3, 2),
+            loginPhoneNumber='(123) 456-7890', participantId=2
+        )
+        sam_account = ParticipantSummary(
+            firstName='Sam', lastName='Test', dateOfBirth=date(2020, 3, 2),
+            loginPhoneNumber='0987654321', participantId=3
+        )
+        foo_account = ParticipantSummary(
+            firstName='Foo', lastName='Bar', dateOfBirth=date(2020, 3, 2),
+            loginPhoneNumber='0987654321', participantId=4
+        )
+
+        self.all_participants_mock.return_value = [
+            johnson_account, drummer_account, sam_account, foo_account
+        ]
+        self.participants_to_check_mock.return_value = [johnson_account, foo_account]
+
+        DuplicateDetection.find_duplicates(datetime.now(), session=mock.MagicMock())
+        self.assertEqual(2, self.save_duplicate_mock.call_count)
+
+        saved_record = self.save_duplicate_mock.call_args_list[0].kwargs
+        self.assertEqual(johnson_account.participantId, saved_record['participant_a_id'])
+        self.assertEqual(drummer_account.participantId, saved_record['participant_b_id'])
+
+        saved_record = self.save_duplicate_mock.call_args_list[1].kwargs
+        self.assertEqual(foo_account.participantId, saved_record['participant_a_id'])
+        self.assertEqual(sam_account.participantId, saved_record['participant_b_id'])
+
+    def test_existing_duplicate_is_ignored(self):
+        """DAO throws exception to notify a duplicate is already known, making sure it doesn't crash anything"""
+        first_sam = ParticipantSummary(
+            firstName='Sam', lastName='Smith', dateOfBirth=date(2020, 3, 2),
+            email="firstsam@msn.com", participantId=1
+        )
+        second_sam = ParticipantSummary(
+            firstName='Sam', lastName='Smith', dateOfBirth=date(2020, 3, 2),
+            email="secondsam@gmail.com", participantId=2
+        )
+
+        self.all_participants_mock.return_value = [
+            first_sam, second_sam
+        ]
+        self.participants_to_check_mock.return_value = [second_sam]
+
+        self.save_duplicate_mock.side_effect = mock.Mock(side_effect=DuplicateExistsException(None))
+        DuplicateDetection.find_duplicates(datetime.now(), session=mock.MagicMock())


### PR DESCRIPTION
## Resolves *[DA-4141](https://precisionmedicineinitiative.atlassian.net/browse/DA-4141)*
RDR will need to implement a process for automatically detecting duplicate accounts.

## Description of changes/additions
This implements a cron job that will load any participants that have been modified in the last day (with a few extra hours to make sure there's overlap rather than a gap). If these participants have been modified, they may have had their name or birthday updated to show that they match another participant.

With the recently modified participants loaded, we then compare their data to all other participants in the system. That could be costly in terms of time, so we gather all participant data into a set of dictionaries to make the comparison run quicker.

Then we save any duplicates that we detected (ignoring them if they're already recorded).

## Tests
- [x] unit tests




[DA-4141]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ