### PR TITLE
Update Workbench Query JOINs to be more Efficient

### DIFF
--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -492,43 +492,58 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                     .filter(WorkbenchWorkspaceUser.isCreator == 1)
                     .subquery()
             )
-            count_query = (session.query(distinct(WorkbenchWorkspaceApproved.workspaceSourceId))
-                           .join(WorkbenchWorkspaceUser, WorkbenchResearcher, WorkbenchInstitutionalAffiliations)
-                           .filter(or_(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
-                                       WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)
-                                       ),
-                                   WorkbenchWorkspaceApproved.status == int(WorkbenchWorkspaceStatus.ACTIVE),
-                                   WorkbenchInstitutionalAffiliations.isVerified == 1,
-                                   or_(WorkbenchWorkspaceUser.isCreator == 1,
-                                       and_(
-                                           WorkbenchWorkspaceUser.role == int(WorkbenchWorkspaceUserRole.OWNER),
-                                           WorkbenchWorkspaceApproved.id.notin_(subquery)
-                                       )),
-                                   WorkbenchWorkspaceApproved.creationTime > start_date
-                                   )
-                           )
+
+            count_query = (
+                session.query(
+                    distinct(WorkbenchWorkspaceApproved.workspaceSourceId)
+                ).join(WorkbenchWorkspaceUser,
+                       WorkbenchWorkspaceUser.workspaceId == WorkbenchWorkspaceApproved.id
+                       ).join(WorkbenchResearcher,
+                              WorkbenchResearcher.id == WorkbenchWorkspaceUser.researcherId
+                              ).join(WorkbenchInstitutionalAffiliations,
+                                     WorkbenchInstitutionalAffiliations.researcherId == WorkbenchResearcher.id
+                ).filter(or_(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
+                             WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)),
+                         WorkbenchWorkspaceApproved.status == int(WorkbenchWorkspaceStatus.ACTIVE),
+                         WorkbenchInstitutionalAffiliations.isVerified == 1,
+                         or_(WorkbenchWorkspaceUser.isCreator == 1,
+                             and_(
+                                 WorkbenchWorkspaceUser.role == int(WorkbenchWorkspaceUserRole.OWNER),
+                                 WorkbenchWorkspaceApproved.id.notin_(subquery)
+                             )),
+                         WorkbenchWorkspaceApproved.creationTime > start_date
+                )
+            )
             total = count_query.count()
 
             snapshot_subquery = (
-                session.query(func.max(WorkbenchWorkspaceSnapshot.id).label('snapshot_id'),
-                              WorkbenchWorkspaceSnapshot.workspaceSourceId)
-                    .filter(or_(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
-                                WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)
-                                ))
-                    .group_by(WorkbenchWorkspaceSnapshot.workspaceSourceId).subquery()
+                session.query(
+                    func.max(WorkbenchWorkspaceSnapshot.id).label('snapshot_id'),
+                    WorkbenchWorkspaceSnapshot.workspaceSourceId
+                ).join(
+                    WorkbenchWorkspaceApproved,
+                    WorkbenchWorkspaceApproved.workspaceSourceId == WorkbenchWorkspaceSnapshot.workspaceSourceId
+                ).filter(
+                    or_(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
+                        WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)),
+                ).group_by(WorkbenchWorkspaceSnapshot.workspaceSourceId).subquery()
             )
+
             query = (
                 session.query(
                     WorkbenchWorkspaceApproved,
                     WorkbenchResearcher,
                     WorkbenchWorkspaceUser,
                     snapshot_subquery.c.snapshot_id
+                ).join(
+                    WorkbenchResearcher,
+                    WorkbenchResearcher.id == WorkbenchWorkspaceUser.researcherId
+                ).join(
+                    WorkbenchWorkspaceApproved,
+                    WorkbenchWorkspaceApproved.id == WorkbenchWorkspaceUser.workspaceId
                 ).filter(
-                    WorkbenchWorkspaceUser.researcherId == WorkbenchResearcher.id,
-                    WorkbenchWorkspaceApproved.id == WorkbenchWorkspaceUser.workspaceId,
                     or_(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
-                        WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)
-                        ),
+                        WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)),
                     WorkbenchWorkspaceApproved.workspaceSourceId == snapshot_subquery.c.workspace_source_id,
                     WorkbenchWorkspaceApproved.creationTime > start_date
                 ).order_by(
@@ -539,14 +554,16 @@ class WorkbenchWorkspaceDao(UpdatableDao):
             match_count_query = (
                 session.query(
                     distinct(WorkbenchWorkspaceApproved.workspaceSourceId)
-                ).filter(
-                    WorkbenchWorkspaceUser.researcherId == WorkbenchResearcher.id,
-                    WorkbenchWorkspaceApproved.id == WorkbenchWorkspaceUser.workspaceId,
+                ).join(WorkbenchWorkspaceUser,
+                       WorkbenchWorkspaceUser.workspaceId == WorkbenchWorkspaceApproved.id
+                       ).join(WorkbenchResearcher,
+                              WorkbenchResearcher.id == WorkbenchWorkspaceUser.researcherId
+                              ).join(WorkbenchInstitutionalAffiliations,
+                                     WorkbenchInstitutionalAffiliations.researcherId == WorkbenchResearcher.id
+                                     ).filter(
                     or_(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
-                        WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)
-                        ),
+                        WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)),
                     WorkbenchWorkspaceApproved.workspaceSourceId == snapshot_subquery.c.workspace_source_id,
-                    WorkbenchResearcher.id == WorkbenchInstitutionalAffiliations.researcherId,
                     WorkbenchInstitutionalAffiliations.isVerified == 1,
                     WorkbenchWorkspaceApproved.creationTime > start_date
                 )

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -536,15 +536,17 @@ class WorkbenchWorkspaceDao(UpdatableDao):
                     WorkbenchWorkspaceUser,
                     snapshot_subquery.c.snapshot_id
                 ).join(
+                    WorkbenchWorkspaceApproved,
+                    WorkbenchWorkspaceApproved.workspaceSourceId == snapshot_subquery.c.workspace_source_id
+                ).join(
+                    WorkbenchWorkspaceUser,
+                    WorkbenchWorkspaceUser.workspaceId == WorkbenchWorkspaceApproved.id
+                ).join(
                     WorkbenchResearcher,
                     WorkbenchResearcher.id == WorkbenchWorkspaceUser.researcherId
-                ).join(
-                    WorkbenchWorkspaceApproved,
-                    WorkbenchWorkspaceApproved.id == WorkbenchWorkspaceUser.workspaceId
                 ).filter(
                     or_(WorkbenchWorkspaceApproved.excludeFromPublicDirectory == 0,
                         WorkbenchWorkspaceApproved.excludeFromPublicDirectory.is_(None)),
-                    WorkbenchWorkspaceApproved.workspaceSourceId == snapshot_subquery.c.workspace_source_id,
                     WorkbenchWorkspaceApproved.creationTime > start_date
                 ).order_by(
                     desc(WorkbenchWorkspaceApproved.modifiedTime)

--- a/rdr_service/model/workbench_workspace.py
+++ b/rdr_service/model/workbench_workspace.py
@@ -104,7 +104,7 @@ class WorkbenchWorkspaceUser(Base):
     """The last modified time for this record."""
 
     workspaceId = Column("workspace_id", Integer, ForeignKey("workbench_workspace_approved.id"), nullable=False)
-    researcherId = Column("researcher_Id", Integer, ForeignKey("workbench_researcher.id"), nullable=False)
+    researcherId = Column("researcher_Id", Integer, ForeignKey("workbench_researcher.id"), nullable=False, quote=False)
     userId = Column("user_id", Integer, nullable=False)
     role = Column("role", Enum(WorkbenchWorkspaceUserRole), default=WorkbenchWorkspaceUserRole.UNSET)
     status = Column("status", Enum(WorkbenchWorkspaceStatus), default=WorkbenchWorkspaceStatus.UNSET)


### PR DESCRIPTION
## Resolves *NA*

## Description of changes/additions
Queries coming from the Workbench API are causing the RDR CPU utilization to spike and timeouts on Workbench. The `researchHub/projectDirectory` endpoint is called whenever the workbench main page is loaded. This calls the get_workspaces_with_user_detail() function which has a couple of queries that run. For each query, JOINs are not being performed with a specified column causing a large number of rows to be processed.

This PR updates the `researchHub/projectDirectory` query to JOIN on foreign keys which greatly improves the number of rows being processed.

Number of Rows Before the PR Updates:
* 25290 x 1 x 1 x 3883 x 15595 x 20442

Number of Rows After the PR Updates:
* 4068 x 1 x 1 x 1 x 15595 x 1

## Tests
- [] unit tests
- Tested in Sandbox

**New SQL Query**
```
SELECT workbench_workspace_approved.workspace_source_id, workbench_workspace_approved.creation_time, workbench_workspace_approved.modified_time, workbench_workspace_approved.exclude_from_public_directory, workbench_workspace_approved.review_requested, workbench_workspace_approved.disease_focused_research, workbench_workspace_approved.disease_focused_research_name, workbench_workspace_approved.other_purpose_details, workbench_workspace_approved.methods_development, workbench_workspace_approved.control_set, workbench_workspace_approved.social_behavioral, workbench_workspace_approved.population_health, workbench_workspace_approved.drug_development, workbench_workspace_approved.commercial_purpose, workbench_workspace_approved.other_purpose, workbench_workspace_approved.scientific_approaches, workbench_workspace_approved.intend_to_study, workbench_workspace_approved.findings_from_study, workbench_workspace_approved.ethical_legal_social_implications, workbench_workspace_approved.focus_on_underrepresented_populations, workbench_workspace_approved.race_ethnicity, workbench_workspace_approved.sex_at_birth, workbench_workspace_approved.gender_identity, workbench_workspace_approved.sexual_orientation, workbench_workspace_approved.disability_status, workbench_workspace_approved.access_to_care, workbench_workspace_approved.education_level, workbench_workspace_approved.income_level, workbench_workspace_approved.access_tier, workbench_workspace_approved.is_reviewed, workbench_workspace_approved.cdr_version, workbench_workspace_approved.name, workbench_workspace_approved.status, workbench_workspace_approved.ancestry, workbench_workspace_approved.educational, workbench_workspace_approved.age, workbench_workspace_approved.geography, workbench_workspace_approved.others, workbench_workspace_approved.resource, workbench_workspace_approved.id, workbench_workspace_approved.created, workbench_workspace_approved.modified, workbench_researcher.user_source_id, workbench_researcher.creation_time, workbench_researcher.modified_time, workbench_researcher.given_name, workbench_researcher.family_name, workbench_researcher.street_address1, workbench_researcher.street_address2, workbench_researcher.zip_code, workbench_researcher.sex_at_birth, workbench_researcher.identifies_as_lgbtq, workbench_researcher.lgbtq_identity, workbench_researcher.access_tier_short_names, workbench_researcher.dsv2_completion_time, workbench_researcher.dsv2_ethnic_categories, workbench_researcher.dsv2_ethnicity_aian_other, workbench_researcher.dsv2_ethnicity_asian_other, workbench_researcher.dsv2_ethnicity_black_other, workbench_researcher.dsv2_ethnicity_hispanic_other, workbench_researcher.dsv2_ethnicity_mena_other, workbench_researcher.dsv2_ethnicity_nhpi_other, workbench_researcher.dsv2_ethnicity_white_other, workbench_researcher.dsv2_ethnicity_other, workbench_researcher.dsv2_gender_identities, workbench_researcher.dsv2_gender_other, workbench_researcher.dsv2_sexual_orientations, workbench_researcher.dsv2_orientation_other, workbench_researcher.dsv2_sex_at_birth, workbench_researcher.dsv2_sex_at_birth_other, workbench_researcher.dsv2_year_of_birth, workbench_researcher.dsv2_year_of_birth_prefer_not, workbench_researcher.dsv2_disability_hearing, workbench_researcher.dsv2_disability_seeing, workbench_researcher.dsv2_disability_concentrating, workbench_researcher.dsv2_disability_walking, workbench_researcher.dsv2_disability_dressing, workbench_researcher.dsv2_disability_errands, workbench_researcher.dsv2_disability_other, workbench_researcher.dsv2_education, workbench_researcher.dsv2_disadvantaged, workbench_researcher.dsv2_survey_comments, workbench_researcher.email, workbench_researcher.city, workbench_researcher.state, workbench_researcher.country, workbench_researcher.ethnicity, workbench_researcher.gender, workbench_researcher.race, workbench_researcher.education, workbench_researcher.degree, workbench_researcher.disability, workbench_researcher.resource, workbench_researcher.id, workbench_researcher.created, workbench_researcher.modified, workbench_workspace_user.workspace_id, workbench_workspace_user.researcher_Id, workbench_workspace_user.user_id, workbench_workspace_user.is_creator, workbench_workspace_user.id, workbench_workspace_user.created, workbench_workspace_user.modified, workbench_workspace_user.role, workbench_workspace_user.status, anon_1.snapshot_id
FROM (SELECT max(workbench_workspace_snapshot.id) AS snapshot_id,
             workbench_workspace_snapshot.workspace_source_id AS workspace_source_id
      FROM workbench_workspace_snapshot
          JOIN workbench_workspace_approved ON workbench_workspace_approved.workspace_source_id = workbench_workspace_snapshot.workspace_source_id
      WHERE workbench_workspace_approved.exclude_from_public_directory = 0 OR workbench_workspace_approved.exclude_from_public_directory IS NULL
      GROUP BY workbench_workspace_snapshot.workspace_source_id) AS anon_1
    JOIN workbench_workspace_approved ON workbench_workspace_approved.workspace_source_id = anon_1.workspace_source_id
    JOIN workbench_workspace_user ON workbench_workspace_user.workspace_id = workbench_workspace_approved.id
    JOIN workbench_researcher ON workbench_researcher.id = workbench_workspace_user.researcher_Id
WHERE (workbench_workspace_approved.exclude_from_public_directory = 0 OR workbench_workspace_approved.exclude_from_public_directory IS NULL)
  AND workbench_workspace_approved.creation_time > '2020-05-27 00:00:00'
ORDER BY workbench_workspace_approved.modified_time DESC
;
```
