### PR TITLE
[DA-4243] More updates for validating consent files

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -408,6 +408,7 @@ class CeConsentFactory(ConsentFileAbstractFactory):
             'el Estudio WEAR de All of Us',
             'Estudio del uso desensores portátiles',
             'Estudio del uso de sensores\nportátiles',
+            'Estudio del uso de sensoresportátiles',
             'Estudio\ndel uso de sensores portátiles',
             'All of Us Wearable Study',
             'All of Us Wearable\nStudy'
@@ -786,7 +787,7 @@ class VibrentEhrConsentFile(EhrConsentFile):
         if self._is_english_mar_24_version():
             return Rect.from_edges(left=130, right=250, bottom=255, top=260)
         elif self._is_spanish_mar_24_version():
-            return Rect.from_edges(left=130, right=250, bottom=280, top=285)
+            return Rect.from_edges(left=130, right=250, bottom=270, top=280)
         else:
             return Rect.from_edges(left=130, right=250, bottom=160, top=165)
 
@@ -794,7 +795,7 @@ class VibrentEhrConsentFile(EhrConsentFile):
         if self._is_english_mar_24_version():
             return Rect.from_edges(left=130, right=250, bottom=100, top=105)
         elif self._is_spanish_mar_24_version():
-            return Rect.from_edges(left=130, right=250, bottom=120, top=125)
+            return Rect.from_edges(left=130, right=250, bottom=113, top=123)
         else:
             return Rect.from_edges(left=130, right=250, bottom=110, top=115)
 
@@ -1006,24 +1007,27 @@ class VibrentPediatricEhrConsentFile(PediatricEhrConsentFile, VibrentEhrConsentF
 
 
 class VibrentWearConsentFile(WearConsentFile):
-    _SIGNATURE_PAGE = 7
+    def _get_signature_page(self):
+        return self.pdf.get_page_number_of_text([
+            ('sign your full name', 'Firme con su nombre completo')
+        ])
 
     def _get_signature_elements(self):
         return self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=150, right=400, bottom=155, top=160),
-            page=self._SIGNATURE_PAGE
+            page=self._get_signature_page()
         )
 
     def _get_date_elements(self):
         return self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=130, right=400, bottom=110, top=115),
-            page=self._SIGNATURE_PAGE
+            page=self._get_signature_page()
         )
 
     def _get_printed_name_elements(self):
         return self.pdf.get_elements_intersecting_box(
             Rect.from_edges(left=350, right=500, bottom=45, top=50),
-            page=self._SIGNATURE_PAGE
+            page=self._get_signature_page()
         )
 
 

--- a/tests/service_tests/consent_tests/test_consent_file_parsing.py
+++ b/tests/service_tests/consent_tests/test_consent_file_parsing.py
@@ -490,13 +490,13 @@ class ConsentFileParsingTest(BaseTestCase):
                     cls=LTTextLineHorizontal,
                     text='Relación con el participante',
                 ),
-                self._build_form_element(text='March 2024 File', bbox=(125, 280, 450, 290)),
+                self._build_form_element(text='Marzo 2024 File', bbox=(125, 275, 450, 290)),
                 self._build_form_element(text='Nov 5 2024', bbox=(125, 120, 450, 130))
             ]
         ])
         mar_24_spanish_ehr_case = EhrConsentTestData(
             file=files.VibrentEhrConsentFile(pdf=mar_24_spanish_ehr_pdf, blob=mock.MagicMock()),
-            expected_signature='March 2024 File',
+            expected_signature='Marzo 2024 File',
             expected_sign_date=date(2024, 11, 5)
         )
 


### PR DESCRIPTION
## Resolves *[DA-4243](https://precisionmedicineinitiative.atlassian.net/browse/DA-4243)*
This makes a few more adjustments for validating EHR and WEAR consents. The EHR search boxes needed to be shifted slightly to be able to find some signatures for some outliers. 

A new version of the WEAR consents was released around the start of the year. And the signature is on a different page number, so this updates the validation code to be able to dynamically find the signature page.


## Tests
- [ ] unit tests




[DA-4243]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ