### PR TITLE
CEBYOK Fix to skip origin check 

### DIFF
--- a/rdr_service/config/config_dev.json
+++ b/rdr_service/config/config_dev.json
@@ -29,6 +29,21 @@
         ]
       }
     },
+    "example@cebyok.com": {
+      "roles": [
+        "ptc"
+      ],
+      "bypassOriginCheck": 1,
+      "clientId": "example",
+      "allow_list_ip_ranges": {
+        "ip6": [
+          ""
+        ],
+        "ip4": [
+          "127.0.0.33/45"
+        ]
+      }
+    },
     "example@spellman.com": {
       "roles": [
         "ptc",

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -20,8 +20,15 @@ from rdr_service.api_util import (
     get_organization_id_from_external_id,
     get_site_id_from_google_group,
     parse_json_enum,
-    DEV_MAIL)
-from rdr_service.app_util import get_oauth_id, lookup_user_info, get_account_origin_id, is_care_evo_and_not_prod
+    DEV_MAIL,
+)
+from rdr_service.app_util import (
+    get_oauth_id,
+    lookup_user_info,
+    get_account_origin_id,
+    is_care_evo_and_not_prod,
+    get_validated_user_info,
+)
 from rdr_service.code_constants import UNSET, ORIGINATING_SOURCES
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
 from rdr_service.dao.consent_dao import ConsentDao
@@ -94,8 +101,7 @@ class ParticipantDao(UpdatableDao):
         with self.session() as session:
             obj = self.get_with_session(session, id_)
         if obj:
-            email = get_oauth_id()
-            user_info = lookup_user_info(email)
+            _, user_info = get_validated_user_info()
             if user_info.get("bypassOriginCheck"):
                 return obj
             client = get_account_origin_id()

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -94,6 +94,10 @@ class ParticipantDao(UpdatableDao):
         with self.session() as session:
             obj = self.get_with_session(session, id_)
         if obj:
+            email = get_oauth_id()
+            user_info = lookup_user_info(email)
+            if user_info.get("bypassOriginCheck"):
+                return obj
             client = get_account_origin_id()
             # Care evolution can GET participants from PTSC as long as env < prod.
             if obj.participantOrigin != client and client in ORIGINATING_SOURCES and not is_care_evo_and_not_prod():

--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -26,8 +26,7 @@ from rdr_service.app_util import (
     get_oauth_id,
     lookup_user_info,
     get_account_origin_id,
-    is_care_evo_and_not_prod,
-    get_validated_user_info,
+    is_care_evo_and_not_prod
 )
 from rdr_service.code_constants import UNSET, ORIGINATING_SOURCES
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
@@ -101,7 +100,8 @@ class ParticipantDao(UpdatableDao):
         with self.session() as session:
             obj = self.get_with_session(session, id_)
         if obj:
-            _, user_info = get_validated_user_info()
+            email = get_oauth_id()
+            user_info = lookup_user_info(email)
             if user_info.get("bypassOriginCheck"):
                 return obj
             client = get_account_origin_id()

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -1,11 +1,9 @@
 import datetime
 import http.client
-from copy import deepcopy
 
 import mock
 from typing import Collection
 
-from rdr_service import config
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.utils import from_client_participant_id
 from rdr_service.clock import FakeClock
@@ -848,22 +846,20 @@ class ParticipantApiTest(BaseTestCase, PDRGeneratorTestMixin):
         })
         summary_update_mock.assert_not_called()
 
-    def test_bypass_origin_check_in_dev_config(self):
-        response = self.send_post("Participant", self.participant)
-        participant_id = response["participantId"]
-        new_user_info = deepcopy(config.getSettingJson(config.USER_INFO))
-        if new_user_info["example@cebyok.com"]["bypassOriginCheck"]:
-            get_response = self.send_get("Participant/%s" % participant_id)
-        self.assertEqual(response, get_response)
 
     def test_bypass_origin_check_with_users(self):
         BaseTestCase.switch_auth_user("example@spellman.com", "vibrent")
         response = self.send_post("Participant", self.participant)
         participant_id = response["participantId"]
+        # Expecting a Failed Response without the bypass origin check  flag
+        BaseTestCase.switch_auth_user("example@cebyok.com", "example")
+        bad_get_response = self.send_get("Participant/%s" % participant_id, expected_status=http.client.BAD_REQUEST)
+        self.assertEqual(bad_get_response.json['message'], 'Can not retrieve participant from a different origin')
+        # Expecting a passing response with the bypass origin check flag
         BaseTestCase.switch_auth_user("example@cebyok.com", "example", bypass_origin_check=True)
         get_response = self.send_get("Participant/%s" % participant_id)
-        BaseTestCase.switch_auth_user("example@example.com", "example")
         self.assertEqual(response, get_response)
+        BaseTestCase.switch_auth_user("example@example.com", "example")
 
 
 def _add_code_answer(code_answers, link_id, code):

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -885,7 +885,7 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
             print("Creation mock buckets failed")
 
     @staticmethod
-    def switch_auth_user(new_auth_user, client_id=None):
+    def switch_auth_user(new_auth_user, client_id=None, bypass_origin_check=False):
         config.LOCAL_AUTH_USER = new_auth_user
         if client_id:
             config_user_info = {
@@ -900,6 +900,8 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
                     'roles': api_util.ALL_ROLES,
                 }
             }
+        if bypass_origin_check:
+            config_user_info[new_auth_user]['bypassOriginCheck'] = 1
         config.override_setting("user_info", config_user_info)
 
     @classmethod


### PR DESCRIPTION
CEBYOK is having issues sending GET requests to the participant api. This fix allows for CEBYOK to make GET requests for vibrent participants. 

@dtharpeuno `s approach for adding the bypass origin check to the config was pretty genius and saved us a lot of time and effort in the long run here

## Resolves *NO TICKET*


## Description of changes/additions
Adding check in the participant dao to see if the user config has a  bypass origin check flag. 
created cebyok user in dev config
updated switch_auth_user function to accept a bypass origin check
created 2 unit tests for bypass origin check

## Tests
- [x] unit tests


