### PR TITLE
Change scaling and instance class for Resource Service

### DIFF
--- a/rdr_service/resource.yaml
+++ b/rdr_service/resource.yaml
@@ -4,9 +4,16 @@ runtime: python311
 service: resource
 entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 600 rdr_service.resource.main:app
 
-instance_class: B4
+# Changing to Automatic Scaling based on recommendation from Google Support
+instance_class: F4
 
-# We need to specify basic scaling in order to use a backend instance class.
-basic_scaling:
-  max_instances: 20
-  idle_timeout: 60m
+inbound_services:
+- warmup
+
+# Required for automatic scaling
+handlers:
+- url: /_ah/warmup
+  script: auto
+
+automatic_scaling:
+  min_idle_instances: 5

--- a/rdr_service/resource/main.py
+++ b/rdr_service/resource/main.py
@@ -9,7 +9,7 @@ from rdr_service.api import cloud_tasks_api, genomic_cloud_tasks_api, message_br
     ancillary_study_cloud_tasks_api
 from rdr_service.api.resource_api import ResourceRequestApi
 
-from rdr_service.services.flask import RESOURCE_PREFIX, TASK_PREFIX, flask_start, flask_stop
+from rdr_service.services.flask import RESOURCE_PREFIX, TASK_PREFIX, flask_start, flask_stop, flask_warmup
 from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging, \
     flask_restful_log_exception_error
 
@@ -272,6 +272,7 @@ def _build_resource_app():
         methods=['POST']
     )
 
+    _app.add_url_rule("/_ah/warmup", endpoint="warmup", view_func=flask_warmup, methods=["GET"])
     _app.add_url_rule('/_ah/start', endpoint='start', view_func=flask_start, methods=["GET"])
     _app.add_url_rule('/_ah/stop', endpoint='stop', view_func=flask_stop, methods=["GET"])
 


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This is part of an ongoing investigation to resolve the intermittent 502 errors. Per Google Support's suggestion, this PR sets the minimum idle instances of the `resource` service to 5. To do this, Automatic Scaling is required. This change required a change to the instance class as well as creating a warmup handler. 

## Tests
- deployed to sandbox and triggered a cloud task via a Cloud Function


