### PR TITLE
PPSC Support for multi-select survey answers

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -118,11 +118,19 @@ class PPSCIntakeAPI(BaseApi):
                 'participant_id': self.dao.extract_prefix_from_val(req_data['participantId']),
                 'event_type_name': req_data['eventType'],
                 'event_authored_time': self.activity_date_time_value,
-                'data_element_name': data_element['dataElementName'],
-                'data_element_value': data_element['dataElementValue']
+                'data_element_name': data_element['dataElementName']
             }
 
-            records_to_insert.append(event_dict)
+            # PPSC sends strings or arrays (multi-select)
+            if isinstance(data_element['dataElementValue'], list):
+                # The below iteration is to handle multi-select answers
+                for value in data_element['dataElementValue']:
+                    event_copy = event_dict.copy()
+                    event_copy["data_element_value"] = value
+                    records_to_insert.append(event_copy)
+            else:
+                event_dict["data_element_value"] = data_element['dataElementValue']
+                records_to_insert.append(event_dict)
 
         activity_event_dao.insert_bulk(records_to_insert)
 

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -376,6 +376,64 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual('activity_date_time', survey_events[1].data_element_name)
         self.assertEqual("2024-05-20T14:30:00Z", survey_events[1].data_element_value)
 
+    def test_intake_survey_data_insert(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+
+        payload = {
+            "activity": "Survey Completion",
+            "eventType": "Basics Data",
+            "participantId": f"P{participant.id}",
+            "dataElements": [
+                {
+                    "dataElementName": "thebasics_birthplace",
+                    "dataElementValue": [
+                        "USA"
+                    ]
+                },
+                {
+                    "dataElementName": "race_whatraceethnicity",
+                    "dataElementValue": [
+                        "WhatRaceEthnicity_AIAN",
+                        "WhatRaceEthnicity_Hispanic"
+                    ]
+                },
+                {
+                    "dataElementName": "biologicalsexatbirth_sexatbirth",
+                    "dataElementValue": [
+                        "SexAtBirth_Male"
+                    ]
+                },
+                {
+                    "dataElementName": "activity_date_time",
+                    "dataElementValue": "2024-05-20T14:30:00Z"
+                },
+            ]
+        }
+
+        test_time = datetime(2024, 6, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
+
+        survey_events = self.survey_completion_event_dao.get_all()
+        self.assertEqual(5, len(survey_events))
+        self.assertEqual(participant.id, survey_events[0].participant_id)
+        self.assertEqual('Basics Data', survey_events[0].event_type_name)
+
+        self.assertEqual('thebasics_birthplace', survey_events[0].data_element_name)
+        self.assertEqual('USA', survey_events[0].data_element_value)
+
+        self.assertEqual('race_whatraceethnicity', survey_events[1].data_element_name)
+        self.assertEqual('WhatRaceEthnicity_AIAN', survey_events[1].data_element_value)
+
+        self.assertEqual('race_whatraceethnicity', survey_events[2].data_element_name)
+        self.assertEqual('WhatRaceEthnicity_Hispanic', survey_events[2].data_element_value)
+
+        self.assertEqual('biologicalsexatbirth_sexatbirth', survey_events[3].data_element_name)
+        self.assertEqual('SexAtBirth_Male', survey_events[3].data_element_value)
+
+        self.assertEqual('activity_date_time', survey_events[4].data_element_name)
+        self.assertEqual("2024-05-20T14:30:00Z", survey_events[4].data_element_value)
+
     def test_intake_profile_updates_event_type_validation(self):
         participant = self.ppsc_data_gen.create_database_participant()
 


### PR DESCRIPTION
## Resolves *PPSC Testing Support*


## Description of changes/additions
This PR adds a nested iteration for payloads that contain array values. This is in support of survey data payloads that can contain multi-select answers.

## Tests
- [x] unit tests


