### PR TITLE
updating ehr validation for spanish differences

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -783,20 +783,29 @@ class VibrentEhrConsentFile(EhrConsentFile):
         return bool(initial_text_found)
 
     def _get_signature_search_box(self):
-        if self._is_mar_24_version():
+        if self._is_english_mar_24_version():
+            return Rect.from_edges(left=130, right=250, bottom=255, top=260)
+        elif self._is_spanish_mar_24_version():
             return Rect.from_edges(left=130, right=250, bottom=280, top=285)
         else:
             return Rect.from_edges(left=130, right=250, bottom=160, top=165)
 
     def _get_date_search_box(self):
-        if self._is_mar_24_version():
+        if self._is_english_mar_24_version():
             return Rect.from_edges(left=130, right=250, bottom=100, top=105)
+        elif self._is_spanish_mar_24_version():
+            return Rect.from_edges(left=130, right=250, bottom=120, top=125)
         else:
             return Rect.from_edges(left=130, right=250, bottom=110, top=115)
 
-    def _is_mar_24_version(self):
+    def _is_english_mar_24_version(self):
         return self.pdf.get_page_number_of_text([(
-            'Relationship to the individual', 'Relación con el participante'
+            'Relationship to the individual'
+        )]) is not None
+
+    def _is_spanish_mar_24_version(self):
+        return self.pdf.get_page_number_of_text([(
+            'Relación con el participante'
         )]) is not None
 
 

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -469,7 +469,7 @@ class ConsentFileParsingTest(BaseTestCase):
                     cls=LTTextLineHorizontal,
                     text='Relationship to the individual',
                 ),
-                self._build_form_element(text='March 2024 File', bbox=(125, 230, 450, 290)),
+                self._build_form_element(text='March 2024 File', bbox=(125, 250, 450, 260)),
                 self._build_form_element(text='Nov 5 2024', bbox=(125, 95, 450, 108))
             ]
         ])
@@ -479,7 +479,28 @@ class ConsentFileParsingTest(BaseTestCase):
             expected_sign_date=date(2024, 11, 5)
         )
 
-        return [basic_ehr_case, va_ehr_case, mar_24_ehr_case]
+        mar_24_spanish_ehr_pdf = self._build_pdf(pages=[
+            *six_empty_pages,
+            [
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='You will have access to a signed copy of this form',
+                ),
+                self._build_pdf_element(
+                    cls=LTTextLineHorizontal,
+                    text='Relación con el participante',
+                ),
+                self._build_form_element(text='March 2024 File', bbox=(125, 280, 450, 290)),
+                self._build_form_element(text='Nov 5 2024', bbox=(125, 120, 450, 130))
+            ]
+        ])
+        mar_24_spanish_ehr_case = EhrConsentTestData(
+            file=files.VibrentEhrConsentFile(pdf=mar_24_spanish_ehr_pdf, blob=mock.MagicMock()),
+            expected_signature='March 2024 File',
+            expected_sign_date=date(2024, 11, 5)
+        )
+
+        return [basic_ehr_case, va_ehr_case, mar_24_ehr_case, mar_24_spanish_ehr_case]
 
     def _build_sensitive_ehr(self, with_initials: bool) -> files.EhrConsentFile:
         seven_empty_pages = [[], [], [], [], [], [], []]


### PR DESCRIPTION
## Resolves *[DA-4223](https://precisionmedicineinitiative.atlassian.net/browse/DA-4223)*
We're seeing that the new EHR layout is different between Spanish and English versions (less whitespace in the margins for the Spanish version). So the search boxes for validating the files need to be adjusted a bit and dependent on the language of the file.


## Tests
- [x] unit tests




[DA-4223]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ