### PR TITLE
[ROC-1878] Fixing cache bug in enrollment dependencies

### DIFF
--- a/rdr_service/dao/enrollment_dependencies_dao.py
+++ b/rdr_service/dao/enrollment_dependencies_dao.py
@@ -15,8 +15,12 @@ class EnrollmentDependenciesDao:
     def get_enrollment_dependencies(cls, participant_id: int, session: Session) -> Optional[EnrollmentDependencies]:
         if participant_id in cache:
             cached_record = cache[participant_id]
-            merge_result = session.merge(cached_record)
-            return merge_result
+            if Session.object_session(cached_record) == session:
+                return cached_record
+            else:
+                merge_result = session.merge(cached_record)
+                cache[participant_id] = merge_result
+                return merge_result
 
         result = session.query(EnrollmentDependencies).filter(
             EnrollmentDependencies.participant_id == participant_id

--- a/rdr_service/dao/enrollment_dependencies_dao.py
+++ b/rdr_service/dao/enrollment_dependencies_dao.py
@@ -14,7 +14,9 @@ class EnrollmentDependenciesDao:
     @classmethod
     def get_enrollment_dependencies(cls, participant_id: int, session: Session) -> Optional[EnrollmentDependencies]:
         if participant_id in cache:
-            return cache[participant_id]
+            cached_record = cache[participant_id]
+            merge_result = session.merge(cached_record)
+            return merge_result
 
         result = session.query(EnrollmentDependencies).filter(
             EnrollmentDependencies.participant_id == participant_id

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -526,6 +526,7 @@ class QuestionnaireResponseDao(BaseDao):
             session=session
         )
         if summary:
+            session.commit()
             ParticipantSummaryDao().update_enrollment_status(summary, session=session)
             dispatch_task(
                 endpoint='update_retention_status',

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -1950,9 +1950,8 @@ class ParticipantSummaryApiTest(BaseTestCase):
         )
         if test_code in config.getSettingList(config.DNA_SAMPLE_TEST_CODES):
             participant_id_int = from_client_participant_id(participant["participantId"])
-            EnrollmentDependenciesDao.set_biobank_received_dna_time(
-                time, participant_id_int, self.session
-            )
+            EnrollmentDependenciesDao.set_biobank_received_dna_time(time, participant_id_int, self.session)
+            self.session.commit()
 
     def testQuery_ehrConsent(self):
         questionnaire_id = self.create_questionnaire("all_consents_questionnaire.json")

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -257,6 +257,7 @@ class BiobankSamplesPipelineTest(BaseTestCase, PDRGeneratorTestMixin):
             arbitrary_date, core_participant_id, self.session
         )
         participant_summary_dao.update(core_summary)
+        self.session.commit()
 
         samples_json = test_data.open_biobank_samples(biobank_ids=biobank_ids, tests=test_codes)
         self.send_put('Biobank/specimens', request_data=samples_json)


### PR DESCRIPTION
## Resolves *[ROC-1878](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1878)*
This addresses a bug in the code for storing enrollment dependency data. Some participants have authored dates in their participant summary for surveys and consents, but their enrollment dependencies record has nulls for those values instead. It appears that the caching mechanism is to blame in this. A record can be in the cache, but the session associated with the record may have already been committed and closed. So if this record is retrieved from the cache and used again, any further modifications wouldn't persist (since the session wouldn't be told to commit again).

## Description of changes/additions
This updates the code to reinitialize any cached objects on the new session. This way any further modifications to the record's data will be persisted when the new session commits.

## Tests
- [x] unit tests




[ROC-1878]: https://precisionmedicineinitiative.atlassian.net/browse/ROC-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ