### PR TITLE
Upgrading cryptography

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -23,9 +23,6 @@ security: # configuration for the `safety check` command
         70612:
           reason: jinja2 version 3.1.4 has a vulnerability
           expires: '2025-05-31'
-        71684:
-          reason: cryptography version 42.0.5 has a vulnerability -> dep package of pdfminer uses earlier version, so cannot bump the version
-          expires: '2025-07-22'
     continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
     security:

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 click==8.1.3              # via flask, pip-tools
 configargparse==1.2.3     # via locust
 coverage==7.2.5             # via -r requirements.in
-cryptography==42.0.5       # via oauthlib, pyopenssl, requests
+cryptography==43.0.0      # via oauthlib, pyopenssl, requests
 defusedxml==0.6.0         # via jira
 dictalchemy3==1.0.0       # via -r requirements.in
 dnspython==2.6.1         # via -r requirements.in
@@ -77,7 +77,7 @@ pycparser==2.20           # via cffi
 pygments==2.15.1           # via sphinx
 pyjwt==2.4.0              # via oauthlib
 pylint==2.17.4            # via -r requirements.in
-pyopenssl==24.0.0         # via requests
+pyopenssl==24.2.1         # via requests
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via alembic, faker
 python-editor==1.0.4      # via alembic


### PR DESCRIPTION
## Resolves *no ticket*
Upgrading cryptography because of recent vulnerability. Also upgrading pyopenssl because the earlier version required a lower version of cryptography.

