### PR TITLE
Adding safety ignore check for current pip version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,9 +110,6 @@ jobs:
           project-id: all-of-us-rdr-ptsc-2-test
           git-target: << pipeline.git.tag >>
 
-
-
-
   job_deploy_to_ce:
     <<: *job_defaults
     steps:

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -17,6 +17,9 @@ security: # configuration for the `safety check` command
         65213:
             reason: RDR code not run on PowerPC architecture
             expires: '2030-01-01'
+        67599:
+            reason: pip v 24.0 installs a vulnerability
+            expires: '2025-05-14'
     continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
     security:


### PR DESCRIPTION
## Resolves *[NA]


## Description of changes/additions
Safety is currently flagging the latest version of PIP for having a security vulnerability. 

Since this is the latest version of pip there is not a new version to upgrade to, to be able to  mitigate the safety flagging, so added a bypass to the safety policy.

https://pypi.org/project/pip/

## Tests
- [] unit tests


