### PR TITLE
[DA-4127] enrollment status calc task updates

### DIFF
--- a/rdr_service/api/cloud_tasks_api.py
+++ b/rdr_service/api/cloud_tasks_api.py
@@ -404,9 +404,16 @@ class UpdateEnrollmentStatus(Resource):
                 session=session,
                 participant_id=participant_id
             )
+
+            additional_parameters = {}
+            for param_name in ('allow_downgrade', 'pdr_pubsub'):
+                if param_name in task_data:
+                    additional_parameters[param_name] = task_data[param_name]
+
             dao.update_enrollment_status(
                 summary=summary,
-                session=session
+                session=session,
+                **additional_parameters
             )
 
 

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -84,6 +84,23 @@ class TaskApiTest(BaseTestCase):
         )
         self.assertEqual(site_rebuild_task_mock.call_count, 1)
 
+    @mock.patch('rdr_service.api.cloud_tasks_api.ParticipantSummaryDao')
+    def test_enrollment_status_task(self, summary_dao_mock):
+        self._call_task_endpoint(
+            task_path='UpdateEnrollmentStatus',
+            json={
+                'participant_id': 1234,
+                'allow_downgrade': True,
+                'pdr_pubsub': False
+            }
+        )
+        summary_dao_mock.return_value.update_enrollment_status.assert_called_with(
+            allow_downgrade=True,
+            pdr_pubsub=False,
+            summary=mock.ANY,
+            session=mock.ANY
+        )
+
     def _call_task_endpoint(self, task_path, json):
         response = self.send_post(
             f'/resource/task/{task_path}',


### PR DESCRIPTION
## Resolves *[DA-4127](https://precisionmedicineinitiative.atlassian.net/browse/DA-4127)*
This updates the enrollment status task to accept a couple more parameters. And updates the tool/script for enrollment status backfill so that we can use the task queue to update enrollment statuses in the cloud.

## Tests
- [x] unit tests




[DA-4127]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ