### PR TITLE
[PDR-2700] Workaround for correcting pid's EHR consent history in PDR

### DIFF
--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1924,8 +1924,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :param ro_session:  A read-only session object
         """
 
-        # PDR-2700/DA-4514:  See PR notes for the reason this is a hardcoded return value for this particular response
-        if consent_response_rec.questionnaireResponseId == 888231156:
+        # PDR-2700/DA-4514:  See PR notes for the reason we need hardcoded return values for some responses
+        # Can expand this list or add other override lists (e.g. override_with_submitted_no_consent...) as needed
+        override_with_submitted_qr_id_list = [888231156]
+
+        if consent_response_rec.questionnaireResponseId in override_with_submitted_qr_id_list:
             return BQModuleStatusEnum.SUBMITTED
 
         # Cutoff for avoiding incorrectly assuming SUBMITTED_NOT_VALIDATED.  Timestamp comes from RDR data (could not

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -1923,6 +1923,11 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         :param module_name:  Consent module name.  *** Only EHRConsentPII currently supported
         :param ro_session:  A read-only session object
         """
+
+        # PDR-2700/DA-4514:  See PR notes for the reason this is a hardcoded return value for this particular response
+        if consent_response_rec.questionnaireResponseId == 888231156:
+            return BQModuleStatusEnum.SUBMITTED
+
         # Cutoff for avoiding incorrectly assuming SUBMITTED_NOT_VALIDATED.  Timestamp comes from RDR data (could not
         # have assigned SUBMITTED_NOT_VALIDATED to EHR consents authored prior to this)
         pdf_validation_start_date = datetime.datetime(2023, 3, 11, 1, 34, 2)

--- a/rdr_service/tools/tool_libs/module_data_analyzer.py
+++ b/rdr_service/tools/tool_libs/module_data_analyzer.py
@@ -101,8 +101,7 @@ class ModuleDataAnalyzer(ToolBase):
         ).outerjoin(
             answer, QuestionnaireResponseAnswer.valueCodeId == answer.codeId
         ).filter(
-            QuestionnaireResponse.questionnaireResponseId == response_id,
-            QuestionnaireResponse.classificationType != QuestionnaireResponseClassificationType.DUPLICATE
+            QuestionnaireResponse.questionnaireResponseId == response_id
         ).order_by(QuestionnaireResponse.authored,
                    QuestionnaireResponse.created
                    ).all()


### PR DESCRIPTION
## Resolves *[PDR-2700](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2700)*
Also see *[DA-4514](https://precisionmedicineinitiative.atlassian.net/browse/DA-4514)*

## Description of changes/additions
The participant in ticket PDR-2700 has a convoluted EHR consent response/replay and PDF validation history in RDR.  Details on remediations done to address issues found in the PTSC/RDR data are outlined in the PDR/DA tickets.  But that led to uncovering another issue in the RDR data that can still cause the PDR-generated "most recent EHR consent status" to conflict with what's in RDR `participant_summary`

The most recent issue found is that RDR has two conflicting `consent_file` validation records (one indicating a failed validation, one successful) for the same `questionnaire_response_id`.  So the PDR generator can't correctly determine which status (SUBMITTED or SUBMITTED_INVALID) applies.   The easiest workaround, given the PDR generator code will be turned off soon after PPSC transition, is to just hardcode any confirmed statuses that should be applied to specific `questionnaire_response_id` values.  (This solution is also extensible, since other cases may exist)

This PR also fixes an issue with the `module-data-analyzer` tool that was used to investigate the EHR response history.

## Tests
- [x] unit tests (existing)




[PDR-2700]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DA-4514]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ