### PR TITLE
Updating ParticipantCountsOverTime Job to use BQ Tables

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -293,6 +293,12 @@ SENSITIVE_EHR_RELEASE_DATE = 'sensitive_ehr_release_date'
 PM_HEIGHT_CODES = 'pm_height_codes'
 PM_WEIGHT_CODES = 'pm_weight_codes'
 
+# The ParticipantCountsOverTime job runs in the AOU RDR Prod, but the job uses participant and participant_summary
+# tables from the Warehouse project BigQuery. This maps the RDR project to the correct Warehouse project.
+PUBLIC_METRICS_PROJECT_MAP = "public_metrics_project_map"
+PUBLIC_METRICS_PARTICIPANT_TABLE = "public_metrics_participant_table"
+PUBLIC_METRICS_PARTICIPANT_SUMMARY_TABLE = "public_metrics_participant_summary_table"
+
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}
 

--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -1,9 +1,12 @@
 import datetime
 import logging
+import time
 import warnings
 
 from werkzeug.exceptions import BadRequest
+from google.cloud import bigquery
 
+from rdr_service import config
 from rdr_service.dao.base_dao import BaseDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.metrics_cache_dao import (
@@ -34,6 +37,49 @@ from rdr_service.dao.metrics_cache_dao import TEMP_TABLE_PREFIX
 
 
 class ParticipantCountsOverTimeService(BaseDao):
+    QUERIES = {
+        "participant_sql": """
+            SELECT {columns} FROM `{participant_bq_table}` AS p
+            LEFT JOIN `{participant_summary_bq_table}` AS ps
+            ON p.participant_id = ps.participant_id
+            WHERE p.hpo_id != @test_hpo_id
+            AND p.is_ghost_id != 1
+            AND p.is_test_participant != 1
+            AND (ps.email IS NULL OR NOT ps.email LIKE @test_email_pattern)
+            AND p.withdrawal_status = @not_withdraw
+            AND p.hpo_id = @hpo_id
+            ;""",
+    }
+
+    PARTICIPANT_FIELDS = ['participant_id', 'biobank_id', 'sign_up_time', 'withdrawal_status',
+                          'hpo_id', 'organization_id', 'site_id', 'participant_origin']
+
+    TEMP_FIELDS = [('participant_id','int'), ('biobank_id', 'int'), ('sign_up_time', 'datetime'),
+                   ('first_name', 'varchar(255)'), ('last_name', 'varchar(255)'), ('suspension_status', 'smallint'),
+                   ('deceased_status', 'smallint'), ('is_ehr_data_available', 'tinyint(1)'),
+                   ('is_participant_mediated_ehr_data_available', 'tinyint(1)'),
+                   ('was_participant_mediated_ehr_available', 'tinyint(1)'), ('withdrawal_status', 'smallint'),
+                   ('hpo_id', 'int'), ('organization_id', 'int'), ('site_id', 'int'),
+                   ('participant_origin', 'varchar(80)'), ('date_of_birth', 'date'),
+                   ('consent_for_study_enrollment_time', 'datetime'), ('enrollment_status', 'smallint'),
+                   ('enrollment_status_member_time', 'datetime'),
+                   ('enrollment_status_core_stored_sample_time', 'datetime'),
+                   ('questionnaire_on_the_basics', 'smallint'), ('primary_language', 'varchar(80)'),
+                   ('language_id', 'int'), ('gender_identity_id', 'int'), ('gender_identity', 'smallint'),
+                   ('race', 'smallint'), ('questionnaire_on_the_basics_time', 'datetime'),
+                   ('questionnaire_on_lifestyle_time', 'datetime'), ('questionnaire_on_medications_time', 'datetime'),
+                   ('questionnaire_on_family_health_time', 'datetime'),
+                   ('questionnaire_on_overall_health_time', 'datetime'),
+                   ('questionnaire_on_healthcare_access_time', 'datetime'),
+                   ('questionnaire_on_medical_history_time', 'datetime'),
+                   ('clinic_physical_measurements_time', 'datetime'),
+                   ('self_reported_physical_measurements_authored', 'datetime'),
+                   ('sample_status_1ed10_time', 'datetime'), ('sample_status_2ed10_time', 'datetime'),
+                   ('sample_status_1ed04_time', 'datetime'), ('sample_status_1sal_time', 'datetime'),
+                   ('sample_status_1sal2_time', 'datetime'), ('state_id', 'int'),
+                   ('consent_for_electronic_health_records', 'int'),
+                   ('clinic_physical_measurements_finalized_time', 'datetime')]
+
     def __init__(self):
         super(ParticipantCountsOverTimeService, self).__init__(ParticipantSummary, alembic=True)
         self.test_hpo_id = HPODao().get_by_name(TEST_HPO_NAME).hpoId
@@ -42,6 +88,15 @@ class ParticipantCountsOverTimeService(BaseDao):
         self.end_date = datetime.datetime.now().date() + datetime.timedelta(days=10)
         self.stage_number = MetricsCronJobStage.STAGE_ONE
         self.cronjob_time = datetime.datetime.now().replace(microsecond=0)
+
+        public_metrics_project_map = config.getSettingJson(config.PUBLIC_METRICS_PROJECT_MAP, {})
+
+        self.client = bigquery.Client()
+        self.bq_project = public_metrics_project_map.get(self.client.project)
+        self.participant_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_TABLE,
+                                                       'lake_operational_data.rdr_participant')
+        self.participant_summary_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_SUMMARY_TABLE,
+                                                               'lake_operational_data.rdr_participant_summary')
 
     def init_tmp_table(self):
         with self.session() as session:
@@ -54,19 +109,13 @@ class ParticipantCountsOverTimeService(BaseDao):
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore')
                     session.execute('DROP TABLE IF EXISTS {};'.format(temp_table_name))
-                # generated columns can not be inserted any value, need to drop them
-                exclude_columns = [
-                    'health_data_stream_sharing_status',
-                    'health_data_stream_sharing_status_time',
-                    'retention_eligible_time',
-                    'retention_eligible_status',
-                    'was_ehr_data_available'
-                ]
-                session.execute('CREATE TABLE {} LIKE participant_summary'.format(temp_table_name))
+
+                temp_table_columns = ", ".join([a + ' ' + b for a, b in self.TEMP_FIELDS])
+
+                sql_string = 'CREATE TABLE {} ({})'.format(temp_table_name, temp_table_columns)
+                session.execute(sql_string)
 
                 indexes_cursor = session.execute('SHOW INDEX FROM {}'.format(temp_table_name))
-                for exclude_column_name in exclude_columns:
-                    session.execute('ALTER TABLE {} DROP COLUMN  {}'.format(temp_table_name, exclude_column_name))
 
                 index_name_list = []
                 for index in indexes_cursor:
@@ -77,50 +126,15 @@ class ParticipantCountsOverTimeService(BaseDao):
                     if index_name != 'PRIMARY':
                         session.execute('ALTER TABLE {} DROP INDEX  {}'.format(temp_table_name, index_name))
 
-                # The ParticipantSummary table requires these, but there may not be a participant_summary for
-                # all participants that we insert
-                session.execute('ALTER TABLE {} MODIFY first_name VARCHAR(255)'.format(temp_table_name))
-                session.execute('ALTER TABLE {} MODIFY last_name VARCHAR(255)'.format(temp_table_name))
-                session.execute('ALTER TABLE {} MODIFY suspension_status SMALLINT'.format(temp_table_name))
-                session.execute('ALTER TABLE {} MODIFY participant_origin VARCHAR(80)'.format(temp_table_name))
-                session.execute('ALTER TABLE {} MODIFY deceased_status SMALLINT'.format(temp_table_name))
-                session.execute('ALTER TABLE {} MODIFY is_ehr_data_available TINYINT(1)'.format(temp_table_name))
-                session.execute(
-                    f'ALTER TABLE {temp_table_name} MODIFY is_participant_mediated_ehr_data_available TINYINT(1)'
-                )
-                session.execute('ALTER TABLE {} MODIFY was_participant_mediated_ehr_available TINYINT(1)'
-                                 .format(temp_table_name))
+                columns_str = ", ".join(['p.' + a if a in self.PARTICIPANT_FIELDS else 'ps.' + a for a, b in
+                                         self.TEMP_FIELDS])
 
-                columns_cursor = session.execute('SELECT * FROM {} LIMIT 0'.format(temp_table_name))
-
-                participant_fields = ['participant_id', 'biobank_id', 'sign_up_time', 'withdrawal_status',
-                                      'hpo_id', 'organization_id', 'site_id', 'participant_origin']
-
-                def get_field_name(name):
-                    if name in participant_fields:
-                        return 'p.' + name
-                    else:
-                        return 'ps.' + name
-
-                columns = map(get_field_name, columns_cursor.keys())
-                columns_str = ','.join(columns)
-
-                participant_sql = """
-                  INSERT INTO
-                  """ + temp_table_name + """
-                  SELECT
-                  """ + columns_str + """
-                  FROM participant p
-                  left join participant_summary ps on p.participant_id = ps.participant_id
-                  WHERE p.hpo_id <> :test_hpo_id
-                  AND p.is_ghost_id IS NOT TRUE
-                  AND p.is_test_participant IS NOT TRUE
-                  AND (ps.email IS NULL OR NOT ps.email LIKE :test_email_pattern)
-                  AND p.withdrawal_status = :not_withdraw
-                  AND p.hpo_id = :hpo_id
-                """
-                params = {'test_hpo_id': self.test_hpo_id, 'test_email_pattern': self.test_email_pattern,
-                          'not_withdraw': int(WithdrawalStatus.NOT_WITHDRAWN), 'hpo_id': hpo.hpoId}
+                params = [
+                    bigquery.ScalarQueryParameter("test_hpo_id", "INT64", self.test_hpo_id),
+                    bigquery.ScalarQueryParameter("test_email_pattern", "STRING", self.test_email_pattern),
+                    bigquery.ScalarQueryParameter("not_withdraw", "INT64", int(WithdrawalStatus.NOT_WITHDRAWN)),
+                    bigquery.ScalarQueryParameter("hpo_id", "INT64", hpo.hpoId),
+                ]
 
                 session.execute('CREATE INDEX idx_sign_up_time ON {} (sign_up_time)'.format(temp_table_name))
                 session.execute('CREATE INDEX idx_date_of_birth ON {} (date_of_birth)'.format(temp_table_name))
@@ -133,8 +147,10 @@ class ParticipantCountsOverTimeService(BaseDao):
                 session.execute('CREATE INDEX idx_participant_origin ON {} (participant_origin)'
                                 .format(temp_table_name))
 
-                session.execute(participant_sql, params)
-                logging.info('crete temp table for hpo_id: ' + str(hpo.hpoId))
+                participant_data = self.build_participant_sql(params, columns_str)
+                self.batch_insert_results(session, temp_table_name, participant_data)
+
+                logging.info('create temp table for hpo_id: ' + str(hpo.hpoId))
 
             session.execute('DROP TABLE IF EXISTS metrics_tmp_participant_origin;')
             session.execute('CREATE TABLE metrics_tmp_participant_origin (participant_origin VARCHAR(50))')
@@ -145,6 +161,49 @@ class ParticipantCountsOverTimeService(BaseDao):
             session.execute(participant_origin_sql)
 
             logging.info('Init temp table for metrics cron job.')
+
+    def build_participant_sql(self, params, columns):
+        p_table_path = f"{self.bq_project}.{self.participant_table}"
+        ps_table_path = f"{self.bq_project}.{self.participant_summary_table}"
+        job_config = bigquery.QueryJobConfig(query_parameters=params)
+        sql = self.QUERIES['participant_sql'].format(participant_bq_table=p_table_path,
+                                                     participant_summary_bq_table=ps_table_path,
+                                                     columns=columns)
+        return self.run_bq_query(sql, job_config)
+
+    def run_bq_query(self, sql: str, job_config=None):
+        # Run the job with exponential backoff to avoid 403: rateLimitExceeded Error
+        # https://cloud.google.com/bigquery/docs/troubleshoot-quotas,
+        max_tries = 10
+        for n in range(max_tries):
+            try:
+                query_job = self.client.query(sql, job_config)
+                return query_job
+            except Exception:  # pylint: disable=broad-except
+                if n == max_tries - 1:
+                    raise Exception
+                time.sleep(2 ** n)
+
+    def batch_insert_results(self, session, temp_table_name, results):
+        # Insert results into RDR table, implement batching of the results
+        records_to_insert, batch_size = [], 100
+
+        columns_str = ", ".join([a for a, b in self.TEMP_FIELDS])
+        values_str = ",".join([':' + a for a, b in self.TEMP_FIELDS])
+        batch_insert_stmt = ('insert into `{temp_table_name}` ({columns_str}) values ({values_str});'
+                             .format(temp_table_name=temp_table_name, columns_str=columns_str, values_str=values_str))
+
+        for record in results:
+            x = dict(record.items())
+            records_to_insert.append(x)
+
+            if len(records_to_insert) == batch_size:
+                session.execute(batch_insert_stmt, records_to_insert)
+                records_to_insert.clear()
+
+        if records_to_insert:
+            session.execute(batch_insert_stmt, records_to_insert)
+            records_to_insert.clear()
 
     def clean_tmp_tables(self):
         with self.session() as session:

--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -91,7 +91,7 @@ class ParticipantCountsOverTimeService(BaseDao):
 
         public_metrics_project_map = config.getSettingJson(config.PUBLIC_METRICS_PROJECT_MAP, {})
 
-        self.client = bigquery.Client(config.GAE_PROJECT)
+        self.client = bigquery.Client(project=config.GAE_PROJECT)
         self.bq_project = public_metrics_project_map.get(self.client.project)
         self.participant_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_TABLE,
                                                        'lake_operational_data.rdr_participant')

--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -91,7 +91,7 @@ class ParticipantCountsOverTimeService(BaseDao):
 
         public_metrics_project_map = config.getSettingJson(config.PUBLIC_METRICS_PROJECT_MAP, {})
 
-        self.client = bigquery.Client()
+        self.client = bigquery.Client(config.GAE_PROJECT)
         self.bq_project = public_metrics_project_map.get(self.client.project)
         self.participant_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_TABLE,
                                                        'lake_operational_data.rdr_participant')

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 import mock
 
 from rdr_service import config
@@ -333,7 +334,7 @@ class PublicMetricsApiTest(BaseTestCase):
 
         return summary, generate_mock_results(participant, summary, the_basics)
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_enrollment_status_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
@@ -357,13 +358,12 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time4,
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [],
-                                 [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
 
         calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 3)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 3)
 
         qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08"
 
@@ -379,7 +379,7 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 1}}, results)
         self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 1}}, results)
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_gender_api(self, big_query):
 
         self.init_gender_codes()
@@ -510,14 +510,13 @@ class PublicMetricsApiTest(BaseTestCase):
             )
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [],
-                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4,
-                                  expected_bq_results_6]]
+        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
+                                                                       expected_bq_results_4, expected_bq_results_6]]
 
         calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 3)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 3)
 
         qs = "&stratification=GENDER_IDENTITY" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -735,7 +734,7 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_gender_api_v2(self, big_query):
 
         self.init_gender_codes()
@@ -861,21 +860,22 @@ class PublicMetricsApiTest(BaseTestCase):
             )
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [],
-                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4,
-                                  expected_bq_results_6], [expected_bq_results_1], [],
-                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4,
-                                  expected_bq_results_6]]
+        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
+                                                                       expected_bq_results_4, expected_bq_results_6],
+                                         [expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
+                                                                       expected_bq_results_4, expected_bq_results_6]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
+
+        time.sleep(2)
 
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 6)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 6)
 
         qs = "&stratification=GENDER_IDENTITY" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -1154,7 +1154,7 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_age_range_api(self, big_query):
         dob1 = datetime.date(1978, 10, 10)
         dob2 = datetime.date(1988, 10, 10)
@@ -1202,19 +1202,21 @@ class PublicMetricsApiTest(BaseTestCase):
             dob=dob4
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [],
-                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4],
-                                 [expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = [[expected_bq_results_1], [],
+                                         [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4],
+                                         [expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
+
+        time.sleep(2)
 
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 6)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 6)
 
         qs = "&stratification=AGE_RANGE" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -1457,7 +1459,7 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_total_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
@@ -1482,12 +1484,12 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time5,
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
 
         calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 3)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 3)
 
         qs = "&stratification=TOTAL" "&startDate=2018-01-01" "&endDate=2018-01-08"
 
@@ -1507,7 +1509,7 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-07", "metrics": {"TOTAL": 2}}, response)
         self.assertIn({"date": "2018-01-08", "metrics": {"TOTAL": 2}}, response)
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_race_api(self, big_query):
 
         questionnaire_id = self.create_demographics_questionnaire()
@@ -1563,14 +1565,14 @@ class PublicMetricsApiTest(BaseTestCase):
         _, expected_bq_results_7 = self.update_participant_summary(p7["participantId"][1:])
         _, expected_bq_results_8 = self.update_participant_summary(p8["participantId"][1:])
 
-        big_query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
-                                  expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                 [expected_bq_results_7, expected_bq_results_8]]
+        big_query().query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
+                                              expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                         [expected_bq_results_7, expected_bq_results_8]]
 
         calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 3)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 3)
 
         qs = "&stratification=RACE" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -1730,7 +1732,7 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_race_api_v2(self, big_query):
 
         questionnaire_id = self.create_demographics_questionnaire()
@@ -1788,22 +1790,24 @@ class PublicMetricsApiTest(BaseTestCase):
         _, expected_bq_results_7 = self.update_participant_summary(p7["participantId"][1:])
         _, expected_bq_results_8 = self.update_participant_summary(p8["participantId"][1:])
 
-        big_query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
-                                      expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                 [expected_bq_results_7, expected_bq_results_8],
-                                 [], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
-                                      expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                 [expected_bq_results_7, expected_bq_results_8]]
+        big_query().query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
+                                              expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                         [expected_bq_results_7, expected_bq_results_8],
+                                         [], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
+                                              expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                         [expected_bq_results_7, expected_bq_results_8]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
+
+        time.sleep(2)
 
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 6)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 6)
 
         qs = "&stratification=RACE" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -1964,7 +1968,7 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_region_api(self, big_query):
 
         code1 = Code(
@@ -2093,14 +2097,14 @@ class PublicMetricsApiTest(BaseTestCase):
             state_id=4,
         )
 
-        big_query.side_effect = [[expected_bq_results_1],
-                                 [expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                 [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = [[expected_bq_results_1],
+                                         [expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                         [expected_bq_results_2, expected_bq_results_3]]
 
         calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 3)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 3)
 
         qs1 = "&stratification=GEO_STATE" "&endDate=2017-12-31"
 
@@ -2189,7 +2193,7 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-02", "count": 3, "hpo": "PITT"}, results3)
         self.assertIn({"date": "2018-01-02", "count": 2, "hpo": "AZ_TUCSON"}, results3)
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_lifecycle_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
@@ -2261,20 +2265,22 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time5,
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
-                                 [expected_bq_results_2, expected_bq_results_3],
-                                 [expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
-                                 [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
+                                         [expected_bq_results_2, expected_bq_results_3],
+                                         [expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
+                                         [expected_bq_results_2, expected_bq_results_3]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
+
+        time.sleep(2)
 
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
 
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 6)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 6)
 
         qs1 = "&stratification=LIFECYCLE" "&endDate=2018-01-03"
 
@@ -2368,7 +2374,7 @@ class PublicMetricsApiTest(BaseTestCase):
             ],
         )
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_language_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
@@ -2405,20 +2411,20 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time4,
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [],
-                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4]]
+        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
+                                                                       expected_bq_results_4]]
 
         calculate_participant_metrics()
         qs = "&stratification=LANGUAGE" "&startDate=2017-12-30" "&endDate=2018-01-03"
 
         results = self.send_get("PublicMetrics", query_string=qs)
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 3)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 3)
         self.assertIn({"date": "2017-12-30", "metrics": {"EN": 0, "UNSET": 0, "ES": 0}}, results)
         self.assertIn({"date": "2017-12-31", "metrics": {"EN": 1, "UNSET": 2, "ES": 0}}, results)
         self.assertIn({"date": "2018-01-03", "metrics": {"EN": 1, "UNSET": 2, "ES": 1}}, results)
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_primary_consent_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
@@ -2490,13 +2496,15 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time5,
         )
 
-        big_query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
-                                 [expected_bq_results_2, expected_bq_results_3], [expected_bq_results_1],
-                                 [expected_bq_results_4, expected_bq_results_5],
-                                 [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
+                                         [expected_bq_results_2, expected_bq_results_3], [expected_bq_results_1],
+                                         [expected_bq_results_4, expected_bq_results_5],
+                                         [expected_bq_results_2, expected_bq_results_3]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
+
+        time.sleep(2)
 
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
@@ -2505,13 +2513,13 @@ class PublicMetricsApiTest(BaseTestCase):
         qs = "&stratification=PRIMARY_CONSENT" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
         results = self.send_get("PublicMetrics", query_string=qs)
-        self.assertTrue(big_query.called)
-        self.assertEqual(big_query.call_count, 6)
+        self.assertTrue(big_query().query.called)
+        self.assertEqual(big_query().query.call_count, 6)
         self.assertIn({"date": "2017-12-31", "metrics": {"Primary_Consent": 1}}, results)
         self.assertIn({"date": "2018-01-02", "metrics": {"Primary_Consent": 2}}, results)
         self.assertIn({"date": "2018-01-06", "metrics": {"Primary_Consent": 5}}, results)
 
-    @mock.patch('google.cloud.bigquery.Client.query')
+    @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_ehr_consent_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
@@ -2602,7 +2610,7 @@ class PublicMetricsApiTest(BaseTestCase):
 
         qs = "&stratification=EHR_METRICS" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
-        self.assertTrue(big_query.called)
+        self.assertTrue(big_query().query.called)
         results = self.send_get("PublicMetrics", query_string=qs)
         self.assertIn(
             {"date": "2017-12-31", "metrics": {"ORGANIZATIONS_ACTIVE": 0, "EHR_RECEIVED": 0, "EHR_CONSENTED": 1}},
@@ -2661,7 +2669,7 @@ class PublicMetricsApiTest(BaseTestCase):
         return self.create_questionnaire("questionnaire3.json")
 
     def post_demographics_questionnaire(
-        self, participant_id, questionnaire_id, cabor_signature_string=False, time=TIME_1, **kwargs
+        self, participant_id, questionnaire_id, cabor_signature_string=False, test_time=TIME_1, **kwargs
     ):
         """POSTs answers to the demographics questionnaire for the participant"""
         answers = {
@@ -2690,7 +2698,7 @@ class PublicMetricsApiTest(BaseTestCase):
 
         response_data = self.make_questionnaire_response_json(participant_id, questionnaire_id, **answers)
 
-        with FakeClock(time):
+        with FakeClock(test_time):
             url = "Participant/%s/QuestionnaireResponse" % participant_id
             return self.send_post(url, request_data=response_data)
 

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -140,11 +140,16 @@ class PublicMetricsApiTest(BaseTestCase):
         self.clear_table_after_test('metrics_language_cache')
 
         self.temporarily_override_config_setting(config.PUBLIC_METRICS_PROJECT_MAP, {
+            "localhost": "aou-warehouse-test",
             "all-of-us-rdr-sandbox": "aou-warehouse-test",
             "all-of-us-rdr-staging": "aou-warehouse-test",
             "all-of-us-rdr-stable": "aou-warehouse-test",
             "all-of-us-rdr-prod": "aou-warehouse-test",
         })
+
+    def tearDown(self):
+        self.clear_table_after_test("rdr.metrics_enrollment_status_cache")
+        super().tearDown()
 
     def _insert(
         self,

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -2506,7 +2506,8 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-02", "metrics": {"Primary_Consent": 2}}, results)
         self.assertIn({"date": "2018-01-06", "metrics": {"Primary_Consent": 5}}, results)
 
-    def test_public_metrics_get_ehr_consent_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_ehr_consent_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
         self._insert(
@@ -2596,6 +2597,7 @@ class PublicMetricsApiTest(BaseTestCase):
 
         qs = "&stratification=EHR_METRICS" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
+        self.assertTrue(big_query.called)
         results = self.send_get("PublicMetrics", query_string=qs)
         self.assertIn(
             {"date": "2017-12-31", "metrics": {"ORGANIZATIONS_ACTIVE": 0, "EHR_RECEIVED": 0, "EHR_CONSENTED": 1}},

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -1,5 +1,7 @@
 import datetime
+import mock
 
+from rdr_service import config
 from rdr_service.clock import FakeClock
 from rdr_service.code_constants import (
     PMI_SKIP_CODE,
@@ -16,6 +18,7 @@ from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.offline.participant_counts_over_time import calculate_participant_metrics
 from rdr_service.dao.organization_dao import OrganizationDao
+from rdr_service.dao.participant_counts_over_time_service import ParticipantCountsOverTimeService
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.site_dao import SiteDao
 from rdr_service.dao.participant_summary_dao import ParticipantGenderAnswersDao, ParticipantSummaryDao
@@ -42,6 +45,43 @@ TIME_3 = datetime.datetime(2018, 2, 10)
 
 def _questionnaire_response_url(participant_id):
     return "Participant/%s/QuestionnaireResponse" % participant_id
+
+
+def generate_mock_results(participant, summary, the_basics=None):
+    expected_bq_results = dict()
+
+    for field, _ in ParticipantCountsOverTimeService.TEMP_FIELDS:
+        temp = field.split('_')
+        camel_field = temp[0] + ''.join(f.title() for f in temp[1:])
+
+        try:
+            value = getattr(summary, camel_field)
+
+            if field in ParticipantCountsOverTimeService.PARTICIPANT_FIELDS:
+                value = getattr(participant, camel_field)
+        except Exception:  # pylint: disable=broad-except
+            value = None
+
+        expected_bq_results[field] = value
+
+    expected_bq_results['sample_status_1ed10_time'] = getattr(summary, 'sampleStatus1ED10Time')
+    expected_bq_results['sample_status_2ed10_time'] = getattr(summary, 'sampleStatus2ED10Time')
+    expected_bq_results['sample_status_1ed04_time'] = getattr(summary, 'sampleStatus1ED04Time')
+    expected_bq_results['sample_status_1sal_time'] = getattr(summary, 'sampleStatus1SALTime')
+    expected_bq_results['sample_status_1sal2_time'] = getattr(summary, 'sampleStatus1SAL2Time')
+
+    expected_bq_results['withdrawal_status'] = 1
+    expected_bq_results['suspension_status'] = 1
+    expected_bq_results['enrollment_status'] = 3
+    expected_bq_results['deceased_status'] = 0
+    expected_bq_results['race'] = 0
+    expected_bq_results['questionnaire_on_the_basics'] = 1
+    expected_bq_results['consent_for_electronic_health_records'] = 0
+
+    if the_basics is not None:
+        expected_bq_results['questionnaire_on_the_basics'] = 0
+
+    return expected_bq_results
 
 
 class PublicMetricsApiTest(BaseTestCase):
@@ -99,6 +139,13 @@ class PublicMetricsApiTest(BaseTestCase):
         self.clear_table_after_test('metrics_lifecycle_cache')
         self.clear_table_after_test('metrics_language_cache')
 
+        self.temporarily_override_config_setting(config.PUBLIC_METRICS_PROJECT_MAP, {
+            "all-of-us-rdr-sandbox": "aou-warehouse-test",
+            "all-of-us-rdr-staging": "aou-warehouse-test",
+            "all-of-us-rdr-stable": "aou-warehouse-test",
+            "all-of-us-rdr-prod": "aou-warehouse-test",
+        })
+
     def _insert(
         self,
         participant,
@@ -132,6 +179,8 @@ class PublicMetricsApiTest(BaseTestCase):
     :return: Participant object
     """
 
+        expected_bq_results = dict()
+
         if unconsented is True:
             enrollment_status = None
         elif time_mem is None:
@@ -149,7 +198,21 @@ class PublicMetricsApiTest(BaseTestCase):
             self.dao.update(participant)
 
         if enrollment_status is None:
-            return None
+            for field, _ in ParticipantCountsOverTimeService.TEMP_FIELDS:
+                temp = field.split('_')
+                camel_field = temp[0] + ''.join(f.title() for f in temp[1:])
+
+                try:
+                    value = getattr(participant, camel_field)
+                except Exception:  # pylint: disable=broad-except
+                    value = None
+
+                expected_bq_results[field] = value
+
+            expected_bq_results['withdrawal_status'] = 1
+            expected_bq_results['suspension_status'] = 1
+
+            return None, expected_bq_results
 
         summary = self.participant_summary(participant)
 
@@ -212,10 +275,10 @@ class PublicMetricsApiTest(BaseTestCase):
 
         self.ps_dao.insert(summary)
 
-        return summary
+        return summary, generate_mock_results(participant, summary)
 
     def update_participant_summary(
-        self, participant_id, time_mem=None, time_fp=None, time_fp_stored=None, time_study=None
+        self, participant_id, time_mem=None, time_fp=None, time_fp_stored=None, time_study=None, the_basics=None
     ):
 
         participant = self.dao.get(participant_id)
@@ -263,20 +326,21 @@ class PublicMetricsApiTest(BaseTestCase):
 
         self.ps_dao.update(summary)
 
-        return summary
+        return summary, generate_mock_results(participant, summary, the_basics)
 
-    def test_public_metrics_get_enrollment_status_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_enrollment_status_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(p1, "Alice", "Aardvark", "UNSET", unconsented=True, time_int=self.time1, time_study=self.time1)
+        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", unconsented=True, time_int=self.time1, time_study=self.time1)
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2, "Bob", "Builder", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time2, time_study=self.time2
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -288,7 +352,13 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time4,
         )
 
+        big_query.side_effect = [[expected_bq_results_1], [],
+                                 [expected_bq_results_2, expected_bq_results_3]]
+
         calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 3)
 
         qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08"
 
@@ -304,7 +374,8 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 1}}, results)
         self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 1}}, results)
 
-    def test_public_metrics_get_gender_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_gender_api(self, big_query):
 
         self.init_gender_codes()
         gender_code_dict = {
@@ -319,7 +390,8 @@ class PublicMetricsApiTest(BaseTestCase):
 
         participant_gender_answer_dao = ParticipantGenderAnswersDao()
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1, gender_identity=3)
+        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1,
+                                                gender_identity=3)
         participant_gender_answer_dao.insert(
             ParticipantGenderAnswers(
                 **dict(
@@ -332,7 +404,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2,
             "Bob",
             "Builder",
@@ -355,7 +427,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -378,7 +450,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=4, biobankId=7)
-        self._insert(
+        _, expected_bq_results_4 = self._insert(
             p4,
             "Chad2",
             "Caterpillar2",
@@ -401,7 +473,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p6 = Participant(participantId=6, biobankId=9)
-        self._insert(
+        _, expected_bq_results_6 = self._insert(
             p6,
             "Chad3",
             "Caterpillar3",
@@ -433,23 +505,14 @@ class PublicMetricsApiTest(BaseTestCase):
             )
         )
 
-        # ghost participant should be filtered out
-        p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
-        self._insert(
-            p_ghost, "Ghost", "G", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time1, gender_identity=5
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=5,
-                    created=self.time1,
-                    modified=self.time1,
-                    codeId=gender_code_dict["GenderIdentity_Transgender"],
-                )
-            )
-        )
+        big_query.side_effect = [[expected_bq_results_1], [],
+                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4,
+                                  expected_bq_results_6]]
 
         calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 3)
 
         qs = "&stratification=GENDER_IDENTITY" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -667,7 +730,8 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    def test_public_metrics_get_gender_api_v2(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_gender_api_v2(self, big_query):
 
         self.init_gender_codes()
         gender_code_dict = {
@@ -682,7 +746,8 @@ class PublicMetricsApiTest(BaseTestCase):
 
         participant_gender_answer_dao = ParticipantGenderAnswersDao()
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1, gender_identity=3)
+        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1,
+                                                gender_identity=3)
         participant_gender_answer_dao.insert(
             ParticipantGenderAnswers(
                 **dict(
@@ -695,7 +760,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2,
             "Bob",
             "Builder",
@@ -717,7 +782,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -739,7 +804,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=4, biobankId=7)
-        self._insert(
+        _, expected_bq_results_4 = self._insert(
             p4,
             "Chad2",
             "Caterpillar2",
@@ -760,7 +825,7 @@ class PublicMetricsApiTest(BaseTestCase):
             )
         )
         p6 = Participant(participantId=6, biobankId=9)
-        self._insert(
+        _, expected_bq_results_6 = self._insert(
             p6,
             "Chad3",
             "Caterpillar3",
@@ -791,21 +856,11 @@ class PublicMetricsApiTest(BaseTestCase):
             )
         )
 
-        # ghost participant should be filtered out
-        p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
-        self._insert(
-            p_ghost, "Ghost", "G", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time1, gender_identity=5
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=5,
-                    created=self.time1,
-                    modified=self.time1,
-                    codeId=gender_code_dict["GenderIdentity_Transgender"],
-                )
-            )
-        )
+        big_query.side_effect = [[expected_bq_results_1], [],
+                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4,
+                                  expected_bq_results_6], [expected_bq_results_1], [],
+                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4,
+                                  expected_bq_results_6]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -813,6 +868,9 @@ class PublicMetricsApiTest(BaseTestCase):
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 6)
 
         qs = "&stratification=GENDER_IDENTITY" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -1091,16 +1149,17 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    def test_public_metrics_get_age_range_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_age_range_api(self, big_query):
         dob1 = datetime.date(1978, 10, 10)
         dob2 = datetime.date(1988, 10, 10)
         dob3 = datetime.date(1988, 10, 10)
         dob4 = datetime.date(1998, 10, 10)
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1, dob=dob1)
+        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1, dob=dob1)
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2,
             "Bob",
             "Builder",
@@ -1113,7 +1172,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -1126,7 +1185,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=4, biobankId=7)
-        self._insert(
+        _, expected_bq_results_4 = self._insert(
             p4,
             "Chad2",
             "Caterpillar2",
@@ -1138,9 +1197,9 @@ class PublicMetricsApiTest(BaseTestCase):
             dob=dob4
         )
 
-        # ghost participant should be filtered out
-        p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
-        self._insert(p_ghost, "Ghost", "G", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time1, dob=dob3)
+        big_query.side_effect = [[expected_bq_results_1], [],
+                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4],
+                                 [expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -1148,6 +1207,9 @@ class PublicMetricsApiTest(BaseTestCase):
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 6)
 
         qs = "&stratification=AGE_RANGE" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -1390,18 +1452,20 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    def test_public_metrics_get_total_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_total_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(p1, "Alice", "Aardvark", "UNSET", unconsented=True, time_int=self.time1, time_study=self.time1)
+        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", unconsented=True, time_int=self.time1,
+                                                time_study=self.time1)
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2, "Bob", "Builder", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time2, time_study=self.time2
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -1413,21 +1477,12 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time5,
         )
 
-        # ghost participant should be filtered out
-        p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
-        self._insert(
-            p_ghost,
-            "Ghost",
-            "G",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time4,
-            time_fp_stored=self.time5,
-        )
+        big_query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
 
         calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 3)
 
         qs = "&stratification=TOTAL" "&startDate=2018-01-01" "&endDate=2018-01-08"
 
@@ -1447,7 +1502,8 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-07", "metrics": {"TOTAL": 2}}, response)
         self.assertIn({"date": "2018-01-08", "metrics": {"TOTAL": 2}}, response)
 
-    def test_public_metrics_get_race_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_race_api(self, big_query):
 
         questionnaire_id = self.create_demographics_questionnaire()
 
@@ -1484,20 +1540,32 @@ class PublicMetricsApiTest(BaseTestCase):
             return participant
 
         p1 = setup_participant(self.time1, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        self.update_participant_summary(p1["participantId"][1:], time_mem=self.time2)
+        _, expected_bq_results_1 = self.update_participant_summary(p1["participantId"][1:], time_mem=self.time2)
         p2 = setup_participant(self.time2, [RACE_NONE_OF_THESE_CODE], self.provider_link)
-        self.update_participant_summary(p2["participantId"][1:], time_mem=self.time3, time_fp_stored=self.time5)
+        _, expected_bq_results_2 = self.update_participant_summary(p2["participantId"][1:], time_mem=self.time3,
+                                                                   time_fp_stored=self.time5)
         p3 = setup_participant(self.time3, [RACE_AIAN_CODE], self.provider_link)
-        setup_participant(self.time3, [PMI_SKIP_CODE], self.provider_link, no_demographic=True)
-        self.update_participant_summary(p3["participantId"][1:], time_mem=self.time4)
+        p6 = setup_participant(self.time3, [PMI_SKIP_CODE], self.provider_link, no_demographic=True)
+        _, expected_bq_results_3 = self.update_participant_summary(p3["participantId"][1:], time_mem=self.time4)
+        _, expected_bq_results_6 = self.update_participant_summary(p6["participantId"][1:], the_basics=0)
         p4 = setup_participant(self.time4, [PMI_SKIP_CODE], self.provider_link)
-        self.update_participant_summary(p4["participantId"][1:], time_mem=self.time5)
+        _, expected_bq_results_4 = self.update_participant_summary(p4["participantId"][1:], time_mem=self.time5)
         p5 = setup_participant(self.time4, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        self.update_participant_summary(p5["participantId"][1:], time_mem=self.time4, time_fp_stored=self.time5)
-        setup_participant(self.time2, [RACE_AIAN_CODE], self.az_provider_link)
-        setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
+        _, expected_bq_results_5 = self.update_participant_summary(p5["participantId"][1:], time_mem=self.time4,
+                                                                   time_fp_stored=self.time5)
+        p7 = setup_participant(self.time2, [RACE_AIAN_CODE], self.az_provider_link)
+        p8 = setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
+        _, expected_bq_results_7 = self.update_participant_summary(p7["participantId"][1:])
+        _, expected_bq_results_8 = self.update_participant_summary(p8["participantId"][1:])
+
+        big_query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
+                                  expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                 [expected_bq_results_7, expected_bq_results_8]]
 
         calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 3)
 
         qs = "&stratification=RACE" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -1657,7 +1725,8 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    def test_public_metrics_get_race_api_v2(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_race_api_v2(self, big_query):
 
         questionnaire_id = self.create_demographics_questionnaire()
 
@@ -1694,20 +1763,32 @@ class PublicMetricsApiTest(BaseTestCase):
             return participant
 
         p1 = setup_participant(self.time1, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        self.update_participant_summary(p1["participantId"][1:], time_mem=self.time2)
+        _, expected_bq_results_1 = self.update_participant_summary(p1["participantId"][1:], time_mem=self.time2)
         p2 = setup_participant(self.time2, [RACE_NONE_OF_THESE_CODE], self.provider_link)
-        self.update_participant_summary(p2["participantId"][1:], time_mem=self.time3, time_fp_stored=self.time5)
+        _, expected_bq_results_2 = self.update_participant_summary(p2["participantId"][1:], time_mem=self.time3,
+                                                                   time_fp_stored=self.time5)
         p3 = setup_participant(self.time3, [RACE_AIAN_CODE], self.provider_link)
-        self.update_participant_summary(p3["participantId"][1:], time_mem=self.time4)
+        _, expected_bq_results_3 = self.update_participant_summary(p3["participantId"][1:], time_mem=self.time4)
         # Setup participant with no demographic questionnaire.
-        setup_participant(self.time3, [PMI_SKIP_CODE], self.provider_link, no_demographic=True)
+        p6 = setup_participant(self.time3, [PMI_SKIP_CODE], self.provider_link, no_demographic=True)
+        _, expected_bq_results_6 = self.update_participant_summary(p6["participantId"][1:], the_basics=0)
 
         p4 = setup_participant(self.time4, [PMI_SKIP_CODE], self.provider_link)
-        self.update_participant_summary(p4["participantId"][1:], time_mem=self.time5)
+        _, expected_bq_results_4 = self.update_participant_summary(p4["participantId"][1:], time_mem=self.time5)
         p5 = setup_participant(self.time4, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        self.update_participant_summary(p5["participantId"][1:], time_mem=self.time4, time_fp_stored=self.time5)
-        setup_participant(self.time2, [RACE_AIAN_CODE], self.az_provider_link)
-        setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
+        _, expected_bq_results_5 = self.update_participant_summary(p5["participantId"][1:], time_mem=self.time4,
+                                                                   time_fp_stored=self.time5)
+        p7 = setup_participant(self.time2, [RACE_AIAN_CODE], self.az_provider_link)
+        p8 = setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
+        _, expected_bq_results_7 = self.update_participant_summary(p7["participantId"][1:])
+        _, expected_bq_results_8 = self.update_participant_summary(p8["participantId"][1:])
+
+        big_query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
+                                      expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                 [expected_bq_results_7, expected_bq_results_8],
+                                 [], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
+                                      expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                 [expected_bq_results_7, expected_bq_results_8]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -1715,6 +1796,9 @@ class PublicMetricsApiTest(BaseTestCase):
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 6)
 
         qs = "&stratification=RACE" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -1875,7 +1959,8 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
-    def test_public_metrics_get_region_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_region_api(self, big_query):
 
         code1 = Code(
             codeId=1,
@@ -1921,7 +2006,7 @@ class PublicMetricsApiTest(BaseTestCase):
         self.code_dao.insert(code4)
 
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(
+        _, expected_bq_results_1 = self._insert(
             p1,
             "Alice",
             "Aardvark",
@@ -1934,7 +2019,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2,
             "Bob",
             "Builder",
@@ -1948,7 +2033,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -1962,7 +2047,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=4, biobankId=7)
-        self._insert(
+        _, expected_bq_results_4 = self._insert(
             p4,
             "Chad2",
             "Caterpillar2",
@@ -1976,7 +2061,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p5 = Participant(participantId=6, biobankId=9)
-        self._insert(
+        _, expected_bq_results_5 = self._insert(
             p5,
             "Chad3",
             "Caterpillar3",
@@ -1989,23 +2074,8 @@ class PublicMetricsApiTest(BaseTestCase):
             state_id=2,
         )
 
-        # ghost participant should be filtered out
-        p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
-        self._insert(
-            p_ghost,
-            "Ghost",
-            "G",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time1,
-            time_fp_stored=self.time1,
-            state_id=1,
-        )
-
         p6 = Participant(participantId=7, biobankId=10)
-        self._insert(
+        _, expected_bq_results_6 = self._insert(
             p6,
             "Angela",
             "Alligator",
@@ -2018,7 +2088,14 @@ class PublicMetricsApiTest(BaseTestCase):
             state_id=4,
         )
 
+        big_query.side_effect = [[expected_bq_results_1],
+                                 [expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
+                                 [expected_bq_results_2, expected_bq_results_3]]
+
         calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 3)
 
         qs1 = "&stratification=GEO_STATE" "&endDate=2017-12-31"
 
@@ -2107,10 +2184,11 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-02", "count": 3, "hpo": "PITT"}, results3)
         self.assertIn({"date": "2018-01-02", "count": 2, "hpo": "AZ_TUCSON"}, results3)
 
-    def test_public_metrics_get_lifecycle_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_lifecycle_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(
+        _, expected_bq_results_1 = self._insert(
             p1,
             "Alice",
             "Aardvark",
@@ -2123,7 +2201,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2,
             "Bob",
             "Builder",
@@ -2137,7 +2215,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -2151,7 +2229,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=4, biobankId=7)
-        self._insert(
+        _, expected_bq_results_4 = self._insert(
             p4,
             "Chad2",
             "Caterpillar2",
@@ -2165,7 +2243,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=6, biobankId=9)
-        self._insert(
+        _, expected_bq_results_5 = self._insert(
             p4,
             "Chad3",
             "Caterpillar3",
@@ -2178,20 +2256,10 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time5,
         )
 
-        # ghost participant should be filtered out
-        p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
-        self._insert(
-            p_ghost,
-            "Ghost",
-            "G",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time1,
-            time_fp=self.time1,
-            time_fp_stored=self.time1,
-        )
+        big_query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
+                                 [expected_bq_results_2, expected_bq_results_3],
+                                 [expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
+                                 [expected_bq_results_2, expected_bq_results_3]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -2199,6 +2267,9 @@ class PublicMetricsApiTest(BaseTestCase):
         # test copy historical cache for stage two
         with FakeClock(TIME_3):
             calculate_participant_metrics()
+
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 6)
 
         qs1 = "&stratification=LIFECYCLE" "&endDate=2018-01-03"
 
@@ -2292,18 +2363,20 @@ class PublicMetricsApiTest(BaseTestCase):
             ],
         )
 
-    def test_public_metrics_get_language_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_language_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(p1, "Alice", "Aardvark", "UNSET", unconsented=True, time_int=self.time1, primary_language="en")
+        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET",
+                                                unconsented=True, time_int=self.time1, primary_language="en")
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
-            p2, "Bob", "Builder", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time2, primary_language="es"
+        _, expected_bq_results_2 = self._insert(p2, "Bob", "Builder", "AZ_TUCSON",
+                                                "AZ_TUCSON_BANNER_HEALTH", time_int=self.time2, primary_language="es"
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -2316,7 +2389,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=5, biobankId=7)
-        self._insert(
+        _, expected_bq_results_4 = self._insert(
             p4,
             "Chad2",
             "Caterpillar2",
@@ -2327,18 +2400,24 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time4,
         )
 
+        big_query.side_effect = [[expected_bq_results_1], [],
+                                 [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4]]
+
         calculate_participant_metrics()
         qs = "&stratification=LANGUAGE" "&startDate=2017-12-30" "&endDate=2018-01-03"
 
         results = self.send_get("PublicMetrics", query_string=qs)
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 3)
         self.assertIn({"date": "2017-12-30", "metrics": {"EN": 0, "UNSET": 0, "ES": 0}}, results)
         self.assertIn({"date": "2017-12-31", "metrics": {"EN": 1, "UNSET": 2, "ES": 0}}, results)
         self.assertIn({"date": "2018-01-03", "metrics": {"EN": 1, "UNSET": 2, "ES": 1}}, results)
 
-    def test_public_metrics_get_primary_consent_api(self):
+    @mock.patch('google.cloud.bigquery.Client.query')
+    def test_public_metrics_get_primary_consent_api(self, big_query):
 
         p1 = Participant(participantId=1, biobankId=4)
-        self._insert(
+        _, expected_bq_results_1 = self._insert(
             p1,
             "Alice",
             "Aardvark",
@@ -2351,7 +2430,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p2 = Participant(participantId=2, biobankId=5)
-        self._insert(
+        _, expected_bq_results_2 = self._insert(
             p2,
             "Bob",
             "Builder",
@@ -2365,7 +2444,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p3 = Participant(participantId=3, biobankId=6)
-        self._insert(
+        _, expected_bq_results_3 = self._insert(
             p3,
             "Chad",
             "Caterpillar",
@@ -2379,7 +2458,7 @@ class PublicMetricsApiTest(BaseTestCase):
         )
 
         p4 = Participant(participantId=4, biobankId=7)
-        self._insert(
+        _, expected_bq_results_4 = self._insert(
             p4,
             "Chad2",
             "Caterpillar2",
@@ -2392,9 +2471,9 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time5,
         )
 
-        p4 = Participant(participantId=6, biobankId=9)
-        self._insert(
-            p4,
+        p5 = Participant(participantId=6, biobankId=9)
+        _, expected_bq_results_5 = self._insert(
+            p5,
             "Chad3",
             "Caterpillar3",
             "PITT",
@@ -2406,20 +2485,10 @@ class PublicMetricsApiTest(BaseTestCase):
             time_fp_stored=self.time5,
         )
 
-        # ghost participant should be filtered out
-        p_ghost = Participant(participantId=5, biobankId=8, isGhostId=True)
-        self._insert(
-            p_ghost,
-            "Ghost",
-            "G",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time1,
-            time_fp=self.time1,
-            time_fp_stored=self.time1,
-        )
+        big_query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
+                                 [expected_bq_results_2, expected_bq_results_3], [expected_bq_results_1],
+                                 [expected_bq_results_4, expected_bq_results_5],
+                                 [expected_bq_results_2, expected_bq_results_3]]
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -2431,6 +2500,8 @@ class PublicMetricsApiTest(BaseTestCase):
         qs = "&stratification=PRIMARY_CONSENT" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
         results = self.send_get("PublicMetrics", query_string=qs)
+        self.assertTrue(big_query.called)
+        self.assertEqual(big_query.call_count, 6)
         self.assertIn({"date": "2017-12-31", "metrics": {"Primary_Consent": 1}}, results)
         self.assertIn({"date": "2018-01-02", "metrics": {"Primary_Consent": 2}}, results)
         self.assertIn({"date": "2018-01-06", "metrics": {"Primary_Consent": 5}}, results)


### PR DESCRIPTION
## Resolves *[DA-4230](https://precisionmedicineinitiative.atlassian.net/browse/DA-4230)*


## Description of changes/additions
When the ParticipantCountsOverTime job runs to calculate participant metrics, a new 'temp table' is created for each HPO id and ALL participant summary fields are copied into the temp table. This 
- Updated the `participant_sql` query that is used to populate data into the `temp_tables` to use the `lake_operational_data` datastream tables for participant and participant_summary data
- Updated the `temp_tables` to only include fields necessary for the metrics calculations
- Implemented batching of results when inserting data into the `temp_tables`
- Updated the existing unit tests to Mock calls to BigQuery
- Updated rdr_service/config with values for the `lake_operational_data` tables and mappings from RDR projects to Warehouse projects. The configs will be updated with the below values before release.

base-config:
```
"public_metrics_participant_table": "lake_operational_data.rdr_participant"
"public_metrics_participant_summary_table": "lake_operational_data.rdr_participant_summary"
```
Sandbox config:
```
"public_metrics_project_map": {
    "all-of-us-rdr-sandbox": "aou-warehouse-test"
}
```
Prod config:
```
"public_metrics_project_map": {
    "all-of-us-rdr-prod": "aou-warehouse-prod"
}
```

## Tests
- [X] unit tests
- Manually tested BigQuery connection to RDR Sandbox & Warehouse Test environment
- Manually ran the new `participant_sql` SELECT query in Warehouse PreProd BigQuery to check for the expected output




[DA-4230]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ