### PR TITLE
[ROC-1994] Bug fix for total count when filtering by pediatric field

### DIFF
--- a/rdr_service/dao/participant_summary_dao.py
+++ b/rdr_service/dao/participant_summary_dao.py
@@ -683,7 +683,11 @@ class ParticipantSummaryDao(UpdatableDao):
                 lambda query_to_filter: query_to_filter.outerjoin(
                     ParticipantSummary.pediatricData
                 ).filter(
-                    PediatricDataLog.id.is_(None) if value.lower() == 'unset' else PediatricDataLog.id.isnot(None)
+                    PediatricDataLog.id.is_(None) if value.lower() == 'unset'
+                    else and_(
+                        PediatricDataLog.id.isnot(None),
+                        PediatricDataLog.data_type == PediatricDataType.AGE_RANGE
+                    )
                 ),
                 'dateOfBirth'
             )

--- a/tests/api_tests/test_participant_summary_api.py
+++ b/tests/api_tests/test_participant_summary_api.py
@@ -4906,6 +4906,13 @@ class ParticipantSummaryApiTest(BaseTestCase):
                 value='test'
             )
         )
+        self.session.add(
+            PediatricDataLog(
+                participant_id=pediatric_summary.participantId,
+                data_type=PediatricDataType.ENVIRONMENTAL_EXPOSURES,
+                value='2024-10-10'
+            )
+        )
         adult_summary = self.data_generator.create_database_participant_summary()
 
         adult_response = self.send_get(f"ParticipantSummary?isPediatric=UNSET")
@@ -4915,12 +4922,13 @@ class ParticipantSummaryApiTest(BaseTestCase):
             from_client_participant_id(adult_response['entry'][0]['resource']['participantId'])
         )
 
-        pediatric_response = self.send_get(f"ParticipantSummary?isPediatric=TRUE")
+        pediatric_response = self.send_get(f"ParticipantSummary?isPediatric=TRUE&_includeTotal=true")
         self.assertEqual(1, len(pediatric_response['entry']))
         self.assertEqual(
             pediatric_summary.participantId,
             from_client_participant_id(pediatric_response['entry'][0]['resource']['participantId'])
         )
+        self.assertEqual(1, pediatric_response['total'])
 
     @classmethod
     def _get_summary_response_id_list(self, response):


### PR DESCRIPTION
## Resolves *[ROC-1994](https://precisionmedicineinitiative.atlassian.net/browse/ROC-1994)*
When filtering the ParticipantSummaryAPI using the isPediatric field, the total count value was counting each pediatric_data_log row rather than just the number of participants.

## Description of changes/additions
This limits the pediatric_data_log join to just one row per participant.

## Tests
- [x] unit tests




[ROC-1994]: https://precisionmedicineinitiative.atlassian.net/browse/ROC-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ