### PR TITLE
[PDR-2517] (Partial) Disable consent_metric PDR generators

### DIFF
--- a/rdr_service/offline/sync_consent_files.py
+++ b/rdr_service/offline/sync_consent_files.py
@@ -31,7 +31,6 @@ from rdr_service.model.site import Site
 from rdr_service.model.utils import to_client_participant_id
 from rdr_service.participant_enums import QuestionnaireStatus
 
-from rdr_service.resource.tasks import dispatch_rebuild_consent_metrics_tasks
 from rdr_service.services.gcp_utils import gcp_cp
 from rdr_service.storage import GoogleCloudStorageProvider, GoogleCloudStorageZipFile
 
@@ -311,9 +310,6 @@ class ConsentSyncController:
                 if len(files_synced):
                     self.consent_dao.batch_update_consent_files(session=session, consent_files=files_synced)
                     session.commit()
-
-                    # Queue tasks to rebuild consent metrics resource data records (for PDR)
-                    dispatch_rebuild_consent_metrics_tasks([file.id for file in files_synced])
 
     def _build_participant_pairing_map(self, files: List[ConsentFile]) -> Dict[int, ParticipantPairingInfo]:
         """

--- a/rdr_service/services/consent/validation.py
+++ b/rdr_service/services/consent/validation.py
@@ -23,7 +23,6 @@ from rdr_service.model.consent_file import ConsentFile as ParsingResult, Consent
 from rdr_service.model.consent_response import ConsentResponse
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.participant_enums import ParticipantCohort, QuestionnaireStatus
-from rdr_service.resource.tasks import dispatch_rebuild_consent_metrics_tasks
 from rdr_service.services.consent import files
 from rdr_service.storage import GoogleCloudStorageProvider
 
@@ -209,7 +208,6 @@ class StoreResultStrategy(ValidationOutputStrategy):
         if new_results_to_store:
             updated_ids = [result.id for result in new_results_to_store]
             updated_ids.extend([file.id for file in self._reconsented_files])
-            dispatch_rebuild_consent_metrics_tasks(updated_ids, project_id=self.project_id)
 
         EhrStatusUpdater(session=self._session, project_name=self.project_id).process_results(new_results_to_store)
 
@@ -281,7 +279,6 @@ class ReplacementStoringStrategy(ValidationOutputStrategy):
         if results_to_update:
             updated_ids = [result.id for result in results_to_update]
             updated_ids.extend([file.id for file in self._reconsented_files])
-            dispatch_rebuild_consent_metrics_tasks(updated_ids, project_id=self.project_id)
 
         EhrStatusUpdater(session=self.session, project_name=self.project_id).process_results(results_to_update)
 
@@ -362,9 +359,6 @@ class UpdateResultStrategy(ReplacementStoringStrategy):
                         self.session.add(ready_for_sync)
 
         self.session.commit()
-
-        if results_to_build:
-            dispatch_rebuild_consent_metrics_tasks([r.id for r in results_to_build], project_id=self.project_id)
 
         EhrStatusUpdater(session=self.session, project_name=self.project_id).process_results(results_to_build)
 

--- a/rdr_service/tools/tool_libs/consents.py
+++ b/rdr_service/tools/tool_libs/consents.py
@@ -15,7 +15,6 @@ from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.dao.participant_dao import ParticipantHistoryDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao
-from rdr_service.resource.tasks import dispatch_rebuild_consent_metrics_tasks
 from rdr_service.services.gcp_utils import gcp_make_auth_header
 from rdr_service.model.consent_file import ConsentFile, ConsentSyncStatus, ConsentType, CONSENT_TYPE_MODULE_NAMES
 from rdr_service.model.consent_response import ConsentResponse
@@ -243,8 +242,6 @@ class ConsentTool(ToolBase):
                 )
                 self._consent_dao.batch_update_consent_files([file], session)
                 session.commit()
-                dispatch_rebuild_consent_metrics_tasks([file.id],
-                                                       project_id=self.gcp_env.project, build_locally=True)
 
     def validate_consents(self):
         consent_types = None
@@ -317,9 +314,6 @@ class ConsentTool(ToolBase):
                     setattr(consent_file, field_name, value)
 
                 file_ids_modified.append(consent_file.id)
-
-        if file_ids_modified:
-            dispatch_rebuild_consent_metrics_tasks(file_ids_modified, project_id=self.gcp_env.project)
 
     @classmethod
     def _get_date_error_details(cls, file: ConsentFile, verbose: bool = False):

--- a/tests/service_tests/consent_tests/test_consent_validation.py
+++ b/tests/service_tests/consent_tests/test_consent_validation.py
@@ -282,10 +282,7 @@ class ConsentValidationTesting(BaseTestCase):
             self.validator.get_gror_validation_results()
         )
 
-    @mock.patch(
-        'rdr_service.services.consent.validation.dispatch_rebuild_consent_metrics_tasks'
-    )
-    def test_missing_file_validation_storage(self, mock_consent_metrics_rebuild):
+    def test_missing_file_validation_storage(self):
         """
         A bug was found with the validation storage strategies. This ensures that any records that indicate
         missing files don't interfere with each other and all the needed records get stored.
@@ -335,13 +332,8 @@ class ConsentValidationTesting(BaseTestCase):
 
         # Verify that both records that provide new validation information were stored
         consent_dao_mock.batch_update_consent_files.assert_called_with([new_primary_result, new_gror_result], mock.ANY)
-        mock_consent_metrics_rebuild.assert_called_once_with(
-            [new_primary_result.id, new_gror_result.id],
-            project_id=None
-        )
 
-    @mock.patch('rdr_service.services.consent.validation.dispatch_rebuild_consent_metrics_tasks')
-    def test_multiple_distinct_consents(self, _):
+    def test_multiple_distinct_consents(self):
         """
         It's possible to have multiple consents that need to be processed independently
         rather than ignored as duplicates. For example, when a new EHR consent is submitted, the participant's


### PR DESCRIPTION
## Partially Resolves *[PDR-2517](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2517)*


## Description of changes/additions
The `consent_file` (aka `consent_metric` in PDR) data generation for PDR has been migrated to the new  pipeline.

Disabling/removing dispatching of old pipeline tasks to build consent validation metrics data for PDR, and removing associated unit test code.   The old resource service Rebuild API endpoint will remain in place for now in case of any unexpected/missed invocations.  Warnings will be emitted if the endpoint is reached.

## Tests
- [x] unit tests - confirmed updated tests are passing




[PDR-2517]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ