### PR TITLE
Fix for CEBYOK - PUT - 400 BAD REQUEST 

### DIFF
--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -186,11 +186,12 @@ class ParticipantDao(UpdatableDao):
                     base_name = "example"  # TODO: This is a hack because something sets up configs different
                     # when running all tests and it doesnt have the clientId key.
             base_name = base_name.lower()
-            if base_name in ORIGINATING_SOURCES and base_name != existing_obj.participantOrigin:
-                logging.warning(f"{base_name} tried to modify participant from \
-                        {existing_obj.participantOrigin}")
-                raise BadRequest(f"{base_name} not able to update participant from \
-                        {existing_obj.participantOrigin}")
+            if not user_info.get("bypassOriginCheck"):
+                if base_name in ORIGINATING_SOURCES and base_name != existing_obj.participantOrigin:
+                    logging.warning(f"{base_name} tried to modify participant from \
+                            {existing_obj.participantOrigin}")
+                    raise BadRequest(f"{base_name} not able to update participant from \
+                            {existing_obj.participantOrigin}")
         super(ParticipantDao, self)._validate_update(session, obj, existing_obj)
         # Once a participant marks their withdrawal status as NO_USE, it can't be changed back.
         # TODO: Consider the future ability to un-withdraw.

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -853,42 +853,43 @@ class ParticipantApiTest(BaseTestCase, PDRGeneratorTestMixin):
         without the bypass origin check flag
         """
         BaseTestCase.switch_auth_user("example@spellman.com", "vibrent")
-        with FakeClock(TIME_1):
-            response = self.send_post("Participant", self.participant)
-            participant_id = response["participantId"]
-            # Expecting a Failed Response without the bypass origin check flag
-            BaseTestCase.switch_auth_user("example@cebyok.com", "example")
-            bad_get_response = self.send_get(
-                "Participant/%s" % participant_id, expected_status=http.client.BAD_REQUEST
-            )
-            bad_put_response = self.send_put(
-                f"Participant/{participant_id}",
-                response,
-                headers={"If-Match": 'W/"1"'},
-                expected_status=http.client.BAD_REQUEST
-            )
-            self.assertEqual(
-                bad_get_response.json["message"],
-                "Can not retrieve participant from a different origin",
-            )
-            self.assertEqual(
-                bad_put_response.json["message"],
-                "example not able to update participant from                             vibrent",
-            )
-            # Expecting a passing response with the bypass origin check flag
-            BaseTestCase.switch_auth_user(
-                "example@cebyok.com", "example", bypass_origin_check=True
-            )
-            get_response = self.send_get("Participant/%s" % participant_id)
-            put_response = self.send_put(
-                f"Participant/{participant_id}",
-                response,
-                headers={"If-Match": 'W/"1"'},
-            )
-            self.assertEqual(response, get_response)
-            del response['meta']['versionId']
-            del put_response['meta']['versionId']
-            self.assertEqual(response, put_response)
+        response = self.send_post("Participant", self.participant)
+        participant_id = response["participantId"]
+        # Expecting a Failed Response without the bypass origin check flag
+        BaseTestCase.switch_auth_user("example@cebyok.com", "example")
+        bad_get_response = self.send_get(
+            "Participant/%s" % participant_id, expected_status=http.client.BAD_REQUEST
+        )
+        bad_put_response = self.send_put(
+            f"Participant/{participant_id}",
+            response,
+            headers={"If-Match": 'W/"1"'},
+            expected_status=http.client.BAD_REQUEST
+        )
+        self.assertEqual(
+            bad_get_response.json["message"],
+            "Can not retrieve participant from a different origin",
+        )
+        self.assertEqual(
+            bad_put_response.json["message"],
+            "example not able to update participant from                             vibrent",
+        )
+        # Expecting a passing response with the bypass origin check flag
+        BaseTestCase.switch_auth_user(
+            "example@cebyok.com", "example", bypass_origin_check=True
+        )
+        get_response = self.send_get("Participant/%s" % participant_id)
+        put_response = self.send_put(
+            f"Participant/{participant_id}",
+            response,
+            headers={"If-Match": 'W/"1"'},
+        )
+        self.assertEqual(response, get_response)
+        del response['meta']['versionId']
+        del response['lastModified']
+        del put_response['meta']['versionId']
+        del put_response['lastModified']
+        self.assertEqual(response, put_response)
         BaseTestCase.switch_auth_user("example@example.com", "example")
 
 

--- a/tests/api_tests/test_participant_api.py
+++ b/tests/api_tests/test_participant_api.py
@@ -848,17 +848,47 @@ class ParticipantApiTest(BaseTestCase, PDRGeneratorTestMixin):
 
 
     def test_bypass_origin_check_with_users(self):
+        """
+        ensuring GET and PUT requests against the participant API from different origins still get a 404 BAD REQUEST
+        without the bypass origin check flag
+        """
         BaseTestCase.switch_auth_user("example@spellman.com", "vibrent")
-        response = self.send_post("Participant", self.participant)
-        participant_id = response["participantId"]
-        # Expecting a Failed Response without the bypass origin check  flag
-        BaseTestCase.switch_auth_user("example@cebyok.com", "example")
-        bad_get_response = self.send_get("Participant/%s" % participant_id, expected_status=http.client.BAD_REQUEST)
-        self.assertEqual(bad_get_response.json['message'], 'Can not retrieve participant from a different origin')
-        # Expecting a passing response with the bypass origin check flag
-        BaseTestCase.switch_auth_user("example@cebyok.com", "example", bypass_origin_check=True)
-        get_response = self.send_get("Participant/%s" % participant_id)
-        self.assertEqual(response, get_response)
+        with FakeClock(TIME_1):
+            response = self.send_post("Participant", self.participant)
+            participant_id = response["participantId"]
+            # Expecting a Failed Response without the bypass origin check flag
+            BaseTestCase.switch_auth_user("example@cebyok.com", "example")
+            bad_get_response = self.send_get(
+                "Participant/%s" % participant_id, expected_status=http.client.BAD_REQUEST
+            )
+            bad_put_response = self.send_put(
+                f"Participant/{participant_id}",
+                response,
+                headers={"If-Match": 'W/"1"'},
+                expected_status=http.client.BAD_REQUEST
+            )
+            self.assertEqual(
+                bad_get_response.json["message"],
+                "Can not retrieve participant from a different origin",
+            )
+            self.assertEqual(
+                bad_put_response.json["message"],
+                "example not able to update participant from                             vibrent",
+            )
+            # Expecting a passing response with the bypass origin check flag
+            BaseTestCase.switch_auth_user(
+                "example@cebyok.com", "example", bypass_origin_check=True
+            )
+            get_response = self.send_get("Participant/%s" % participant_id)
+            put_response = self.send_put(
+                f"Participant/{participant_id}",
+                response,
+                headers={"If-Match": 'W/"1"'},
+            )
+            self.assertEqual(response, get_response)
+            del response['meta']['versionId']
+            del put_response['meta']['versionId']
+            self.assertEqual(response, put_response)
         BaseTestCase.switch_auth_user("example@example.com", "example")
 
 


### PR DESCRIPTION
## Resolves *NO TICKET*


## Description of changes/additions
CEBYOK is running in to a similar issue with PUT requests that we just resolved with GET requests. Applying the same fix to the PUT requests to look for the bypass origin check flag.

## Tests
- [x] unit tests


