### PR TITLE
[DA-4285] Filtering to latest consents for validation

### DIFF
--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -36,7 +36,9 @@ class ConsentDao(BaseDao):
         )
 
     @classmethod
-    def get_consent_responses_to_validate(cls, session) -> (Dict[int, List[ConsentResponse]], bool):
+    def get_consent_responses_to_validate(
+        cls, session, since_date: datetime = None
+    ) -> (Dict[int, List[ConsentResponse]], bool):
         """
         Gets all the consent responses that need to be validated.
         :return: Dictionary with keys being participant ids and values being collections of ConsentResponses
@@ -45,7 +47,7 @@ class ConsentDao(BaseDao):
 
         # A ConsentResponse will need to be validated if there are not yet any ConsentFile objects
         # that are of the same type and for the same participant.
-        consent_responses = (
+        query = (
             session.query(ConsentResponse)
             .join(QuestionnaireResponse)
             .join(Participant)
@@ -77,8 +79,16 @@ class ConsentDao(BaseDao):
             ).options(
                 joinedload(ConsentResponse.response)
             )
-        ).limit(consent_batch_limit).all()
+        )
 
+        if since_date:
+            query = query.filter(
+                QuestionnaireResponse.created >= since_date
+            ).with_hint(
+                QuestionnaireResponse, 'USE INDEX (idx_created_q_id)'
+            )
+
+        consent_responses = query.limit(consent_batch_limit).all()
         grouped_results = defaultdict(list)
         for consent_response in consent_responses:
             grouped_results[consent_response.response.participantId].append(consent_response)

--- a/rdr_service/dao/consent_dao.py
+++ b/rdr_service/dao/consent_dao.py
@@ -83,7 +83,8 @@ class ConsentDao(BaseDao):
 
         if since_date:
             query = query.filter(
-                QuestionnaireResponse.created >= since_date
+                QuestionnaireResponse.created >= since_date,
+                QuestionnaireResponse.questionnaireId > 0  # needed to use prod's index of the created date
             ).with_hint(
                 QuestionnaireResponse, 'USE INDEX (idx_created_q_id)'
             )

--- a/rdr_service/offline/main.py
+++ b/rdr_service/offline/main.py
@@ -281,6 +281,8 @@ def check_for_consent_corrections():
 @app_util.auth_required_cron
 def validate_consent_files():
     consent_dao = ConsentDao()
+    # Consents are validated every hour, putting a bunch of overlap in case something went wrong in the recent passes
+    three_hours_ago = datetime.utcnow() - timedelta(hours=3)
     with consent_dao.session() as session, StoreResultStrategy(
         session=session,
         consent_dao=consent_dao
@@ -289,7 +291,7 @@ def validate_consent_files():
             session=session,
             consent_dao=consent_dao
         )
-        validation_controller.validate_consent_uploads(store_strategy)
+        validation_controller.validate_consent_uploads(store_strategy, since=three_hours_ago)
     return '{"success": "true"}'
 
 @app_util.auth_required_cron

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -668,7 +668,7 @@ class ConsentValidationController:
         # DA-3423:  Populate the consent_response_id values for the ConsentFile validation results as needed
         output_strategy.set_consent_response_ids_for_results()
 
-    def validate_consent_uploads(self, output_strategy: ValidationOutputStrategy):
+    def validate_consent_uploads(self, output_strategy: ValidationOutputStrategy, since: datetime = None):
         """
         Find all the expected consents (filtering by dates if provided) and check the files that have been uploaded
         """

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -676,7 +676,8 @@ class ConsentValidationController:
         is_last_batch = False
         while not is_last_batch:
             participant_id_consent_map, is_last_batch = self.consent_dao.get_consent_responses_to_validate(
-                session=self._session
+                session=self._session,
+                since_date=since
             )
             self._process_id_consent_map(
                 participant_id_consent_map=participant_id_consent_map,

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -47,6 +47,34 @@ class ConsentFileDaoTest(BaseTestCase):
         consent_response = pid_consent_response_map[response_to_validate.participantId][0]
         self.assertEqual(response_to_validate.questionnaireResponseId, consent_response.questionnaire_response_id)
 
+    def test_getting_recent_response(self):
+        filter_date = datetime(2022, 4, 1)
+
+        # add a few before the filter date
+        self.session.add(
+            ConsentResponse(response=self.data_generator.create_database_questionnaire_response(
+                created=datetime(2021, 11, 8)
+            ))
+        )
+        self.session.add(
+            ConsentResponse(response=self.data_generator.create_database_questionnaire_response(
+                created=datetime(2022, 3, 25)
+            ))
+        )
+
+        # add one after the filter date
+        response_to_validate = self.data_generator.create_database_questionnaire_response(
+            created=datetime(2022, 4, 5)
+        )
+        self.session.add(ConsentResponse(response=response_to_validate, type=ConsentType.EHR))
+        self.session.commit()
+
+        # Make sure we get the correct response from the DAO
+        pid_consent_response_map, _ = self.consent_dao.get_consent_responses_to_validate(session=self.session)
+
+        consent_response = pid_consent_response_map[response_to_validate.participantId][0]
+        self.assertEqual(response_to_validate.questionnaireResponseId, consent_response.questionnaire_response_id)
+
     def test_finding_consent_responses_by_participant(self):
         # create a few consent responses for a participant
         participant = self.data_generator.create_database_participant()

--- a/tests/dao_tests/test_consent_file_dao.py
+++ b/tests/dao_tests/test_consent_file_dao.py
@@ -70,10 +70,19 @@ class ConsentFileDaoTest(BaseTestCase):
         self.session.commit()
 
         # Make sure we get the correct response from the DAO
-        pid_consent_response_map, _ = self.consent_dao.get_consent_responses_to_validate(session=self.session)
+        pid_consent_response_map, _ = self.consent_dao.get_consent_responses_to_validate(
+            session=self.session,
+            since_date=filter_date
+        )
 
-        consent_response = pid_consent_response_map[response_to_validate.participantId][0]
-        self.assertEqual(response_to_validate.questionnaireResponseId, consent_response.questionnaire_response_id)
+        self.assertEqual(1, len(pid_consent_response_map))
+        self.assertIn(response_to_validate.participantId, pid_consent_response_map)
+
+        resulting_consent_response = pid_consent_response_map[response_to_validate.participantId][0]
+        self.assertEqual(
+            response_to_validate.questionnaireResponseId,
+            resulting_consent_response.questionnaire_response_id
+        )
 
     def test_finding_consent_responses_by_participant(self):
         # create a few consent responses for a participant


### PR DESCRIPTION
## Resolves *[DA-4285](https://precisionmedicineinitiative.atlassian.net/browse/DA-4285)*
The consent validation cron job hasn't been validating consents lately because it's stuck on consent_responses that are in the system but don't need to be validated.

## Description of changes/additions
For now, we can create a workaround of only validating the recent/new consent_responses (ignoring any that give validation results that don't save).

## Tests
- [x] unit tests




[DA-4285]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ