### PR TITLE
[ROC-1852] Adding comments to PS fields for documentation

### DIFF
--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -531,6 +531,9 @@ class ParticipantSummary(Base):
             persisted=True
         )
     )
+    """
+    Provides whether EHR files have been or currently are available for the participant
+    """
 
     # If both ehrUpdateTime and latestParticipantMediatedEhrReceiptTime are null, result is null
     # If one is null, result is the non-null timestamp
@@ -549,6 +552,10 @@ class ParticipantSummary(Base):
             persisted=True
         )
     )
+    """
+    UTC timestamp indicating the most recent timestamp
+    between the ehrUpdateTime and latestParticipantMediatedEhrReceiptTime
+    """
 
     clinicPhysicalMeasurementsStatus = Column(
         "clinic_physical_measurements_status", Enum(PhysicalMeasurementsStatus),


### PR DESCRIPTION
## Resolves *[ROC-1852](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1852)*


## Description of changes/additions
when looking at the [documentation](https://all-of-us-raw-data-repository.readthedocs.io/en/latest/api_workflows/field_reference/participant_summary_field_list.html#rdr_service.model.participant_summary.ParticipantSummary.healthDataStreamSharingStatus) to answer a question on the healthDataStreamSharingStatus field, I noticed there was no information on these fields in the documentation. Looking through the code, I think these comments should be an ok description. 

## Tests
- [] unit tests




[ROC-1852]: https://precisionmedicineinitiative.atlassian.net/browse/ROC-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ