### PR TITLE
[DA-4257] Updates to Physical Measurements Data Generator

### DIFF
--- a/rdr_service/data_gen/generators/physical_measurements.py
+++ b/rdr_service/data_gen/generators/physical_measurements.py
@@ -1,7 +1,9 @@
 #
 # Physical Measurements Generator
 #
+import json
 import logging
+import os.path
 import random
 import string
 
@@ -27,14 +29,16 @@ class PhysicalMeasurementsGen(BaseGen):
     _measurement_specs = None
     _qualifier_map = None
 
-    def __init__(self):
+    def __init__(self, load_data=False):
         """
     Initialize physical measurements generator.
     """
-        super(PhysicalMeasurementsGen, self).__init__()
+        super(PhysicalMeasurementsGen, self).__init__(load_data=load_data)
 
         qualifier_concepts = set()
-        measurement_specs = self._app_data["measurement_specs"]
+        file_path = os.path.join(os.path.dirname(__file__), '../../app_data/measurement_specs.json')
+        with open(file_path) as f:
+            measurement_specs = json.load(f)
         for measurement in measurement_specs:
             for qualifier in measurement["qualifiers"]:
                 qualifier_concepts.add(Concept(qualifier["system"], qualifier["code"]))
@@ -331,8 +335,8 @@ class PhysicalMeasurementsGen(BaseGen):
                         self._make_author("finalizer@pmi-ops.org", "finalized"),
                     ],
                     "extension": [
-                        {"url": created_ext, "valueReference": "{0}{1}".format("Location/", self._site.id)},
-                        {"url": finalized_ext, "valueReference": "{0}{1}".format("Location/", self._site.id)},
+                        {"url": created_ext, "valueReference": "{0}{1}".format("Location/", self._site.name)},
+                        {"url": finalized_ext, "valueReference": "{0}{1}".format("Location/", self._site.name)},
                     ],
                     "date": now,
                     "resourceType": "Composition",


### PR DESCRIPTION
## Resolves *[DA-4257](https://precisionmedicineinitiative.atlassian.net/browse/DA-4257)*

## Description of changes/additions
When creating test physical measurement payloads on ptsc-1-test, I ran in to some issues with submitting a payload with the site.id. I looked at other incoming payloads and we are ingesting with the google group. This updates the generator to use the google group, and uses the os.path to find the measurement_specs file. 

## Tests
Tested with manual payloads being sent to /rdr/v1/Participant/{{pid}}/PhysicalMeasurements 



[DA-4257]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ