### PR TITLE
[DA-3833] Adding ageAtConsentMonths to Participant Summary API

### DIFF
--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -169,6 +169,12 @@ class ParticipantSummary(Base):
     :ref:`Enumerated values <age_range>`
     """
 
+    ageAtConsentMonths = None
+    """
+    Whole number representing the age of the participant, in months, the first time
+    they signed the Primary consent.
+    """
+
     genderIdentityId = Column("gender_identity_id", Integer, ForeignKey("code.code_id"))
     genderIdentity = Column("gender_identity", Enum(GenderIdentity))
     """

--- a/rdr_service/query.py
+++ b/rdr_service/query.py
@@ -2,6 +2,7 @@
 from protorpc import messages
 from sqlalchemy import func, not_, or_
 
+
 class Operator(messages.Enum):
     EQUALS = 0  # Case insensitive comparison for strings, exact comparison otherwise
     LESS_THAN = 1
@@ -81,6 +82,23 @@ class FieldFilter(object):
         if not query:
             raise ValueError("Invalid operator: %r." % self.operator)
         return query
+
+
+class GenericExpressionFilter:
+    OPERATOR_MAP = {
+        "lt": '__lt__',
+        "le": '__le__',
+        "gt": '__gt__',
+        "ge": '__ge__',
+        "ne": '__ne__',
+    }
+
+    def __init__(self, sqlalchemy_expression, field_name):
+        self._expression = sqlalchemy_expression
+        self.field_name = field_name
+
+    def add_to_sqlalchemy_query(self, query):
+        return query.filter(self._expression)
 
 
 class OrderBy(object):

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -55,6 +55,7 @@ TIME_6 = datetime.datetime(2015, 1, 1)
 TEST_AGE_BUCKET_DOB_DATE_OBJ = datetime.date(1980, 10, 9)
 
 participant_summary_default_values = {
+    "ageAtConsentMonths": 0,
     "ageRange": "UNSET",
     "race": "PMI_Skip",
     "hpoId": "UNSET",

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -6,6 +6,7 @@ import threading
 import unittest
 
 from copy import deepcopy
+from dateutil.relativedelta import relativedelta
 from mock import patch
 from urllib.parse import urlencode
 
@@ -344,6 +345,7 @@ class ParticipantSummaryApiTest(BaseTestCase):
         if patient_statuses:
             expected["patientStatus"] = patient_statuses
 
+        age_at_consent_delta = relativedelta(TIME_1, dob)
         expected.update(
             {
                 "enrollmentStatus": "INTERESTED",
@@ -368,7 +370,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
                 "enrollmentStatusParticipantV3_0Time": "2016-01-01T00:00:00",
                 "enrollmentStatusParticipantV3_2Time": TIME_1.isoformat(),
                 'enrollmentStatusEnrolledParticipantV3_2Time': TIME_1.isoformat(),
-                "isParticipantMediatedEhrDataAvailable": False
+                "isParticipantMediatedEhrDataAvailable": False,
+                "ageAtConsentMonths": age_at_consent_delta.years * 12 + age_at_consent_delta.months
             }
         )
 
@@ -4759,6 +4762,47 @@ class ParticipantSummaryApiTest(BaseTestCase):
         self.temporarily_override_config_setting(config.ENABLED_STATUS_FIELD_LIST, ['enrollmentStatusV3_2'])
         response = self.send_get(f'Participant/P{summary.participantId}/Summary')
         self.assertEqual('ENROLLED_PARTICIPANT', response['enrollmentStatusV3_2'])
+
+    def test_age_at_consent(self):
+        participant_summary = self.data_generator.create_database_participant_summary(
+            consentForStudyEnrollmentFirstYesAuthored=datetime.datetime(2021, 7, 17),
+            dateOfBirth=datetime.date(1978, 10, 9),
+        )
+        response = self.send_get(f"Participant/P{participant_summary.participantId}/Summary")
+        self.assertEqual(513, response['ageAtConsentMonths'])
+
+        filter_response = self.send_get(f"ParticipantSummary?ageAtConsentMonths=513")
+        self.assertEqual(1, len(filter_response['entry']))
+
+        younger_summary = self.data_generator.create_database_participant_summary(
+            consentForStudyEnrollmentFirstYesAuthored=datetime.datetime(2020, 9, 1),
+            dateOfBirth=datetime.date(2018, 7, 9),
+        )
+        older_summary = self.data_generator.create_database_participant_summary(
+            consentForStudyEnrollmentFirstYesAuthored=datetime.datetime(1998, 7, 1),
+            dateOfBirth=datetime.date(1923, 10, 1),
+        )
+
+        filter_response = self.send_get(f"ParticipantSummary?ageAtConsentMonths=ge513")
+        self.assertSetEqual(
+            {f'P{participant_summary.participantId}', f'P{older_summary.participantId}'},
+            {participant['resource']['participantId'] for participant in filter_response['entry']}
+        )
+        filter_response = self.send_get(f"ParticipantSummary?ageAtConsentMonths=lt513")
+        self.assertEqual(
+            [f'P{younger_summary.participantId}'],
+            [participant['resource']['participantId'] for participant in filter_response['entry']]
+        )
+
+        sort_response = self.send_get(f"ParticipantSummary?_sort:desc=ageAtConsentMonths&_sync=true")
+        self.assertEqual(
+            [
+                f'P{older_summary.participantId}',
+                f'P{participant_summary.participantId}',
+                f'P{younger_summary.participantId}'
+            ],
+            [participant['resource']['participantId'] for participant in sort_response['entry']]
+        )
 
     @classmethod
     def _get_summary_response_id_list(self, response):


### PR DESCRIPTION
## Resolves *[DA-3833](https://precisionmedicineinitiative.atlassian.net/browse/DA-3833)*
Program would like to know at what age each pediatric participant was when they first consented into the program by calculating the participant's age at consent.

## Description of changes/additions
This updates the participant summary api code to calculate the participant's age at consent (based on their date of birth, and when they first signed the consent). Sorting and filtering was also implemented.

## Tests
- [x] unit tests




[DA-3833]: https://precisionmedicineinitiative.atlassian.net/browse/DA-3833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ