### PR TITLE
[DA-4359] Gracefully handling missing guardian name

### DIFF
--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -1017,15 +1017,19 @@ class ConsentValidator:
             ).filter(ParticipantSummary.participantId == guardian_id_list.pop()).one_or_none()
 
         # compare first and last name to parsed string
-        file_guardian_name_parts = result.guardian_printed_name.lower().split(' ')
-        if (
-            not guardian_summary
-            or len(file_guardian_name_parts) < 2
-            or guardian_summary.firstName.lower() != file_guardian_name_parts[0]
-            or guardian_summary.lastName.lower() != file_guardian_name_parts[-1]
-        ):
+        if not result.guardian_printed_name:
             self._append_other_error(ConsentOtherErrors.UNEXPECTED_GUARDIAN_NAME, result)
             result.sync_status = ConsentSyncStatus.NEEDS_CORRECTING
+        else:
+            file_guardian_name_parts = result.guardian_printed_name.lower().split(' ')
+            if (
+                not guardian_summary
+                or len(file_guardian_name_parts) < 2
+                or guardian_summary.firstName.lower() != file_guardian_name_parts[0]
+                or guardian_summary.lastName.lower() != file_guardian_name_parts[-1]
+            ):
+                self._append_other_error(ConsentOtherErrors.UNEXPECTED_GUARDIAN_NAME, result)
+                result.sync_status = ConsentSyncStatus.NEEDS_CORRECTING
 
     def _additional_ehr_checks(self, consent: files.EhrConsentFile, result: ParsingResult):
         self._validate_is_va_file(consent, result)


### PR DESCRIPTION
## Resolves *[DA-4359](https://precisionmedicineinitiative.atlassian.net/browse/DA-4359)*
We were seeing consent responses that weren't being validated. Consent validation should run every hour and validate anything that needs it that is as old as 3 hours. But there was an occasional issue with pediatric consents missing the guardian name that was causing validation to crash, missing any other validations in that time window.

## Description of changes/additions
This fixes the crash that happens when missing the guardian name so validations can continue as normal.

## Tests
- [ ] unit tests




[DA-4359]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ