### PR TITLE
[DA-4594] Refactor Intake to PS Jobs

### DIFF
--- a/rdr_service/config/config_dev.json
+++ b/rdr_service/config/config_dev.json
@@ -259,8 +259,8 @@
     "1ur10",
     "1ur90"
   ],
-  "ppsc_datafeed_src_dataset": ["ppsc_staging_data"],
-  "ppsc_datafeed_dest_dataset": ["ppsc_staging_data"],
+  "ppsc_datafeed_src_dataset": ["rdr_operational_datastream"],
+  "ppsc_datafeed_dest_dataset": ["rdr_operational_datastream"],
   "enable_health_sharing_status_3": true,
   "enable_participant_mediated_ehr": true
 }

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -254,7 +254,7 @@ where TRUE
 def get_health_data_to_stream(project: str, destination_dataset: str) -> str:
     return f"""
     SELECT distinct participant_id, ignore_flag, event_date_time, health_data_stream_sharing_status
-    FROM `{project}.{destination_dataset}.datafeed_input_heathdata_sharing` s
+    FROM `{project}.{destination_dataset}.datafeed_input_healthdata_sharing` s
     where TRUE
       AND NOT EXISTS (
             SELECT 1

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -16,7 +16,7 @@ from rdr_service.workflow_management.ppsc import data_feed_queries
 from rdr_service.workflow_management.ppsc.ppsc_intake_to_ps_queries import get_consent_activity_to_stream, \
     get_profile_updates_activity_to_stream, get_withdrawal_activity_to_stream, get_deactivation_activity_to_stream, \
     get_participant_status_activity_to_stream, get_survey_completion_activity_to_stream, \
-    get_attribution_activity_to_stream
+    get_attribution_activity_to_stream, insert_intake_summary_records_sent
 from rdr_service.workflow_management.ppsc.ppsc_to_legacy_de_mappings import map_source_to_summary, \
     consent_data_elements, withdrawal_data_elements, profile_updates_data_elements, deactivation_data_elements, \
     participant_status_data_elements, survey_completion_data_elements, attribution_data_elements, \
@@ -119,10 +119,11 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
         self.bq_client = bigquery.Client()
 
     def make_datafeed_job(self, job_def):
-        return self.bq_client.query(job_def)
+        return self.bq_client.query(job_def).result()
 
     def get_datafeed_definition(self, datafeed) -> dict:
         src = config.getSettingJson(config.PPSC_DATAFEED_SRC_DATASET)[0]
+        sent_table_name = "intake_summary_datafeed_sent"
         if datafeed == "Consent":
             source_data_sql = get_consent_activity_to_stream(project=self.project, source_dataset=src)
             destination_model = ParticipantSummary
@@ -143,7 +144,18 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
             de_mapping = deactivation_data_elements
 
         elif datafeed == "Participant Status":
-            source_data_sql = get_participant_status_activity_to_stream(project=self.project, source_dataset=src)
+            temp_table_name = "temp_ranked_events_participant_status"
+            source_data_sql = get_participant_status_activity_to_stream(project=self.project,
+                                                                        source_dataset=src,
+                                                                        temp_table_name=temp_table_name,
+                                                                        sent_table_name=sent_table_name)
+            insert_sent_sql = insert_intake_summary_records_sent(
+                project=self.project,
+                source_dataset=src,
+                sent_table_name=sent_table_name,
+                temp_table_name=temp_table_name,
+                datafeed=datafeed
+            )
             destination_model = ParticipantSummary
             de_mapping = participant_status_data_elements
 
@@ -162,6 +174,9 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
 
         return {
             "source_data": source_data_sql,
+            "temp_table_name": temp_table_name,
+            "sent_table_name": sent_table_name,
+            "insert_sent_sql": insert_sent_sql,
             "destination_model": destination_model,
             "de_mapping": de_mapping
         }
@@ -173,8 +188,15 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
             logging.warning(f"Could not run {datafeed} of invalid config")
             return
 
+        # Create the temp table in BigQuery
+        logging.info(f"Creating temp table for {datafeed}")
+        self.make_datafeed_job(job_def['source_data'])
+        logging.info(f"Temp table created for {datafeed}")
+
         # Get Source Data
-        source_data = list(self.make_datafeed_job(job_def['source_data']))
+        # Step 2: Retrieve source data from the temp table
+        source_query = f"SELECT * FROM `{job_def['temp_table_name']}`"
+        source_data = list(self.make_datafeed_job(source_query))
 
         if source_data:
             logging.info(f"{datafeed} Source Data retrieved.")
@@ -213,6 +235,11 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
                 summary_session.commit()
                 participant_session.commit()
                 logging.info(f"{len(source_data)} {datafeed} records updated.")
+
+            # Step 3: Insert processed records into the datafeed_sent table
+            logging.info(f"Inserting processed records into {job_def['sent_table_name']}")
+            self.make_datafeed_job(job_def['insert_sent_sql'])
+            logging.info(f"Processed records inserted into {job_def['sent_table_name']}")
 
         else:
             logging.warning(f"No Staged Rows for {datafeed} Data Feed")

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -211,7 +211,7 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
         job_def = self.get_datafeed_definition(datafeed)
 
         if not job_def:
-            logging.warning(f"Could not run {datafeed} of invalid config")
+            logging.warning(f"Could not run {datafeed} because of invalid config")
             return
 
         # Create the temp table in BigQuery
@@ -220,7 +220,7 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
         logging.info(f"Temp table created for {datafeed}")
 
         # Get Source Data
-        # Step 2: Retrieve source data from the temp table
+        # Retrieve source data from the temp table
         source_query = f"SELECT * FROM `{job_def['temp_table_name']}`"
         source_data = list(self.make_datafeed_job(source_query))
 
@@ -262,7 +262,7 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
                 participant_session.commit()
                 logging.info(f"{len(source_data)} {datafeed} records updated.")
 
-            # Step 3: Insert processed records into the datafeed_sent table
+            # Insert processed records into the datafeed_sent table
             logging.info(f"Inserting processed records into {job_def['sent_table_name']}")
             self.make_datafeed_job(job_def['insert_sent_sql'])
             logging.info(f"Processed records inserted into {job_def['sent_table_name']}")

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -125,21 +125,37 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
         src = config.getSettingJson(config.PPSC_DATAFEED_SRC_DATASET)[0]
         sent_table_name = "intake_summary_datafeed_sent"
         if datafeed == "Consent":
-            source_data_sql = get_consent_activity_to_stream(project=self.project, source_dataset=src)
+            temp_table_name = "temp_ranked_events_consent"
+            source_data_sql = get_consent_activity_to_stream(project=self.project,
+                                                                        source_dataset=src,
+                                                                        temp_table_name=temp_table_name,
+                                                                        sent_table_name=sent_table_name)
             destination_model = ParticipantSummary
             de_mapping = consent_data_elements
 
         elif datafeed == "Profile Updates":
-            source_data_sql = get_profile_updates_activity_to_stream(project=self.project, source_dataset=src)
+            temp_table_name = "temp_ranked_events_profile_updates"
+            source_data_sql = get_profile_updates_activity_to_stream(project=self.project,
+                                                                        source_dataset=src,
+                                                                        temp_table_name=temp_table_name,
+                                                                        sent_table_name=sent_table_name)
             destination_model = ParticipantSummary
             de_mapping = profile_updates_data_elements
 
         elif datafeed == "Withdrawal":
-            source_data_sql = get_withdrawal_activity_to_stream(project=self.project, source_dataset=src)
+            temp_table_name = "temp_ranked_events_withdrawal"
+            source_data_sql = get_withdrawal_activity_to_stream(project=self.project,
+                                                                        source_dataset=src,
+                                                                        temp_table_name=temp_table_name,
+                                                                        sent_table_name=sent_table_name)
             destination_model = ParticipantSummary
             de_mapping = withdrawal_data_elements
         elif datafeed == "Deactivation":
-            source_data_sql = get_deactivation_activity_to_stream(project=self.project, source_dataset=src)
+            temp_table_name = "temp_ranked_events_deactivation"
+            source_data_sql = get_deactivation_activity_to_stream(project=self.project,
+                                                                        source_dataset=src,
+                                                                        temp_table_name=temp_table_name,
+                                                                        sent_table_name=sent_table_name)
             destination_model = ParticipantSummary
             de_mapping = deactivation_data_elements
 
@@ -149,28 +165,38 @@ class Intake2SummaryFeed(PPSCBigQueryDatafeedBase):
                                                                         source_dataset=src,
                                                                         temp_table_name=temp_table_name,
                                                                         sent_table_name=sent_table_name)
-            insert_sent_sql = insert_intake_summary_records_sent(
-                project=self.project,
-                source_dataset=src,
-                sent_table_name=sent_table_name,
-                temp_table_name=temp_table_name,
-                datafeed=datafeed
-            )
+
             destination_model = ParticipantSummary
             de_mapping = participant_status_data_elements
 
         elif datafeed == "Survey Completion":
-            source_data_sql = get_survey_completion_activity_to_stream(project=self.project, source_dataset=src)
+            temp_table_name = "temp_ranked_events_survey_completion"
+            source_data_sql = get_survey_completion_activity_to_stream(project=self.project,
+                                                                        source_dataset=src,
+                                                                        temp_table_name=temp_table_name,
+                                                                        sent_table_name=sent_table_name)
             destination_model = ParticipantSummary
             de_mapping = survey_completion_data_elements
 
         elif datafeed == "Attribution":
-            source_data_sql = get_attribution_activity_to_stream(project=self.project, source_dataset=src)
+            temp_table_name = "temp_ranked_events_attribution"
+            source_data_sql = get_attribution_activity_to_stream(project=self.project,
+                                                                        source_dataset=src,
+                                                                        temp_table_name=temp_table_name,
+                                                                        sent_table_name=sent_table_name)
             destination_model = ParticipantSummary
             de_mapping = attribution_data_elements
 
         else:
             return {}
+
+        insert_sent_sql = insert_intake_summary_records_sent(
+            project=self.project,
+            source_dataset=src,
+            sent_table_name=sent_table_name,
+            temp_table_name=temp_table_name,
+            datafeed=datafeed
+        )
 
         return {
             "source_data": source_data_sql,

--- a/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
@@ -170,30 +170,40 @@ GROUP BY participant_id
     """
 
 
-def get_participant_status_activity_to_stream(project: str, source_dataset: str) -> str:
+def get_participant_status_activity_to_stream(project: str,
+                                              source_dataset: str,
+                                              temp_table_name: str,
+                                              sent_table_name: str) -> str:
     return f"""
+CREATE OR REPLACE TABLE `{project}.{source_dataset}.{temp_table_name}` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `{project}.{source_dataset}.ppsc_participant_status_event` se
   WHERE TRUE
-  AND se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `{project}.{source_dataset}.rdr_participant_summary`
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `{project}.{source_dataset}.{sent_table_name}` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and se.event_type_name IN ('Test Account', 'Death', 'Retention Status', 'Enrollment Status')
   and data_element_name IN ("activity_status", '​activity_status', "retention_type", "participant", "participant", "participant_ehr_consent", "enrolled", "pmb_eligible", "core_minus_pm", "core_participant")
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
 
   -- Test Account
   MAX(CASE WHEN event_type_name = 'Test Account' AND data_element_name IN ("activity_status", '​activity_status') THEN data_element_value END) AS test_account,
@@ -217,7 +227,8 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Enrollment Status' AND data_element_name = 'core_participant' AND data_element_value = "yes" THEN event_authored_time END) AS core_participant_time
 
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 
@@ -302,6 +313,7 @@ FROM ranked_events
 GROUP BY participant_id
     """
 
+
 def get_attribution_activity_to_stream(project: str, source_dataset: str) -> str:
     return f"""
 WITH ranked_events AS (
@@ -332,3 +344,30 @@ SELECT
 FROM ranked_events
 GROUP BY participant_id
     """
+
+
+def insert_intake_summary_records_sent(project: str,
+                                       source_dataset: str,
+                                       sent_table_name: str,
+                                       temp_table_name: str,
+                                       datafeed: str) -> str:
+    return f"""
+            INSERT INTO `{project}.{source_dataset}.{sent_table_name}` (
+                participant_id,
+                event_id,
+                event_type_name,
+                datafeed_name,
+                created,
+                modified,
+                ignore_flag
+            )
+            SELECT
+                participant_id,
+                event_id,
+                event_type_name,
+                '{datafeed}' AS datafeed_name,
+                CURRENT_DATETIME() AS created,
+                CURRENT_DATETIME() AS modified,
+                FALSE AS ignore_flag
+            FROM `{project}.{source_dataset}.{temp_table_name}`
+            """

--- a/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
@@ -1,25 +1,36 @@
-def get_consent_activity_to_stream(project: str, source_dataset: str) -> str:
+def get_consent_activity_to_stream(project: str,
+                                              source_dataset: str,
+                                              temp_table_name: str,
+                                              sent_table_name: str) -> str:
     return f"""
+CREATE OR REPLACE TABLE `{project}.{source_dataset}.{temp_table_name}` AS
 WITH ranked_events AS (
   SELECT
-    ce.participant_id,
-    ce.event_type_name,
-    ce.event_authored_time,
-    ce.data_element_name,
-    ce.data_element_value,
+    se.participant_id,
+    se.event_id,
+    se.event_type_name,
+    se.event_authored_time,
+    se.data_element_name,
+    se.data_element_value,
     ROW_NUMBER() OVER (
-      PARTITION BY ce.participant_id, ce.event_type_name
-      ORDER BY ce.event_authored_time DESC
+      PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `{project}.{source_dataset}.ppsc_consent_event` ce
-  WHERE ce.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `{project}.{source_dataset}.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `{project}.{source_dataset}.{sent_table_name}` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("activity_status", '​activity_status')
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   MAX(CASE WHEN event_type_name = 'EHR Authorization' AND data_element_name = 'activity_status' AND rank = 1
            THEN data_element_value END) AS ehr_authorization,
   MAX(CASE WHEN event_type_name = 'EHR Authorization' AND rank = 1
@@ -29,32 +40,44 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND rank = 1
            THEN event_authored_time END) AS primary_consent_event_authored_time
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 
-def get_profile_updates_activity_to_stream(project: str, source_dataset: str) -> str:
+def get_profile_updates_activity_to_stream(project: str,
+                                              source_dataset: str,
+                                              temp_table_name: str,
+                                              sent_table_name: str) -> str:
     return f"""
+CREATE OR REPLACE TABLE `{project}.{source_dataset}.{temp_table_name}` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `{project}.{source_dataset}.ppsc_profile_updates_event` se
-  WHERE se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `{project}.{source_dataset}.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `{project}.{source_dataset}.{sent_table_name}` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("piiname_first","piiname_middle","piiname_last","streetaddress_piizip","streetaddress_piistate","streetaddress_piicity","piiaddress_streetaddress","piiaddress_streetaddress2","piicontactinformation_phone","piicontactinformation_email","language_preference","piibirthinformation_birthdate")
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   -- First Name
   MAX(CASE WHEN event_type_name = 'Profile Data' AND data_element_name = 'piiname_first' AND rank = 1
            THEN data_element_value END) AS first_name,
@@ -92,32 +115,44 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Profile Data' AND data_element_name = 'piibirthinformation_birthdate' AND rank = 1
            THEN data_element_value END) AS birthdate
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 
-def get_withdrawal_activity_to_stream(project: str, source_dataset: str) -> str:
+def get_withdrawal_activity_to_stream(project: str,
+                                              source_dataset: str,
+                                              temp_table_name: str,
+                                              sent_table_name: str) -> str:
     return f"""
+CREATE OR REPLACE TABLE `{project}.{source_dataset}.{temp_table_name}` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `{project}.{source_dataset}.ppsc_withdrawal_event` se
-  WHERE se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `{project}.{source_dataset}.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `{project}.{source_dataset}.{sent_table_name}` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("activity_status", '​activity_status', 'withdrawal_reason')
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   MAX(CASE WHEN event_type_name = 'Withdrawal'
       AND data_element_name IN ("activity_status", '​activity_status')
       AND rank = 1
@@ -131,27 +166,37 @@ SELECT
       AND rank = 1
     THEN data_element_value END) AS withdrawal_reason
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 
-def get_deactivation_activity_to_stream(project: str, source_dataset: str) -> str:
+def get_deactivation_activity_to_stream(project: str,
+                                              source_dataset: str,
+                                              temp_table_name: str,
+                                              sent_table_name: str) -> str:
     return f"""
-    WITH ranked_events AS (
+CREATE OR REPLACE TABLE `{project}.{source_dataset}.{temp_table_name}` AS
+WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `{project}.{source_dataset}.ppsc_deactivation_event` se
-  WHERE se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `{project}.{source_dataset}.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `{project}.{source_dataset}.{sent_table_name}` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("activity_status", '​activity_status')
 )
@@ -166,7 +211,8 @@ SELECT
       AND rank = 1
     THEN event_authored_time END) AS deactivation_status_time
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 
@@ -232,24 +278,32 @@ GROUP BY participant_id, event_id, event_type_name
     """
 
 
-def get_survey_completion_activity_to_stream(project: str, source_dataset: str) -> str:
+def get_survey_completion_activity_to_stream(project: str,
+                                              source_dataset: str,
+                                              temp_table_name: str,
+                                              sent_table_name: str) -> str:
     return f"""
+CREATE OR REPLACE TABLE `{project}.{source_dataset}.{temp_table_name}` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `{project}.{source_dataset}.ppsc_survey_completion_event` se
   WHERE TRUE
-  AND se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `{project}.{source_dataset}.rdr_participant_summary`
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `{project}.{source_dataset}.{sent_table_name}` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and se.event_type_name IN ("Basics Data", "Basics Data", "Overall Health", "Lifestyle", "The Basics", "Health Care Access", "Social Determinants of Health", "Personal and Family Health History", "Life Functioning Survey", "Emotional Health History and Well Being", "Behavioral Health and Personality", "Pediatric Environmental Health")
   and data_element_name IN ("activity_status", '​activity_status', "gender_genderidentity","biologicalsexatbirth_sexatbirth","thebasics_sexualorientation","race_whatraceethnicity","educationlevel_highestgrade","income_annualincome")
@@ -310,28 +364,37 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Pediatric Environmental Health' AND data_element_name IN ("activity_status", '​activity_status') THEN data_element_value END) AS questionnaire_on_environmental_exposures_authored
 
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 
-def get_attribution_activity_to_stream(project: str, source_dataset: str) -> str:
+def get_attribution_activity_to_stream(project: str,
+                                              source_dataset: str,
+                                              temp_table_name: str,
+                                              sent_table_name: str) -> str:
     return f"""
+CREATE OR REPLACE TABLE `{project}.{source_dataset}.{temp_table_name}` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `{project}.{source_dataset}.ppsc_attribution_event` se
   WHERE TRUE
-  AND se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `{project}.{source_dataset}.rdr_participant_summary`
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `{project}.{source_dataset}.{sent_table_name}` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and se.event_type_name IN ('Org Attribution')
   and data_element_name IN ("activity_status", '​activity_status')
@@ -342,7 +405,8 @@ SELECT
     AND data_element_name IN ("activity_status", '​activity_status') AND rank = 1
            THEN data_element_value END) AS organization
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 

--- a/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
@@ -16,7 +16,7 @@ WITH ranked_events AS (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
       ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
-  FROM `{project}.{source_dataset}.ppsc_consent_event` ce
+  FROM `{project}.{source_dataset}.ppsc_consent_event` se
   WHERE TRUE
   AND NOT EXISTS (
     SELECT 1

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -2,11 +2,11 @@ core_data_expected_sql = """
 WITH earliest_ehr AS (
     SELECT participant_id,
            MIN(event_date_time) AS event_date_time
-    FROM `test.ppsc_staging_data.datafeed_input_ehr`
+    FROM `test.rdr_operational_datastream.datafeed_input_ehr`
     GROUP BY participant_id
 )
 
-INSERT INTO `test.ppsc_staging_data.datafeed_input_core_data` (
+INSERT INTO `test.rdr_operational_datastream.datafeed_input_core_data` (
     participant_id,
     has_core_data,
     ignore_flag,
@@ -28,12 +28,12 @@ SELECT DISTINCT
     ) AS event_date_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
-FROM `test.ppsc_staging_data.ppsc_participant` p
-JOIN `test.ppsc_staging_data.ppsc_consent_event` c
+FROM `test.rdr_operational_datastream.ppsc_participant` p
+JOIN `test.rdr_operational_datastream.ppsc_consent_event` c
     ON c.participant_id = p.id
 
 -- EHR Consent
-JOIN `test.ppsc_staging_data.ppsc_consent_event` ehrc
+JOIN `test.rdr_operational_datastream.ppsc_consent_event` ehrc
     ON c.participant_id = ehrc.participant_id
     AND c.data_element_value = "submitted_yes"
     AND c.event_type_name = "EHR Authorization"
@@ -43,34 +43,34 @@ JOIN earliest_ehr
     ON c.participant_id = earliest_ehr.participant_id
 
 -- Basics Completion
-JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` basics
+JOIN `test.rdr_operational_datastream.ppsc_survey_completion_event` basics
     ON basics.participant_id = c.participant_id
     AND basics.event_type_name = "The Basics"
     AND basics.data_element_value = "submitted_yes"
 
 -- Overall Health Completion
-JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` overall
+JOIN `test.rdr_operational_datastream.ppsc_survey_completion_event` overall
     ON overall.participant_id = c.participant_id
     AND overall.event_type_name = "Overall Health"
     AND overall.data_element_value = "submitted_yes"
 
 -- Lifestyle Completion
-JOIN `test.ppsc_staging_data.ppsc_survey_completion_event` lifestyle
+JOIN `test.rdr_operational_datastream.ppsc_survey_completion_event` lifestyle
     ON lifestyle.participant_id = c.participant_id
     AND lifestyle.event_type_name = "Lifestyle"
     AND lifestyle.data_element_value = "submitted_yes"
 
 -- Physical Measurements
-JOIN `test.ppsc_staging_data.rdr_physical_measurements` pm
+JOIN `test.rdr_operational_datastream.rdr_physical_measurements` pm
     ON pm.participant_id = c.participant_id
 
 -- Height Measurement
-JOIN `test.ppsc_staging_data.rdr_measurement` height
+JOIN `test.rdr_operational_datastream.rdr_measurement` height
     ON height.physical_measurements_id = pm.physical_measurements_id
     AND height.code_value = "height"
 
 -- Weight Measurement
-JOIN `test.ppsc_staging_data.rdr_measurement` weight
+JOIN `test.rdr_operational_datastream.rdr_measurement` weight
     ON weight.physical_measurements_id = pm.physical_measurements_id
     AND weight.code_value = "weight"
 
@@ -81,24 +81,24 @@ WHERE
     -- Insert only if participant_id doesn't exist in the target table
     AND NOT EXISTS (
         SELECT 1
-        FROM `test.ppsc_staging_data.datafeed_input_core_data` t
+        FROM `test.rdr_operational_datastream.datafeed_input_core_data` t
         WHERE t.participant_id = c.participant_id
     );"""
 
 core_data_expected_streaming_sql = """
     SELECT distinct participant_id, ignore_flag, event_date_time, has_core_data
-    FROM `test.ppsc_staging_data.datafeed_input_core_data` s
+    FROM `test.rdr_operational_datastream.datafeed_input_core_data` s
     where TRUE
       AND NOT EXISTS (
             SELECT 1
-            FROM `test.ppsc_staging_data.ppsc_ppsc_core` t
+            FROM `test.rdr_operational_datastream.ppsc_ppsc_core` t
             WHERE t.participant_id = s.participant_id
                 AND t.event_date_time = s.event_date_time
         )
     ;"""
 
 biospecimen_expected_sql = """
-INSERT INTO `test.ppsc_staging_data.datafeed_input_biospecimen` (
+INSERT INTO `test.rdr_operational_datastream.datafeed_input_biospecimen` (
     participant_id,
     ignore_flag,
     event_date_time,
@@ -120,13 +120,13 @@ SELECT DISTINCT
         ELSE null
     END AS specimen_type,
     1 as specimen_status
-FROM `test.ppsc_staging_data.ppsc_participant` p
+FROM `test.rdr_operational_datastream.ppsc_participant` p
   JOIN `test.rdr_operational_datastream.rdr_biobank_stored_sample` ss ON ss.biobank_id = p.biobank_id
 WHERE TRUE
   AND ss.test IN ('1ed04', '1ed10', '1ed02', '2ed02', '2ed04', '1sal2', '1sal', '2sal0', '3sal1', '1ur10', '1ur90')
   AND NOT EXISTS (
         SELECT 1
-        FROM `test.ppsc_staging_data.datafeed_input_biospecimen` t
+        FROM `test.rdr_operational_datastream.datafeed_input_biospecimen` t
         WHERE t.participant_id = p.id
     )
 ;
@@ -134,18 +134,18 @@ WHERE TRUE
 
 biospecimen_expected_streaming_sql = """
     SELECT distinct participant_id, ignore_flag, event_date_time, specimen_type, specimen_status
-    FROM `test.ppsc_staging_data.datafeed_input_biospecimen` s
+    FROM `test.rdr_operational_datastream.datafeed_input_biospecimen` s
     where TRUE
       AND NOT EXISTS (
             SELECT 1
-            FROM `test.ppsc_staging_data.ppsc_ppsc_biobank_sample` t
+            FROM `test.rdr_operational_datastream.ppsc_ppsc_biobank_sample` t
             WHERE t.participant_id = s.participant_id
                 AND t.event_date_time = s.event_date_time
         )
     ;"""
 
 ehr_expected_sql = """
-INSERT INTO `test.ppsc_staging_data.datafeed_input_ehr` (
+INSERT INTO `test.rdr_operational_datastream.datafeed_input_ehr` (
     participant_id,
     ignore_flag,
     event_date_time,
@@ -158,14 +158,14 @@ SELECT DISTINCT
     participant_ehr.latest_upload_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
-FROM `test.ppsc_staging_data.ppsc_participant` p
+FROM `test.rdr_operational_datastream.ppsc_participant` p
     -- EHR Ops table
     JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
         ON p.participant_id = participant_ehr.person_id
 WHERE TRUE
   AND NOT EXISTS (
         SELECT 1
-        FROM `test.ppsc_staging_data.datafeed_input_ehr` t
+        FROM `test.rdr_operational_datastream.datafeed_input_ehr` t
         WHERE t.participant_id = p.id
             AND t.event_date_time = participant_ehr.latest_upload_time
     )
@@ -174,18 +174,18 @@ WHERE TRUE
 
 ehr_expected_streaming_sql = """
 SELECT distinct participant_id, ignore_flag, event_date_time
-FROM `test.ppsc_staging_data.datafeed_input_ehr` s
+FROM `test.rdr_operational_datastream.datafeed_input_ehr` s
 where TRUE
   AND NOT EXISTS (
         SELECT 1
-        FROM `test.ppsc_staging_data.ppsc_ppsc_ehr` t
+        FROM `test.rdr_operational_datastream.ppsc_ppsc_ehr` t
         WHERE t.participant_id = s.participant_id
             AND t.event_date_time = s.event_date_time
     )
 ;"""
 
 health_data_sharing_expected_sql = """
-INSERT INTO `test.ppsc_staging_data.datafeed_input_healthdata_sharing` (
+INSERT INTO `test.rdr_operational_datastream.datafeed_input_healthdata_sharing` (
     participant_id,
     ignore_flag,
     health_data_stream_sharing_status,
@@ -203,9 +203,9 @@ SELECT DISTINCT
     iehr.event_date_time,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
-FROM `test.ppsc_staging_data.ppsc_participant` p
+FROM `test.rdr_operational_datastream.ppsc_participant` p
     -- PPSC Notified of EHR Received
-    JOIN `test.ppsc_staging_data.datafeed_input_ehr` iehr
+    JOIN `test.rdr_operational_datastream.datafeed_input_ehr` iehr
         ON iehr.participant_id = p.participant_id
     -- Participant in EHR Ops table
     LEFT JOIN `test-ehr-project.participant_ehr.ehr_upload_pids` participant_ehr
@@ -214,7 +214,7 @@ WHERE TRUE
     -- Don't send if participant is already in the destination table with the same event time.
     AND NOT EXISTS (
         SELECT 1
-        FROM `test.ppsc_staging_data.datafeed_input_healthdata_sharing` t
+        FROM `test.rdr_operational_datastream.datafeed_input_healthdata_sharing` t
         WHERE t.participant_id = p.id
             AND t.event_date_time = iehr.event_date_time
     )
@@ -223,11 +223,11 @@ WHERE TRUE
 
 health_data_expected_streaming_sql = """
     SELECT distinct participant_id, ignore_flag, event_date_time, health_data_stream_sharing_status
-    FROM `test.ppsc_staging_data.datafeed_input_heathdata_sharing` s
+    FROM `test.rdr_operational_datastream.datafeed_input_healthdata_sharing` s
     where TRUE
       AND NOT EXISTS (
             SELECT 1
-            FROM `test.ppsc_staging_data.ppsc_ppsc_health_data` t
+            FROM `test.rdr_operational_datastream.ppsc_ppsc_health_data` t
             WHERE t.participant_id = s.participant_id
                 AND t.event_date_time = s.event_date_time
         )
@@ -247,10 +247,10 @@ WITH ranked_events AS (
       PARTITION BY ce.participant_id, ce.event_type_name
       ORDER BY ce.event_authored_time DESC
     ) AS rank
-  FROM `test.ppsc_staging_data.ppsc_consent_event` ce
+  FROM `test.rdr_operational_datastream.ppsc_consent_event` ce
   WHERE ce.event_authored_time > (
     SELECT MAX(last_modified)
-    FROM `test.ppsc_staging_data.rdr_participant_summary`
+    FROM `test.rdr_operational_datastream.rdr_participant_summary`
   )
   and data_element_name IN ("activity_status", '​activity_status')
 )
@@ -280,10 +280,10 @@ WITH ranked_events AS (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
       ORDER BY se.event_authored_time DESC
     ) AS rank
-  FROM `test.ppsc_staging_data.ppsc_profile_updates_event` se
+  FROM `test.rdr_operational_datastream.ppsc_profile_updates_event` se
   WHERE se.event_authored_time > (
     SELECT MAX(last_modified)
-    FROM `test.ppsc_staging_data.rdr_participant_summary`
+    FROM `test.rdr_operational_datastream.rdr_participant_summary`
   )
   and data_element_name IN ("piiname_first","piiname_middle","piiname_last","streetaddress_piizip","streetaddress_piistate","streetaddress_piicity","piiaddress_streetaddress","piiaddress_streetaddress2","piicontactinformation_phone","piicontactinformation_email","language_preference","piibirthinformation_birthdate")
 )
@@ -341,10 +341,10 @@ WITH ranked_events AS (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
       ORDER BY se.event_authored_time DESC
     ) AS rank
-  FROM `test.ppsc_staging_data.ppsc_withdrawal_event` se
+  FROM `test.rdr_operational_datastream.ppsc_withdrawal_event` se
   WHERE se.event_authored_time > (
     SELECT MAX(last_modified)
-    FROM `test.ppsc_staging_data.rdr_participant_summary`
+    FROM `test.rdr_operational_datastream.rdr_participant_summary`
   )
   and data_element_name IN ("activity_status", '​activity_status', 'withdrawal_reason')
 )
@@ -378,10 +378,10 @@ WITH ranked_events AS (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
       ORDER BY se.event_authored_time DESC
     ) AS rank
-  FROM `test.ppsc_staging_data.ppsc_deactivation_event` se
+  FROM `test.rdr_operational_datastream.ppsc_deactivation_event` se
   WHERE se.event_authored_time > (
     SELECT MAX(last_modified)
-    FROM `test.ppsc_staging_data.rdr_participant_summary`
+    FROM `test.rdr_operational_datastream.rdr_participant_summary`
   )
   and data_element_name IN ("activity_status", '​activity_status')
 )
@@ -400,28 +400,35 @@ GROUP BY participant_id
 """
 
 participant_status_activity_expected_sql = f"""
+CREATE OR REPLACE TABLE `test.rdr_operational_datastream.temp_ranked_events_participant_status` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
-  FROM `test.ppsc_staging_data.ppsc_participant_status_event` se
+  FROM `test.rdr_operational_datastream.ppsc_participant_status_event` se
   WHERE TRUE
-  AND se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `test.ppsc_staging_data.rdr_participant_summary`
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `test.rdr_operational_datastream.intake_summary_datafeed_sent` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and se.event_type_name IN ('Test Account', 'Death', 'Retention Status', 'Enrollment Status')
   and data_element_name IN ("activity_status", '​activity_status', "retention_type", "participant", "participant", "participant_ehr_consent", "enrolled", "pmb_eligible", "core_minus_pm", "core_participant")
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
 
   -- Test Account
   MAX(CASE WHEN event_type_name = 'Test Account' AND data_element_name IN ("activity_status", '​activity_status') THEN data_element_value END) AS test_account,
@@ -445,7 +452,8 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Enrollment Status' AND data_element_name = 'core_participant' AND data_element_value = "yes" THEN event_authored_time END) AS core_participant_time
 
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 survey_completion_activity_expected_sql = f"""
@@ -460,11 +468,11 @@ WITH ranked_events AS (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
       ORDER BY se.event_authored_time DESC
     ) AS rank
-  FROM `test.ppsc_staging_data.ppsc_survey_completion_event` se
+  FROM `test.rdr_operational_datastream.ppsc_survey_completion_event` se
   WHERE TRUE
   AND se.event_authored_time > (
     SELECT MAX(last_modified)
-    FROM `test.ppsc_staging_data.rdr_participant_summary`
+    FROM `test.rdr_operational_datastream.rdr_participant_summary`
   )
   and se.event_type_name IN ("Basics Data", "Basics Data", "Overall Health", "Lifestyle", "The Basics", "Health Care Access", "Social Determinants of Health", "Personal and Family Health History", "Life Functioning Survey", "Emotional Health History and Well Being", "Behavioral Health and Personality", "Pediatric Environmental Health")
   and data_element_name IN ("activity_status", '​activity_status', "gender_genderidentity","biologicalsexatbirth_sexatbirth","thebasics_sexualorientation","race_whatraceethnicity","educationlevel_highestgrade","income_annualincome")
@@ -537,11 +545,11 @@ WITH ranked_events AS (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
       ORDER BY se.event_authored_time DESC
     ) AS rank
-  FROM `test.ppsc_staging_data.ppsc_attribution_event` se
+  FROM `test.rdr_operational_datastream.ppsc_attribution_event` se
   WHERE TRUE
   AND se.event_authored_time > (
     SELECT MAX(last_modified)
-    FROM `test.ppsc_staging_data.rdr_participant_summary`
+    FROM `test.rdr_operational_datastream.rdr_participant_summary`
   )
   and se.event_type_name IN ('Org Attribution')
   and data_element_name IN ("activity_status", '​activity_status')
@@ -554,3 +562,24 @@ SELECT
 FROM ranked_events
 GROUP BY participant_id
     """
+
+insert_sent_records_expected_sql = """
+INSERT INTO `test.rdr_operational_datastream.intake_summary_datafeed_sent` (
+                participant_id,
+                event_id,
+                event_type_name,
+                datafeed_name,
+                created,
+                modified,
+                ignore_flag
+            )
+            SELECT
+                participant_id,
+                event_id,
+                event_type_name,
+                '{%datafeed%}' AS datafeed_name,
+                CURRENT_DATETIME() AS created,
+                CURRENT_DATETIME() AS modified,
+                FALSE AS ignore_flag
+            FROM `test.rdr_operational_datastream.{%temp_table_name%}`
+"""

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -236,26 +236,34 @@ health_data_expected_streaming_sql = """
 # Intake-2-PPSC Test queries
 
 consent_activity_expected_sql = f"""
+CREATE OR REPLACE TABLE `test.rdr_operational_datastream.temp_ranked_events_participant_status` AS
 WITH ranked_events AS (
   SELECT
-    ce.participant_id,
-    ce.event_type_name,
-    ce.event_authored_time,
-    ce.data_element_name,
-    ce.data_element_value,
+    se.participant_id,
+    se.event_id,
+    se.event_type_name,
+    se.event_authored_time,
+    se.data_element_name,
+    se.data_element_value,
     ROW_NUMBER() OVER (
-      PARTITION BY ce.participant_id, ce.event_type_name
-      ORDER BY ce.event_authored_time DESC
+      PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `test.rdr_operational_datastream.ppsc_consent_event` ce
-  WHERE ce.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `test.rdr_operational_datastream.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `test.rdr_operational_datastream.intake_summary_datafeed_sent` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("activity_status", '​activity_status')
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   MAX(CASE WHEN event_type_name = 'EHR Authorization' AND data_element_name = 'activity_status' AND rank = 1
            THEN data_element_value END) AS ehr_authorization,
   MAX(CASE WHEN event_type_name = 'EHR Authorization' AND rank = 1
@@ -265,30 +273,39 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND rank = 1
            THEN event_authored_time END) AS primary_consent_event_authored_time
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 profile_updates_activity_expected_sql = f"""
+CREATE OR REPLACE TABLE `test.rdr_operational_datastream.temp_ranked_events_participant_status` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `test.rdr_operational_datastream.ppsc_profile_updates_event` se
-  WHERE se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `test.rdr_operational_datastream.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `test.rdr_operational_datastream.intake_summary_datafeed_sent` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("piiname_first","piiname_middle","piiname_last","streetaddress_piizip","streetaddress_piistate","streetaddress_piicity","piiaddress_streetaddress","piiaddress_streetaddress2","piicontactinformation_phone","piicontactinformation_email","language_preference","piibirthinformation_birthdate")
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   -- First Name
   MAX(CASE WHEN event_type_name = 'Profile Data' AND data_element_name = 'piiname_first' AND rank = 1
            THEN data_element_value END) AS first_name,
@@ -326,30 +343,39 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Profile Data' AND data_element_name = 'piibirthinformation_birthdate' AND rank = 1
            THEN data_element_value END) AS birthdate
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 withdrawal_activity_expected_sql = f"""
+CREATE OR REPLACE TABLE `test.rdr_operational_datastream.temp_ranked_events_participant_status` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `test.rdr_operational_datastream.ppsc_withdrawal_event` se
-  WHERE se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `test.rdr_operational_datastream.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `test.rdr_operational_datastream.intake_summary_datafeed_sent` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("activity_status", '​activity_status', 'withdrawal_reason')
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   MAX(CASE WHEN event_type_name = 'Withdrawal'
       AND data_element_name IN ("activity_status", '​activity_status')
       AND rank = 1
@@ -363,30 +389,39 @@ SELECT
       AND rank = 1
     THEN data_element_value END) AS withdrawal_reason
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 deactivation_activity_expected_sql = f"""
+CREATE OR REPLACE TABLE `test.rdr_operational_datastream.temp_ranked_events_participant_status` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `test.rdr_operational_datastream.ppsc_deactivation_event` se
-  WHERE se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `test.rdr_operational_datastream.rdr_participant_summary`
+  WHERE TRUE
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `test.rdr_operational_datastream.intake_summary_datafeed_sent` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and data_element_name IN ("activity_status", '​activity_status')
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   MAX(CASE WHEN event_type_name = 'Deactivation'
       AND data_element_name IN ("activity_status", '​activity_status')
       AND rank = 1
@@ -396,7 +431,8 @@ SELECT
       AND rank = 1
     THEN event_authored_time END) AS deactivation_status_time
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
 """
 
 participant_status_activity_expected_sql = f"""
@@ -457,28 +493,35 @@ GROUP BY participant_id, event_id, event_type_name
     """
 
 survey_completion_activity_expected_sql = f"""
+CREATE OR REPLACE TABLE `test.rdr_operational_datastream.temp_ranked_events_participant_status` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `test.rdr_operational_datastream.ppsc_survey_completion_event` se
   WHERE TRUE
-  AND se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `test.rdr_operational_datastream.rdr_participant_summary`
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `test.rdr_operational_datastream.intake_summary_datafeed_sent` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and se.event_type_name IN ("Basics Data", "Basics Data", "Overall Health", "Lifestyle", "The Basics", "Health Care Access", "Social Determinants of Health", "Personal and Family Health History", "Life Functioning Survey", "Emotional Health History and Well Being", "Behavioral Health and Personality", "Pediatric Environmental Health")
   and data_element_name IN ("activity_status", '​activity_status', "gender_genderidentity","biologicalsexatbirth_sexatbirth","thebasics_sexualorientation","race_whatraceethnicity","educationlevel_highestgrade","income_annualincome")
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
 
   -- Basics Data
   MAX(CASE WHEN event_type_name = 'Basics Data' AND data_element_name = 'gender_genderidentity' THEN data_element_value END) AS gender_identity,
@@ -530,37 +573,46 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Pediatric Environmental Health' AND data_element_name IN ("activity_status", '​activity_status') THEN data_element_value END) AS questionnaire_on_environmental_exposures_authored
 
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 attribution_activity_expected_sql = f"""
+CREATE OR REPLACE TABLE `test.rdr_operational_datastream.temp_ranked_events_participant_status` AS
 WITH ranked_events AS (
   SELECT
     se.participant_id,
+    se.event_id,
     se.event_type_name,
     se.event_authored_time,
     se.data_element_name,
     se.data_element_value,
     ROW_NUMBER() OVER (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
-      ORDER BY se.event_authored_time DESC
+      ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
   FROM `test.rdr_operational_datastream.ppsc_attribution_event` se
   WHERE TRUE
-  AND se.event_authored_time > (
-    SELECT MAX(last_modified)
-    FROM `test.rdr_operational_datastream.rdr_participant_summary`
+  AND NOT EXISTS (
+    SELECT 1
+      FROM `test.rdr_operational_datastream.intake_summary_datafeed_sent` sent
+      WHERE sent.participant_id = se.participant_id
+        AND sent.event_id >= se.event_id
+        AND sent.event_type_name = se.event_type_name
   )
   and se.event_type_name IN ('Org Attribution')
   and data_element_name IN ("activity_status", '​activity_status')
 )
 SELECT
   participant_id,
+  event_id,
+  event_type_name,
   MAX(CASE WHEN event_type_name = 'Org Attribution'
     AND data_element_name IN ("activity_status", '​activity_status') AND rank = 1
            THEN data_element_value END) AS organization
 FROM ranked_events
-GROUP BY participant_id
+WHERE rank = 1
+GROUP BY participant_id, event_id, event_type_name
     """
 
 insert_sent_records_expected_sql = """

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -249,7 +249,7 @@ WITH ranked_events AS (
       PARTITION BY se.participant_id, se.event_type_name, se.data_element_name
       ORDER BY se.event_authored_time DESC, se.event_id DESC
     ) AS rank
-  FROM `test.rdr_operational_datastream.ppsc_consent_event` ce
+  FROM `test.rdr_operational_datastream.ppsc_consent_event` se
   WHERE TRUE
   AND NOT EXISTS (
     SELECT 1

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -1,3 +1,4 @@
+# pylint: disable=unused-import
 import datetime
 from unittest import mock
 
@@ -204,6 +205,42 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
                 codeId=code
             )
 
+    def setup_mock_make_datafeed_job(self, mock_make_datafeed_job, activity_rows):
+
+        def mock_job_execution(sql_query):
+            if "CREATE OR REPLACE TABLE" in sql_query:
+                self.source_data_executed_sql = sql_query.strip()
+                return None  # Simulate the temp table creation
+            elif "SELECT * FROM" in sql_query:
+                return iter(activity_rows)  # Simulate the source data retrieval
+            elif "INSERT INTO" in sql_query:
+                self.insert_executed_sql = sql_query.strip()
+                return None  # Simulate the insert records sent operation
+
+        mock_make_datafeed_job.side_effect = mock_job_execution
+
+
+    def setup_expected_insert(self, datafeed):
+        expected_insert_sql = insert_sent_records_expected_sql.replace("{%datafeed%}", datafeed)
+        return expected_insert_sql.replace("{%temp_table_name%}",
+                                                          f"temp_ranked_events_{datafeed.lower().replace(' ', '_')}")
+
+    def setup_datafeed_definition(self, datafeed_name, mock_get_datafeed_definition):
+        converted_df_name = datafeed_name.lower().replace(' ', '_')
+
+        # Generate the expected insert SQL dynamically
+        expected_insert_sql = self.setup_expected_insert(datafeed=datafeed_name)
+
+        # Set the mocked return value for get_datafeed_definition
+        mock_get_datafeed_definition.return_value = {
+            "source_data": eval(f"{converted_df_name}_activity_expected_sql"),
+            "temp_table_name": f"temp_ranked_events_{converted_df_name}",
+            "sent_table_name": "intake_summary_datafeed_sent",
+            "insert_sent_sql": expected_insert_sql,
+            "destination_model": ParticipantSummary,
+            "de_mapping": eval(f"{converted_df_name}_data_elements")
+        }
+
     def test_map_source_to_summary(self):
         record = {
             "participant_id": "348568008",
@@ -226,7 +263,9 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(
         "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.make_datafeed_job")
-    def test_consent_activity(self, mock_make_datafeed_job, mock_bq_client):
+    @mock.patch(
+        "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.get_datafeed_definition")
+    def test_consent_activity(self, mock_get_datafeed_definition, mock_make_datafeed_job, mock_bq_client):
         # Create requisite participant data
         ppsc_participant = self.ppsc_data_gen.create_database_participant(id=110110110)
         rdr_participant = self.data_generator.create_database_participant(participantId=ppsc_participant.id)
@@ -247,19 +286,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        mock_make_datafeed_job.side_effect = lambda query: (
-            iter(activity_rows) if query.strip() == consent_activity_expected_sql.strip() else None
-        )
+        self.setup_mock_make_datafeed_job(mock_make_datafeed_job, activity_rows)
 
-        # Test Feed
+        datafeed_name = "Consent"
+
+        # Set up the mock for get_datafeed_definition
+        self.setup_datafeed_definition(datafeed_name, mock_get_datafeed_definition)
+
+        # Run the datafeed
         feed = Intake2SummaryFeed()
-        feed.get_datafeed_definition = mock.Mock(return_value={
-            "source_data": consent_activity_expected_sql,
-            "destination_model": ParticipantSummary,
-            "de_mapping": consent_data_elements
-        })
 
-        feed.run_datafeed("Consent")
+        feed.run_datafeed(datafeed_name)
 
         ps_dao = ParticipantSummaryDao()
         actual_rows = ps_dao.get_all()
@@ -271,10 +308,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         self.assertEqual(actual_rows[0].consentForElectronicHealthRecordsAuthored,
                          datetime.datetime(2024, 11, 20, 15, 30))
 
+        # Verify the "insert records sent" query was called
+        calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
+        self.assertTrue(any(self.setup_expected_insert(datafeed=datafeed_name) in sql for sql in calls),
+                        "The 'insert records sent' query was not called.")
+
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(
         "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.make_datafeed_job")
-    def test_profile_updates_activity(self, mock_make_datafeed_job, mock_bq_client):
+    @mock.patch(
+        "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.get_datafeed_definition")
+    def test_profile_updates_activity(self, mock_get_datafeed_definition, mock_make_datafeed_job, mock_bq_client):
         # States
         required_codes = [631,632,633,634,635,636,637,638,639,640,641,642,643,644,645,646,647,648,649,650,651,652,653,
                           654,655,656,657,658,659,660,661,662,663,664,665,666,667,668,669,670,671,672,673,674,675,676,
@@ -322,19 +366,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        mock_make_datafeed_job.side_effect = lambda query: (
-            iter(activity_rows) if query.strip() == profile_updates_activity_expected_sql.strip() else None
-        )
+        self.setup_mock_make_datafeed_job(mock_make_datafeed_job, activity_rows)
 
-        # Test Feed
+        datafeed_name = "Profile Updates"
+
+        # Set up the mock for get_datafeed_definition
+        self.setup_datafeed_definition(datafeed_name, mock_get_datafeed_definition)
+
+        # Run the datafeed
         feed = Intake2SummaryFeed()
-        feed.get_datafeed_definition = mock.Mock(return_value={
-            "source_data": profile_updates_activity_expected_sql,
-            "destination_model": ParticipantSummary,
-            "de_mapping": profile_updates_data_elements
-        })
 
-        feed.run_datafeed("Profile Updates")
+        feed.run_datafeed(datafeed_name)
 
         # Verify the database records
         ps_dao = ParticipantSummaryDao()
@@ -355,10 +397,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         self.assertEqual(actual_rows[0].primaryLanguage, "English")
         self.assertEqual(actual_rows[0].dateOfBirth, datetime.date(1985, 6, 26))
 
+        # Verify the "insert records sent" query was called
+        calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
+        self.assertTrue(any(self.setup_expected_insert(datafeed=datafeed_name) in sql for sql in calls),
+                        "The 'insert records sent' query was not called.")
+
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(
         "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.make_datafeed_job")
-    def test_withdrawal_activity(self, mock_make_datafeed_job, mock_bq_client):
+    @mock.patch(
+        "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.get_datafeed_definition")
+    def test_withdrawal_activity(self, mock_get_datafeed_definition, mock_make_datafeed_job, mock_bq_client):
         # Create requisite participant data
         ppsc_participant = self.ppsc_data_gen.create_database_participant(id=110110112)
         rdr_participant = self.data_generator.create_database_participant(participantId=ppsc_participant.id)
@@ -377,19 +426,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        mock_make_datafeed_job.side_effect = lambda query: (
-            iter(activity_rows) if query.strip() == withdrawal_activity_expected_sql.strip() else None
-        )
+        self.setup_mock_make_datafeed_job(mock_make_datafeed_job, activity_rows)
 
-        # Test Feed
+        datafeed_name = "Withdrawal"
+
+        # Set up the mock for get_datafeed_definition
+        self.setup_datafeed_definition(datafeed_name, mock_get_datafeed_definition)
+
+        # Run the datafeed
         feed = Intake2SummaryFeed()
-        feed.get_datafeed_definition = mock.Mock(return_value={
-            "source_data": withdrawal_activity_expected_sql,
-            "destination_model": ParticipantSummary,
-            "de_mapping": withdrawal_data_elements
-        })
 
-        feed.run_datafeed("Withdrawal")
+        feed.run_datafeed(datafeed_name)
 
         # Verify the database records
         ps_dao = ParticipantSummaryDao()
@@ -401,10 +448,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         self.assertEqual(actual_rows[0].withdrawalAuthored, datetime.datetime(2024, 11, 21, 18, 12))
         self.assertEqual(actual_rows[0].withdrawalReason, WithdrawalReason.DUPLICATE)
 
+        # Verify the "insert records sent" query was called
+        calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
+        self.assertTrue(any(self.setup_expected_insert(datafeed=datafeed_name) in sql for sql in calls),
+                        "The 'insert records sent' query was not called.")
+
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(
         "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.make_datafeed_job")
-    def test_deactivation_activity(self, mock_make_datafeed_job, mock_bq_client):
+    @mock.patch(
+        "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.get_datafeed_definition")
+    def test_deactivation_activity(self, mock_get_datafeed_definition, mock_make_datafeed_job, mock_bq_client):
         # Create requisite participant data
         ppsc_participant = self.ppsc_data_gen.create_database_participant(id=110110113)
         rdr_participant = self.data_generator.create_database_participant(participantId=ppsc_participant.id)
@@ -422,19 +476,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        mock_make_datafeed_job.side_effect = lambda query: (
-            iter(activity_rows) if query.strip() == deactivation_activity_expected_sql.strip() else None
-        )
+        self.setup_mock_make_datafeed_job(mock_make_datafeed_job, activity_rows)
 
-        # Test Feed
+        datafeed_name = "Deactivation"
+
+        # Set up the mock for get_datafeed_definition
+        self.setup_datafeed_definition(datafeed_name, mock_get_datafeed_definition)
+
+        # Run the datafeed
         feed = Intake2SummaryFeed()
-        feed.get_datafeed_definition = mock.Mock(return_value={
-            "source_data": deactivation_activity_expected_sql,
-            "destination_model": ParticipantSummary,
-            "de_mapping": deactivation_data_elements
-        })
 
-        feed.run_datafeed("Deactivation")
+        feed.run_datafeed(datafeed_name)
 
         # Verify the database records
         ps_dao = ParticipantSummaryDao()
@@ -445,10 +497,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         self.assertEqual(actual_rows[0].suspensionStatus, SuspensionStatus.NO_CONTACT)
         self.assertEqual(actual_rows[0].suspensionTime, datetime.datetime(2024, 11, 22, 12, 45))
 
+        # Verify the "insert records sent" query was called
+        calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
+        self.assertTrue(any(self.setup_expected_insert(datafeed=datafeed_name) in sql for sql in calls),
+                        "The 'insert records sent' query was not called.")
+
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(
         "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.make_datafeed_job")
-    def test_participant_status_activity(self, mock_make_datafeed_job, mock_bq_client):
+    @mock.patch(
+        "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.get_datafeed_definition")
+    def test_participant_status_activity(self, mock_get_datafeed_definition, mock_make_datafeed_job, mock_bq_client):
         # Create requisite participant data
         ppsc_participant = self.ppsc_data_gen.create_database_participant(id=110110114)
         rdr_participant = self.data_generator.create_database_participant(participantId=ppsc_participant.id)
@@ -476,31 +535,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        def mock_job_execution(sql_query):
-            if "CREATE OR REPLACE TABLE" in sql_query:
-                self.source_data_executed_sql = sql_query.strip()
-                return None  # Simulate the temp table creation
-            elif "SELECT * FROM" in sql_query:
-                return iter(activity_rows)  # Simulate the source data retrieval
-            elif "INSERT INTO" in sql_query:
-                return None  # Simulate the insert records sent operation
+        self.setup_mock_make_datafeed_job(mock_make_datafeed_job, activity_rows)
 
-        mock_make_datafeed_job.side_effect = mock_job_execution
+        datafeed_name = "Participant Status"
 
-        # Test Feed
-        expected_insert_sql = insert_sent_records_expected_sql.replace("{%datafeed%}", "Participant Status")
-        expected_insert_sql = expected_insert_sql.replace("{%temp_table_name%}", "temp_ranked_events_participant_status")
+        # Set up the mock for get_datafeed_definition
+        self.setup_datafeed_definition(datafeed_name, mock_get_datafeed_definition)
+
+        # Run the datafeed
         feed = Intake2SummaryFeed()
-        feed.get_datafeed_definition = mock.Mock(return_value={
-            "source_data": participant_status_activity_expected_sql,
-            "temp_table_name": "temp_ranked_events_participant_status",
-            "sent_table_name": "intake_summary_datafeed_sent",
-            "insert_sent_sql": expected_insert_sql,
-            "destination_model": ParticipantSummary,
-            "de_mapping": participant_status_data_elements
-        })
 
-        feed.run_datafeed("Participant Status")
+        feed.run_datafeed(datafeed_name)
 
         # Verify the database records
         ps_dao = ParticipantSummaryDao()
@@ -529,12 +574,15 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
 
         # Verify the "insert records sent" query was called
         calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
-        self.assertTrue(any(expected_insert_sql in sql for sql in calls), "The 'insert records sent' query was not called.")
+        self.assertTrue(any(self.setup_expected_insert(datafeed=datafeed_name) in sql for sql in calls),
+                        "The 'insert records sent' query was not called.")
 
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(
         "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.make_datafeed_job")
-    def test_survey_completion_activity(self, mock_make_datafeed_job, mock_bq_client):
+    @mock.patch(
+        "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.get_datafeed_definition")
+    def test_survey_completion_activity(self, mock_get_datafeed_definition, mock_make_datafeed_job, mock_bq_client):
         required_codes = [302, 303, 301, 304, 924307, 311, 310, 309, 308, 39, 33, 36, 35,
                           38, 32, 37, 34, 292, 291, 297, 293, 294, 295, 290, 296, 298]
         self.create_required_codes(required_codes)
@@ -581,19 +629,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        mock_make_datafeed_job.side_effect = lambda query: (
-            iter(activity_rows) if query.strip() == survey_completion_activity_expected_sql.strip() else None
-        )
+        self.setup_mock_make_datafeed_job(mock_make_datafeed_job, activity_rows)
 
-        # Test Feed
+        datafeed_name = "Survey Completion"
+
+        # Set up the mock for get_datafeed_definition
+        self.setup_datafeed_definition(datafeed_name, mock_get_datafeed_definition)
+
+        # Run the datafeed
         feed = Intake2SummaryFeed()
-        feed.get_datafeed_definition = mock.Mock(return_value={
-            "source_data": survey_completion_activity_expected_sql,
-            "destination_model": ParticipantSummary,
-            "de_mapping": survey_completion_data_elements
-        })
 
-        feed.run_datafeed("Survey Completion")
+        feed.run_datafeed(datafeed_name)
 
         # Verify the database records
         ps_dao = ParticipantSummaryDao()
@@ -655,10 +701,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         # self.assertEqual(actual_rows[0].questionnaireOnEnvironmentalExposuresAuthored,
         #                  datetime.datetime(2024, 11, 20, 16, 0))
 
+        # Verify the "insert records sent" query was called
+        calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
+        self.assertTrue(any(self.setup_expected_insert(datafeed=datafeed_name) in sql for sql in calls),
+                        "The 'insert records sent' query was not called.")
+
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(
         "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.make_datafeed_job")
-    def test_attribution_activity(self, mock_make_datafeed_job, mock_bq_client):
+    @mock.patch(
+        "rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed.Intake2SummaryFeed.get_datafeed_definition")
+    def test_attribution_activity(self, mock_get_datafeed_definition, mock_make_datafeed_job, mock_bq_client):
         # Create requisite participant data
         ppsc_participant = self.ppsc_data_gen.create_database_participant(id=110110120)
         rdr_participant = self.data_generator.create_database_participant(participantId=ppsc_participant.id)
@@ -675,19 +728,17 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        mock_make_datafeed_job.side_effect = lambda query: (
-            iter(activity_rows) if query.strip() == attribution_activity_expected_sql.strip() else None
-        )
+        self.setup_mock_make_datafeed_job(mock_make_datafeed_job, activity_rows)
 
-        # Test Feed
+        datafeed_name = "Attribution"
+
+        # Set up the mock for get_datafeed_definition
+        self.setup_datafeed_definition(datafeed_name, mock_get_datafeed_definition)
+
+        # Run the datafeed
         feed = Intake2SummaryFeed()
-        feed.get_datafeed_definition = mock.Mock(return_value={
-            "source_data": attribution_activity_expected_sql,
-            "destination_model": ParticipantSummary,
-            "de_mapping": attribution_data_elements
-        })
 
-        feed.run_datafeed("Attribution")
+        feed.run_datafeed(datafeed_name)
 
         # Verify the database records
         ps_dao = ParticipantSummaryDao()
@@ -696,3 +747,8 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         # Assertions for Attribution Data
         self.assertEqual(actual_rows[0].participantId, activity_rows[0]['participant_id'])
         self.assertEqual(actual_rows[0].organizationId, 3)
+
+        # Verify the "insert records sent" query was called
+        calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
+        self.assertTrue(any(self.setup_expected_insert(datafeed=datafeed_name) in sql for sql in calls),
+                        "The 'insert records sent' query was not called.")

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -18,7 +18,8 @@ from tests.workflow_tests.test_data.ppsc_data_feed_test_data import core_data_ex
     ehr_expected_sql, health_data_sharing_expected_sql, ehr_expected_streaming_sql, core_data_expected_streaming_sql, \
     biospecimen_expected_streaming_sql, health_data_expected_streaming_sql, consent_activity_expected_sql, \
     profile_updates_activity_expected_sql, withdrawal_activity_expected_sql, deactivation_activity_expected_sql, \
-    participant_status_activity_expected_sql, survey_completion_activity_expected_sql, attribution_activity_expected_sql
+    participant_status_activity_expected_sql, survey_completion_activity_expected_sql, \
+    attribution_activity_expected_sql, insert_sent_records_expected_sql
 from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import InputFeed, Intake2SummaryFeed
 
 
@@ -175,6 +176,7 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         # pylint: disable=unused-argument
         super().setUp()
         self.ppsc_data_gen = PPSCDataGenerator()
+        self.source_data_executed_sql = ""
         activities = [
             "ENROLLMENT",
             "Consent",
@@ -474,14 +476,26 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
-        mock_make_datafeed_job.side_effect = lambda query: (
-            iter(activity_rows) if query.strip() == participant_status_activity_expected_sql.strip() else None
-        )
+        def mock_job_execution(sql_query):
+            if "CREATE OR REPLACE TABLE" in sql_query:
+                self.source_data_executed_sql = sql_query.strip()
+                return None  # Simulate the temp table creation
+            elif "SELECT * FROM" in sql_query:
+                return iter(activity_rows)  # Simulate the source data retrieval
+            elif "INSERT INTO" in sql_query:
+                return None  # Simulate the insert records sent operation
+
+        mock_make_datafeed_job.side_effect = mock_job_execution
 
         # Test Feed
+        expected_insert_sql = insert_sent_records_expected_sql.replace("{%datafeed%}", "Participant Status")
+        expected_insert_sql = expected_insert_sql.replace("{%temp_table_name%}", "temp_ranked_events_participant_status")
         feed = Intake2SummaryFeed()
         feed.get_datafeed_definition = mock.Mock(return_value={
             "source_data": participant_status_activity_expected_sql,
+            "temp_table_name": "temp_ranked_events_participant_status",
+            "sent_table_name": "intake_summary_datafeed_sent",
+            "insert_sent_sql": expected_insert_sql,
             "destination_model": ParticipantSummary,
             "de_mapping": participant_status_data_elements
         })
@@ -496,6 +510,7 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         test_participant = participant_dao.get(activity_rows[0]['participant_id'])
 
         # Assertions
+        self.assertEqual(participant_status_activity_expected_sql.strip(), self.source_data_executed_sql)
         self.assertEqual(actual_rows[0].participantId, activity_rows[0]['participant_id'])
         self.assertTrue(test_participant.isTestParticipant)
         self.assertEqual(actual_rows[0].deceasedStatus, DeceasedStatus.APPROVED)
@@ -511,6 +526,10 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         self.assertEqual(actual_rows[0].enrollmentStatusPmbEligibleV3_2Time, datetime.datetime(2024, 11, 20, 11, 0))
         self.assertEqual(actual_rows[0].enrollmentStatusCoreMinusPmV3_2Time, datetime.datetime(2024, 11, 20, 12, 0))
         self.assertEqual(actual_rows[0].enrollmentStatusCoreV3_2Time, datetime.datetime(2024, 11, 20, 13, 0))
+
+        # Verify the "insert records sent" query was called
+        calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]
+        self.assertTrue(any(expected_insert_sql in sql for sql in calls), "The 'insert records sent' query was not called.")
 
     @mock.patch("google.cloud.bigquery.Client")
     @mock.patch(


### PR DESCRIPTION
## Resolves *[DA-####](https://precisionmedicineinitiative.atlassian.net/browse/DA-4594)*


## Description of changes/additions
This PR changes the pattern for the retrieval of Intake to Participant Summary source data. Since the participant_summary table is updated at a high frequency by more than one datafeed, this table cannot be used for selection criteria, as the `participant_summary.modified` date will always be greater than any activity's `event_authored_date` in the intake system during steady state. 
To circumvent this, but still ensure duplicate data isn't sent, this PR implements a snapshot pattern and a new BigQuery table to record all events sent for all datafeeds. 
For each datafeed, a temporary snapshot table is created or replaced at the start of every run. Only the latest records that haven't been previously sent are added to the snapshot. In the case that multiples of an `event_type_name` occur during the period between runs, events are ranked by `event_authored_date` and in cases of ties, `event_id`. 
Queries were tested for single and multiple runs on Staging's BigQuery environment.
Unit tests were updated as well to test the python portion.


## Tests
- [x] unit tests


