### PR TITLE
PPSC Data Transfer Input Data Feeds

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -181,6 +181,9 @@ CE_MEDIATED_HPO_ID = 'ce_mediated_hpo_id'
 EXPOSOMICS_MO_MANIFEST_SUBFOLDER = 'm0_manifests'
 EXPOSOMICS_M1_MANIFEST_SUBFOLDER = 'm1_manifests'
 HHEAR_BUCKET_NAME = 'hhear_bucket_name'
+PPSC_DATAFEED_BIOSPECIMEN_TYPES = 'ppsc_datafeed_biospecimen_types'
+PPSC_DATAFEED_SRC_DATASET = 'ppsc_datafeed_src_dataset'
+PPSC_DATAFEED_DEST_DATASET = 'ppsc_datafeed_dest_dataset'
 
 CVL_SITES_DATA_BUCKETS = {
     "bcm": "prod-genomics-data-baylor",

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -237,5 +237,18 @@
   "ppsc_intake_attribution_event_types": ["Org Attribution"],
   "ppsc_intake_nph_opt_in_event_types": ["NPH Opt In"],
   "pm_height_codes": ["height", "8302-2"],
-  "pm_weight_codes": ["weight", "29463-7", "pre-pregnancy-weight"]
+  "pm_weight_codes": ["weight", "29463-7", "pre-pregnancy-weight"],
+  "ppsc_datafeed_biospecimen_types": [
+    "1ed04",
+    "1ed10",
+    "1ed02",
+    "2ed02",
+    "2ed04",
+    "1sal2",
+    "1sal",
+    "2sal0",
+    "3sal1",
+    "1ur10",
+    "1ur90"
+  ]
 }

--- a/rdr_service/config/config_dev.json
+++ b/rdr_service/config/config_dev.json
@@ -246,6 +246,21 @@
     "hasCoreData",
     "hasCoreDataTime"
   ],
+  "ppsc_datafeed_biospecimen_types": [
+    "1ed04",
+    "1ed10",
+    "1ed02",
+    "2ed02",
+    "2ed04",
+    "1sal2",
+    "1sal",
+    "2sal0",
+    "3sal1",
+    "1ur10",
+    "1ur90"
+  ],
+  "ppsc_datafeed_src_dataset": ["ppsc_staging_data"],
+  "ppsc_datafeed_dest_dataset": ["ppsc_staging_data"],
   "enable_health_sharing_status_3": true,
   "enable_participant_mediated_ehr": true
 }

--- a/rdr_service/ppsc_pipeline/main.py
+++ b/rdr_service/ppsc_pipeline/main.py
@@ -2,7 +2,7 @@
 import logging
 import traceback
 
-from flask import Flask, got_request_exception
+from flask import Flask, got_request_exception, request
 from sqlalchemy.exc import DBAPIError
 
 from rdr_service import app_util
@@ -11,6 +11,7 @@ from rdr_service.ppsc.ppsc_data_transfer import PPSCDataTransferCore, PPSCDataTr
 from rdr_service.services.flask import PPSC_PIPELINE_PREFIX, flask_start, flask_stop
 from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging,\
     flask_restful_log_exception_error
+from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import InputFeed
 
 
 @app_util.auth_required_scheduler
@@ -23,6 +24,13 @@ def test_job():
 
     return '{"success": "true"}'
 
+
+@app_util.auth_required_scheduler
+def ppsc_data_transfer_input_feed():
+    datafeed = request.get_json().get("datafeed")
+    input_feed = InputFeed()
+    input_feed.run_datafeed(datafeed)
+    return '{ "success": "true" }'
 
 @app_util.auth_required_scheduler
 def ppsc_data_transfer_core():
@@ -61,7 +69,14 @@ def _build_pipeline_app():
         PPSC_PIPELINE_PREFIX + "TestJob",
         endpoint="test_job",
         view_func=test_job,
-        methods=["GET"],
+        methods=["GET", "POST"],
+    )
+
+    ppsc_pipeline.add_url_rule(
+        PPSC_PIPELINE_PREFIX + "TransferInputFeed",
+        endpoint="ppsc_data_transfer_input_feed",
+        view_func=ppsc_data_transfer_input_feed,
+        methods=["GET", "POST"],
     )
 
     # Cloud Scheduler - Scheduler jobs

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -1,0 +1,102 @@
+from rdr_service import config
+from rdr_service.config import GAE_PROJECT
+
+
+def insert_core_data(project: str, src_operational_dataset: str, destination_dataset: str) -> str:
+    # EHR BQ Data
+    org_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION)[0]
+    participant_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT)[0]
+
+    if GAE_PROJECT == "all-of-us-rdr-prod":
+        ehr_proj = "aou-res-curation-prod"
+    else:
+        ehr_proj = "test-ehr-project"
+
+    return f"""
+INSERT INTO `{project}.{destination_dataset}.datafeed_input_core_data` (
+    participant_id,
+    has_core_data,
+    ignore_flag,
+    event_date_time,
+    created,
+    modified)
+SELECT DISTINCT
+    c.participant_id,
+    1 as has_core_data,
+    0 as ignore_flag,
+    GREATEST(
+        c.event_authored_time,
+        ehrc.event_authored_time,
+        basics.event_authored_time,
+        overall.event_authored_time,
+        lifestyle.event_authored_time,
+        pm.finalized,
+        IFNULL(participant_ehr.authored_date, organization_ehr.authored_date)
+    ) AS event_date_time,
+    CURRENT_TIMESTAMP() AS created,
+    CURRENT_TIMESTAMP() AS modified
+FROM `{project}.{destination_dataset}.ppsc_participant` p
+JOIN `{project}.{destination_dataset}.ppsc_consent_event` c
+    ON c.participant_id = p.id
+
+-- EHR Consent
+JOIN `{project}.{destination_dataset}.ppsc_consent_event` ehrc
+    ON c.participant_id = ehrc.participant_id
+    AND c.data_element_value = "submitted_yes"
+    AND c.event_type_name = "EHR Authorization"
+
+-- EHR Received
+-- EHR tables - Record might exist in either table
+LEFT JOIN `{ehr_proj}.{participant_ehr_dataset}.ehr_upload_pids` participant_ehr
+    ON c.participant_id = participant_ehr.person_id
+
+LEFT JOIN `{ehr_proj}.{org_ehr_dataset}.ehr_upload_pids` organization_ehr
+    ON c.participant_id = organization_ehr.person_id
+
+-- Basics Completion
+JOIN `{project}.{destination_dataset}.ppsc_survey_completion_event` basics
+    ON basics.participant_id = c.participant_id
+    AND basics.event_type_name = "The Basics"
+    AND basics.data_element_value = "submitted_yes"
+
+-- Overall Health Completion
+JOIN `{project}.{destination_dataset}.ppsc_survey_completion_event` overall
+    ON overall.participant_id = c.participant_id
+    AND overall.event_type_name = "Overall Health"
+    AND overall.data_element_value = "submitted_yes"
+
+-- Lifestyle Completion
+JOIN `{project}.{destination_dataset}.ppsc_survey_completion_event` lifestyle
+    ON lifestyle.participant_id = c.participant_id
+    AND lifestyle.event_type_name = "Lifestyle"
+    AND lifestyle.data_element_value = "submitted_yes"
+
+-- Physical Measurements
+JOIN `{project}.{src_operational_dataset}.rdr_physical_measurements` pm
+    ON pm.participant_id = c.participant_id
+
+-- Height Measurement
+JOIN `{project}.{src_operational_dataset}.rdr_measurement` height
+    ON height.physical_measurements_id = pm.physical_measurements_id
+    AND height.code_value = "height"
+
+-- Weight Measurement
+JOIN `{project}.{src_operational_dataset}.rdr_measurement` weight
+    ON weight.physical_measurements_id = pm.physical_measurements_id
+    AND weight.code_value = "weight"
+
+WHERE
+    c.data_element_value = "submitted_yes"
+    AND c.event_type_name = "Primary Consent"
+
+    -- Ensure at least one EHR record exists
+    AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
+
+    -- Insert only if participant_id doesn't exist in the target table
+    AND NOT EXISTS (
+        SELECT 1
+        FROM `{project}.{destination_dataset}.datafeed_input_core_data` t
+        WHERE t.participant_id = c.participant_id
+    );"""
+
+

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -165,3 +165,49 @@ WHERE TRUE
     )
 ;
 """
+
+def insert_health_data_sharing(project: str, src_operational_dataset: str, destination_dataset: str) -> str:
+    # EHR BQ Data
+    participant_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT)[0]
+
+    if GAE_PROJECT == "all-of-us-rdr-prod":
+        ehr_proj = "aou-res-curation-prod"
+    else:
+        ehr_proj = "test-ehr-project"
+
+    return f"""
+INSERT INTO `{project}.{destination_dataset}.datafeed_input_healthdata_sharing` (
+    participant_id,
+    ignore_flag,
+    health_data_stream_sharing_status,
+    event_date_time,
+    created,
+    modified
+)
+SELECT DISTINCT
+    p.id,
+    0 AS ignore_flag,
+    CASE
+        WHEN participant_ehr.person_id IS NOT NULL THEN 3
+        ELSE 2
+    END AS health_data_stream_sharing_status,
+    iehr.event_date_time,
+    CURRENT_TIMESTAMP() AS created,
+    CURRENT_TIMESTAMP() AS modified
+FROM `{project}.{src_operational_dataset}.ppsc_participant` p
+    -- PPSC Notified of EHR Received
+    JOIN `{project}.{destination_dataset}.datafeed_input_ehr` iehr
+        ON iehr.participant_id = p.participant_id
+    -- Participant in EHR Ops table
+    LEFT JOIN `{ehr_proj}.{participant_ehr_dataset}.ehr_upload_pids` participant_ehr
+        ON p.participant_id = participant_ehr.person_id
+WHERE TRUE
+    -- Don't send if participant is already in the destination table with the same event time.
+    AND NOT EXISTS (
+        SELECT 1
+        FROM `{project}.{destination_dataset}.datafeed_input_healthdata_sharing` t
+        WHERE t.participant_id = p.id
+            AND t.event_date_time = iehr.event_date_time
+    )
+;
+"""

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -3,16 +3,14 @@ from rdr_service.config import GAE_PROJECT
 
 
 def insert_core_data(project: str, src_operational_dataset: str, destination_dataset: str) -> str:
-    # EHR BQ Data
-    org_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION)[0]
-    participant_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT)[0]
-
-    if GAE_PROJECT == "all-of-us-rdr-prod":
-        ehr_proj = "aou-res-curation-prod"
-    else:
-        ehr_proj = "test-ehr-project"
-
     return f"""
+WITH earliest_ehr AS (
+    SELECT participant_id,
+           MIN(event_date_time) AS event_date_time
+    FROM `{project}.{destination_dataset}.datafeed_input_ehr`
+    GROUP BY participant_id
+)
+
 INSERT INTO `{project}.{destination_dataset}.datafeed_input_core_data` (
     participant_id,
     has_core_data,
@@ -31,7 +29,7 @@ SELECT DISTINCT
         overall.event_authored_time,
         lifestyle.event_authored_time,
         pm.finalized,
-        IFNULL(participant_ehr.authored_date, organization_ehr.authored_date)
+        earliest_ehr.event_date_time
     ) AS event_date_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
@@ -45,13 +43,9 @@ JOIN `{project}.{destination_dataset}.ppsc_consent_event` ehrc
     AND c.data_element_value = "submitted_yes"
     AND c.event_type_name = "EHR Authorization"
 
--- EHR Received
--- EHR tables - Record might exist in either table
-LEFT JOIN `{ehr_proj}.{participant_ehr_dataset}.ehr_upload_pids` participant_ehr
-    ON c.participant_id = participant_ehr.person_id
-
-LEFT JOIN `{ehr_proj}.{org_ehr_dataset}.ehr_upload_pids` organization_ehr
-    ON c.participant_id = organization_ehr.person_id
+-- Earliest EHR Received
+JOIN earliest_ehr
+    ON c.participant_id = earliest_ehr.participant_id
 
 -- Basics Completion
 JOIN `{project}.{destination_dataset}.ppsc_survey_completion_event` basics
@@ -88,9 +82,6 @@ JOIN `{project}.{src_operational_dataset}.rdr_measurement` weight
 WHERE
     c.data_element_value = "submitted_yes"
     AND c.event_type_name = "Primary Consent"
-
-    -- Ensure at least one EHR record exists
-    AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
 
     -- Insert only if participant_id doesn't exist in the target table
     AND NOT EXISTS (
@@ -140,7 +131,6 @@ WHERE TRUE
 
 def insert_ehr_receipt(project: str, src_operational_dataset: str, destination_dataset: str) -> str:
     # EHR BQ Data
-    org_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION)[0]
     participant_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT)[0]
 
     if GAE_PROJECT == "all-of-us-rdr-prod":
@@ -159,21 +149,19 @@ INSERT INTO `{project}.{destination_dataset}.datafeed_input_ehr` (
 SELECT DISTINCT
     p.id,
     0 as ignore_flag,
-    IFNULL(participant_ehr.authored_date, organization_ehr.authored_date),
+    participant_ehr.latest_upload_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
 FROM `{project}.{src_operational_dataset}.ppsc_participant` p
-    -- EHR tables - Record might exist in either table
-    LEFT JOIN `{ehr_proj}.{participant_ehr_dataset}.ehr_upload_pids` participant_ehr
+    -- EHR Ops table
+    JOIN `{ehr_proj}.{participant_ehr_dataset}.ehr_upload_pids` participant_ehr
         ON p.participant_id = participant_ehr.person_id
-    LEFT JOIN `{ehr_proj}.{org_ehr_dataset}.ehr_upload_pids` organization_ehr
-        ON p.participant_id = organization_ehr.person_id
 WHERE TRUE
-  AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
   AND NOT EXISTS (
         SELECT 1
         FROM `{project}.{destination_dataset}.datafeed_input_ehr` t
         WHERE t.participant_id = p.id
+            AND t.event_date_time = participant_ehr.latest_upload_time
     )
 ;
 """

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -137,3 +137,43 @@ WHERE TRUE
     )
 ;
 """
+
+def insert_ehr_receipt(project: str, src_operational_dataset: str, destination_dataset: str) -> str:
+    # EHR BQ Data
+    org_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION)[0]
+    participant_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT)[0]
+
+    if GAE_PROJECT == "all-of-us-rdr-prod":
+        ehr_proj = "aou-res-curation-prod"
+    else:
+        ehr_proj = "test-ehr-project"
+
+    return f"""
+INSERT INTO `{project}.{destination_dataset}.datafeed_input_ehr` (
+    participant_id,
+    ignore_flag,
+    event_date_time,
+    created,
+    modified
+)
+SELECT DISTINCT
+    p.id,
+    0 as ignore_flag,
+    IFNULL(participant_ehr.authored_date, organization_ehr.authored_date),
+    CURRENT_TIMESTAMP() AS created,
+    CURRENT_TIMESTAMP() AS modified
+FROM `{project}.{src_operational_dataset}.ppsc_participant` p
+    -- EHR tables - Record might exist in either table
+    LEFT JOIN `{ehr_proj}.{participant_ehr_dataset}.ehr_upload_pids` participant_ehr
+        ON p.participant_id = participant_ehr.person_id
+    LEFT JOIN `{ehr_proj}.{org_ehr_dataset}.ehr_upload_pids` organization_ehr
+        ON p.participant_id = organization_ehr.person_id
+WHERE TRUE
+  AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
+  AND NOT EXISTS (
+        SELECT 1
+        FROM `{project}.{destination_dataset}.datafeed_input_ehr` t
+        WHERE t.participant_id = p.id
+    )
+;
+"""

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -1,5 +1,7 @@
 import logging
 
+from werkzeug.exceptions import BadRequest
+
 from rdr_service import config
 from rdr_service.cloud_utils import bigquery
 from rdr_service.workflow_management.ppsc import data_feed_queries
@@ -36,7 +38,7 @@ class InputFeed:
 
         else:
             # Raise error
-            return False
+            raise BadRequest(f"Invalid Datafeed: {datafeed}")
 
     def run_datafeed(self, datafeed):
         """

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -7,7 +7,7 @@ from rdr_service.workflow_management.ppsc import data_feed_queries
 datafeeds = [
     "core data",
     "biospecimen",
-    "health sharing",
+    "healthdata sharing",
     "ehr"
 ]
 
@@ -28,8 +28,8 @@ class InputFeed:
         elif datafeed == "biospecimen":
             return data_feed_queries.insert_biospecimen(self.project, src, destination)
 
-        elif datafeed == "health sharing":
-            return ""
+        elif datafeed == "health data sharing":
+            return data_feed_queries.insert_health_data_sharing(self.project, src, destination)
 
         elif datafeed == "ehr":
             return data_feed_queries.insert_ehr_receipt(self.project, src, destination)

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -19,14 +19,14 @@ class InputFeed:
         return bigquery.BigQueryJob(job_def)
 
     def get_datafeed_definition(self, datafeed):
+        src = config.getSettingJson(config.PPSC_DATAFEED_SRC_DATASET)[0]
+        destination = config.getSettingJson(config.PPSC_DATAFEED_DEST_DATASET)[0]
+
         if datafeed == "core data":
-            src = config.getSettingJson(config.PPSC_DATAFEED_SRC_DATASET)[0]
-            destination = config.getSettingJson(config.PPSC_DATAFEED_DEST_DATASET)[0]
             return data_feed_queries.insert_core_data(self.project, src, destination)
 
         elif datafeed == "biospecimen":
-            # specimen_types = config.getSettingJson(config.PPSC_DATAFEED_BIOSPECIMEN_TYPES)
-            return ""
+            return data_feed_queries.insert_biospecimen(self.project, src, destination)
 
         elif datafeed == "health sharing":
             return ""

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -1,0 +1,52 @@
+import logging
+
+from rdr_service import config
+from rdr_service.cloud_utils import bigquery
+from rdr_service.workflow_management.ppsc import data_feed_queries
+
+datafeeds = [
+    "core data",
+    "biospecimen",
+    "health sharing",
+    "ehr"
+]
+
+class InputFeed:
+    def __init__(self, project='test'):
+        self.project = project
+
+    def make_datafeed_job(self, job_def):
+        return bigquery.BigQueryJob(job_def)
+
+    def get_datafeed_definition(self, datafeed):
+        if datafeed == "core data":
+            src = config.getSettingJson(config.PPSC_DATAFEED_SRC_DATASET)[0]
+            destination = config.getSettingJson(config.PPSC_DATAFEED_DEST_DATASET)[0]
+            return data_feed_queries.insert_core_data(self.project, src, destination)
+
+        elif datafeed == "biospecimen":
+            # specimen_types = config.getSettingJson(config.PPSC_DATAFEED_BIOSPECIMEN_TYPES)
+            return ""
+
+        elif datafeed == "health sharing":
+            return ""
+
+        elif datafeed == "ehr":
+            return ""
+
+        else:
+            # Raise error
+            return False
+
+    def run_datafeed(self, datafeed):
+        """
+        Loads datafeed results in batches and commits updates to database per batch.
+        """
+        job_def = self.get_datafeed_definition(datafeed)
+
+        job = self.make_datafeed_job(job_def)
+
+        if job is not None:
+            logging.info(f"{datafeed} Data Feed completed")
+        else:
+            logging.warning(f"Could not run {datafeed} Data Feed because of invalid config")

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -32,7 +32,7 @@ class InputFeed:
             return ""
 
         elif datafeed == "ehr":
-            return ""
+            return data_feed_queries.insert_ehr_receipt(self.project, src, destination)
 
         else:
             # Raise error

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -1,19 +1,5 @@
-from rdr_service import config
-from rdr_service.config import GAE_PROJECT
-
-
-def insert_core_data(project: str, src_operational_dataset: str, destination_dataset: str) -> str:
-    # EHR BQ Data
-    org_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION)[0]
-    participant_ehr_dataset = config.getSettingJson(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT)[0]
-
-    if GAE_PROJECT == "all-of-us-rdr-prod":
-        ehr_proj = "aou-res-curation-prod"
-    else:
-        ehr_proj = "test-ehr-project"
-
-    return f"""
-INSERT INTO `{project}.{destination_dataset}.datafeed_input_core_data` (
+core_data_expected_sql = """
+INSERT INTO `test.ppsc_staging_data.datafeed_input_core_data` (
     participant_id,
     has_core_data,
     ignore_flag,
@@ -35,53 +21,53 @@ SELECT DISTINCT
     ) AS event_date_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
-FROM `{project}.{destination_dataset}.ppsc_participant` p
-JOIN `{project}.{destination_dataset}.ppsc_consent_event` c
+FROM `test.ppsc_staging_data.ppsc_participant` p
+JOIN `test.ppsc_staging_data.ppsc_consent_event` c
     ON c.participant_id = p.id
 
 -- EHR Consent
-JOIN `{project}.{destination_dataset}.ppsc_consent_event` ehrc
+JOIN `test.ppsc_staging_data.ppsc_consent_event` ehrc
     ON c.participant_id = ehrc.participant_id
     AND c.data_element_value = "submitted_yes"
     AND c.event_type_name = "EHR Authorization"
 
 -- EHR Received
 -- EHR tables - Record might exist in either table
-LEFT JOIN `{ehr_proj}.{participant_ehr_dataset}.ehr_upload_pids` participant_ehr
+LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
     ON c.participant_id = participant_ehr.person_id
 
-LEFT JOIN `{ehr_proj}.{org_ehr_dataset}.ehr_upload_pids` organization_ehr
+LEFT JOIN `test-ehr-project.org_ehr.ehr_upload_pids` organization_ehr
     ON c.participant_id = organization_ehr.person_id
 
 -- Basics Completion
-JOIN `{project}.{destination_dataset}.ppsc_survey_completion_event` basics
+JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` basics
     ON basics.participant_id = c.participant_id
     AND basics.event_type_name = "The Basics"
     AND basics.data_element_value = "submitted_yes"
 
 -- Overall Health Completion
-JOIN `{project}.{destination_dataset}.ppsc_survey_completion_event` overall
+JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` overall
     ON overall.participant_id = c.participant_id
     AND overall.event_type_name = "Overall Health"
     AND overall.data_element_value = "submitted_yes"
 
 -- Lifestyle Completion
-JOIN `{project}.{destination_dataset}.ppsc_survey_completion_event` lifestyle
+JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` lifestyle
     ON lifestyle.participant_id = c.participant_id
     AND lifestyle.event_type_name = "Lifestyle"
     AND lifestyle.data_element_value = "submitted_yes"
 
 -- Physical Measurements
-JOIN `{project}.{src_operational_dataset}.rdr_physical_measurements` pm
+JOIN `test.ppsc_staging_data.rdr_physical_measurements` pm
     ON pm.participant_id = c.participant_id
 
 -- Height Measurement
-JOIN `{project}.{src_operational_dataset}.rdr_measurement` height
+JOIN `test.ppsc_staging_data.rdr_measurement` height
     ON height.physical_measurements_id = pm.physical_measurements_id
     AND height.code_value = "height"
 
 -- Weight Measurement
-JOIN `{project}.{src_operational_dataset}.rdr_measurement` weight
+JOIN `test.ppsc_staging_data.rdr_measurement` weight
     ON weight.physical_measurements_id = pm.physical_measurements_id
     AND weight.code_value = "weight"
 
@@ -95,16 +81,12 @@ WHERE
     -- Insert only if participant_id doesn't exist in the target table
     AND NOT EXISTS (
         SELECT 1
-        FROM `{project}.{destination_dataset}.datafeed_input_core_data` t
+        FROM `test.ppsc_staging_data.datafeed_input_core_data` t
         WHERE t.participant_id = c.participant_id
     );"""
 
-
-def insert_biospecimen(project: str, src_operational_dataset: str, destination_dataset: str) -> str:
-    biospecimen_list = config.getSettingJson(config.PPSC_DATAFEED_BIOSPECIMEN_TYPES)
-    formatted_values = ", ".join(f"'{value}'" for value in biospecimen_list)
-    return f"""
-INSERT INTO `{project}.{destination_dataset}.datafeed_input_biospecimen` (
+biospecimen_expected_sql = """
+INSERT INTO `test.ppsc_staging_data.datafeed_input_biospecimen` (
     participant_id,
     ignore_flag,
     event_date_time,
@@ -126,13 +108,13 @@ SELECT DISTINCT
         ELSE null
     END AS specimen_type,
     1 as specimen_status
-FROM `{project}.{src_operational_dataset}.ppsc_participant` p
-  JOIN `{project}.rdr_operational_datastream.rdr_biobank_stored_sample` ss ON ss.biobank_id = p.biobank_id
+FROM `test.ppsc_staging_data.ppsc_participant` p
+  JOIN `test.rdr_operational_datastream.rdr_biobank_stored_sample` ss ON ss.biobank_id = p.biobank_id
 WHERE TRUE
-  AND ss.test IN ({formatted_values})
+  AND ss.test IN ('1ed04', '1ed10', '1ed02', '2ed02', '2ed04', '1sal2', '1sal', '2sal0', '3sal1', '1ur10', '1ur90')
   AND NOT EXISTS (
         SELECT 1
-        FROM `{project}.{destination_dataset}.datafeed_input_biospecimen` t
+        FROM `test.ppsc_staging_data.datafeed_input_biospecimen` t
         WHERE t.participant_id = p.id
     )
 ;

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -1,4 +1,11 @@
 core_data_expected_sql = """
+WITH earliest_ehr AS (
+    SELECT participant_id,
+           MIN(event_date_time) AS event_date_time
+    FROM `test.ppsc_staging_data.datafeed_input_ehr`
+    GROUP BY participant_id
+)
+
 INSERT INTO `test.ppsc_staging_data.datafeed_input_core_data` (
     participant_id,
     has_core_data,
@@ -17,7 +24,7 @@ SELECT DISTINCT
         overall.event_authored_time,
         lifestyle.event_authored_time,
         pm.finalized,
-        IFNULL(participant_ehr.authored_date, organization_ehr.authored_date)
+        earliest_ehr.event_date_time
     ) AS event_date_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
@@ -31,13 +38,9 @@ JOIN `test.ppsc_staging_data.ppsc_consent_event` ehrc
     AND c.data_element_value = "submitted_yes"
     AND c.event_type_name = "EHR Authorization"
 
--- EHR Received
--- EHR tables - Record might exist in either table
-LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
-    ON c.participant_id = participant_ehr.person_id
-
-LEFT JOIN `test-ehr-project.org_ehr.ehr_upload_pids` organization_ehr
-    ON c.participant_id = organization_ehr.person_id
+-- Earliest EHR Received
+JOIN earliest_ehr
+    ON c.participant_id = earliest_ehr.participant_id
 
 -- Basics Completion
 JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` basics
@@ -74,9 +77,6 @@ JOIN `test.ppsc_staging_data.rdr_measurement` weight
 WHERE
     c.data_element_value = "submitted_yes"
     AND c.event_type_name = "Primary Consent"
-
-    -- Ensure at least one EHR record exists
-    AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
 
     -- Insert only if participant_id doesn't exist in the target table
     AND NOT EXISTS (
@@ -131,21 +131,19 @@ INSERT INTO `test.ppsc_staging_data.datafeed_input_ehr` (
 SELECT DISTINCT
     p.id,
     0 as ignore_flag,
-    IFNULL(participant_ehr.authored_date, organization_ehr.authored_date),
+    participant_ehr.latest_upload_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
 FROM `test.ppsc_staging_data.ppsc_participant` p
-    -- EHR tables - Record might exist in either table
-    LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
+    -- EHR Ops table
+    JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
         ON p.participant_id = participant_ehr.person_id
-    LEFT JOIN `test-ehr-project.org_ehr.ehr_upload_pids` organization_ehr
-        ON p.participant_id = organization_ehr.person_id
 WHERE TRUE
-  AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
   AND NOT EXISTS (
         SELECT 1
         FROM `test.ppsc_staging_data.datafeed_input_ehr` t
         WHERE t.participant_id = p.id
+            AND t.event_date_time = participant_ehr.latest_upload_time
     )
 ;
 """

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -119,3 +119,33 @@ WHERE TRUE
     )
 ;
 """
+
+ehr_expected_sql = """
+INSERT INTO `test.ppsc_staging_data.datafeed_input_ehr` (
+    participant_id,
+    ignore_flag,
+    event_date_time,
+    created,
+    modified
+)
+SELECT DISTINCT
+    p.id,
+    0 as ignore_flag,
+    IFNULL(participant_ehr.authored_date, organization_ehr.authored_date),
+    CURRENT_TIMESTAMP() AS created,
+    CURRENT_TIMESTAMP() AS modified
+FROM `test.ppsc_staging_data.ppsc_participant` p
+    -- EHR tables - Record might exist in either table
+    LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
+        ON p.participant_id = participant_ehr.person_id
+    LEFT JOIN `test-ehr-project.org_ehr.ehr_upload_pids` organization_ehr
+        ON p.participant_id = organization_ehr.person_id
+WHERE TRUE
+  AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
+  AND NOT EXISTS (
+        SELECT 1
+        FROM `test.ppsc_staging_data.datafeed_input_ehr` t
+        WHERE t.participant_id = p.id
+    )
+;
+"""

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -147,3 +147,41 @@ WHERE TRUE
     )
 ;
 """
+
+
+health_data_sharing_expected_sql = """
+INSERT INTO `test.ppsc_staging_data.datafeed_input_healthdata_sharing` (
+    participant_id,
+    ignore_flag,
+    health_data_stream_sharing_status,
+    event_date_time,
+    created,
+    modified
+)
+SELECT DISTINCT
+    p.id,
+    0 AS ignore_flag,
+    CASE
+        WHEN participant_ehr.person_id IS NOT NULL THEN 3
+        ELSE 2
+    END AS health_data_stream_sharing_status,
+    iehr.event_date_time,
+    CURRENT_TIMESTAMP() AS created,
+    CURRENT_TIMESTAMP() AS modified
+FROM `test.ppsc_staging_data.ppsc_participant` p
+    -- PPSC Notified of EHR Received
+    JOIN `test.ppsc_staging_data.datafeed_input_ehr` iehr
+        ON iehr.participant_id = p.participant_id
+    -- Participant in EHR Ops table
+    LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
+        ON p.participant_id = participant_ehr.person_id
+WHERE TRUE
+    -- Don't send if participant is already in the destination table with the same event time.
+    AND NOT EXISTS (
+        SELECT 1
+        FROM `test.ppsc_staging_data.datafeed_input_healthdata_sharing` t
+        WHERE t.participant_id = p.id
+            AND t.event_date_time = iehr.event_date_time
+    )
+;
+"""

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -2,7 +2,8 @@ from unittest import mock
 
 from rdr_service import config
 from tests.service_tests.test_genomic_datagen import GenomicDataGenMixin
-from tests.workflow_tests.test_data.ppsc_data_feed_test_data import core_data_expected_sql, biospecimen_expected_sql
+from tests.workflow_tests.test_data.ppsc_data_feed_test_data import core_data_expected_sql, biospecimen_expected_sql, \
+    ehr_expected_sql
 from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import InputFeed
 
 
@@ -15,7 +16,6 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
     @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
     def test_core_data_datafeed(self, mock_bq):
-
         feed = InputFeed()
 
         query = feed.get_datafeed_definition("core data")
@@ -29,7 +29,6 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
     @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
     def test_biospecimen_datafeed(self, mock_bq):
-
         feed = InputFeed()
 
         query = feed.get_datafeed_definition("biospecimen")
@@ -40,3 +39,16 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
         # Assert that BigQueryJob was instantiated with the correct SQL
         mock_bq.assert_called_once_with(biospecimen_expected_sql)
+
+    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+    def test_ehr_datafeed(self, mock_bq):
+        feed = InputFeed()
+
+        query = feed.get_datafeed_definition("ehr")
+
+        self.assertEqual(ehr_expected_sql.strip(), query.strip())
+
+        feed.run_datafeed("ehr")
+
+        # Assert that BigQueryJob was instantiated with the correct SQL
+        mock_bq.assert_called_once_with(ehr_expected_sql)

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -3,7 +3,7 @@ from unittest import mock
 from rdr_service import config
 from tests.service_tests.test_genomic_datagen import GenomicDataGenMixin
 from tests.workflow_tests.test_data.ppsc_data_feed_test_data import core_data_expected_sql, biospecimen_expected_sql, \
-    ehr_expected_sql
+    ehr_expected_sql, health_data_sharing_expected_sql
 from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import InputFeed
 
 
@@ -52,3 +52,16 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
         # Assert that BigQueryJob was instantiated with the correct SQL
         mock_bq.assert_called_once_with(ehr_expected_sql)
+
+    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+    def test_health_data_sharing_datafeed(self, mock_bq):
+        feed = InputFeed()
+
+        query = feed.get_datafeed_definition("health data sharing")
+
+        self.assertEqual(health_data_sharing_expected_sql.strip(), query.strip())
+
+        feed.run_datafeed("health data sharing")
+
+        # Assert that BigQueryJob was instantiated with the correct SQL
+        mock_bq.assert_called_once_with(health_data_sharing_expected_sql)

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -1,0 +1,113 @@
+from unittest import mock
+
+from rdr_service import config
+from tests.service_tests.test_genomic_datagen import GenomicDataGenMixin
+from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import InputFeed
+
+
+class DataTransferInputTest(GenomicDataGenMixin):
+    def setUp(self, *args, **kwargs) -> None:
+        # pylint: disable=unused-argument
+        super().setUp()
+
+    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+    def test_get_core_data_definition(self, mock_bq):
+        self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT, ["participant_ehr"])
+        self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION, ["org_ehr"])
+        core_data_expected_sql = """
+INSERT INTO `test.ppsc_staging_data.datafeed_input_core_data` (
+    participant_id,
+    has_core_data,
+    ignore_flag,
+    event_date_time,
+    created,
+    modified)
+SELECT DISTINCT
+    c.participant_id,
+    1 as has_core_data,
+    0 as ignore_flag,
+    GREATEST(
+        c.event_authored_time,
+        ehrc.event_authored_time,
+        basics.event_authored_time,
+        overall.event_authored_time,
+        lifestyle.event_authored_time,
+        pm.finalized,
+        IFNULL(participant_ehr.authored_date, organization_ehr.authored_date)
+    ) AS event_date_time,
+    CURRENT_TIMESTAMP() AS created,
+    CURRENT_TIMESTAMP() AS modified
+FROM `test.ppsc_staging_data.ppsc_participant` p
+JOIN `test.ppsc_staging_data.ppsc_consent_event` c
+    ON c.participant_id = p.id
+
+-- EHR Consent
+JOIN `test.ppsc_staging_data.ppsc_consent_event` ehrc
+    ON c.participant_id = ehrc.participant_id
+    AND c.data_element_value = "submitted_yes"
+    AND c.event_type_name = "EHR Authorization"
+
+-- EHR Received
+-- EHR tables - Record might exist in either table
+LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
+    ON c.participant_id = participant_ehr.person_id
+
+LEFT JOIN `test-ehr-project.org_ehr.ehr_upload_pids` organization_ehr
+    ON c.participant_id = organization_ehr.person_id
+
+-- Basics Completion
+JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` basics
+    ON basics.participant_id = c.participant_id
+    AND basics.event_type_name = "The Basics"
+    AND basics.data_element_value = "submitted_yes"
+
+-- Overall Health Completion
+JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` overall
+    ON overall.participant_id = c.participant_id
+    AND overall.event_type_name = "Overall Health"
+    AND overall.data_element_value = "submitted_yes"
+
+-- Lifestyle Completion
+JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` lifestyle
+    ON lifestyle.participant_id = c.participant_id
+    AND lifestyle.event_type_name = "Lifestyle"
+    AND lifestyle.data_element_value = "submitted_yes"
+
+-- Physical Measurements
+JOIN `test.ppsc_staging_data.rdr_physical_measurements` pm
+    ON pm.participant_id = c.participant_id
+
+-- Height Measurement
+JOIN `test.ppsc_staging_data.rdr_measurement` height
+    ON height.physical_measurements_id = pm.physical_measurements_id
+    AND height.code_value = "height"
+
+-- Weight Measurement
+JOIN `test.ppsc_staging_data.rdr_measurement` weight
+    ON weight.physical_measurements_id = pm.physical_measurements_id
+    AND weight.code_value = "weight"
+
+WHERE
+    c.data_element_value = "submitted_yes"
+    AND c.event_type_name = "Primary Consent"
+
+    -- Ensure at least one EHR record exists
+    AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
+
+    -- Insert only if participant_id doesn't exist in the target table
+    AND NOT EXISTS (
+        SELECT 1
+        FROM `test.ppsc_staging_data.datafeed_input_core_data` t
+        WHERE t.participant_id = c.participant_id
+    );"""
+
+        feed = InputFeed()
+
+        query = feed.get_datafeed_definition("core data")
+
+        self.assertEqual(core_data_expected_sql.strip(), query.strip())
+
+        feed.run_datafeed("core data")
+
+        # Assert that BigQueryJob was instantiated with the correct SQL
+        mock_bq.assert_called_once_with(core_data_expected_sql)

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -2,104 +2,19 @@ from unittest import mock
 
 from rdr_service import config
 from tests.service_tests.test_genomic_datagen import GenomicDataGenMixin
+from tests.workflow_tests.test_data.ppsc_data_feed_test_data import core_data_expected_sql, biospecimen_expected_sql
 from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import InputFeed
 
 
 class DataTransferInputTest(GenomicDataGenMixin):
     def setUp(self, *args, **kwargs) -> None:
         # pylint: disable=unused-argument
+        self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT, ["participant_ehr"])
+        self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION, ["org_ehr"])
         super().setUp()
 
     @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
-    def test_get_core_data_definition(self, mock_bq):
-        self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT, ["participant_ehr"])
-        self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION, ["org_ehr"])
-        core_data_expected_sql = """
-INSERT INTO `test.ppsc_staging_data.datafeed_input_core_data` (
-    participant_id,
-    has_core_data,
-    ignore_flag,
-    event_date_time,
-    created,
-    modified)
-SELECT DISTINCT
-    c.participant_id,
-    1 as has_core_data,
-    0 as ignore_flag,
-    GREATEST(
-        c.event_authored_time,
-        ehrc.event_authored_time,
-        basics.event_authored_time,
-        overall.event_authored_time,
-        lifestyle.event_authored_time,
-        pm.finalized,
-        IFNULL(participant_ehr.authored_date, organization_ehr.authored_date)
-    ) AS event_date_time,
-    CURRENT_TIMESTAMP() AS created,
-    CURRENT_TIMESTAMP() AS modified
-FROM `test.ppsc_staging_data.ppsc_participant` p
-JOIN `test.ppsc_staging_data.ppsc_consent_event` c
-    ON c.participant_id = p.id
-
--- EHR Consent
-JOIN `test.ppsc_staging_data.ppsc_consent_event` ehrc
-    ON c.participant_id = ehrc.participant_id
-    AND c.data_element_value = "submitted_yes"
-    AND c.event_type_name = "EHR Authorization"
-
--- EHR Received
--- EHR tables - Record might exist in either table
-LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
-    ON c.participant_id = participant_ehr.person_id
-
-LEFT JOIN `test-ehr-project.org_ehr.ehr_upload_pids` organization_ehr
-    ON c.participant_id = organization_ehr.person_id
-
--- Basics Completion
-JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` basics
-    ON basics.participant_id = c.participant_id
-    AND basics.event_type_name = "The Basics"
-    AND basics.data_element_value = "submitted_yes"
-
--- Overall Health Completion
-JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` overall
-    ON overall.participant_id = c.participant_id
-    AND overall.event_type_name = "Overall Health"
-    AND overall.data_element_value = "submitted_yes"
-
--- Lifestyle Completion
-JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` lifestyle
-    ON lifestyle.participant_id = c.participant_id
-    AND lifestyle.event_type_name = "Lifestyle"
-    AND lifestyle.data_element_value = "submitted_yes"
-
--- Physical Measurements
-JOIN `test.ppsc_staging_data.rdr_physical_measurements` pm
-    ON pm.participant_id = c.participant_id
-
--- Height Measurement
-JOIN `test.ppsc_staging_data.rdr_measurement` height
-    ON height.physical_measurements_id = pm.physical_measurements_id
-    AND height.code_value = "height"
-
--- Weight Measurement
-JOIN `test.ppsc_staging_data.rdr_measurement` weight
-    ON weight.physical_measurements_id = pm.physical_measurements_id
-    AND weight.code_value = "weight"
-
-WHERE
-    c.data_element_value = "submitted_yes"
-    AND c.event_type_name = "Primary Consent"
-
-    -- Ensure at least one EHR record exists
-    AND (participant_ehr.person_id IS NOT NULL OR organization_ehr.person_id IS NOT NULL)
-
-    -- Insert only if participant_id doesn't exist in the target table
-    AND NOT EXISTS (
-        SELECT 1
-        FROM `test.ppsc_staging_data.datafeed_input_core_data` t
-        WHERE t.participant_id = c.participant_id
-    );"""
+    def test_core_data_datafeed(self, mock_bq):
 
         feed = InputFeed()
 
@@ -111,3 +26,17 @@ WHERE
 
         # Assert that BigQueryJob was instantiated with the correct SQL
         mock_bq.assert_called_once_with(core_data_expected_sql)
+
+    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+    def test_biospecimen_datafeed(self, mock_bq):
+
+        feed = InputFeed()
+
+        query = feed.get_datafeed_definition("biospecimen")
+
+        self.assertEqual(biospecimen_expected_sql.strip(), query.strip())
+
+        feed.run_datafeed("biospecimen")
+
+        # Assert that BigQueryJob was instantiated with the correct SQL
+        mock_bq.assert_called_once_with(biospecimen_expected_sql)


### PR DESCRIPTION
## Resolves *[DA-4499](https://precisionmedicineinitiative.atlassian.net/browse/DA-4499)*


## Description of changes/additions
This PR implements the workflows to load the PPSC data transfer tables. The workflows are executed using Google Cloud Scheduler. Queries are executed in BigQuery for the PPSC operational data streamed from the input API, as well as from EHR Operations.
Queries are defined in SQL in the `data_feed_queries` module and datasets are configured based on the GCP project configs. The destination tables mirror the schema of the PPSC MySQL data transfer tables. The data is streamed from the BigQuery destination tables to the MySQL tables using GCP Datastream.

## Tests
- [x] unit tests




[DA-4499]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ