### PR TITLE
[DA] fix for setting participant summary ehr status after validation

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -58,7 +58,8 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
         # Filter down to just the EHR results and organize them by participant
         ehr_consents_by_participant = defaultdict(lambda: [])
         for result in result_list:
-            ehr_consents_by_participant[result.participant_id].append(result)
+            if result.type in [ConsentType.EHR, ConsentType.EHR_RECONSENT, ConsentType.PEDIATRIC_EHR]:
+                ehr_consents_by_participant[result.participant_id].append(result)
 
         for participant_id, result_list in ehr_consents_by_participant.items():
             self._update_status(

--- a/tests/service_tests/consent_tests/test_validation_strategies.py
+++ b/tests/service_tests/consent_tests/test_validation_strategies.py
@@ -1,7 +1,10 @@
+from datetime import date
 import mock.mock
 
 from rdr_service.dao.consent_dao import ConsentDao
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.participant_enums import QuestionnaireStatus
 from rdr_service.services.consent.validation import ReplacementStoringStrategy, StoreResultStrategy
 from tests.helpers.unittest_base import BaseTestCase
 
@@ -98,4 +101,39 @@ class ValidationOutputStrategyIntegrationTest(BaseTestCase):
         self.assertEqual(
             [result_a1, result_b1, result_b2],
             stored_results
+        )
+
+    @mock.patch('rdr_service.services.consent.validation.dispatch_rebuild_consent_metrics_tasks')
+    @mock.patch('rdr_service.services.consent.validation.GCPCloudTask')
+    def test_store_updates_ehr_status_correctly(self, _, __):
+        # Initialize the data
+        participant_id = self.data_generator.create_database_participant_summary(
+            consentForElectronicHealthRecords=QuestionnaireStatus.SUBMITTED_NOT_VALIDATED
+        ).participantId
+        primary_result = ConsentFile(
+            participant_id=participant_id,
+            type=ConsentType.PRIMARY,
+            sync_status=ConsentSyncStatus.READY_FOR_SYNC,
+            file_exists=True,
+            file_path='new_primary_file',
+            consent_response=mock.MagicMock(id=1),
+            expected_sign_date=date.today()
+        )
+        ehr_result = ConsentFile(
+            participant_id=participant_id,
+            type=ConsentType.EHR,
+            sync_status=ConsentSyncStatus.NEEDS_CORRECTING,
+            file_exists=True,
+            file_path='new_ehr_file',
+            consent_response=mock.MagicMock(id=2),
+            expected_sign_date=date.today()
+        )
+
+        consent_dao = mock.MagicMock()
+        with StoreResultStrategy(self.session, consent_dao) as strategy:
+            strategy.add_all([primary_result, ehr_result])
+
+        participant_summary = self.session.query(ParticipantSummary).get(participant_id)
+        self.assertEqual(
+            QuestionnaireStatus.SUBMITTED_INVALID, participant_summary.consentForElectronicHealthRecords
         )


### PR DESCRIPTION
## Resolves *[DA-4249](https://precisionmedicineinitiative.atlassian.net/browse/DA-4249)*
The code for updating the participant summary EHR status based on the consent validation has had a bug. It was meant to only set the status based on the validation results of only EHR files, but was using the results of any file type.

## Description of changes/additions
This updates the code to only update the participant summary EHR status based on EHR file results.

## Tests
- [x] unit tests




[DA-4249]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ