### PR TITLE
[DA-4564] Creating researchers offline service

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,8 @@ if __name__ == '__main__':
     parser.add_argument("--resource", help="start resource web app", default=False, action="store_true")  # noqa
     parser.add_argument("--ppsc_pipeline",
                         help="start ppsc_pipeline web app", default=False, action="store_true")  # noqa
+    parser.add_argument("--researchers_offline",
+                        help="start researchers_offline web app", default=False, action="store_true")  # noqa
 
     args = parser.parse_args()
 
@@ -61,6 +63,9 @@ if __name__ == '__main__':
         elif args.ppsc_pipeline:
             from rdr_service.ppsc_pipeline.main import app
             app.run(host='127.0.0.1', port=8080, debug=args.debug)
+        elif args.researchers_offline:
+            from rdr_service.researchers_offline.main import app
+            app.run(host='127.0.0.1', port=8080, debug=args.debug)
         else:
             from rdr_service.main import app
             app.run(host='127.0.0.1', port=8080, debug=args.debug)
@@ -80,6 +85,8 @@ if __name__ == '__main__':
             command = command.replace('rdr_service.main:app', 'rdr_service.resource.main:app')
         if args.ppsc_pipeline:
             command = command.replace('rdr_service.main:app', 'rdr_service.ppsc_pipeline.main:app')
+        if args.researchers_offline:
+            command = command.replace('rdr_service.main:app', 'rdr_service.researchers_offline.main:app')
         p_args = shlex.split(command)
         print(p_args)
         p = subprocess.Popen(p_args, env=env)
@@ -92,6 +99,8 @@ if __name__ == '__main__':
         config_file = 'rdr_service/services/supervisor_resource.conf'
     elif args.ppsc_pipeline:
         config_file = 'rdr_service/services/supervisor_ppsc_pipeline.conf'
+    elif args.researchers_offline:
+        config_file = 'rdr_service/services/supervisor_researchers_offline.conf'
     else:
         config_file = 'rdr_service/services/supervisor.conf'
 

--- a/rdr_service/researchers_offline.yaml
+++ b/rdr_service/researchers_offline.yaml
@@ -1,0 +1,13 @@
+# Configuration for offline pipeline service. Should be kept in sync with test.yaml.
+
+runtime: python311
+service: researchers-offline
+entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 --max-requests 10 --max-requests-jitter 3 rdr_service.offline.main:app
+
+# RDR Cron Jobs run for longer than 10 minutes, B4_1G allows basic scaling, which handles requests up to 24 hours.
+# https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#scaling_elements
+instance_class: B2
+basic_scaling:
+  max_instances: 10
+  idle_timeout: 1m
+

--- a/rdr_service/researchers_offline/main.py
+++ b/rdr_service/researchers_offline/main.py
@@ -1,0 +1,53 @@
+"""The main API definition file for researchers-offline service endpoints."""
+import logging
+import traceback
+
+from flask import Flask, got_request_exception
+from sqlalchemy.exc import DBAPIError
+
+from rdr_service import app_util
+from rdr_service.services.flask import RESEARCHERS_OFFLINE_PREFIX, flask_start, flask_stop
+from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging,\
+    flask_restful_log_exception_error
+
+
+@app_util.auth_required_scheduler
+def test_job():
+    try:
+        logging.info("Test Job Executed")
+    except Exception as e:  # pylint: disable=broad-except
+        logging.error(f"An error occurred: {e}\nStack trace: {traceback.format_exc()}")
+        return "Error occurred", 500
+
+    return '{"success": "true"}'
+
+
+def _build_pipeline_app():
+    """Configure and return the app with non-resource pipeline-triggering endpoints."""
+    researchers_offline = Flask(__name__)
+    researchers_offline.config['TRAP_HTTP_EXCEPTIONS'] = True
+
+    researchers_offline.add_url_rule(
+        RESEARCHERS_OFFLINE_PREFIX + "ParticipantCountsOverTimeTest",
+        endpoint="test_job",
+        view_func=test_job,
+        methods=["GET"],
+    )
+
+    researchers_offline.add_url_rule('/_ah/start', endpoint='start', view_func=flask_start, methods=["GET"])
+    researchers_offline.add_url_rule("/_ah/stop", endpoint="stop", view_func=flask_stop, methods=["GET"])
+
+    researchers_offline.before_request(begin_request_logging)  # Must be first before_request() call.
+    researchers_offline.before_request(app_util.request_logging)
+
+    researchers_offline.after_request(app_util.add_headers)
+    researchers_offline.after_request(end_request_logging)  # Must be last after_request() call.
+
+    researchers_offline.register_error_handler(DBAPIError, app_util.handle_database_disconnect)
+
+    got_request_exception.connect(flask_restful_log_exception_error, researchers_offline)
+
+    return researchers_offline
+
+
+app = _build_pipeline_app()

--- a/rdr_service/services/flask.py
+++ b/rdr_service/services/flask.py
@@ -21,6 +21,7 @@ OFFLINE_PREFIX = "/offline/"
 RESOURCE_PREFIX = '/resource/'
 TASK_PREFIX = "/resource/task/"
 PPSC_PIPELINE_PREFIX = "/ppsc_pipeline/"
+RESEARCHERS_OFFLINE_PREFIX = "/researchers_offline/"
 
 # If we are being run under gunicorn, hookup gunicorn's logging handler.
 if __name__ != '__main__':

--- a/rdr_service/services/gcp_config.py
+++ b/rdr_service/services/gcp_config.py
@@ -55,7 +55,8 @@ GCP_SERVICES = [
     'default',
     'offline',
     'resource',
-    'ppsc_pipeline'
+    'ppsc_pipeline',
+    'researchers_offline'
 ]
 
 
@@ -86,6 +87,12 @@ GCP_SERVICE_CONFIG_MAP = OrderedDict({
             'type': 'service',
             'default': [
                 'rdr_service/ppsc_pipeline.yaml'
+            ]
+        },
+        'researchers_offline': {
+            'type': 'service',
+            'default': [
+                'rdr_service/researchers_offline.yaml'
             ]
         },
         'cron': {
@@ -141,6 +148,12 @@ GCP_SERVICE_CONFIG_MAP = OrderedDict({
             'type': 'service',
             'default': [
                 'rdr_service/ppsc_pipeline.yaml'
+            ]
+        },
+        'researchers_offline': {
+            'type': 'service',
+            'default': [
+                'rdr_service/researchers_offline.yaml'
             ]
         },
         'cron': {

--- a/rdr_service/services/supervisor_researchers_offline_.conf
+++ b/rdr_service/services/supervisor_researchers_offline_.conf
@@ -1,0 +1,30 @@
+#
+# Supervisor configuration file
+#
+# http://supervisord.org/configuration.html
+#
+[supervisord]
+logfile=/dev/fd/1
+logfile_maxbytes=0
+loglevel=info
+pidfile=/tmp/supervisord.pid
+nodaemon=True
+
+[inet_http_server]
+port = 127.0.0.1:9001
+
+[supervisorctl]
+serverurl = http://127.0.0.1:9001
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:flask_wsgi]
+command=gunicorn -c rdr_service/services/gunicorn_config.py rdr_service.researchers_offline.main:app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+; redirect_stderr=true


### PR DESCRIPTION
## Resolves *[DA-4564](https://precisionmedicineinitiative.atlassian.net/browse/DA-4564)*


## Description of changes/additions
This PR creates a new App Engine service to be used for all Workbench and Researcher related processing jobs: `researchers_offline`. It also runs a test for migrating the `participant-counts-over-time-job` to Cloud Scheduler from CRON job.

## Tests
- Tested on Sandbox




[DA-4564]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ