### PR TITLE
[DA-4295] Adding asynchronicity to BigQueryJob

### DIFF
--- a/rdr_service/offline/update_ehr_status.py
+++ b/rdr_service/offline/update_ehr_status.py
@@ -299,7 +299,10 @@ def make_update_organizations_job():
         bigquery_view = None
     if bigquery_view:
         query = "SELECT org_id, person_upload_time FROM `{}`".format(bigquery_view)
-        return bigquery.BigQueryJob(query, default_dataset_id="operations_analytics", page_size=1000)
+        twenty_second_timeout = 20_000
+        return bigquery.BigQueryJob(
+            query, default_dataset_id="operations_analytics", page_size=1000, socket_timeout=twenty_second_timeout
+        )
     else:
         return None
 


### PR DESCRIPTION
## Resolves *[DA-4295](https://precisionmedicineinitiative.atlassian.net/browse/DA-4295)*
The UpdateEhrStatusOrganization cron job is failing because of a timeout. It is likely from the BigQuery job taking just a bit long enough compared to when it was working. When submitting the BigQuery request, we have a timeout default of 10 minutes, meaning the request wouldn't return until the 10 minutes are up or it's complete. I believe the timeout we're seeing is from a default in the library being used in the Google SDK to make the HTTP request.

## Description of changes/additions
Asynchronous requests are possible with the BigQuery API. Setting a short timeout (20 seconds for the UpdateEhrStatusOrganization) would give us a response that the query isn't yet complete, but would give us the job id so we can make another request to check on it again. Checking for results uses the same API endpoint we're using for getting the next page of results.

## Tests
- [ ] unit tests




[DA-4295]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ