### PR TITLE
[DA-4659] Adding check for test account for NPH Opt In Sync

### DIFF
--- a/rdr_service/dao/ppsc_dao.py
+++ b/rdr_service/dao/ppsc_dao.py
@@ -5,7 +5,7 @@ from sqlalchemy.sql import functions
 from sqlalchemy.orm import aliased
 
 from rdr_service.dao.base_dao import BaseDao, UpsertableDao
-from rdr_service.model.ppsc import Participant, Site, NPHOptInEvent, ProfileUpdatesEvent
+from rdr_service.model.ppsc import Participant, Site, NPHOptInEvent, ProfileUpdatesEvent, ParticipantStatusEvent
 from rdr_service.model.study_nph import EligibleParticipants
 
 
@@ -135,6 +135,12 @@ class PPSCNphOptEventInDao(BaseDao):
             ).outerjoin(
               EligibleParticipants,
               EligibleParticipants.primary_participant_id == ProfileUpdatesEvent.participant_id
+            ).outerjoin(
+                ParticipantStatusEvent,
+                and_(
+                    ParticipantStatusEvent.participant_id == ProfileUpdatesEvent.participant_id,
+                    ParticipantStatusEvent.event_type_name.ilike('%Test Account%')
+                )
             ).filter(
                 ProfileUpdatesEvent.data_element_name.in_(
                     ['piiname_first',
@@ -145,7 +151,8 @@ class PPSCNphOptEventInDao(BaseDao):
                      'language_preference']
                 ),
                 profile_updates_alias.id.is_(None),
-                EligibleParticipants.id.is_(None)
+                EligibleParticipants.id.is_(None),
+                ParticipantStatusEvent.id.is_(None)
             ).group_by(
                 ProfileUpdatesEvent.participant_id,
                 case(
@@ -210,3 +217,4 @@ class PPSCNphOptEventInDao(BaseDao):
                 self.model_type,
                 batch
             )
+

--- a/rdr_service/data_gen/generators/ppsc.py
+++ b/rdr_service/data_gen/generators/ppsc.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from rdr_service import clock
 from rdr_service.dao import database_factory
 from rdr_service.model.ppsc import Participant, Activity, EnrollmentEventType, ConsentEvent, ProfileUpdatesEvent, \
-    SurveyCompletionEvent, PartnerActivity, Site, ParticipantEventActivity, NPHOptInEvent
+    SurveyCompletionEvent, PartnerActivity, Site, ParticipantEventActivity, NPHOptInEvent, ParticipantStatusEvent
 from rdr_service.model.ppsc_partner_data_transfer import (
     PPSCDataTransferAuth, PPSCDataTransferEndpoint,
     PPSCDataTransferRecord, PPSCHealthData, PPSCBiobankSample, PPSCEHR, PPSCCore, RTINphOptIn, RTIDataTransferEndpoint
@@ -215,3 +215,12 @@ class PPSCDataGenerator(PPSCBaseDataGenerator):
         event = self._nph_opt_in_event(**kwargs)
         self._commit_to_database(event)
         return event
+
+    @staticmethod
+    def _participant_status_event(**kwargs):
+        return ParticipantStatusEvent(**kwargs)
+
+    def create_database_participant_status_event(self, **kwargs):
+        participant_status_event = self._participant_status_event(**kwargs)
+        self._commit_to_database(participant_status_event)
+        return participant_status_event

--- a/tests/ppsc_tests/test_ppsc_partner_data_sync.py
+++ b/tests/ppsc_tests/test_ppsc_partner_data_sync.py
@@ -103,7 +103,7 @@ class PPSCPartnerDataSyncTest(BaseTestCase):
                     'activity_status': 'test',
                     'activity_date_time': clock.CLOCK.now()
                 }
-                for key, value in status_elements.items():
+                for key in status_elements:
                     self.ppsc_data_gen.create_database_participant_status_event(
                         participant_id=current_participant_ids[num],
                         event_type_name='Test Account',

--- a/tests/ppsc_tests/test_ppsc_partner_data_sync.py
+++ b/tests/ppsc_tests/test_ppsc_partner_data_sync.py
@@ -97,12 +97,31 @@ class PPSCPartnerDataSyncTest(BaseTestCase):
                     event_authored_time=clock.CLOCK.now()
                 )
 
+            # add test participant
+            if current_participant_ids[num] == 100000001:
+                status_elements = {
+                    'activity_status': 'test',
+                    'activity_date_time': clock.CLOCK.now()
+                }
+                for key, value in status_elements.items():
+                    self.ppsc_data_gen.create_database_participant_status_event(
+                        participant_id=current_participant_ids[num],
+                        event_type_name='Test Account',
+                        event_id=participant_event_activity_profile.id,
+                        data_element_name=key,
+                        data_element_value=status_elements[key],
+                        event_authored_time=clock.CLOCK.now()
+                    )
+
         nph_opt_in_sync = NphOptInSync()
         nph_opt_in_sync.run_sync()
 
-        self.assertEqual(len(nph_opt_in_sync.items_ready_for_sync), 2)
+        self.assertEqual(len(nph_opt_in_sync.items_ready_for_sync), 1)
 
         current_sync_ids = [obj.participant_id for obj in nph_opt_in_sync.items_ready_for_sync]
+
+        # check test participant not included
+        self.assertTrue(100000001 not in current_sync_ids)
 
         # eligible records
         updated_eligible_records = [obj for obj in self.eligible_dao.get_all()


### PR DESCRIPTION
## Resolves *[DA-4659](https://precisionmedicineinitiative.atlassian.net/browse/DA-4659)*


## Description of changes/additions
Adding check for NPH Opt In test participants

## Tests
- [x] unit tests




[DA-4659]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ