### PR TITLE
Update to Spanish translation of pediatric primary signature page text

### DIFF
--- a/rdr_service/services/consent/files.py
+++ b/rdr_service/services/consent/files.py
@@ -922,7 +922,10 @@ class VibrentEtmConsentFile(EtmConsentFile):
 class VibrentPediatricPrimaryConsentFile(PediatricPrimaryConsentFile, VibrentPrimaryConsentFile):
     def _get_signature_page(self):
         return self.pdf.get_page_number_of_text([
-            ('I freely and willingly choose', 'Decido participar libremente y por voluntad propia')
+            (
+                'I freely and willingly choose',
+                'Elijo libre y voluntariamente inscribir a mi menor de edad en el Programa Científico'
+            )
         ])
 
     def _get_signature_elements(self):


### PR DESCRIPTION
## Resolves *no ticket*
The Spanish text used to find the signature page for pediatric Primary consents isn't matching up with what we're getting in the PDFs. This updates the validation code so we can more accurately validate the files.

## Tests
- [ ] unit tests


