### PR TITLE
[DA-4464] Adding new data fields to NPH sample API

### DIFF
--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1149,7 +1149,9 @@ class NphBiospecimenDao(BaseDao):
                 {
                     "limsID": stored_sample.get('limsID'),
                     "biobankModified": stored_sample.get('biobankModified'),
-                    "status": str(StoredSampleStatus.lookup_by_number(stored_sample.get('status')))
+                    "status": str(StoredSampleStatus.lookup_by_number(stored_sample.get('status'))),
+                    "freezeThawCount": stored_sample.get('freezeThawCount'),
+                    "specimenVolumeUl": stored_sample.get('specimenVolumeUl')
                 } for stored_sample in stored_samples
             ]
         return order_samples
@@ -1168,7 +1170,9 @@ class NphBiospecimenDao(BaseDao):
                             'limsID', StoredSample.lims_id,
                             'biobankModified', StoredSample.biobank_modified,
                             'status', StoredSample.status,
-                            'orderSampleID', StoredSample.sample_id
+                            'orderSampleID', StoredSample.sample_id,
+                            'freezeThawCount', StoredSample.freeze_thaw_count,
+                            'specimenVolumeUl', StoredSample.specimen_volume_ul
                         )
                     ), type_=JSON
                 ).label('orders_sample_biobank_status')

--- a/tests/api_tests/test_nph_biospecimen_api.py
+++ b/tests/api_tests/test_nph_biospecimen_api.py
@@ -77,7 +77,9 @@ class NphBiospecimenAPITest(BaseTestCase):
                             biobank_id=participant.biobank_id,
                             sample_id=f'11{participant.id}',
                             lims_id=f"33{participant.id}",
-                            status=StoredSampleStatus.RECEIVED
+                            status=StoredSampleStatus.RECEIVED,
+                            freeze_thaw_count=3,
+                            specimen_volume_ul=79
                         )
 
     def test_biospecimen_non_existent_participant_id(self):
@@ -114,7 +116,10 @@ class NphBiospecimenAPITest(BaseTestCase):
             for response_ordered_sample in response_ordered_samples:
                 self.assertIsNotNone(response_ordered_sample.get('biobankStatus'))
                 # should have for stored sample(s) for each ordered sample
-                self.assertEqual(len(response_ordered_sample.get('biobankStatus')), 1)
+                stored_sample_list = response_ordered_sample.get('biobankStatus')
+                self.assertEqual(len(stored_sample_list), 1)
+                self.assertEqual(3, stored_sample_list[0]['freezeThawCount'])
+                self.assertEqual(79, stored_sample_list[0]['specimenVolumeUl'])
 
     def test_biospecimen_by_last_modified_returns_correctly(self):
         fake_date_one = parser.parse('2020-05-28T08:00:01-05:00')


### PR DESCRIPTION
## Resolves *[DA-4464](https://precisionmedicineinitiative.atlassian.net/browse/DA-4464)*
Making freeze thaw count and specimen volume fields received from Biobank available on the NPH biospecimen API.

## Tests
- [x] unit tests




[DA-4464]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ