### PR TITLE
[DA-4346] reloading ehr consent status during validation

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -96,6 +96,7 @@ class EhrStatusUpdater(ConsentMetadataUpdater):
             participant_id=participant_id,
             session=self._session
         )
+        self._session.refresh(participant_summary)
         did_modify_status = False
 
         if participant_summary.consentForElectronicHealthRecords == status_check:


### PR DESCRIPTION
## Partially Resolves *[DA-4346](https://precisionmedicineinitiative.atlassian.net/browse/DA-4346)*
We've seen some cases where the validation process will alter an EHR consent status that shouldn't be changed. When the validation process starts, it loads a set of participant summaries into memory and maintains that as a cache. If we validate an EHR consent, the status we see on their participant summary is the status they had when that batch of summaries was loaded. Validating an EHR consent would update a SUBMITTED_NOT_VALIDATED status to whatever the validation result was, and if the status was anything else it would leave it alone.

We've seen some cases where the validation starts with a participant that provided consent (and had the SUBMITTED_NOT_VALIDATED status) but then submitted a response revoking consent while the validation was still running. So while the database would show that the EHR consent status was no, the validation process still had the SUBMITTED_NOT_VALIDATED status in the cache.

## Description of changes/additions
This updates the code to refresh the validation status just before checking it to see if it's still something that needs validated.

## Tests
- [x] unit tests




[DA-4346]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ