### PR TITLE
Additional fixes for consent validation

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -793,7 +793,7 @@ class VibrentEhrConsentFile(EhrConsentFile):
 
     def _get_date_search_box(self):
         if self._is_english_mar_24_version():
-            return Rect.from_edges(left=130, right=250, bottom=100, top=105)
+            return Rect.from_edges(left=130, right=250, bottom=90, top=105)
         elif self._is_spanish_mar_24_version():
             return Rect.from_edges(left=130, right=250, bottom=113, top=123)
         else:

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -84,7 +84,10 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
         if not valid_files:
             return None
 
-        return min(result.expected_sign_date for result in valid_files)
+        return min(
+            datetime(result.expected_sign_date.year, result.expected_sign_date.month, result.expected_sign_date.day)
+            for result in valid_files
+        )
 
     def _update_status(
         self, participant_id, has_valid_file, authored_time, status_check=QuestionnaireStatus.SUBMITTED_NOT_VALIDATED


### PR DESCRIPTION
## Resolves *no ticket*
The validation cron job is running into an issue with date objects being stored in a datetime field. This updates the code to convert the expected authored times to datetimes. There's also a version of the new EHR file that has the signing date field slightly displaced. The search box is updated to find the date on those PDFs.

## Tests
- [ ] unit tests


