### PR TITLE
[DA-4315] recording origin of remote pm

### DIFF
--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -591,6 +591,10 @@ class QuestionnaireResponseDao(BaseDao):
             questions = QuestionnaireQuestionDao().get_all_with_session(session, question_ids)
             code_ids = [question.codeId for question in questions]
 
+            platform_origin = session.query(Participant.participantOrigin).filter(
+                Participant.participantId == questionnaire_response.participantId
+            ).scalar()
+
         code_dao = CodeDao()
         pm_unite_code = code_dao.get_code(PPI_SYSTEM, REMOTE_PM_UNIT)
         if not pm_unite_code:
@@ -693,7 +697,7 @@ class QuestionnaireResponseDao(BaseDao):
             logPosition=LogPosition(),
             finalized=authored,
             measurements=measurements,
-            origin='vibrent',
+            origin='ce' if platform_origin == 'careevolution' else platform_origin,
             collectType=PhysicalMeasurementsCollectType.SELF_REPORTED,
             originMeasurementUnit=origin_measurement_unit,
             questionnaireResponseId=questionnaire_response.questionnaireResponseId


### PR DESCRIPTION
## Resolves *[DA-4315](https://precisionmedicineinitiative.atlassian.net/browse/DA-4315)*
When recording a physical measurements record from a remote-pm survey response, we should know if it came from Vibrent's platform or CE's.

## Description of changes/additions
This updates the remote-pm code to find the participant's originating platform and save the physical measurements origin based on that.

## Tests
- [x] unit tests




[DA-4315]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ