### PR TITLE
Fix for cron scheduling syntax

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -136,7 +136,7 @@ cron:
   timezone: America/New_York
 - description: Test Participant Cleanup Reminder
   url: /offline/PTSCTestParticipantCleanupRequest
-  schedule: 1 of december, march, june, september, 09:00
+  schedule: 1 of december, march, june, september 09:00
   target: offline
   timezone: America/New_York
 - description: Daily Duplicate Account Check


### PR DESCRIPTION
## Resolves *no ticket*
Recent changes to cron scheduling have been behaving strangely (adding a new schedule for one of the consent jobs, rather than updating the current schedule). Testing on sandbox shows that it could be caused by a syntax error in one of the cron jobs. This updates the schedule for that job to get rid of the syntax error.


