### PR TITLE
PPSC Datafeed refactor

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -211,3 +211,55 @@ WHERE TRUE
     )
 ;
 """
+
+def get_ppsc_core_to_stream(project: str, destination_dataset: str) -> str:
+    return f"""
+    SELECT distinct participant_id, ignore_flag, event_date_time, has_core_data
+    FROM `{project}.{destination_dataset}.datafeed_input_core_data` s
+    where TRUE
+      AND NOT EXISTS (
+            SELECT 1
+            FROM `{project}.{destination_dataset}.ppsc_ppsc_core` t
+            WHERE t.participant_id = s.participant_id
+                AND t.event_date_time = s.event_date_time
+        )
+    ;"""
+
+def get_ppsc_biospecimen_to_stream(project: str, destination_dataset: str) -> str:
+    return f"""
+    SELECT distinct participant_id, ignore_flag, event_date_time, specimen_type, specimen_status
+    FROM `{project}.{destination_dataset}.datafeed_input_biospecimen` s
+    where TRUE
+      AND NOT EXISTS (
+            SELECT 1
+            FROM `{project}.{destination_dataset}.ppsc_ppsc_biobank_sample` t
+            WHERE t.participant_id = s.participant_id
+                AND t.event_date_time = s.event_date_time
+        )
+    ;"""
+
+def get_ppsc_ehr_to_stream(project: str, destination_dataset: str) -> str:
+    return f"""
+SELECT distinct participant_id, ignore_flag, event_date_time
+FROM `{project}.{destination_dataset}.datafeed_input_ehr` s
+where TRUE
+  AND NOT EXISTS (
+        SELECT 1
+        FROM `{project}.{destination_dataset}.ppsc_ppsc_ehr` t
+        WHERE t.participant_id = s.participant_id
+            AND t.event_date_time = s.event_date_time
+    )
+;"""
+
+def get_health_data_to_stream(project: str, destination_dataset: str) -> str:
+    return f"""
+    SELECT distinct participant_id, ignore_flag, event_date_time, health_data_stream_sharing_status
+    FROM `{project}.{destination_dataset}.datafeed_input_heathdata_sharing` s
+    where TRUE
+      AND NOT EXISTS (
+            SELECT 1
+            FROM `{project}.{destination_dataset}.ppsc_ppsc_health_data` t
+            WHERE t.participant_id = s.participant_id
+                AND t.event_date_time = s.event_date_time
+        )
+    ;"""

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -16,6 +16,7 @@ datafeeds = [
     "ehr"
 ]
 
+
 class InputFeed:
     def __init__(self, project='test'):
         self.project = project
@@ -78,7 +79,7 @@ class InputFeed:
             logging.info(f"{datafeed} Data Feed Staged")
             # Insert into Cloud SQL Table
             rows = [dict(row) for row in streaming_data_rows]
-            dao = PPSCDataTransferBaseDao()
+            dao = PPSCDataTransferBaseDao(job_def['output_model'])
             with dao.session() as session:
                 session.bulk_insert_mappings(job_def['output_model'], rows)
         else:

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -1,9 +1,12 @@
 import logging
 
+from google.cloud import bigquery
 from werkzeug.exceptions import BadRequest
 
 from rdr_service import config
-from rdr_service.cloud_utils import bigquery
+from rdr_service.dao.ppsc_partner_transfer_dao import PPSCDataTransferBaseDao
+from rdr_service.model.ppsc_partner_data_transfer import PPSCCore, PPSCBiobankSample, PPSCHealthData, PPSCEHR
+# from rdr_service.cloud_utils import bigquery
 from rdr_service.workflow_management.ppsc import data_feed_queries
 
 datafeeds = [
@@ -16,25 +19,40 @@ datafeeds = [
 class InputFeed:
     def __init__(self, project='test'):
         self.project = project
+        self.bq_client = bigquery.Client()
 
     def make_datafeed_job(self, job_def):
-        return bigquery.BigQueryJob(job_def)
+        return self.bq_client.query(job_def)
 
     def get_datafeed_definition(self, datafeed):
         src = config.getSettingJson(config.PPSC_DATAFEED_SRC_DATASET)[0]
         destination = config.getSettingJson(config.PPSC_DATAFEED_DEST_DATASET)[0]
 
+        job_def = {}
+
         if datafeed == "core data":
-            return data_feed_queries.insert_core_data(self.project, src, destination)
+            job_def['staging_data'] = data_feed_queries.insert_core_data(self.project, src, destination)
+            job_def['streaming_data'] = data_feed_queries.get_ppsc_core_to_stream(self.project, destination)
+            job_def['output_model'] = PPSCCore
+            return job_def
 
         elif datafeed == "biospecimen":
-            return data_feed_queries.insert_biospecimen(self.project, src, destination)
+            job_def['staging_data'] = data_feed_queries.insert_biospecimen(self.project, src, destination)
+            job_def['streaming_data'] = data_feed_queries.get_ppsc_biospecimen_to_stream(self.project, destination)
+            job_def['output_model'] = PPSCBiobankSample
+            return job_def
 
         elif datafeed == "health data sharing":
-            return data_feed_queries.insert_health_data_sharing(self.project, src, destination)
+            job_def['staging_data'] = data_feed_queries.insert_health_data_sharing(self.project, src, destination)
+            job_def['streaming_data'] = data_feed_queries.get_health_data_to_stream(self.project, destination)
+            job_def['output_model'] = PPSCHealthData
+            return job_def
 
         elif datafeed == "ehr":
-            return data_feed_queries.insert_ehr_receipt(self.project, src, destination)
+            job_def['staging_data'] = data_feed_queries.insert_ehr_receipt(self.project, src, destination)
+            job_def['streaming_data'] = data_feed_queries.get_ppsc_ehr_to_stream(self.project, destination)
+            job_def['output_model'] = PPSCEHR
+            return job_def
 
         else:
             # Raise error
@@ -46,9 +64,22 @@ class InputFeed:
         """
         job_def = self.get_datafeed_definition(datafeed)
 
-        job = self.make_datafeed_job(job_def)
+        # Stage the Data
+        job = self.make_datafeed_job(job_def['staging_data'])
 
         if job is not None:
-            logging.info(f"{datafeed} Data Feed completed")
+            logging.info(f"{datafeed} Data Feed Staged")
         else:
             logging.warning(f"Could not run {datafeed} Data Feed because of invalid config")
+
+        streaming_data_rows = list(self.make_datafeed_job(job_def['streaming_data']))
+
+        if streaming_data_rows:
+            logging.info(f"{datafeed} Data Feed Staged")
+            # Insert into Cloud SQL Table
+            rows = [dict(row) for row in streaming_data_rows]
+            dao = PPSCDataTransferBaseDao()
+            with dao.session() as session:
+                session.bulk_insert_mappings(job_def['output_model'], rows)
+        else:
+            logging.warning(f"No Staged Rows for {datafeed} Data Feed")

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -85,6 +85,18 @@ WHERE
         WHERE t.participant_id = c.participant_id
     );"""
 
+core_data_expected_streaming_sql = """
+    SELECT distinct participant_id, ignore_flag, event_date_time, has_core_data
+    FROM `test.ppsc_staging_data.datafeed_input_core_data` s
+    where TRUE
+      AND NOT EXISTS (
+            SELECT 1
+            FROM `test.ppsc_staging_data.ppsc_ppsc_core` t
+            WHERE t.participant_id = s.participant_id
+                AND t.event_date_time = s.event_date_time
+        )
+    ;"""
+
 biospecimen_expected_sql = """
 INSERT INTO `test.ppsc_staging_data.datafeed_input_biospecimen` (
     participant_id,
@@ -120,6 +132,18 @@ WHERE TRUE
 ;
 """
 
+biospecimen_expected_streaming_sql = """
+    SELECT distinct participant_id, ignore_flag, event_date_time, specimen_type, specimen_status
+    FROM `test.ppsc_staging_data.datafeed_input_biospecimen` s
+    where TRUE
+      AND NOT EXISTS (
+            SELECT 1
+            FROM `test.ppsc_staging_data.ppsc_ppsc_biobank_sample` t
+            WHERE t.participant_id = s.participant_id
+                AND t.event_date_time = s.event_date_time
+        )
+    ;"""
+
 ehr_expected_sql = """
 INSERT INTO `test.ppsc_staging_data.datafeed_input_ehr` (
     participant_id,
@@ -148,6 +172,17 @@ WHERE TRUE
 ;
 """
 
+ehr_expected_streaming_sql = """
+SELECT distinct participant_id, ignore_flag, event_date_time
+FROM `test.ppsc_staging_data.datafeed_input_ehr` s
+where TRUE
+  AND NOT EXISTS (
+        SELECT 1
+        FROM `test.ppsc_staging_data.ppsc_ppsc_ehr` t
+        WHERE t.participant_id = s.participant_id
+            AND t.event_date_time = s.event_date_time
+    )
+;"""
 
 health_data_sharing_expected_sql = """
 INSERT INTO `test.ppsc_staging_data.datafeed_input_healthdata_sharing` (
@@ -185,3 +220,15 @@ WHERE TRUE
     )
 ;
 """
+
+health_data_expected_streaming_sql = """
+    SELECT distinct participant_id, ignore_flag, event_date_time, health_data_stream_sharing_status
+    FROM `test.ppsc_staging_data.datafeed_input_heathdata_sharing` s
+    where TRUE
+      AND NOT EXISTS (
+            SELECT 1
+            FROM `test.ppsc_staging_data.ppsc_ppsc_health_data` t
+            WHERE t.participant_id = s.participant_id
+                AND t.event_date_time = s.event_date_time
+        )
+    ;"""

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -122,8 +122,13 @@ class DataTransferInputTest(GenomicDataGenMixin):
             self.assertEqual(expected, actual,
                              f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
 
+    @mock.patch("google.cloud.bigquery.Client")
     @mock.patch("rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.InputFeed.make_datafeed_job")
-    def test_run_datafeed(self, mock_make_datafeed_job):
+    def test_run_datafeed(self, mock_make_datafeed_job, mock_bq_client):
+        # Mock the BQ client to prevent API calls
+        mock_bq_instance = mock_bq_client.return_value
+        mock_bq_instance.query.return_value.result.return_value = []
+
         ppsc_data_gen = PPSCDataGenerator()
         test_participant = ppsc_data_gen.create_database_participant()
         # Test data

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -3,7 +3,8 @@ from unittest import mock
 from rdr_service import config
 from tests.service_tests.test_genomic_datagen import GenomicDataGenMixin
 from tests.workflow_tests.test_data.ppsc_data_feed_test_data import core_data_expected_sql, biospecimen_expected_sql, \
-    ehr_expected_sql, health_data_sharing_expected_sql
+    ehr_expected_sql, health_data_sharing_expected_sql, ehr_expected_streaming_sql, core_data_expected_streaming_sql, \
+    biospecimen_expected_streaming_sql, health_data_expected_streaming_sql
 from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import InputFeed
 
 
@@ -14,54 +15,102 @@ class DataTransferInputTest(GenomicDataGenMixin):
         self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION, ["org_ehr"])
         super().setUp()
 
-    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+    @mock.patch("google.cloud.bigquery.Client.query")
     def test_core_data_datafeed(self, mock_bq):
         feed = InputFeed()
 
-        query = feed.get_datafeed_definition("core data")
+        query = feed.get_datafeed_definition("core data")['staging_data'].strip()
+        staging_data_expected_sql = core_data_expected_sql.strip()
+        streaming_data_expected_sql = core_data_expected_streaming_sql.strip()
 
-        self.assertEqual(core_data_expected_sql.strip(), query.strip())
+        self.assertEqual(staging_data_expected_sql, query)
 
         feed.run_datafeed("core data")
 
-        # Assert that BigQueryJob was instantiated with the correct SQL
-        mock_bq.assert_called_once_with(core_data_expected_sql)
+        self.assertEqual(mock_bq.call_count, 2)
 
-    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+        # Check the actual calls made
+        expected_calls = [
+            staging_data_expected_sql,
+            streaming_data_expected_sql,
+        ]
+        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+
+        for expected, actual in zip(expected_calls, actual_calls):
+            self.assertEqual(expected, actual,
+                             f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
+
+    @mock.patch("google.cloud.bigquery.Client.query")
     def test_biospecimen_datafeed(self, mock_bq):
         feed = InputFeed()
 
-        query = feed.get_datafeed_definition("biospecimen")
+        query = feed.get_datafeed_definition("biospecimen")['staging_data'].strip()
+        staging_data_expected_sql = biospecimen_expected_sql.strip()
+        streaming_data_expected_sql = biospecimen_expected_streaming_sql.strip()
 
-        self.assertEqual(biospecimen_expected_sql.strip(), query.strip())
+        self.assertEqual(staging_data_expected_sql, query)
 
         feed.run_datafeed("biospecimen")
 
-        # Assert that BigQueryJob was instantiated with the correct SQL
-        mock_bq.assert_called_once_with(biospecimen_expected_sql)
+        self.assertEqual(mock_bq.call_count, 2)
 
-    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+        # Check the actual calls made
+        expected_calls = [
+            staging_data_expected_sql,
+            streaming_data_expected_sql,
+        ]
+        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+
+        for expected, actual in zip(expected_calls, actual_calls):
+            self.assertEqual(expected, actual,
+                             f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
+
+    @mock.patch("google.cloud.bigquery.Client.query")
     def test_ehr_datafeed(self, mock_bq):
         feed = InputFeed()
 
-        query = feed.get_datafeed_definition("ehr")
+        query = feed.get_datafeed_definition("ehr")['staging_data'].strip()
+        staging_data_expected_sql = ehr_expected_sql.strip()
+        streaming_data_expected_sql = ehr_expected_streaming_sql.strip()
 
-        self.assertEqual(ehr_expected_sql.strip(), query.strip())
+        self.assertEqual(staging_data_expected_sql, query)
 
         feed.run_datafeed("ehr")
 
-        # Assert that BigQueryJob was instantiated with the correct SQL
-        mock_bq.assert_called_once_with(ehr_expected_sql)
+        self.assertEqual(mock_bq.call_count, 2)
 
-    @mock.patch("rdr_service.cloud_utils.bigquery.BigQueryJob")
+        # Check the actual calls made
+        expected_calls = [
+            staging_data_expected_sql,
+            streaming_data_expected_sql,
+        ]
+        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+
+        for expected, actual in zip(expected_calls, actual_calls):
+            self.assertEqual(expected, actual,
+                             f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
+
+    @mock.patch("google.cloud.bigquery.Client.query")
     def test_health_data_sharing_datafeed(self, mock_bq):
         feed = InputFeed()
 
-        query = feed.get_datafeed_definition("health data sharing")
+        query = feed.get_datafeed_definition("health data sharing")['staging_data'].strip()
+        staging_data_expected_sql = health_data_sharing_expected_sql.strip()
+        streaming_data_expected_sql = health_data_expected_streaming_sql.strip()
 
-        self.assertEqual(health_data_sharing_expected_sql.strip(), query.strip())
+        self.assertEqual(staging_data_expected_sql, query)
 
         feed.run_datafeed("health data sharing")
 
-        # Assert that BigQueryJob was instantiated with the correct SQL
-        mock_bq.assert_called_once_with(health_data_sharing_expected_sql)
+        self.assertEqual(mock_bq.call_count, 2)
+
+        # Check the actual calls made
+        expected_calls = [
+            staging_data_expected_sql,
+            streaming_data_expected_sql,
+        ]
+        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+
+        for expected, actual in zip(expected_calls, actual_calls):
+            self.assertEqual(expected, actual,
+                             f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -18,8 +18,9 @@ class DataTransferInputTest(GenomicDataGenMixin):
         self.temporarily_override_config_setting(config.EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION, ["org_ehr"])
         super().setUp()
 
-    @mock.patch("google.cloud.bigquery.Client.query")
+    @mock.patch("google.cloud.bigquery.Client")
     def test_core_data_datafeed(self, mock_bq):
+        mock_bq_instance = mock_bq.return_value
         feed = InputFeed()
 
         query = feed.get_datafeed_definition("core data")['staging_data'].strip()
@@ -30,21 +31,22 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
         feed.run_datafeed("core data")
 
-        self.assertEqual(mock_bq.call_count, 2)
+        self.assertEqual(mock_bq_instance.query.call_count, 2)
 
         # Check the actual calls made
         expected_calls = [
             staging_data_expected_sql,
             streaming_data_expected_sql,
         ]
-        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+        actual_calls = [call.args[0].strip() for call in mock_bq_instance.query.mock_calls if call.args]
 
         for expected, actual in zip(expected_calls, actual_calls):
             self.assertEqual(expected, actual,
                              f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
 
-    @mock.patch("google.cloud.bigquery.Client.query")
+    @mock.patch("google.cloud.bigquery.Client")
     def test_biospecimen_datafeed(self, mock_bq):
+        mock_bq_instance = mock_bq.return_value
         feed = InputFeed()
 
         query = feed.get_datafeed_definition("biospecimen")['staging_data'].strip()
@@ -55,21 +57,22 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
         feed.run_datafeed("biospecimen")
 
-        self.assertEqual(mock_bq.call_count, 2)
+        self.assertEqual(mock_bq_instance.query.call_count, 2)
 
         # Check the actual calls made
         expected_calls = [
             staging_data_expected_sql,
             streaming_data_expected_sql,
         ]
-        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+        actual_calls = [call.args[0].strip() for call in mock_bq_instance.query.mock_calls if call.args]
 
         for expected, actual in zip(expected_calls, actual_calls):
             self.assertEqual(expected, actual,
                              f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
 
-    @mock.patch("google.cloud.bigquery.Client.query")
+    @mock.patch("google.cloud.bigquery.Client")
     def test_ehr_datafeed(self, mock_bq):
+        mock_bq_instance = mock_bq.return_value
         feed = InputFeed()
 
         query = feed.get_datafeed_definition("ehr")['staging_data'].strip()
@@ -80,21 +83,22 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
         feed.run_datafeed("ehr")
 
-        self.assertEqual(mock_bq.call_count, 2)
+        self.assertEqual(mock_bq_instance.query.call_count, 2)
 
         # Check the actual calls made
         expected_calls = [
             staging_data_expected_sql,
             streaming_data_expected_sql,
         ]
-        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+        actual_calls = [call.args[0].strip() for call in mock_bq_instance.query.mock_calls if call.args]
 
         for expected, actual in zip(expected_calls, actual_calls):
             self.assertEqual(expected, actual,
                              f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
 
-    @mock.patch("google.cloud.bigquery.Client.query")
+    @mock.patch("google.cloud.bigquery.Client")
     def test_health_data_sharing_datafeed(self, mock_bq):
+        mock_bq_instance = mock_bq.return_value
         feed = InputFeed()
 
         query = feed.get_datafeed_definition("health data sharing")['staging_data'].strip()
@@ -105,14 +109,14 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
         feed.run_datafeed("health data sharing")
 
-        self.assertEqual(mock_bq.call_count, 2)
+        self.assertEqual(mock_bq_instance.query.call_count, 2)
 
         # Check the actual calls made
         expected_calls = [
             staging_data_expected_sql,
             streaming_data_expected_sql,
         ]
-        actual_calls = [call.args[0].strip() for call in mock_bq.mock_calls if call.args]
+        actual_calls = [call.args[0].strip() for call in mock_bq_instance.query.mock_calls if call.args]
 
         for expected, actual in zip(expected_calls, actual_calls):
             self.assertEqual(expected, actual,

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -1,6 +1,9 @@
 from unittest import mock
 
 from rdr_service import config
+from rdr_service.dao.ppsc_partner_transfer_dao import PPSCDataTransferBaseDao
+from rdr_service.data_gen.generators.ppsc import PPSCDataGenerator
+from rdr_service.model.ppsc_partner_data_transfer import PPSCEHR
 from tests.service_tests.test_genomic_datagen import GenomicDataGenMixin
 from tests.workflow_tests.test_data.ppsc_data_feed_test_data import core_data_expected_sql, biospecimen_expected_sql, \
     ehr_expected_sql, health_data_sharing_expected_sql, ehr_expected_streaming_sql, core_data_expected_streaming_sql, \
@@ -114,3 +117,31 @@ class DataTransferInputTest(GenomicDataGenMixin):
         for expected, actual in zip(expected_calls, actual_calls):
             self.assertEqual(expected, actual,
                              f"Mismatch in SQL call:\nExpected:\n{expected}\n\nActual:\n{actual}")
+
+    @mock.patch("rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.InputFeed.make_datafeed_job")
+    def test_run_datafeed(self, mock_make_datafeed_job):
+        ppsc_data_gen = PPSCDataGenerator()
+        test_participant = ppsc_data_gen.create_database_participant()
+        # Test data
+        mock_streaming_data_rows = [
+            {"participant_id": test_participant.id, "event_date_time": "2024-11-20"},
+        ]
+
+        # Mock make_datafeed_job() to return the mocked streaming_data
+        mock_make_datafeed_job.side_effect = lambda query: iter(
+            mock_streaming_data_rows) if ehr_expected_streaming_sql in query else None
+
+        # Test Feed
+        feed = InputFeed()
+        feed.get_datafeed_definition = mock.Mock(return_value={
+            "staging_data": ehr_expected_sql,
+            "streaming_data": ehr_expected_streaming_sql,
+            "output_model": PPSCEHR
+        })
+
+        feed.run_datafeed("ehr")
+
+        # Test insert into MySQL table worked
+        ehr_dao = PPSCDataTransferBaseDao(PPSCEHR)
+        actual_rows = ehr_dao.get_all()
+        self.assertEqual(actual_rows[0].participant_id, mock_streaming_data_rows[0]['participant_id'])


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR refactors the PPSC return datafeed to write from the BigQuery staging tables to the appropriate Cloud SQL models. The original plan was to use GCP Datastream to write data from BigQuery to MySQL, but this is currently not supported in GCP.

## Tests
- [x] unit tests


