### PR TITLE
[DA-4257] Part II. Updating hyperlink in Physical Measurements Data Generator 

### DIFF
--- a/rdr_service/data_gen/generators/physical_measurements.py
+++ b/rdr_service/data_gen/generators/physical_measurements.py
@@ -1,7 +1,9 @@
 #
 # Physical Measurements Generator
 #
+import json
 import logging
+import os.path
 import random
 import string
 
@@ -27,14 +29,16 @@ class PhysicalMeasurementsGen(BaseGen):
     _measurement_specs = None
     _qualifier_map = None
 
-    def __init__(self):
+    def __init__(self, load_data=False):
         """
     Initialize physical measurements generator.
     """
-        super(PhysicalMeasurementsGen, self).__init__()
+        super(PhysicalMeasurementsGen, self).__init__(load_data=load_data)
 
         qualifier_concepts = set()
-        measurement_specs = self._app_data["measurement_specs"]
+        file_path = os.path.join(os.path.dirname(__file__), '../../app_data/measurement_specs.json')
+        with open(file_path) as f:
+            measurement_specs = json.load(f)
         for measurement in measurement_specs:
             for qualifier in measurement["qualifiers"]:
                 qualifier_concepts.add(Concept(qualifier["system"], qualifier["code"]))
@@ -331,8 +335,8 @@ class PhysicalMeasurementsGen(BaseGen):
                         self._make_author("finalizer@pmi-ops.org", "finalized"),
                     ],
                     "extension": [
-                        {"url": created_ext, "valueReference": "{0}{1}".format("Location/", self._site.id)},
-                        {"url": finalized_ext, "valueReference": "{0}{1}".format("Location/", self._site.id)},
+                        {"url": created_ext, "valueReference": "{0}{1}".format("Location/", self._site.name)},
+                        {"url": finalized_ext, "valueReference": "{0}{1}".format("Location/", self._site.name)},
                     ],
                     "date": now,
                     "resourceType": "Composition",

--- a/rdr_service/data_gen/generators/physical_measurements.py
+++ b/rdr_service/data_gen/generators/physical_measurements.py
@@ -84,7 +84,7 @@ class PhysicalMeasurementsGen(BaseGen):
 
     def _make_base_measurement_resource(self, measurement, mean, measurement_count):
 
-        system = "https://terminology.pmi-ops.org/CodeSystem/physical-measurements"
+        system = "http://terminology.pmi-ops.org/CodeSystem/physical-measurements"
 
         resource = {
             "code": {


### PR DESCRIPTION
## Resolves *[DA-4257](https://precisionmedicineinitiative.atlassian.net/browse/DA-4257)*


## Description of changes/additions
when sending the test payloads to ptsc, they were not able to ingest secure hyperlinks. This updates the generator to create the test payload to use http:// hyperlinks instead of https:// hyperlinks. 

## Tests
Manually tested on ptsc-1-test using the endpoint
rdr/v1/Participant/P968476362/PhysicalMeasurements



[DA-4257]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ