### PR TITLE
[DA-4477] Add `target_throughput_utilization` and `target_cpu_utilization` in Prod's `app.yml`

### DIFF
--- a/rdr_service/app_prod.yaml
+++ b/rdr_service/app_prod.yaml
@@ -2,8 +2,11 @@
 instance_class: F4
 
 # Have 5 idle instances to prepare for sudden traffic spikes.
+# Setting target_throughput_utilization and target_cpu_utilization to test if it helps in reducing 502 errors
 automatic_scaling:
   min_idle_instances: 5
+  target_throughput_utilization: 0.55
+  target_cpu_utilization: 0.55
 
 # to have fixed outbound US. ip address
 vpc_access_connector:


### PR DESCRIPTION
## Resolves *[DA-4477](https://precisionmedicineinitiative.atlassian.net/browse/DA-4477)*


## Description of changes/additions
- Google support recommended that we try setting `target_throughput_utilization` and `target_cpu_utilization` to see if it helps reduce the 502 errors. The default for these settings are 0.6, so I set it to 0.55, which is recommended by Google support.

## Tests
- Tested adding in those settings to `app_sandbox.yaml` and deployed it to sandbox. I was able to see the config updated  in app engine with these new parameters and requests being processed.

Reference:
- https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#:~:text=your%20application%27s%20performance.-,target_cpu_utilization,-Optional.%20Specify%20a


[DA-4477]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ