### PR TITLE
[DA-4440] pediatric ehr validation updates

### DIFF
--- a/rdr_service/code_constants.py
+++ b/rdr_service/code_constants.py
@@ -224,6 +224,7 @@ VA_EHR_RECONSENT = 'vaehrreconsent'
 
 # ConsentPII Questions
 RECEIVE_CARE_STATE = "ReceiveCare_PIIState"
+PEDIATRIC_RECEIVE_CARE_STATE = "ChildPermission_LiveandHealthCare_healthcare"
 
 # ConsentPII Answers
 OR_CARE_STATE = "PIIStateCare_OR"

--- a/rdr_service/dao/questionnaire_response_dao.py
+++ b/rdr_service/dao/questionnaire_response_dao.py
@@ -1722,14 +1722,18 @@ class QuestionnaireResponseDao(BaseDao):
         return answer.value if answer else None
 
     @classmethod
-    def get_latest_answer_for_state_receiving_care(cls, session: Session, participant_id) -> str:
+    def get_latest_answer_for_state_receiving_care(cls, session: Session, participant_id, for_pediatric=False) -> str:
         """
         Return the most recently authored answer code value string for the ReceiveCarePIIState question code
         """
+        if for_pediatric:
+            question_code = code_constants.PEDIATRIC_RECEIVE_CARE_STATE
+        else:
+            question_code = code_constants.RECEIVE_CARE_STATE
         answer = cls.get_latest_answer_to_question(
             session=session,
             participant_id=participant_id,
-            question_code_value=code_constants.RECEIVE_CARE_STATE
+            question_code_value=question_code
         )
         return answer.value if answer else None
 


### PR DESCRIPTION
## Resolves *[DA-4440](https://precisionmedicineinitiative.atlassian.net/browse/DA-4440)*
Removing guardian name check (per Slack conversation), and updating state-of-care code (per DA-4440).


## Tests
- [ ] unit tests




[DA-4440]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ