### PR TITLE
[DA-4410] Default legacy stool sample ProcessingDateUTC to finalized timestamp

### DIFF
--- a/rdr_service/offline/study_nph_biobank_file_export.py
+++ b/rdr_service/offline/study_nph_biobank_file_export.py
@@ -127,9 +127,13 @@ def _get_ordered_samples(order_id: int) -> List[OrderedSample]:
 
 
 def get_processing_timestamp(ordered_sample: OrderedSample) -> Optional[datetime]:
-    """Get finalized ts for stool samples & collected ts for other samples."""
-    if ordered_sample.test is not None and ordered_sample.test.startswith("ST"):
+    """Get freezed ts for stool samples & collected ts for other samples.
+       Default to finalized for stool samples without freezed"""
+    if (ordered_sample.test is not None and ordered_sample.test.startswith("ST")
+            and "freezed" in ordered_sample.supplemental_fields):
         return datetime.strptime(ordered_sample.supplemental_fields["freezed"], "%Y-%m-%dT%H:%M:%SZ")
+    elif ordered_sample.test is not None and ordered_sample.test.startswith("ST"):
+        return ordered_sample.finalized
     elif ordered_sample.parent is not None:
         return ordered_sample.collected
     return None

--- a/tests/workflow_tests/test_nph_biobank_workflows.py
+++ b/tests/workflow_tests/test_nph_biobank_workflows.py
@@ -2,7 +2,8 @@ import os
 
 from rdr_service.api_util import open_cloud_file
 from rdr_service.dao.study_nph_dao import NphStoredSampleDao
-from rdr_service.data_gen.generators.nph import NphDataGenerator
+from rdr_service.data_gen.generators.nph import NphDataGenerator, NphSmsDataGenerator
+from rdr_service.offline.study_nph_biobank_file_export import get_processing_timestamp
 from rdr_service.offline.study_nph_biobank_import_inventory_file import import_biobank_inventory_into_stored_samples
 from tests.helpers.unittest_base import BaseTestCase
 from tests.test_data import data_path
@@ -56,3 +57,18 @@ class NphBiobankWorkflowsTest(BaseTestCase):
         stored_samples = ss_dao.get_all()
         self.assertEqual(stored_samples[0].sample_id, "00005")
         self.assertEqual(stored_samples[1].sample_id, "00006")
+
+    def test_no_error_on_timestamp(self):
+        sms_datagen = NphSmsDataGenerator()
+        sample = sms_datagen.create_database_ordered_sample(
+            nph_sample_id=10006,
+            test="ST01",
+            supplemental_fields={
+                "bowelMovement": "I had normal formed stool, and my stool looks like Type 3 and/or 4",
+                "bowelMovementQuality": "I tend to have normal formed stool - Type 3 and 4"
+            },
+            collected="2024-04-08T15:11:00",
+            finalized="2024-05-09T15:11:00",
+        )
+        timestamp = get_processing_timestamp(sample)
+        self.assertEqual(timestamp, sample.finalized)


### PR DESCRIPTION
## Resolves *[DA-4410](https://precisionmedicineinitiative.atlassian.net/browse/DA-4410)*


## Description of changes/additions
Added function to default ProcessingDateUTC to ordered_sample.finalized for stool samples in the event that the required "freezed" date is not present.

## Tests
- [tests.workflow_tests.test_nph_biobank_workflows.NphBiobankWorkflowsTest.no_error_on_timestamp] unit test




[DA-4410]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ