### PR TITLE
Fix for the ParticipantCountsOverTime Job

### DIFF
--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -43,7 +43,7 @@ class ParticipantCountsOverTimeService(BaseDao):
             LEFT JOIN `{participant_summary_bq_table}` AS ps
             ON p.participant_id = ps.participant_id
             WHERE p.hpo_id != @test_hpo_id
-            AND p.is_ghost_id != 1
+            AND (p.is_ghost_id != 1 OR p.is_ghost_id IS NULL)
             AND p.is_test_participant != 1
             AND (ps.email IS NULL OR NOT ps.email LIKE @test_email_pattern)
             AND p.withdrawal_status = @not_withdraw

--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -112,8 +112,10 @@ class ParticipantCountsOverTimeService(BaseDao):
 
                 temp_table_columns = ", ".join([a + ' ' + b for a, b in self.TEMP_FIELDS])
 
-                sql_string = 'CREATE TABLE {} ({})'.format(temp_table_name, temp_table_columns)
+                sql_string = 'CREATE TABLE {} ({}) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'.format(
+                    temp_table_name, temp_table_columns)
                 session.execute(sql_string)
+                logging.info('temp table created for hpo_id: ' + str(hpo.hpoId))
 
                 indexes_cursor = session.execute('SHOW INDEX FROM {}'.format(temp_table_name))
 
@@ -150,7 +152,7 @@ class ParticipantCountsOverTimeService(BaseDao):
                 participant_data = self.build_participant_sql(params, columns_str)
                 self.batch_insert_results(session, temp_table_name, participant_data)
 
-                logging.info('create temp table for hpo_id: ' + str(hpo.hpoId))
+                logging.info('data inserted into temp table for hpo_id: ' + str(hpo.hpoId))
 
             session.execute('DROP TABLE IF EXISTS metrics_tmp_participant_origin;')
             session.execute('CREATE TABLE metrics_tmp_participant_origin (participant_origin VARCHAR(50))')

--- a/rdr_service/offline/participant_counts_over_time.py
+++ b/rdr_service/offline/participant_counts_over_time.py
@@ -22,4 +22,3 @@ def calculate_participant_metrics():
     # calculate data earlier than 30 days
     service.refresh_metrics_cache_data(stage_two_start_date, stage_two_end_date, MetricsCronJobStage.STAGE_TWO)
     logging.info('calculate participant metrics stage two is done.')
-    service.clean_tmp_tables()


### PR DESCRIPTION
## Resolves *[NA]*


## Description of changes/additions
* The PublicMetrics API is returning incorrect metrics due to the  ParticipantCountsOverTime Job excluding participants with `is_ghost_id = null`. This PR updates the `participant_sql` query that populates the `temp_tables` to include all participants with `is_ghost_id = null`. This should correct the metrics cache tables and the metric counts for the PublicMetrics API.
* Previously, the job would DROP all temp_tables at the beginning and at the end of each job run. To allow for easier troubleshooting in the future, we want to only delete the temp_tables at the beginning of the job. This PR removes the dropping of tables at the end of the job.

## Tests
- [X] unit tests
- Ran the updated `participant_sql` query manually on BigQuery in AoU Warehouse PreProd. It now includes participants with `is_ghost_id = null` as expected. 1,171,640 records were returned when not filtering for a specific HPO id.
- Manually ran the `init_tmp_tables` portion of the job with AoU Warehouse PreProd to ensure that the temp tables are populated as expected. In total, 1,171,640 rows were populated across all temp tables which matches the number of rows when the `participant_sql` query was run in BigQuery


