### PR TITLE
[DA-4449] Optimize retention eligibility import

### DIFF
--- a/rdr_service/dao/retention_eligible_metrics_dao.py
+++ b/rdr_service/dao/retention_eligible_metrics_dao.py
@@ -1,6 +1,4 @@
 
-from sqlalchemy.orm import Session
-
 from rdr_service.cloud_utils.gcp_cloud_tasks import GCPCloudTask
 from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.base_dao import UpdatableDao
@@ -17,21 +15,17 @@ class RetentionEligibleMetricsDao(UpdatableDao):
         super(RetentionEligibleMetricsDao, self).__init__(RetentionEligibleMetrics, order_by_ending=["id"])
 
     @classmethod
-    def find_metric_with_session(cls, session: Session, metrics_obj: RetentionEligibleMetrics) -> (int, bool):
+    def find_metric(cls, metrics_obj: RetentionEligibleMetrics, retention_data_cache) -> (int, bool):
         """
         Used to check the db for existing metrics objects for a participant. If a metrics object exists, then its
         id is returned as the first value. The second parameter is used to indicate whether the database has the
         same values, returning True if an upsert is needed to bring the new data into the database.
         """
 
-        db_result = session.query(RetentionEligibleMetrics).filter(
-            RetentionEligibleMetrics.participantId == metrics_obj.participantId
-        ).first()
+        db_result = retention_data_cache.get(metrics_obj.participantId)
 
         if not db_result:
             return None, True
-
-        needs_update = False
 
         is_same_data = (
             db_result.retentionEligibleStatus == metrics_obj.retentionEligibleStatus

--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -71,7 +71,6 @@ def import_retention_eligible_metrics_file(task_data):
                     record.id = existing_id
                 if needs_update:
                     metrics_cache[record.participantId] = record
-                    _supplement_with_rdr_calculations(record, session)
                     records.append(record)
                     batch_count += 1
 
@@ -80,6 +79,7 @@ def import_retention_eligible_metrics_file(task_data):
                     records.clear()
                     batch_count = 0
             except (IntegrityError, InvalidRequestError):
+                session.rollback()
                 failed_records_count += batch_count
                 records.clear()
                 batch_count = 0

--- a/rdr_service/offline/retention_eligible_import.py
+++ b/rdr_service/offline/retention_eligible_import.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import Optional
+from typing import Optional, List
 
 from dateutil.parser import parse
 from sqlalchemy.exc import IntegrityError, InvalidRequestError
@@ -49,21 +49,29 @@ def import_retention_eligible_metrics_file(task_data):
     batch_count = upsert_count = 0
     records = list()
     failed_records_count = 0
+    participant_ids_seen = set()
     with dao.session() as session:
+        metrics_cache = _build_metrics_cache(session)
+
         for row in csv_reader:
             try:
                 if not row[RetentionEligibleMetricCsvColumns.PARTICIPANT_ID]:
                     continue
                 record = _create_retention_eligible_metrics_obj_from_row(row, upload_date)
 
-                existing_id, needs_update = RetentionEligibleMetricsDao.find_metric_with_session(
-                    session=session,
-                    metrics_obj=record
+                if record.participantId in participant_ids_seen:
+                    continue
+                participant_ids_seen.add(record.participantId)
+
+                existing_id, needs_update = RetentionEligibleMetricsDao.find_metric(
+                    metrics_obj=record,
+                    retention_data_cache=metrics_cache
                 )
                 if existing_id:
                     record.id = existing_id
                 if needs_update:
-                    _supplement_with_rdr_calculations(metrics_data=record, session=session)
+                    metrics_cache[record.participantId] = record
+                    _supplement_with_rdr_calculations(record, session)
                     records.append(record)
                     batch_count += 1
 
@@ -436,6 +444,11 @@ def _get_latest_etm_task_response_timestamp(session, participant_id, task_types=
     etm_responses = EtmResponseRepository.get_etm_responses(session=session, participant_id=participant_id,
                                                             task_types=task_types)
     return max(r.authored for r in etm_responses if r.authored) if etm_responses else None
+
+
+def _build_metrics_cache(session):
+    metric_list: List[RetentionEligibleMetrics] = session.query(RetentionEligibleMetrics).all()
+    return {metric.participantId: metric for metric in metric_list}
 
 
 class RetentionEligibleMetricCsvColumns(object):

--- a/tests/cron_job_tests/test_retention_eligible_import_task.py
+++ b/tests/cron_job_tests/test_retention_eligible_import_task.py
@@ -236,7 +236,7 @@ class RetentionEligibleImportTest(BaseTestCase):
                 passively_retained='1'
             ),
             self._build_csv_row(
-                participant_id=ps2.participantId,
+                participant_id=123000,  # participant id that doesn't exist in the database
                 retention_eligible='1',
                 retention_eligible_date='2020-02-20',
                 actively_retained='1',

--- a/tests/cron_job_tests/test_retention_eligible_import_task.py
+++ b/tests/cron_job_tests/test_retention_eligible_import_task.py
@@ -273,8 +273,7 @@ class RetentionEligibleImportTest(BaseTestCase):
         pytz.timezone('US/Central').localize(test_date)
 
         # Check that exception is thrown with small batch size
-        with (self.assertRaises(InvalidRequestError),
-              mock.patch("rdr_service.offline.retention_eligible_import._BATCH_SIZE", 3)):
+        with mock.patch("rdr_service.offline.retention_eligible_import._BATCH_SIZE", 3):
             retention_eligible_import.import_retention_eligible_metrics_file({
                 "bucket": 'test_bucket',
                 "upload_date": test_date.isoformat(),
@@ -305,7 +304,7 @@ class RetentionEligibleImportTest(BaseTestCase):
         # Check that Slack alert was sent with correct failure count
         self.slack_client_instance.send_message_to_webhook.assert_called_with(
             message_data={'text': 'PTSC Retention File Import Status: File at file path - '
-                                  'gs://test_bucket/test_file.csv, had 6 records fail to ingest'}
+                                  'gs://test_bucket/test_file.csv, had 5 records fail to ingest'}
         )
 
     @mock.patch('rdr_service.offline.retention_eligible_import.GoogleCloudStorageCSVReader')


### PR DESCRIPTION
## Resolves *[DA-4449](https://precisionmedicineinitiative.atlassian.net/browse/DA-4449)*
The retention eligibility import task is timing out. These changes should help it run faster and hopefully quick enough to complete the import before timing out.

## Description of changes/additions
Two updates were made to increase performance:
1. Rather than looking for retention records in the db for each row, all retention metrics are loaded into memory and referenced from there.
2. RDR's version of the calculation isn't used downstream, so the code that calculates it is removed from the process.

## Tests
- [x] unit tests




[DA-4449]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ