### PR TITLE
[DA-4172] Implementing filter for isPediatric

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -84,7 +84,7 @@ from rdr_service.participant_enums import (
     PhysicalMeasurementsCollectType
 )
 from rdr_service.model.code import Code
-from rdr_service.query import FieldFilter, FieldJsonContainsFilter, Operator, OrderBy, PropertyType
+from rdr_service.query import FieldFilter, FieldJsonContainsFilter, Operator, OrderBy, PropertyType, QueryMutatingFilter
 from rdr_service.repository.obfuscation_repository import ObfuscationRepository
 from rdr_service.services.retention_calculation import RetentionEligibility
 from rdr_service.services.system_utils import min_or_none
@@ -659,6 +659,15 @@ class ParticipantSummaryDao(UpdatableDao):
                 ),
                 value,
                 PropertyType.DATETIME,
+                'dateOfBirth'
+            )
+        if field_name == 'isPediatric':
+            return QueryMutatingFilter(
+                lambda query_to_filter: query_to_filter.outerjoin(
+                    ParticipantSummary.pediatricData
+                ).filter(
+                    PediatricDataLog.id.is_(None) if value.lower() == 'unset' else PediatricDataLog.id.isnot(None)
+                ),
                 'dateOfBirth'
             )
 

--- a/rdr_service/query.py
+++ b/rdr_service/query.py
@@ -101,6 +101,15 @@ class GenericExpressionFilter:
         return query.filter(self._expression)
 
 
+class QueryMutatingFilter:
+    def __init__(self, callback, field_name):
+        self._callback = callback
+        self.field_name = field_name
+
+    def add_to_sqlalchemy_query(self, query):
+        return self._callback(query)
+
+
 class OrderBy(object):
     def __init__(self, field_name, ascending):
         self.field_name = field_name

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -4821,6 +4821,31 @@ class ParticipantSummaryApiTest(BaseTestCase):
             [participant['resource']['participantId'] for participant in sort_response['entry']]
         )
 
+    def test_is_pediatric_filter(self):
+        pediatric_summary = self.data_generator.create_database_participant_summary()
+        self.session.add(
+            PediatricDataLog(
+                participant_id=pediatric_summary.participantId,
+                data_type=PediatricDataType.AGE_RANGE,
+                value='test'
+            )
+        )
+        adult_summary = self.data_generator.create_database_participant_summary()
+
+        adult_response = self.send_get(f"ParticipantSummary?isPediatric=UNSET")
+        self.assertEqual(1, len(adult_response['entry']))
+        self.assertEqual(
+            adult_summary.participantId,
+            from_client_participant_id(adult_response['entry'][0]['resource']['participantId'])
+        )
+
+        pediatric_response = self.send_get(f"ParticipantSummary?isPediatric=TRUE")
+        self.assertEqual(1, len(pediatric_response['entry']))
+        self.assertEqual(
+            pediatric_summary.participantId,
+            from_client_participant_id(pediatric_response['entry'][0]['resource']['participantId'])
+        )
+
     @classmethod
     def _get_summary_response_id_list(self, response):
         return [from_client_participant_id(entry['resource']['participantId']) for entry in response['entry']]


### PR DESCRIPTION
## Resolves *[DA-4172](https://precisionmedicineinitiative.atlassian.net/browse/DA-4172)*
This sets up a filter for the `isPediatric` field of the ParticipantSummary API


## Tests
- [x] unit tests




[DA-4172]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ