### PR TITLE
Consent validation updates

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -1058,9 +1058,11 @@ class CeFileWrapper:
 
         signature_label_strings = [
             "Participant's Name (printed)",
+            "Participant’s Name (printed)",
             "'s Name (printed)",
             "Name (printed)",
-            'Nombre'
+            'Nombre',
+            'consent-printed-name-label'
         ]
 
         for offset in signature_offsets:
@@ -1075,6 +1077,8 @@ class CeFileWrapper:
         signature_footer_location = self._get_location_of_string(signature_page, 'Date')
         if not signature_footer_location:
             signature_footer_location = self._get_location_of_string(signature_page, 'Fecha')
+        if not signature_footer_location:
+            signature_footer_location = self._get_location_of_string(signature_page, 'consent-date-label')
 
         if signature_footer_location:
             date_string_list = self._text_in_bounds(


### PR DESCRIPTION
## Resolves *no ticket*
It was noticed that some CE consents were failing validation but should have passed. This updates the code to account for differences in the text we use for finding the signature and date of the consent.


## Tests
- [ ] unit tests


