### PR TITLE
Updating requests[security] from 2.31.0 to 2.32.2

### DIFF
--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -88,7 +88,7 @@ pyzmq==25.1.0             # via locust
 redis==4.5.4              # via flask-limiter
 requests-oauthlib==1.3.0  # via jira
 requests-toolbelt==0.9.1  # via jira
-requests[security]==2.32.0  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
+requests[security]==2.32.2  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
 rsa==4.7.2                  # via google-auth, oauth2client
 sendgrid==6.9.1           # via -r requirements.in
 simple-geometry==0.1.4  # geometry

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -88,7 +88,7 @@ pyzmq==25.1.0             # via locust
 redis==4.5.4              # via flask-limiter
 requests-oauthlib==1.3.0  # via jira
 requests-toolbelt==0.9.1  # via jira
-requests[security]==2.31.0  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
+requests[security]==2.32.0  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
 rsa==4.7.2                  # via google-auth, oauth2client
 sendgrid==6.9.1           # via -r requirements.in
 simple-geometry==0.1.4  # geometry


### PR DESCRIPTION
## Resolves *NO TICKET*


## Description of changes/additions
When running circle CI tests , there is a new security vulnerability for requests 2.31.0. When looking at the [requests documentation](https://requests.readthedocs.io/en/latest/community/updates/#id4) and the [vulnerability details](https://data.safetycli.com/v/71064/97c/) I think we need to upgrade to 2.32.2

## Tests 
- [] unit tests


