### PR TITLE
Updates to EHR validation

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -712,14 +712,14 @@ class VibrentEhrConsentFile(EhrConsentFile):
     def _get_signature_elements(self):
         signature_page_number = self._get_signature_page_number()
         return self.pdf.get_elements_intersecting_box(
-            Rect.from_edges(left=130, right=250, bottom=160, top=165),
+            self._get_signature_search_box(),
             page=signature_page_number
         )
 
     def _get_date_elements(self):
         signature_page_number = self._get_signature_page_number()
         return self.pdf.get_elements_intersecting_box(
-            Rect.from_edges(left=130, right=250, bottom=110, top=115),
+            self._get_date_search_box(),
             page=signature_page_number
         )
 
@@ -731,10 +731,16 @@ class VibrentEhrConsentFile(EhrConsentFile):
         )
 
     def is_sensitive_form(self):
-        return self.pdf.get_page_number_of_text([(
-            'I agree to release sensitive information from my EHRs',
-            'Acepto compartir información confidencial de mis EHR'
-        )]) is not None
+        return (
+            self.pdf.get_page_number_of_text([(
+                'I agree to release sensitive information from my EHRs',
+                'Acepto compartir información confidencial de mis EHR'
+            )])
+            or self.pdf.get_page_number_of_text([(
+                'I agree to release sensitive information from my electronic',
+                'Acepto compartir información confidencial de mis registros'
+            )])
+        ) is not None
 
     def _get_signature_page_number(self):
         return self.pdf.get_page_number_of_text([(
@@ -774,6 +780,23 @@ class VibrentEhrConsentFile(EhrConsentFile):
                 return False
 
         return bool(initial_text_found)
+
+    def _get_signature_search_box(self):
+        if self._is_mar_24_version():
+            return Rect.from_edges(left=130, right=250, bottom=280, top=285)
+        else:
+            return Rect.from_edges(left=130, right=250, bottom=160, top=165)
+
+    def _get_date_search_box(self):
+        if self._is_mar_24_version():
+            return Rect.from_edges(left=130, right=250, bottom=100, top=105)
+        else:
+            return Rect.from_edges(left=130, right=250, bottom=110, top=115)
+
+    def _is_mar_24_version(self):
+        return self.pdf.get_page_number_of_text([(
+            'Relationship to the individual', 'Relación con el participante'
+        )]) is not None
 
 
 class VibrentGrorConsentFile(GrorConsentFile):

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -458,7 +458,28 @@ class ConsentFileParsingTest(BaseTestCase):
             expected_to_be_va_file=True
         )
 
-        return [basic_ehr_case, va_ehr_case]
+        mar_24_ehr_pdf = self._build_pdf(pages=[
+            *six_empty_pages,
+            [
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='You will have access to a signed copy of this form',
+                ),
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='Relationship to the individual',
+                ),
+                self._build_form_element(text='March 2024 File', bbox=(125, 230, 450, 290)),
+                self._build_form_element(text='Nov 5 2024', bbox=(125, 95, 450, 108))
+            ]
+        ])
+        mar_24_ehr_case = EhrConsentTestData(
+            file=files.VibrentEhrConsentFile(pdf=mar_24_ehr_pdf, blob=mock.MagicMock()),
+            expected_signature='March 2024 File',
+            expected_sign_date=date(2024, 11, 5)
+        )
+
+        return [basic_ehr_case, va_ehr_case, mar_24_ehr_case]
 
     def _build_sensitive_ehr(self, with_initials: bool) -> files.EhrConsentFile:
         seven_empty_pages = [[], [], [], [], [], [], []]


### PR DESCRIPTION
## Resolves *[DA-4192](https://precisionmedicineinitiative.atlassian.net/browse/DA-4192)*
Vibrent is releasing an updated version of the EHR consent. This updates the validation code to detect if an EHR file is the new version and look for the signature in a different spot if it is.

## Tests
- [x] unit tests




[DA-4192]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ