### PR TITLE
Remove update listener for Participant Summary

### DIFF
--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -2032,7 +2032,7 @@ def model_update_lastModified_listener(_, __, summary: ParticipantSummary):
 
 
 event.listen(ParticipantSummary, "before_insert", model_insert_listener)
-event.listen(ParticipantSummary, "before_update", model_update_lastModified_listener)
+event.listen(ParticipantSummary, "before_update", model_update_listener)
 
 
 class ParticipantGenderAnswers(Base):

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -2032,7 +2032,6 @@ def model_update_lastModified_listener(_, __, summary: ParticipantSummary):
 
 
 event.listen(ParticipantSummary, "before_insert", model_insert_listener)
-event.listen(ParticipantSummary, "before_update", model_update_listener)
 
 
 class ParticipantGenderAnswers(Base):

--- a/rdr_service/model/participant_summary.py
+++ b/rdr_service/model/participant_summary.py
@@ -24,7 +24,7 @@ from sqlalchemy.sql import expression
 
 from rdr_service import clock
 from rdr_service.model.account_link import AccountLink
-from rdr_service.model.base import Base, InvalidDataState, model_insert_listener, model_update_listener
+from rdr_service.model.base import Base, model_insert_listener, model_update_listener
 from rdr_service.model.pediatric_data_log import PediatricDataLog, PediatricDataType
 from rdr_service.model.utils import Enum, EnumZeroBased, UTCDateTime, UTCDateTime6
 from rdr_service.participant_enums import (
@@ -2020,18 +2020,13 @@ Index("participant_summary_email", ParticipantSummary.email)
 Index("participant_summary_login_phone_number", ParticipantSummary.loginPhoneNumber)
 
 
-def validate_participant_summary(_, __, summary: ParticipantSummary):
-    if not summary.email and not summary.loginPhoneNumber:
-        raise InvalidDataState('Participant summary missing an email or phone number')
-
-
 def model_update_lastModified_listener(_, __, summary: ParticipantSummary):
     """Auto set `lastModified` column value on updates."""
-    validate_participant_summary(_, __, summary)
     summary.lastModified = clock.CLOCK.now()
 
 
 event.listen(ParticipantSummary, "before_insert", model_insert_listener)
+event.listen(ParticipantSummary, "before_update", model_update_lastModified_listener)
 
 
 class ParticipantGenderAnswers(Base):

--- a/tests/api_tests/test_profile_update_api.py
+++ b/tests/api_tests/test_profile_update_api.py
@@ -598,29 +598,3 @@ class ProfileUpdateApiTest(BaseTestCase):
         )
         mock_log_api_request.assert_called_once()
         self.assertEqual(mock_log_api_request.return_value.participantId, 123123123)
-
-
-
-
-class ProfileUpdateIntegrationTest(BaseTestCase):
-    def test_error_when_removing_login(self):
-        """
-        Ensure the API gracefully handles a request trying to clear any "login" data
-        (leaving a summary without an email or phone number)
-        """
-        summary = self.data_generator.create_database_participant_summary(
-            email='test@foo.com'
-        )
-        self.send_post(
-            'Patient',
-            request_data={
-                'id': f'P{summary.participantId}',
-                'telecom': [
-                    {
-                        'system': 'email',
-                        'value': ''
-                    }
-                ]
-            },
-            expected_status=400
-        )


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR removes the constraints on the update listener so that PPSC data can be updated in the `participant_summary`.

## Tests
- [x] unit tests


