### PR TITLE
[DA-4236] Remove duplicate samples in N1 manifest

### DIFF
--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-from sqlalchemy import func, and_
+from sqlalchemy import func, and_, or_
 from sqlalchemy.orm import aliased
 
 from rdr_service import clock
@@ -147,6 +147,15 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
             raise KeyError("package_id required for N1_MC1")
 
         with self.session() as session:
+            most_recent = session.query(
+                SmsSample.sample_id,
+                func.max(SmsSample.created).label("created")
+            ).group_by(
+                SmsSample.sample_id
+            ).filter(
+                SmsSample.ignore_flag == 0
+            ).subquery()
+
             sample_well = aliased(SmsN1Mc1)
             query = session.query(
                 SmsSample.sample_id,
@@ -181,7 +190,7 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                 SmsSample,
                 and_(
                     SmsN0.sample_id == SmsSample.sample_id,
-                     SmsSample.ignore_flag == 0
+                    SmsSample.ignore_flag == 0
                 )
             ).outerjoin(
                 OrderedSample,
@@ -204,6 +213,12 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                      SmsN0.well_box_position == sample_well.well_box_position,
                      SmsN0.package_id == sample_well.package_id,
                      sample_well.ignore_flag == 0
+                )
+            ).outerjoin(
+                most_recent,
+                and_(
+                    SmsSample.sample_id == most_recent.c.sample_id,
+                    SmsSample.created == most_recent.c.created
                 )
             )
 
@@ -231,7 +246,11 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                 sample_well.id.is_(None),
                 SmsN0.ignore_flag == 0,
                 SmsN0.package_id == kwargs.get('package_id'),
-                SmsN0.file_path.ilike(f'%{kwargs.get("recipient")}%')
+                SmsN0.file_path.ilike(f'%{kwargs.get("recipient")}%'),
+                or_(
+                    SmsSample.created == most_recent.c.created,
+                    SmsSample.created.is_(None)
+                )
             ).distinct().order_by(SmsN0.id)
 
             return query.all()

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 import os
+import time
 from unittest import mock
 
 from rdr_service import api_util, clock
@@ -361,6 +362,19 @@ class NphSmsWorkflowsTest(BaseTestCase):
 
     def test_n1_mc1_generation(self):
         self.create_data_n1_mc1_generation()
+        sms_datagen = NphSmsDataGenerator()
+        time.sleep(1)
+        sms_datagen.create_database_sms_sample(
+            ethnicity="test",
+            race="test",
+            bmi="30",
+            diet="LMT",
+            sex_at_birth="M",
+            sample_identifier="test",
+            sample_id=10002,
+            lims_sample_id="000200",
+            destination="UNC_META"
+        )
 
         generation_data = {
             "job": "FILE_GENERATION",
@@ -433,7 +447,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(manifest_records[1].file_path, expected_csv_path)
         self.assertEqual(manifest_records[1].sample_id, "10002")
         self.assertEqual(manifest_records[1].matrix_id, "1112")
-        self.assertEqual(manifest_records[1].bmi, "28")
+        self.assertEqual(manifest_records[1].bmi, "30")
         self.assertEqual(manifest_records[1].diet, "LMT")
         self.assertEqual(manifest_records[1].collection_site, "UNC")
         self.assertEqual(manifest_records[1].manufacturer_lot, '256838')

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -391,7 +391,6 @@ class NphSmsWorkflowsTest(BaseTestCase):
                 test_client=resource_main.app.test_client(),
             )
 
-
         expected_csv_path = "test-bucket-unc-meta/n1_manifests/UNC_META_n1_2023-04-25T15:13:00.csv"
 
         with open_cloud_file(expected_csv_path, mode='r') as cloud_file:


### PR DESCRIPTION
## Resolves *[DA-4236](https://precisionmedicineinitiative.atlassian.net/browse/DA-4236)*


## Description of changes/additions
Added subquery and filters to only get most recent samples in N1 manifest generation.

## Tests
- [test_nph_sms_worflows.test_n1_mc1_generation] unit tests




[DA-4236]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ