### PR TITLE
[DA-4159] Integrating enrollment status dependencies

### DIFF
--- a/rdr_service/dao/enrollment_dependencies_dao.py
+++ b/rdr_service/dao/enrollment_dependencies_dao.py
@@ -6,19 +6,29 @@ from sqlalchemy.orm import Session
 from rdr_service.model.enrollment_dependencies import EnrollmentDependencies
 from rdr_service.participant_enums import ParticipantCohortEnum
 
+cache = dict()
+
 
 class EnrollmentDependenciesDao:
+
     @classmethod
     def get_enrollment_dependencies(cls, participant_id: int, session: Session) -> Optional[EnrollmentDependencies]:
-        return session.query(EnrollmentDependencies).filter(
+        if participant_id in cache:
+            return cache[participant_id]
+
+        result = session.query(EnrollmentDependencies).filter(
             EnrollmentDependencies.participant_id == participant_id
-        ).one_or_none()
+        ).first()
+        if result:
+            cache[participant_id] = result
+        return result
 
     @classmethod
     def _set_field(cls, field_name: str, value, participant_id: int, session: Session):
         obj = cls.get_enrollment_dependencies(participant_id=participant_id, session=session)
         if not obj:
             obj = EnrollmentDependencies(participant_id=participant_id)
+            cache[participant_id] = obj
             session.add(obj)
 
         if getattr(obj, field_name) is None:

--- a/rdr_service/dao/enrollment_dependencies_dao.py
+++ b/rdr_service/dao/enrollment_dependencies_dao.py
@@ -31,7 +31,7 @@ class EnrollmentDependenciesDao:
             cache[participant_id] = obj
             session.add(obj)
 
-        if getattr(obj, field_name) is None:
+        if getattr(obj, field_name) is None or value is None:
             setattr(obj, field_name, value)
 
     @classmethod

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -795,7 +795,7 @@ class ParticipantSummaryDao(UpdatableDao):
             participant_id=summary.participantId,
             session=session
         )
-        EnrollmentDependenciesDao.set_weight_physical_measurements_time(
+        EnrollmentDependenciesDao.set_height_physical_measurements_time(
             value=min_or_none(meas.finalized for meas in core_measurements if meas.satisfiesHeightRequirements),
             participant_id=summary.participantId,
             session=session

--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 
-from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 import faker
 import re
@@ -31,12 +30,12 @@ from rdr_service.api_util import (
 )
 from rdr_service.app_util import is_care_evo_and_not_prod
 from rdr_service.cloud_utils.gcp_google_pubsub import submit_pipeline_pubsub_msg_from_model
-from rdr_service.code_constants import BIOBANK_TESTS, COHORT_1_REVIEW_CONSENT_YES_CODE, ORIGINATING_SOURCES,\
-    PMI_SKIP_CODE, PPI_SYSTEM, PRIMARY_CONSENT_UPDATE_MODULE, PRIMARY_CONSENT_UPDATE_QUESTION_CODE, UNSET
+from rdr_service.code_constants import BIOBANK_TESTS, ORIGINATING_SOURCES,\
+    PMI_SKIP_CODE, PPI_SYSTEM, UNSET
 from rdr_service.dao.base_dao import UpdatableDao
-from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.database_utils import get_sql_and_params_for_array, replace_null_safe_equals
+from rdr_service.dao.enrollment_dependencies_dao import EnrollmentDependenciesDao
 from rdr_service.dao.genomics_dao import GenomicSetMemberDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.organization_dao import OrganizationDao
@@ -87,7 +86,6 @@ from rdr_service.participant_enums import (
 from rdr_service.model.code import Code
 from rdr_service.query import FieldFilter, FieldJsonContainsFilter, Operator, OrderBy, PropertyType
 from rdr_service.repository.obfuscation_repository import ObfuscationRepository
-from rdr_service.repository.questionnaire_response_repository import QuestionnaireResponseRepository
 from rdr_service.services.retention_calculation import RetentionEligibility
 from rdr_service.services.system_utils import min_or_none
 
@@ -785,85 +783,54 @@ class ParticipantSummaryDao(UpdatableDao):
         """
         from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 
-        earliest_physical_measurements_time = min_or_none([
-            summary.clinicPhysicalMeasurementsFinalizedTime,
-            summary.selfReportedPhysicalMeasurementsAuthored
-        ])
-
         core_measurements = PhysicalMeasurementsDao.get_core_measurements_for_participant(
             session=session,
             participant_id=summary.participantId
         )
-
-        earliest_biobank_received_dna_time = None
-        if summary.samplesToIsolateDNA == SampleStatus.RECEIVED:
-            earliest_biobank_received_dna_time = BiobankStoredSampleDao.get_earliest_confirmed_dna_sample_timestamp(
-                session=session,
-                biobank_id=summary.biobankId
-            )
-
-        # See ROC-1572/PDR-1699.  Provide a default date to get_interest_in_sharing_ehr_ranges() if participant
-        # has SUBMITTED status for their EHR consent.  Remediates data issues w/older consent validations
-        default_ehr_date = summary.consentForElectronicHealthRecordsFirstYesAuthored \
-            if summary.consentForElectronicHealthRecords == QuestionnaireStatus.SUBMITTED else None
-
-        ehr_consent_ranges = QuestionnaireResponseRepository.get_interest_in_sharing_ehr_ranges(
+        EnrollmentDependenciesDao.set_physical_measurements_time(
+            value=min_or_none([
+                summary.clinicPhysicalMeasurementsFinalizedTime,
+                summary.selfReportedPhysicalMeasurementsAuthored
+            ]),
             participant_id=summary.participantId,
-            session=session,
-            default_authored_datetime=default_ehr_date
+            session=session
+        )
+        EnrollmentDependenciesDao.set_weight_physical_measurements_time(
+            value=min_or_none(meas.finalized for meas in core_measurements if meas.satisfiesHeightRequirements),
+            participant_id=summary.participantId,
+            session=session
+        )
+        EnrollmentDependenciesDao.set_weight_physical_measurements_time(
+            value=min_or_none(meas.finalized for meas in core_measurements if meas.satisfiesWeightRequirements),
+            participant_id=summary.participantId,
+            session=session
+        )
+        EnrollmentDependenciesDao.set_has_linked_guardian_account(
+            value=bool(summary.guardianParticipants and len(summary.guardianParticipants) > 0),
+            participant_id=summary.participantId,
+            session=session
         )
 
-        revised_consent_time_list = []
-        response_collection = QuestionnaireResponseRepository.get_responses_to_surveys(
-            session=session,
-            survey_codes=[PRIMARY_CONSENT_UPDATE_MODULE],
-            participant_ids=[summary.participantId]
-        )
-        if summary.participantId in response_collection:
-            program_update_response_list = response_collection[summary.participantId].responses.values()
-            for response in program_update_response_list:
-                reconsent_answer = response.get_single_answer_for(PRIMARY_CONSENT_UPDATE_QUESTION_CODE).value.lower()
-                if reconsent_answer == COHORT_1_REVIEW_CONSENT_YES_CODE.lower():
-                    revised_consent_time_list.append(response.authored_datetime)
-        revised_consent_time = min_or_none(revised_consent_time_list)
 
         wgs_sequencing_time = GenomicSetMemberDao.get_wgs_pass_date(
             session=session,
             biobank_id=summary.biobankId
         )
-        first_exposures_response_time = None
-        for data in (summary.pediatricData or []):
-            if data.data_type == PediatricDataType.ENVIRONMENTAL_EXPOSURES:
-                timestamp = parse(data.value)
-                if first_exposures_response_time is None or timestamp < first_exposures_response_time:
-                    first_exposures_response_time = timestamp
+        EnrollmentDependenciesDao.set_wgs_sequencing_time(wgs_sequencing_time, summary.participantId, session)
+        EnrollmentDependenciesDao.set_first_ehr_file_received_time(
+            value=min_or_none([summary.ehrReceiptTime, summary.firstParticipantMediatedEhrReceiptTime]),
+            participant_id=summary.participantId,
+            session=session
+        )
+        EnrollmentDependenciesDao.set_first_mediated_ehr_received_time(
+            summary.firstParticipantMediatedEhrReceiptTime, summary.participantId, session
+        )
 
         enrl_dependencies = EnrollmentDependencies(
-            consent_cohort=summary.consentCohort,
-            primary_consent_authored_time=summary.consentForStudyEnrollmentFirstYesAuthored,
-            first_full_ehr_consent_authored_time=summary.consentForElectronicHealthRecordsFirstYesAuthored,
-            gror_authored_time=summary.consentForGenomicsRORAuthored,
-            basics_authored_time=summary.questionnaireOnTheBasicsAuthored,
-            overall_health_authored_time=summary.questionnaireOnOverallHealthAuthored,
-            lifestyle_authored_time=summary.questionnaireOnLifestyleAuthored,
-            earliest_ehr_file_received_time=min_or_none(
-                [summary.ehrReceiptTime, summary.firstParticipantMediatedEhrReceiptTime]
-            ),
-            earliest_mediated_ehr_receipt_time=summary.firstParticipantMediatedEhrReceiptTime,
-            earliest_physical_measurements_time=earliest_physical_measurements_time,
-            earliest_biobank_received_dna_time=earliest_biobank_received_dna_time,
-            ehr_consent_date_range_list=ehr_consent_ranges,
-            dna_update_time=revised_consent_time,
-            earliest_height_measurement_time=min_or_none(
-                meas.finalized for meas in core_measurements if meas.satisfiesHeightRequirements
-            ),
-            earliest_weight_measurement_time=min_or_none(
-                meas.finalized for meas in core_measurements if meas.satisfiesWeightRequirements
-            ),
-            wgs_sequencing_time=wgs_sequencing_time,
-            exposures_authored_time=first_exposures_response_time,
-            is_pediatric_participant=summary.isPediatric,
-            has_linked_guardian_accounts=(summary.guardianParticipants and len(summary.guardianParticipants) > 0)
+            EnrollmentDependenciesDao.get_enrollment_dependencies(
+                participant_id=summary.participantId,
+                session=session
+            )
         )
         enrollment_info = EnrollmentCalculation.get_enrollment_info(enrl_dependencies)
 

--- a/rdr_service/dao/pediatric_data_log_dao.py
+++ b/rdr_service/dao/pediatric_data_log_dao.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from rdr_service.clock import CLOCK
 from rdr_service.dao.base_dao import with_session
+from rdr_service.dao.enrollment_dependencies_dao import EnrollmentDependenciesDao
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.pediatric_data_log import PediatricDataLog, PediatricDataType
 from rdr_service.participant_enums import PediatricAgeRange
@@ -24,6 +25,7 @@ class PediatricDataLogDao:
             logging.error(f'Unrecognized age range value "{age_range_str}"')
             return None
 
+        EnrollmentDependenciesDao.set_is_pediatric_participant(True, participant_id, session)
         cls.insert(
             data=PediatricDataLog(
                 participant_id=participant_id,

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -877,12 +877,13 @@ class QuestionnaireResponseDao(BaseDao):
                             if participant_summary.ehrConsentExpireStatus == ConsentExpireStatus.EXPIRED and \
                                 authored < participant_summary.ehrConsentExpireAuthored:
                                 ehr_consent = False
-                            EnrollmentDependenciesDao.set_intent_to_share_ehr_time(
-                                authored, participant_summary.participantId, session
-                            )
-                            EnrollmentDependenciesDao.set_full_ehr_consent_authored_time(
-                                authored, participant_summary.participantId, session
-                            )
+                            if config.getSettingJson('ENROLLMENT_STATUS_SKIP_VALIDATION', False):
+                                EnrollmentDependenciesDao.set_intent_to_share_ehr_time(
+                                    authored, participant_summary.participantId, session
+                                )
+                                EnrollmentDependenciesDao.set_full_ehr_consent_authored_time(
+                                    authored, participant_summary.participantId, session
+                                )
                     elif code.value == EHR_CONSENT_EXPIRED_QUESTION_CODE:
                         if answer.valueString and answer.valueString == EHR_CONSENT_EXPIRED_YES:
                             participant_summary.ehrConsentExpireStatus = ConsentExpireStatus.EXPIRED

--- a/rdr_service/logic/enrollment_info.py
+++ b/rdr_service/logic/enrollment_info.py
@@ -3,13 +3,13 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List, Optional
 
+from rdr_service.model.enrollment_dependencies import EnrollmentDependencies as DbEnrollmentDependencies
 from rdr_service.participant_enums import (
     EnrollmentStatus,
     EnrollmentStatusV30,
     EnrollmentStatusV32,
-    ParticipantCohort
+    ParticipantCohortEnum as ParticipantCohort
 )
-from rdr_service.services.system_utils import DateRange
 
 
 @dataclass
@@ -48,39 +48,87 @@ class EnrollmentDependencies:
     Convenience class for communicating data needed for finding enrollment progress
     """
 
-    consent_cohort: ParticipantCohort
-    primary_consent_authored_time: datetime
-    first_full_ehr_consent_authored_time: datetime
+    def __init__(self, db_obj: DbEnrollmentDependencies):
+        self._db_obj = db_obj
 
-    dna_update_time: datetime  # Cohorts 1 and 2
+    @property
+    def consent_cohort(self) -> ParticipantCohort:
+        return self._db_obj.consent_cohort
 
-    gror_authored_time: datetime
-    basics_authored_time: datetime
-    overall_health_authored_time: datetime
-    lifestyle_authored_time: datetime
-    exposures_authored_time: datetime
+    @property
+    def primary_consent_authored_time(self) -> datetime:
+        return self._db_obj.primary_consent_authored_time
 
-    ehr_consent_date_range_list: List[DateRange]
-    """DateRanges of when the participant expressed interest in sharing EHR data. Must be in chronological order"""
+    @property
+    def first_full_ehr_consent_authored_time(self) -> datetime:
+        return self._db_obj.full_ehr_consent_authored_time
 
-    earliest_biobank_received_dna_time: datetime
-    earliest_ehr_file_received_time: datetime
-    earliest_mediated_ehr_receipt_time: datetime
-    earliest_physical_measurements_time: datetime
+    @property
+    def dna_update_time(self) -> datetime:
+        # Cohorts 1 and 2
+        return self._db_obj.dna_consent_update_time
 
-    earliest_weight_measurement_time: datetime  # Earliest physical measurement that meets core data reqs
-    earliest_height_measurement_time: datetime  # Earliest physical measurement that meets core data reqs
-    wgs_sequencing_time: datetime
+    @property
+    def gror_authored_time(self) -> datetime:
+        return self._db_obj.gror_consent_authored_time
 
-    is_pediatric_participant: bool
-    has_linked_guardian_accounts: bool
+    @property
+    def basics_authored_time(self) -> datetime:
+        return self._db_obj.basics_survey_authored_time
+
+    @property
+    def overall_health_authored_time(self) -> datetime:
+        return self._db_obj.overall_health_survey_authored_time
+
+    @property
+    def lifestyle_authored_time(self) -> datetime:
+        return self._db_obj.lifestyle_survey_authored_time
+
+    @property
+    def exposures_authored_time(self) -> datetime:
+        return self._db_obj.exposures_survey_authored_time
+
+    @property
+    def earliest_biobank_received_dna_time(self) -> datetime:
+        return self._db_obj.biobank_received_dna_time
+
+    @property
+    def earliest_ehr_file_received_time(self) -> datetime:
+        return self._db_obj.first_ehr_file_received_time
+
+    @property
+    def earliest_mediated_ehr_receipt_time(self) -> datetime:
+        return self._db_obj.first_mediated_ehr_received_time
+
+    @property
+    def earliest_physical_measurements_time(self) -> datetime:
+        return self._db_obj.physical_measurements_time
+
+    @property
+    def earliest_weight_measurement_time(self) -> datetime:
+        # Earliest physical measurement that meets core data reqs
+        return self._db_obj.weight_physical_measurements_time
+
+    @property
+    def earliest_height_measurement_time(self) -> datetime:
+        # Earliest physical measurement that meets core data reqs
+        return self._db_obj.height_physical_measurements_time
+
+    @property
+    def wgs_sequencing_time(self) -> datetime:
+        return self._db_obj.wgs_sequencing_time
+
+    @property
+    def is_pediatric_participant(self) -> bool:
+        return self._db_obj.is_pediatric_participant
+
+    @property
+    def has_linked_guardian_accounts(self) -> bool:
+        return self._db_obj.has_linked_guardian_account
 
     @property
     def first_ehr_consent_date(self):
-        if len(self.ehr_consent_date_range_list) > 0:
-            return self.ehr_consent_date_range_list[0].start
-
-        return None
+        return self._db_obj.intent_to_share_ehr_time
 
     @property
     def has_completed_dna_update(self):
@@ -104,7 +152,7 @@ class EnrollmentDependencies:
 
     @property
     def ever_expressed_interest_in_sharing_ehr(self):
-        return len(self.ehr_consent_date_range_list) > 0
+        return self.first_ehr_consent_date is not None
 
     @property
     def biobank_received_dna_sample(self):
@@ -123,7 +171,27 @@ class EnrollmentDependencies:
         return self.earliest_physical_measurements_time is not None
 
     def to_json_dict(self):
-        return {field_name: str(value) for field_name, value in self.__dict__.items()}
+        return {
+            "consent_cohort": (self._db_obj.consent_cohort.name if self._db_obj.consent_cohort else None),
+            "dna_update_time": str(self._db_obj.dna_consent_update_time),
+            "gror_authored_time": str(self._db_obj.gror_consent_authored_time),
+            "wgs_sequencing_time": str(self._db_obj.wgs_sequencing_time),
+            "basics_authored_time": str(self._db_obj.basics_survey_authored_time),
+            "exposures_authored_time": str(self._db_obj.exposures_survey_authored_time),
+            "lifestyle_authored_time": str(self._db_obj.lifestyle_survey_authored_time),
+            "is_pediatric_participant": self._db_obj.is_pediatric_participant,
+            "first_ehr_consent_date": str(self._db_obj.intent_to_share_ehr_time),
+            "has_linked_guardian_accounts": self._db_obj.has_linked_guardian_account,
+            "overall_health_authored_time": str(self._db_obj.overall_health_survey_authored_time),
+            "primary_consent_authored_time": str(self._db_obj.primary_consent_authored_time),
+            "earliest_ehr_file_received_time": str(self._db_obj.first_ehr_file_received_time),
+            "earliest_height_measurement_time": str(self._db_obj.height_physical_measurements_time),
+            "earliest_weight_measurement_time": str(self._db_obj.weight_physical_measurements_time),
+            "earliest_biobank_received_dna_time": str(self._db_obj.biobank_received_dna_time),
+            "earliest_mediated_ehr_receipt_time": str(self._db_obj.first_mediated_ehr_received_time),
+            "earliest_physical_measurements_time": str(self._db_obj.physical_measurements_time),
+            "first_full_ehr_consent_authored_time": str(self._db_obj.full_ehr_consent_authored_time)
+        }
 
 
 class EnrollmentCalculation:

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -21,6 +21,7 @@ from rdr_service.code_constants import (CONSENT_PERMISSION_NO_CODE, CONSENT_PERM
 from rdr_service.concepts import Concept
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
 from rdr_service.dao.code_dao import CodeDao
+from rdr_service.dao.enrollment_dependencies_dao import EnrollmentDependenciesDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.pediatric_data_log_dao import PediatricDataLogDao
@@ -1933,6 +1934,11 @@ class ParticipantSummaryApiTest(BaseTestCase):
                 confirmed=time,
             )
         )
+        if test_code in config.getSettingList(config.DNA_SAMPLE_TEST_CODES):
+            participant_id_int = from_client_participant_id(participant["participantId"])
+            EnrollmentDependenciesDao.set_biobank_received_dna_time(
+                time, participant_id_int, self.session
+            )
 
     def testQuery_ehrConsent(self):
         questionnaire_id = self.create_questionnaire("all_consents_questionnaire.json")

--- a/tests/dao_tests/test_enrollment_dependencies_dao.py
+++ b/tests/dao_tests/test_enrollment_dependencies_dao.py
@@ -83,11 +83,13 @@ class EnrollmentDependenciesDaoTest(BaseTestCase):
             EnrollmentDependenciesDao.set_gror_consent_authored_time(
                 authored_time, self.participant_id, self.session
             )
+            self.session.commit()  # committing to db within context to get faked time
 
         with FakeClock(datetime(2022, 1, 1)):
             EnrollmentDependenciesDao.set_gror_consent_authored_time(
                 datetime(2100, 1, 1), self.participant_id, self.session
             )
+            self.session.commit()
 
         db_obj = self.session.query(EnrollmentDependencies).filter(
             EnrollmentDependencies.participant_id == self.participant_id

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -30,8 +30,9 @@ from rdr_service.dao.bq_code_dao import BQCodeGenerator
 from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.dao.code_dao import CodeDao
-from rdr_service.dao.enrollment_dependencies_dao import cache as enrollment_cache
+from rdr_service.dao.enrollment_dependencies_dao import cache as enrollment_cache, EnrollmentDependenciesDao
 from rdr_service.dao.participant_dao import ParticipantDao
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.biobank_order import BiobankOrderIdentifier, BiobankOrder, BiobankOrderedSample
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.bigquery_sync import BigQuerySync
@@ -928,6 +929,11 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
             ParticipantSummary.participantId == participant_id
         ).one()
         summary.consentForElectronicHealthRecords = participant_enums.QuestionnaireStatus.SUBMITTED
+        EnrollmentDependenciesDao.set_intent_to_share_ehr_time(
+            summary.consentForElectronicHealthRecordsAuthored, participant_id, self.session
+        )
+        dao = ParticipantSummaryDao()
+        dao.update_enrollment_status(summary, self.session)
         self.session.commit()
 
 

--- a/tests/helpers/unittest_base.py
+++ b/tests/helpers/unittest_base.py
@@ -30,6 +30,7 @@ from rdr_service.dao.bq_code_dao import BQCodeGenerator
 from rdr_service.dao.bq_participant_summary_dao import BQParticipantSummaryGenerator
 from rdr_service.dao.bq_questionnaire_dao import BQPDRQuestionnaireResponseGenerator
 from rdr_service.dao.code_dao import CodeDao
+from rdr_service.dao.enrollment_dependencies_dao import cache as enrollment_cache
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.model.biobank_order import BiobankOrderIdentifier, BiobankOrder, BiobankOrderedSample
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
@@ -535,6 +536,8 @@ class BaseTestCase(unittest.TestCase, QuestionnaireTestMixin, CodebookTestMixin)
         for key, original_data in self.config_data_to_reset.items():
             config.override_setting(key, original_data)
         self.config_data_to_reset = {}
+
+        enrollment_cache.clear()  # Remove any enrollment dependency data created by the test
 
     def setup_storage(self):
         temp_folder_path = mkdtemp()

--- a/tests/logic_tests/test_enrollment_info.py
+++ b/tests/logic_tests/test_enrollment_info.py
@@ -323,9 +323,6 @@ class TestEnrollmentInfo(BaseTestCase):
         current_state = EnrollmentCalculation.get_enrollment_info(participant_info)
         self.assertEqual(EnrollmentStatusV32.PMB_ELIGIBLE, current_state.version_3_2_status)
 
-        bobjson = participant_info.to_json_dict()
-        print(bobjson)
-
     def test_pediatric_core(self):
         """
         Test that Exposures survey replaces Lifestyle requirement for Core status for pediatrics,


### PR DESCRIPTION
## Resolves *[DA-4159](https://precisionmedicineinitiative.atlassian.net/browse/DA-4159)*
This integrates the new dao and data model into the rest of the API code. Most places that set data needed for an enrollment status will use the dao to store the data, and the enrollment status calculation loads the model for the calculation. There are some fields that didn't have clear or simple ways to store the enrollment data, so those are left as is (to be read and set just before the calculation).

## Tests
- [x] unit tests




[DA-4159]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ