### PR TITLE
Fixing bug in the backfill_questionnaire_answers table

### DIFF
--- a/rdr_service/tools/tool_libs/backfill_questionnaire_answers.py
+++ b/rdr_service/tools/tool_libs/backfill_questionnaire_answers.py
@@ -75,10 +75,10 @@ class QuestionnaireAnswersBackfillTool(ToolBase):
     def _add_answers(code_id_map, answers, questionnaire_response_id):
         answers_to_insert = []
         for answer, system_and_code in answers:
+            answer.questionnaireResponseId = questionnaire_response_id
             if system_and_code:
                 system, code = system_and_code
                 answer.valueCodeId = code_id_map.get(system, code)
-                answer.questionnaireResponseId = questionnaire_response_id
             answers_to_insert.append(answer)
         return answers_to_insert
 


### PR DESCRIPTION
## Resolves *[DA-4318](https://precisionmedicineinitiative.atlassian.net/browse/DA-4318)*

## Description of changes/additions
I tried running the tool and ran into a bug where QuestionnaireResponse payloads that have the below formatting (no valueCoding defined) were not updating correctly due to missing `questionnaire_response_ids`
```
"answer": [
  {
    "valueString": "<ANSWER_VALUE>"
  }
]
```
This change updates the tool to process these responses successfully.

## Tests
- Tested in Sandbox
    - Sent a new POST QuestionnaireResponse request that only specifies `value_string` in the JSON payload answers
    - Deleted the QuestionnaireResponseAnswer record that was created by the POST request
    - Ran the tool to insert missing records into the `questionnaire_response_answer` table and the deleted record was created as expected

[DA-4318]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ