### PR TITLE
[DA-4317] Add freeze date/time to stool samples

### DIFF
--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -487,8 +487,6 @@ class NphOrderDao(UpdatableDao):
     def _update_if_present(cls, target_obj, target_field_name, source_obj, source_field_name=None):
         source_field_name = source_field_name or target_field_name
         if hasattr(source_obj, source_field_name):
-            if hasattr(source_obj, "freezed") and source_field_name == "finalized":
-                source_field_name = "freezed"
             new_value = getattr(source_obj, source_field_name)
             setattr(target_obj, target_field_name, new_value)
 
@@ -714,7 +712,7 @@ class NphOrderedSampleDao(UpdatableDao):
                              test=obj.sample.test,
                              description=obj.sample.description,
                              collected=obj.sample.collected,
-                             finalized=obj.sample.freezed if obj.sample.test.startswith("ST") else obj.sample.finalized,
+                             finalized=obj.sample.finalized,
                              supplemental_fields=self._fetch_supplemental_fields_for_tube(obj)
                              )
 
@@ -738,7 +736,7 @@ class NphOrderedSampleDao(UpdatableDao):
         return value
 
     def _fetch_supplemental_fields_for_tube(self, order_cls) -> Dict:
-        keys = ["test", "description", "collected", "finalized", "freezed"]
+        keys = ["test", "description", "collected", "finalized"]
         result = {k: self.check_input_struct(v) for k, v in order_cls.sample.__dict__.items() if k not in keys}
         return result
 
@@ -829,7 +827,7 @@ class NphOrderedSampleDao(UpdatableDao):
         order_sample.test = obj.sample.test
         order_sample.description = obj.sample.description
         order_sample.collected = obj.sample.collected
-        order_sample.finalized = obj.sample.freezed if obj.sample.test.startswith("ST") else obj.sample.finalized
+        order_sample.finalized = obj.sample.finalized
         order_sample.supplemental_fields = self._fetch_supplemental_fields_for_tube(obj)
         return order_sample
 
@@ -1245,7 +1243,7 @@ class NphBiospecimenDao(BaseDao):
                             ),
                             'processingDateUTC', case(
                                 [
-                                    (OrderedSample.test.startswith("ST"), OrderedSample.finalized),
+                                    (OrderedSample.test.startswith("ST"), OrderedSample.supplemental_fields.freezed),
                                     (OrderedSample.parent_sample_id.isnot(None), OrderedSample.collected),
                                 ],
                                 else_=None

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -487,6 +487,8 @@ class NphOrderDao(UpdatableDao):
     def _update_if_present(cls, target_obj, target_field_name, source_obj, source_field_name=None):
         source_field_name = source_field_name or target_field_name
         if hasattr(source_obj, source_field_name):
+            if hasattr(source_obj, "freezed") and source_field_name == "finalized":
+                source_field_name = "freezed"
             new_value = getattr(source_obj, source_field_name)
             setattr(target_obj, target_field_name, new_value)
 
@@ -712,7 +714,7 @@ class NphOrderedSampleDao(UpdatableDao):
                              test=obj.sample.test,
                              description=obj.sample.description,
                              collected=obj.sample.collected,
-                             finalized=obj.sample.finalized,
+                             finalized=obj.sample.freezed if obj.sample.test.startswith("ST") else obj.sample.finalized,
                              supplemental_fields=self._fetch_supplemental_fields_for_tube(obj)
                              )
 
@@ -736,7 +738,7 @@ class NphOrderedSampleDao(UpdatableDao):
         return value
 
     def _fetch_supplemental_fields_for_tube(self, order_cls) -> Dict:
-        keys = ["test", "description", "collected", "finalized"]
+        keys = ["test", "description", "collected", "finalized", "freezed"]
         result = {k: self.check_input_struct(v) for k, v in order_cls.sample.__dict__.items() if k not in keys}
         return result
 
@@ -827,7 +829,7 @@ class NphOrderedSampleDao(UpdatableDao):
         order_sample.test = obj.sample.test
         order_sample.description = obj.sample.description
         order_sample.collected = obj.sample.collected
-        order_sample.finalized = obj.sample.finalized
+        order_sample.finalized = obj.sample.freezed if obj.sample.test.startswith("ST") else obj.sample.finalized
         order_sample.supplemental_fields = self._fetch_supplemental_fields_for_tube(obj)
         return order_sample
 
@@ -1243,6 +1245,7 @@ class NphBiospecimenDao(BaseDao):
                             ),
                             'processingDateUTC', case(
                                 [
+                                    (OrderedSample.test.startswith("ST"), OrderedSample.finalized),
                                     (OrderedSample.parent_sample_id.isnot(None), OrderedSample.collected),
                                 ],
                                 else_=None

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1243,7 +1243,7 @@ class NphBiospecimenDao(BaseDao):
                             ),
                             'processingDateUTC', case(
                                 [
-                                    (OrderedSample.test.startswith("ST"), OrderedSample.supplemental_fields.freezed),
+                                    (OrderedSample.test.startswith("ST"), OrderedSample.supplemental_fields["freezed"]),
                                     (OrderedSample.parent_sample_id.isnot(None), OrderedSample.collected),
                                 ],
                                 else_=None

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -126,7 +126,7 @@ def _get_ordered_samples(order_id: int) -> List[OrderedSample]:
         return query.all()
 
 
-def _get_processing_timestamp(ordered_sample: OrderedSample) -> Optional[datetime]:
+def get_processing_timestamp(ordered_sample: OrderedSample) -> Optional[datetime]:
     """Get finalized ts for stool samples & collected ts for other samples."""
     if ordered_sample.test is not None and ordered_sample.test.startswith("ST"):
         return ordered_sample.finalized
@@ -151,7 +151,7 @@ def _convert_ordered_samples_to_samples(
             "volume": ordered_sample.volume,
             "volumeUOM": ordered_sample.volumeUnits,
             "collectionDateUTC": _format_timestamp((ordered_sample.parent or ordered_sample).collected),
-            "processingDateUTC": _format_timestamp(_get_processing_timestamp(ordered_sample)),
+            "processingDateUTC": _format_timestamp(get_processing_timestamp(ordered_sample)),
             "cancelledFlag": "Y" if sample_cancelled else "N",
             "notes": notes,
         }

--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -129,7 +129,7 @@ def _get_ordered_samples(order_id: int) -> List[OrderedSample]:
 def get_processing_timestamp(ordered_sample: OrderedSample) -> Optional[datetime]:
     """Get finalized ts for stool samples & collected ts for other samples."""
     if ordered_sample.test is not None and ordered_sample.test.startswith("ST"):
-        return ordered_sample.finalized
+        return datetime.strptime(ordered_sample.supplemental_fields["freezed"], "%Y-%m-%dT%H:%M:%SZ")
     elif ordered_sample.parent is not None:
         return ordered_sample.collected
     return None

--- a/tests/api_tests/test_nph_participant_biobank_order_api.py
+++ b/tests/api_tests/test_nph_participant_biobank_order_api.py
@@ -512,38 +512,9 @@ class TestNPHParticipantOrderAPI(BaseTestCase):
         app.test_client().post('rdr/v1/api/v1/nph/Participant/100001/BiobankOrder', json=STOOL_DIET_SAMPLE)
         dao = NphOrderedSampleDao()
         sample = dao.get(1)
+        sample_freeze_date = datetime.strptime(sample.supplemental_fields["freezed"], "%Y-%m-%dT%H:%M:%SZ")
         freezeDateUTC = datetime.strptime("2022-11-03 10:30:49", "%Y-%m-%d %H:%M:%S")
-        self.assertEqual(freezeDateUTC, sample.finalized)
-
-        app.test_client().patch(
-            'rdr/v1/api/v1/nph/Participant/100001/BiobankOrder/1',
-            json={
-                'status': 'amended',
-                "amendedInfo": {
-                    "author": {
-                        "system": "https://www.pmi-ops.org\/nph-username",
-                        "value": "test@example.com"
-                    },
-                    "site": {
-                        "system": "https://www.pmi-ops.org\/site-id",
-                        "value": "test-site-1"
-                    }
-                },
-                'sample': {
-                    "test": "ST1",
-                    "description": "95% Ethanol Tube 1",
-                    "collected": "2022-11-03T09:45:49Z",
-                    "finalized": "2022-11-03T10:55:41Z",
-                    "bowelMovement": "I was constipated (had difficulty passing stool), and my stool looks like Type 1 and/or 2",
-                    "bowelMovementQuality": "I tend to be constipated (have difficulty passing stool) - Type 1 and 2",
-                    "freezed": "2022-11-03T10:15:49Z",
-                },
-            }
-        )
-
-        sample = dao.get(1)
-        freezeDateUTC = freezeDateUTC - timedelta(minutes=15)
-        self.assertEqual(freezeDateUTC, sample.finalized)
+        self.assertEqual(freezeDateUTC, sample_freeze_date)
         processingDateUTC = get_processing_timestamp(sample)
         self.assertEqual(freezeDateUTC, processingDateUTC)
 

--- a/tests/api_tests/test_nph_participant_biobank_order_api.py
+++ b/tests/api_tests/test_nph_participant_biobank_order_api.py
@@ -1,5 +1,5 @@
 # Sample ID = NP124820391
-from datetime import datetime, timedelta
+from datetime import datetime
 import json
 from sqlalchemy.orm import Query
 from unittest.mock import MagicMock, patch

--- a/tests/workflow_tests/test_data/test_biobank_order_payloads.py
+++ b/tests/workflow_tests/test_data/test_biobank_order_payloads.py
@@ -161,3 +161,67 @@ URINE_DIET_SAMPLE = {
         "finalized": "Test notes 2"
     }
 }
+
+STOOL_DIET_SAMPLE = {
+  "subject": "Patient/P124820391",
+    "identifier": [{
+      "system": "http://www.pmi-ops.org/order-id",
+      "value": "nph-order-id-kit-12345678"
+      },
+      {
+        "system": "http://www.pmi-ops.org/sample-id",
+        "value": "nph-sample-id-kit-12345679"
+      },
+      {
+        "system": "http://www.pmi-ops.org/client-id",
+        "value": "123456789"
+      }
+    ],
+    "createdInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "collectedInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+    "finalizedInfo": {
+        "author": {
+            "system": "https://www.pmi-ops.org\/nph-username",
+            "value": "test@example.com"
+        },
+        "site": {
+            "system": "https://www.pmi-ops.org\/site-id",
+            "value": "test-site-1"
+        }
+    },
+  "created": "2022-11-03T09:40:21Z",
+  "module": "1",
+  "visitType": "LMT",
+  "timepoint": "Pre LMT",
+  "sample": {
+    "test": "ST1",
+    "description": "95% Ethanol Tube 1",
+    "collected": "2022-11-03T09:45:49Z",
+    "finalized": "2022-11-03T10:55:41Z",
+    "bowelMovement": "I was constipated (had difficulty passing stool), and my stool looks like Type 1 and/or 2",
+    "bowelMovementQuality": "I tend to be constipated (have difficulty passing stool) - Type 1 and 2",
+    "freezed": "2022-11-03T10:30:49Z"
+  },
+  "notes": {
+    "collected": "Test notes 1",
+    "finalized": "Test notes 2"
+  }
+}


### PR DESCRIPTION
## Resolves *[DA-4317](https://precisionmedicineinitiative.atlassian.net/browse/DA-4317)*


## Description of changes/additions
- Added checks for "freezed" in NPH orderedsample payloads
- On stool samples, replaced the "finalized" value with the "freezed" value
- Ensured this will propagate to the nightly JSON file drops

## Tests
- [tests/api_tests/test_nph_participant_biobank_order_api.py test_freeze_stool_order] unit tests




[DA-4317]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ