### PR TITLE
Update/Disable GEM A1

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -97,7 +97,7 @@ cron:
 - description: Genomic GEM A1 Workflow
   url: /offline/GenomicGemA1Workflow
   timezone: America/New_York
-  schedule: every tuesday 00:00
+  schedule: 1 of jan 12:00
   target: offline
 - description: Genomic GEM A3 Workflow
   url: /offline/GenomicGemA3Workflow

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4081,7 +4081,8 @@ class GenomicGemDao(BaseDao):
                 ConsentFile.sync_status.in_([
                     ConsentSyncStatus.READY_FOR_SYNC,
                     ConsentSyncStatus.SYNC_COMPLETE
-                ])
+                ]),
+                GenomicA1Raw.id.is_(None)
             ).group_by(
                 GenomicSetMember.biobankId,
                 GenomicSetMember.sampleId,

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4082,7 +4082,7 @@ class GenomicGemDao(BaseDao):
                     ConsentSyncStatus.READY_FOR_SYNC,
                     ConsentSyncStatus.SYNC_COMPLETE
                 ]),
-                # GenomicA1Raw.id.is_(None)
+                GenomicA1Raw.id.is_(None)
             ).group_by(
                 GenomicSetMember.biobankId,
                 GenomicSetMember.sampleId,

--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -4082,7 +4082,7 @@ class GenomicGemDao(BaseDao):
                     ConsentSyncStatus.READY_FOR_SYNC,
                     ConsentSyncStatus.SYNC_COMPLETE
                 ]),
-                GenomicA1Raw.id.is_(None)
+                # GenomicA1Raw.id.is_(None)
             ).group_by(
                 GenomicSetMember.biobankId,
                 GenomicSetMember.sampleId,

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -2612,7 +2612,7 @@ class GenomicPipelineTest(BaseTestCase):
         with clock.FakeClock(a1_time):
             genomic_gem_pipeline.gem_a1_manifest_workflow()  # run_id = 3
 
-        current_file_records = [obj for obj in self.file_processed_dao.get_all() if 'gem_a1' in obj.file_name.lower()]
+        current_file_records = [obj for obj in self.file_processed_dao.get_all() if 'gem_a1' in obj.fileName.lower()]
         self.assertEqual(len(current_file_records), 1)
 
         # Test Withdrawn and then Reconsented

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -2626,6 +2626,8 @@ class GenomicPipelineTest(BaseTestCase):
         with clock.FakeClock(withdraw_time):
             genomic_gem_pipeline.gem_a3_manifest_workflow()  # run_id 6
 
+        self.clear_table_after_test('genomic_a1_raw')
+
     @mock.patch('rdr_service.genomic.genomic_job_controller.GenomicJobController.execute_cloud_task')
     def test_gem_a3_manifest_workflow(self, cloud_task):
         # Create A1 manifest job run: id = 1

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -2608,6 +2608,13 @@ class GenomicPipelineTest(BaseTestCase):
         for attribute in GenomicA1Raw.__table__.columns:
             self.assertTrue(all(getattr(obj, str(attribute).split('.')[1]) is not None for obj in gem_raw_records))
 
+        # run second time same samples, should not pick up, so only one file generated
+        with clock.FakeClock(a1_time):
+            genomic_gem_pipeline.gem_a1_manifest_workflow()  # run_id = 3
+
+        current_file_records = [obj for obj in self.file_processed_dao.get_all() if 'gem_a1' in obj.file_name.lower()]
+        self.assertEqual(len(current_file_records), 1)
+
         # Test Withdrawn and then Reconsented
         # Do withdraw GROR
         withdraw_time = datetime.datetime(2020, 4, 2, 0, 0, 0, 0)


### PR DESCRIPTION
## Resolves *[NA]*


## Description of changes/additions
The GEM A1 job is being disabled, it is current off in the config, so this change is for the missing outer join to the sample model and disabling the job.

** All current A1 manifests have been imported into the A1 raw model.

## Tests
- [x] unit tests


