### PR TITLE
Adding PPSC Role to API Endpoints

### DIFF
--- a/rdr_service/api/biobank_order_api.py
+++ b/rdr_service/api/biobank_order_api.py
@@ -1,7 +1,7 @@
 from flask import request
 
 from rdr_service.api.base_api import UpdatableApi
-from rdr_service.api_util import PTC_AND_HEALTHPRO
+from rdr_service.api_util import HEALTHPRO, PTC, PPSC
 from rdr_service.app_util import auth_required
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
 
@@ -10,19 +10,19 @@ class BiobankOrderApi(UpdatableApi):
     def __init__(self):
         super(BiobankOrderApi, self).__init__(BiobankOrderDao(), get_returns_children=True)
 
-    @auth_required(PTC_AND_HEALTHPRO)
+    @auth_required([HEALTHPRO, PTC, PPSC])
     def post(self, p_id):
         return super(BiobankOrderApi, self).post(participant_id=p_id)
 
-    @auth_required(PTC_AND_HEALTHPRO)
+    @auth_required([HEALTHPRO, PTC, PPSC])
     def get(self, p_id=None, bo_id=None):  # pylint: disable=unused-argument
         return super(BiobankOrderApi, self).get(id_=bo_id, participant_id=p_id)
 
-    @auth_required(PTC_AND_HEALTHPRO)
+    @auth_required([HEALTHPRO, PTC, PPSC])
     def put(self, p_id, bo_id):  # pylint: disable=unused-argument
         return super(BiobankOrderApi, self).put(bo_id, participant_id=p_id)
 
-    @auth_required(PTC_AND_HEALTHPRO)
+    @auth_required([HEALTHPRO, PTC, PPSC])
     def patch(self, p_id, bo_id):  # pylint: disable=unused-argument
         return super(BiobankOrderApi, self).patch(bo_id)
 

--- a/rdr_service/api/physical_measurements_api.py
+++ b/rdr_service/api/physical_measurements_api.py
@@ -2,7 +2,7 @@ from flask import request
 
 from rdr_service import app_util, config
 from rdr_service.api.base_api import BaseApi, DEFAULT_MAX_RESULTS, log_api_request
-from rdr_service.api_util import HEALTHPRO, PTC, PTC_AND_HEALTHPRO
+from rdr_service.api_util import HEALTHPRO, PTC, PPSC
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.query import FieldFilter, Operator, Query
 
@@ -11,15 +11,15 @@ class PhysicalMeasurementsApi(BaseApi):
     def __init__(self):
         super(PhysicalMeasurementsApi, self).__init__(PhysicalMeasurementsDao())
 
-    @app_util.auth_required(PTC_AND_HEALTHPRO)
+    @app_util.auth_required([HEALTHPRO, PTC, PPSC])
     def get(self, id_=None, p_id=None):
         return super(PhysicalMeasurementsApi, self).get(id_, participant_id=p_id)
 
-    @app_util.auth_required(HEALTHPRO)
+    @app_util.auth_required([HEALTHPRO, PPSC])
     def post(self, p_id):
         return super(PhysicalMeasurementsApi, self).post(p_id)
 
-    @app_util.auth_required(HEALTHPRO)
+    @app_util.auth_required([HEALTHPRO, PPSC])
     def patch(self, id_, p_id):
         resource = self.get_request_json()
         obj = self.dao.patch(id_, resource, p_id)


### PR DESCRIPTION
## Resolves *NA*


## Description of changes/additions
Granting the PPSC role access to the Physical Measurement and Biobank Order APIs.

## Tests
- [X] unit tests


