### PR TITLE
[DA-4454] Update N1 manifest to use `dlw_dosage` table

### DIFF
--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -1,5 +1,5 @@
 from typing import List, Dict
-from sqlalchemy import func, and_, or_
+from sqlalchemy import func, and_, or_, cast, String
 from sqlalchemy.orm import aliased
 
 from rdr_service import clock
@@ -231,7 +231,7 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                     SmsSample.body_weight_kg,
                     DlwDosage.batch_id.label('dlw_dose_batch'),
                     DlwDosage.dose_time.label('dlw_dose_date_time'),
-                    DlwDosage.dose.label('dlw_dose_grams')
+                    DlwDosage.calculated_dose.label('dlw_dose_grams')
                 ).outerjoin(
                     aliquot_sample,
                     SmsSample.sample_id == aliquot_sample.aliquot_id
@@ -240,10 +240,10 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                     aliquot_sample.parent_sample_id == parent_fields.id
                 ).outerjoin(
                     Participant,
-                    Participant.biobank_id == func.substr(SmsN0.biobank_id, 2)
+                    cast(Participant.biobank_id, String) == func.substr(SmsN0.biobank_id, 2)
                 ).outerjoin(
                     DlwDosage,
-                    and_(Participant.id == DlwDosage.participant_id, DlwDosage.c.ignore_flag == 0)
+                    and_(Participant.id == DlwDosage.participant_id, DlwDosage.ignore_flag == 0)
                 )
             else:
                 query = query.add_columns(

--- a/rdr_service/data_gen/generators/nph.py
+++ b/rdr_service/data_gen/generators/nph.py
@@ -2,9 +2,27 @@ from datetime import datetime
 
 from rdr_service.dao import database_factory
 from rdr_service.model.rex import ParticipantMapping
-from rdr_service.model.study_nph import Participant, Site, PairingEvent, ParticipantEventActivity, Activity, \
-    PairingEventType, ConsentEvent, ConsentEventType, EnrollmentEventType, EnrollmentEvent, WithdrawalEvent, \
-    DeactivationEvent, ParticipantOpsDataElement, OrderedSample, StoredSample, Order, StudyCategory, DietEvent
+from rdr_service.model.study_nph import (
+    Participant,
+    Site,
+    PairingEvent,
+    ParticipantEventActivity,
+    Activity,
+    PairingEventType,
+    ConsentEvent,
+    ConsentEventType,
+    EnrollmentEventType,
+    EnrollmentEvent,
+    WithdrawalEvent,
+    DeactivationEvent,
+    ParticipantOpsDataElement,
+    OrderedSample,
+    StoredSample,
+    Order,
+    StudyCategory,
+    DietEvent,
+    DlwDosage,
+)
 from rdr_service.ancillary_study_resources.nph import enums
 from rdr_service.model.study_nph_sms import SmsJobRun, SmsSample, SmsBlocklist, SmsN0, SmsN1Mc1
 
@@ -342,3 +360,11 @@ class NphSmsDataGenerator(NphBaseGenerator):
         self._commit_to_database(obj)
         return obj
 
+    @staticmethod
+    def _dlw_dosage(**kwargs):
+        return DlwDosage(**kwargs)
+
+    def create_database_dlw_dosage(self, **kwargs):
+        obj = self._dlw_dosage(**kwargs)
+        self._commit_to_database(obj)
+        return obj

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -318,11 +318,25 @@ class NphSmsWorkflowsTest(BaseTestCase):
         nph_pid, biobank_id = 1_000_000_000, 11_000_000_002
 
         nph_datagen.create_database_participant(id=nph_pid, biobank_id=biobank_id)
+
+        sms_datagen.create_database_study_category(
+            id=2,
+            type_label="visitPeriod",
+            name="Diet_Period_3_DLW",
+        )
+
+        sms_datagen.create_database_order(
+            id=6,
+            category_id=2,
+            notes={}
+        )
+
         sms_datagen.create_database_ordered_sample(
             id=5,
             nph_sample_id=10004,
         )
         sms_datagen.create_database_ordered_sample(
+            order_id=6,
             nph_sample_id=10005,
             aliquot_id=4,
             parent_sample_id=5
@@ -337,7 +351,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sample_id=4,
             lims_sample_id="000200",
             destination=destination,
-            body_weight_kg="123.4"
+            body_weight_kg="123.4",
         )
         sms_datagen.create_database_sms_n0(
             sample_id=4,
@@ -364,7 +378,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         sms_datagen.create_database_dlw_dosage(
             participant_id=nph_pid,
             module="3",
-            visit_period=VisitPeriod.lookup_by_name("PERIOD1DLW"),
+            visit_period=VisitPeriod.lookup_by_name("PERIOD3DLW"),
             batch_id="12345678",
             participant_weight="56.8",
             dose="456",
@@ -486,7 +500,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(csv_rows[0]['matrix_id'], "1111")
         self.assertEqual(csv_rows[0]['dlw_dose_batch'], "12345678")
         self.assertEqual(csv_rows[0]['dlw_dose_date_time'], "2024-04-08 15:11:00")
-        self.assertEqual(csv_rows[0]['dlw_dose_grams'], "456.7")
+        self.assertEqual(csv_rows[0]['dlw_dose_grams'], "456")
 
         n1_dao = SmsN1Mc1Dao()
         manifest_records = n1_dao.get_all()
@@ -501,7 +515,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(manifest_records[0].body_weight_kg, "123.4")
         self.assertEqual(manifest_records[0].dlw_dose_batch, "12345678")
         self.assertEqual(manifest_records[0].dlw_dose_date_time, "2024-04-08 15:11:00")
-        self.assertEqual(manifest_records[0].dlw_dose_grams, "456.7")
+        self.assertEqual(manifest_records[0].dlw_dose_grams, "456")
 
     @mock.patch("rdr_service.services.ancillary_studies.nph_incident.SlackMessageHandler.send_message_to_webhook")
     def test_n1_mc1_raises_error_on_data_validation_failure(self, mock_send_message_to_webhook):

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -7,11 +7,12 @@ from unittest import mock
 from rdr_service import api_util, clock
 from rdr_service.api_util import open_cloud_file
 from rdr_service.dao.study_nph_sms_dao import SmsSampleDao, SmsN0Dao, SmsN1Mc1Dao, SmsJobRunDao
-from rdr_service.data_gen.generators.nph import NphSmsDataGenerator
+from rdr_service.data_gen.generators.nph import NphSmsDataGenerator, NphDataGenerator
 from rdr_service.workflow_management.nph.sms_pipeline import n1_generation
 from tests.helpers.unittest_base import BaseTestCase
 from rdr_service.workflow_management.nph.sms_workflows import SmsWorkflow
 from tests.test_data import data_path
+from rdr_service.ancillary_study_resources.nph.enums import VisitPeriod
 
 
 class NphSmsWorkflowsTest(BaseTestCase):
@@ -313,7 +314,10 @@ class NphSmsWorkflowsTest(BaseTestCase):
     @staticmethod
     def create_data_pbrc_n1_mc1_generation(destination="PBRC"):
         sms_datagen = NphSmsDataGenerator()
+        nph_datagen = NphDataGenerator()
+        nph_pid, biobank_id = 1_000_000_000, 11_000_000_002
 
+        nph_datagen.create_database_participant(id=nph_pid, biobank_id=biobank_id)
         sms_datagen.create_database_ordered_sample(
             id=5,
             nph_sample_id=10004,
@@ -363,7 +367,18 @@ class NphSmsWorkflowsTest(BaseTestCase):
             quantity_ml="120",
             manufacturer_lot='256837',
             age="22",
-            biobank_id="test",
+            biobank_id=f"T{biobank_id}",
+        )
+
+        sms_datagen.create_database_dlw_dosage(
+            participant_id=nph_pid,
+            module="3",
+            visit_period=VisitPeriod.lookup_by_name("PERIOD1DLW"),
+            batch_id="12345678",
+            participant_weight="56.8",
+            dose="456",
+            calculated_dose="456.7",
+            dose_time="2024-04-08T15:11:00Z",
         )
 
     def test_n1_mc1_generation(self):
@@ -479,7 +494,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(csv_rows[0]['sample_id'], '4')
         self.assertEqual(csv_rows[0]['matrix_id'], "1111")
         self.assertEqual(csv_rows[0]['dlw_dose_batch'], "12345678")
-        self.assertEqual(csv_rows[0]['dlw_dose_date_time'], '"2024-04-08T15:11:00"')
+        self.assertEqual(csv_rows[0]['dlw_dose_date_time'], "2024-04-08 15:11:00")
         self.assertEqual(csv_rows[0]['dlw_dose_grams'], "456.7")
 
         n1_dao = SmsN1Mc1Dao()
@@ -492,10 +507,10 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.assertEqual(manifest_records[0].collection_site, "UNC")
         self.assertEqual(manifest_records[0].manufacturer_lot, '256837')
         self.assertEqual(manifest_records[0].collection_date_time, api_util.parse_date("2023-04-20T15:54:33"))
-        self.assertEqual(manifest_records[0].body_weight_kg, '123.4')
-        self.assertEqual(manifest_records[0].dlw_dose_batch, '12345678')
-        self.assertEqual(manifest_records[0].dlw_dose_date_time, '"2024-04-08T15:11:00"')
-        self.assertEqual(manifest_records[0].dlw_dose_grams, '456.7')
+        self.assertEqual(manifest_records[0].body_weight_kg, "123.4")
+        self.assertEqual(manifest_records[0].dlw_dose_batch, "12345678")
+        self.assertEqual(manifest_records[0].dlw_dose_date_time, "2024-04-08 15:11:00")
+        self.assertEqual(manifest_records[0].dlw_dose_grams, "456.7")
 
     @mock.patch("rdr_service.services.ancillary_studies.nph_incident.SlackMessageHandler.send_message_to_webhook")
     def test_n1_mc1_raises_error_on_data_validation_failure(self, mock_send_message_to_webhook):

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -321,15 +321,6 @@ class NphSmsWorkflowsTest(BaseTestCase):
         sms_datagen.create_database_ordered_sample(
             id=5,
             nph_sample_id=10004,
-            supplemental_fields={
-                "dlwDose": {
-                    "dose": 456.7,
-                    "batchid": 12345678,
-                    "calculateddose": 456.65,
-                    "doseAdministered": "2024-04-08T15:11:00",
-                    "participantweight": 123.4
-                }
-            }
         )
         sms_datagen.create_database_ordered_sample(
             nph_sample_id=10005,


### PR DESCRIPTION
## Resolves *[DA-4454](https://precisionmedicineinitiative.atlassian.net/browse/DA-4454)*


## Description of changes/additions
- Updating the N1 manifest to use `nph.dlw_dosage` table for `dlw_dose_batch`, `dlw_dose_date_time`, `dlw_dose_grams` columns for pbrc.

## Tests
 ✅  unit tests




[DA-4454]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ