### PR TITLE
[No Ticket] Gunicorn Keepalive

### DIFF
--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -17,7 +17,7 @@ if os.getenv('GAE_ENV', '').startswith('standard'):
 
 bind = "0.0.0.0:{0}".format(_port)
 
-timeout = 60
+timeout = 700
 log_level = "debug"
 # Do not use "gevent" for worker class, doesn't work on App Engine.
 # worker_class = "gevent"


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Changes the gunicorn keepalive setting to 700 seconds so that the timeout exceeds the GAE nginx keepalive of 650 seconds.

## Tests
- Tested on sandbox


