### PR TITLE
Update token refresh for PPSC transfers

### DIFF
--- a/rdr_service/model/ppsc_partner_data_transfer.py
+++ b/rdr_service/model/ppsc_partner_data_transfer.py
@@ -50,6 +50,7 @@ class PPSCDataTransferAuth(BaseDataTransferAuth, PPSCBase):
     client_id = Column(String(512), nullable=False)
     client_secret = Column(String(512), nullable=False)
 
+
 event.listen(PPSCDataTransferAuth, "before_insert", model_insert_listener)
 event.listen(PPSCDataTransferAuth, "before_update", model_update_listener)
 

--- a/rdr_service/ppsc/ppsc_partner_data_transfer.py
+++ b/rdr_service/ppsc/ppsc_partner_data_transfer.py
@@ -3,7 +3,9 @@ import json
 import requests
 from abc import ABC, abstractmethod
 from typing import Union
+from datetime import timedelta
 
+from rdr_service import clock
 from rdr_service.dao.ppsc_partner_transfer_dao import (PPSCDataTransferEndpointDao, PPSCDataTransferBaseDao,
                                                        PPSCDataTransferRecordDao, RTIDataTransferEndpointDao,
                                                        RTIDataTransferBaseDao, RTIDataTransferRecordDao)
@@ -82,7 +84,7 @@ class PPSCBaseDataTransfer(BaseDataTransfer):
     def get_headers(self):
         return {
             "Content-Type": "application/json",
-            "Authorization": f'Bearer {self.ppsc_oauth_data.token}'
+            "Authorization": f'Bearer {self.ppsc_oauth_data.token_data.get("access_token")}'
         }
 
     def build_default_obj(self, transfer_item):
@@ -98,8 +100,17 @@ class PPSCBaseDataTransfer(BaseDataTransfer):
     def prepare_obj(self, transfer_item: Union[PPSCCore, PPSCEHR, PPSCBiobankSample, PPSCHealthData]) -> dict:
         return self.build_default_obj(transfer_item)
 
+    def check_token_expiry(self):
+        last_generated = self.ppsc_oauth_data.token_data.get("last_generated")
+        updated_expiry = last_generated + timedelta(seconds=int(self.ppsc_oauth_data.token_data.get("expires")))
+
+        if clock.CLOCK.now() > updated_expiry:
+            self.ppsc_oauth_data.token_data = self.ppsc_oauth_data.generate_token()
+            self.headers = self.get_headers()
+
     def send_items(self):
         for item in self.transfer_items:
+            self.check_token_expiry()
             prepared_obj = self.prepare_obj(item)
             response = self.send_item(prepared_obj)
             self.transfer_record_dao.insert(self.transfer_record_dao.model_type(**{

--- a/rdr_service/ppsc/ppsc_partner_oauth.py
+++ b/rdr_service/ppsc/ppsc_partner_oauth.py
@@ -5,6 +5,7 @@ from abc import abstractmethod, ABC
 
 from rdr_service import clock
 from rdr_service.dao.ppsc_partner_transfer_dao import PPSCDataTransferAuthDao, RTIDataTransferAuthDao
+from rdr_service.model.ppsc_partner_data_transfer import PPSCDataTransferAuth
 from rdr_service.ppsc.ppsc_enums import AuthType
 
 
@@ -20,23 +21,6 @@ class BaseTransferOauth(ABC):
         self.oauth_record.expires = token_dict.get('expires_in')
         self.oauth_record.access_token = token_dict.get("access_token")
         self.dao.update(self.oauth_record)
-
-    def generate_token(self):
-        response = requests.post(
-            url=self.oauth_record.auth_url,
-            headers=self.get_headers()
-        )
-        try:
-            if response and response.status_code in (200, 201):
-                token_dict = response.json()
-                self.store_token(token_dict)
-                return token_dict.get("access_token")
-            else:
-                logging.warning(f'Error generating token for Oauth: {self.auth_type}: Response {response.status_code}')
-                raise RuntimeError(f'Error generating token for Oauth: '
-                                   f'{self.auth_type}: Response {response.status_code}')
-        except Exception as e:  # pylint: disable=broad-except
-            logging.warning(f'Error generating token for Oauth: {self.auth_type}: {e}')
 
     def get_oauth_record(self):
         oauth_record = self.dao.get_auth_record_from_type(self.auth_type)
@@ -55,9 +39,30 @@ class PPSCTransferOauth(BaseTransferOauth):
     def __init__(self):
         self.auth_type = AuthType.PPSC_DATA_TRANSFER
         self.dao = PPSCDataTransferAuthDao()
-        self.oauth_record = self.get_oauth_record()
-        self.encoded_client_str = self.encode_client_data()
-        self.token = self.generate_token()
+        self.oauth_record: PPSCDataTransferAuth = self.get_oauth_record()
+        self.encoded_client_str: str = self.encode_client_data()
+        self.token_data: dict = self.generate_token()
+
+    def generate_token(self):
+        response = requests.post(
+            url=self.oauth_record.auth_url,
+            headers=self.get_headers()
+        )
+        try:
+            if response and response.status_code in (200, 201):
+                token_dict = response.json()
+                self.store_token(token_dict)
+                return {
+                    'last_generated': self.oauth_record.last_generated,
+                    'expires': self.oauth_record.expires,
+                    'access_token': self.oauth_record.access_token
+                }
+            else:
+                logging.warning(f'Error generating token for Oauth: {self.auth_type}: Response {response.status_code}')
+                raise RuntimeError(f'Error generating token for Oauth: '
+                                   f'{self.auth_type}: Response {response.status_code}')
+        except Exception as e:  # pylint: disable=broad-except
+            logging.warning(f'Error generating token for Oauth: {self.auth_type}: {e}')
 
     def get_headers(self):
         return {

--- a/tests/ppsc_tests/test_ppsc_partner_data_transfer.py
+++ b/tests/ppsc_tests/test_ppsc_partner_data_transfer.py
@@ -68,7 +68,11 @@ class PPSCDataTransferTest(BaseTestCase):
     @mock.patch('rdr_service.ppsc.ppsc_partner_data_transfer.PPSCDataTransferCore.send_item')
     def test_send_core_items_for_transfer(self, send_request, oauth_service) -> None:
 
-        oauth_service.return_value = 'wqwqwqwqqwqqwqwqwqwqw'
+        oauth_service.return_value = {
+            'last_generated': clock.CLOCK.now(),
+            'expires': '3600',
+            'access_token': 'wqwqwqqwqwqwqw'
+        }
         send_request.return_value = MockedTransferResponse()
 
         for _ in range(0, 3):
@@ -83,7 +87,7 @@ class PPSCDataTransferTest(BaseTestCase):
             core_transfer.run_data_transfer()
 
         # contructor/__enter__ builds correctly
-        self.assertEqual(core_transfer.ppsc_oauth_data.token, oauth_service.return_value)
+        self.assertEqual(core_transfer.ppsc_oauth_data.token_data , oauth_service.return_value)
         self.assertEqual(core_transfer.transfer_type, DataSyncTransferType.CORE)
 
         current_endpoint = [obj for obj in self.current_endpoint_records
@@ -116,7 +120,11 @@ class PPSCDataTransferTest(BaseTestCase):
     @mock.patch('rdr_service.ppsc.ppsc_partner_data_transfer.PPSCDataTransferEHR.send_item')
     def test_send_ehr_items_for_transfer(self, send_request, oauth_service) -> None:
 
-        oauth_service.return_value = 'wqwqwqwqqwqqwqwqwqwqw'
+        oauth_service.return_value = {
+            'last_generated': clock.CLOCK.now(),
+            'expires': '3600',
+            'access_token': 'wqwqwqqwqwqwqw'
+        }
         send_request.return_value = MockedTransferResponse()
 
         for _ in range(0, 3):
@@ -130,7 +138,7 @@ class PPSCDataTransferTest(BaseTestCase):
             ehr_transfer.run_data_transfer()
 
         # contructor/__enter__ builds correctly
-        self.assertEqual(ehr_transfer.ppsc_oauth_data.token, oauth_service.return_value)
+        self.assertEqual(ehr_transfer.ppsc_oauth_data.token_data, oauth_service.return_value)
         self.assertEqual(ehr_transfer.transfer_type, DataSyncTransferType.EHR)
 
         current_endpoint = [obj for obj in self.current_endpoint_records
@@ -163,7 +171,11 @@ class PPSCDataTransferTest(BaseTestCase):
     @mock.patch('rdr_service.ppsc.ppsc_partner_data_transfer.PPSCDataTransferHealthData.send_item')
     def test_send_health_data_items_for_transfer(self, send_request, oauth_service) -> None:
 
-        oauth_service.return_value = 'wqwqwqwqqwqqwqwqwqwqw'
+        oauth_service.return_value = {
+            'last_generated': clock.CLOCK.now(),
+            'expires': '3600',
+            'access_token': 'wqwqwqqwqwqwqw'
+        }
         send_request.return_value = MockedTransferResponse()
 
         for _ in range(0, 3):
@@ -178,7 +190,7 @@ class PPSCDataTransferTest(BaseTestCase):
             health_transfer.run_data_transfer()
 
         # contructor/__enter__ builds correctly
-        self.assertEqual(health_transfer.ppsc_oauth_data.token, oauth_service.return_value)
+        self.assertEqual(health_transfer.ppsc_oauth_data.token_data, oauth_service.return_value)
         self.assertEqual(health_transfer.transfer_type, DataSyncTransferType.HEALTH_DATA)
 
         current_endpoint = [obj for obj in self.current_endpoint_records
@@ -211,7 +223,11 @@ class PPSCDataTransferTest(BaseTestCase):
     @mock.patch('rdr_service.ppsc.ppsc_partner_data_transfer.PPSCDataTransferBiobank.send_item')
     def test_send_biobank_sample_items_for_transfer(self, send_request, oauth_service) -> None:
 
-        oauth_service.return_value = 'wqwqwqwqqwqqwqwqwqwqw'
+        oauth_service.return_value = {
+            'last_generated': clock.CLOCK.now(),
+            'expires': '3600',
+            'access_token': 'wqwqwqqwqwqwqw'
+        }
         send_request.return_value = MockedTransferResponse()
 
         for _ in range(0, 3):
@@ -227,7 +243,7 @@ class PPSCDataTransferTest(BaseTestCase):
             biobank_transfer.run_data_transfer()
 
         # contructor/__enter__ builds correctly
-        self.assertEqual(biobank_transfer.ppsc_oauth_data.token, oauth_service.return_value)
+        self.assertEqual(biobank_transfer.ppsc_oauth_data.token_data, oauth_service.return_value)
         self.assertEqual(biobank_transfer.transfer_type, DataSyncTransferType.BIOBANK_SAMPLE)
 
         current_endpoint = [obj for obj in self.current_endpoint_records
@@ -272,6 +288,48 @@ class PPSCDataTransferTest(BaseTestCase):
             biobank_transfer.run_data_transfer()
 
         self.assertEqual(len(biobank_transfer.transfer_items), 0)
+
+    @mock.patch('rdr_service.ppsc.ppsc_partner_oauth.PPSCTransferOauth.generate_token')
+    @mock.patch('rdr_service.ppsc.ppsc_partner_data_transfer.PPSCDataTransferBiobank.send_item')
+    def test_send_sample_items_and_token_updates(self, send_request, oauth_service) -> None:
+
+        oauth_service.return_value = {
+            'last_generated': clock.CLOCK.now(),
+            'expires': '0',  # set expire value so token will refresh accordingly
+            'access_token': 'wqwqwqqwqwqwqw'
+        }
+        send_request.return_value = MockedTransferResponse()
+
+        for _ in range(0, 3):
+            participant = self.ppsc_data_gen.create_database_participant()
+            self.ppsc_data_gen.create_database_ppsc_data_biobank(
+                participant_id=participant.id,
+                event_date_time=clock.CLOCK.now(),
+                specimen_type=SpecimenType.BLOOD,
+                specimen_status=SpecimenStatus.RECEIVED
+        )
+
+        with PPSCDataTransferBiobank() as biobank_transfer:
+            # check current mocked token and headers
+            self.assertEqual(biobank_transfer.ppsc_oauth_data.token_data, oauth_service.return_value)
+            current_headers = {
+                "Content-Type": "application/json",
+                "Authorization": f'Bearer {oauth_service.return_value.get("access_token")}'
+            }
+            self.assertEqual(biobank_transfer.headers, current_headers)
+
+            # set new token via updated return value
+            oauth_service.return_value = {
+                'last_generated': clock.CLOCK.now(),
+                'expires': '3600',
+                'access_token': 'ddddddddddddd'
+            }
+            biobank_transfer.run_data_transfer()
+
+        # check updated headers updated with new token
+        self.assertNotEqual(current_headers, biobank_transfer.headers)
+        # check token data updated with with updated mock value
+        self.assertEqual(biobank_transfer.ppsc_oauth_data.token_data, oauth_service.return_value)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/ppsc_tests/test_ppsc_partner_data_transfer.py
+++ b/tests/ppsc_tests/test_ppsc_partner_data_transfer.py
@@ -328,7 +328,7 @@ class PPSCDataTransferTest(BaseTestCase):
 
         # check updated headers updated with new token
         self.assertNotEqual(current_headers, biobank_transfer.headers)
-        # check token data updated with with updated mock value
+        # check token data updated with updated mock value
         self.assertEqual(biobank_transfer.ppsc_oauth_data.token_data, oauth_service.return_value)
 
     def tearDown(self):

--- a/tests/ppsc_tests/test_ppsc_partner_oauth.py
+++ b/tests/ppsc_tests/test_ppsc_partner_oauth.py
@@ -47,9 +47,11 @@ class PPSCDataTransferTest(BaseTestCase):
 
         ppsc_transfer_oauth = PPSCTransferOauth()
 
-        self.assertIsNotNone(ppsc_transfer_oauth.token)
-        self.assertEqual(ppsc_transfer_oauth.token, MockedTransferResponse.json().get('access_token'))
-        self.assertEqual(ppsc_transfer_oauth.expires_in,  MockedTransferResponse.json().get('expires_in'))
+        self.assertIsNotNone(ppsc_transfer_oauth.token_data)
+        self.assertEqual(ppsc_transfer_oauth.token_data.get('access_token'), MockedTransferResponse.json().get(
+            'access_token'))
+        self.assertEqual(ppsc_transfer_oauth.token_data.get('expires'), MockedTransferResponse.json().get(
+            'expires_in'))
 
         current_oauth_record = self.oauth_dao.get_all()
         self.assertEqual(len(current_oauth_record), 1)

--- a/tests/ppsc_tests/test_ppsc_partner_oauth.py
+++ b/tests/ppsc_tests/test_ppsc_partner_oauth.py
@@ -49,6 +49,7 @@ class PPSCDataTransferTest(BaseTestCase):
 
         self.assertIsNotNone(ppsc_transfer_oauth.token)
         self.assertEqual(ppsc_transfer_oauth.token, MockedTransferResponse.json().get('access_token'))
+        self.assertEqual(ppsc_transfer_oauth.expires_in,  MockedTransferResponse.json().get('expires_in'))
 
         current_oauth_record = self.oauth_dao.get_all()
         self.assertEqual(len(current_oauth_record), 1)


### PR DESCRIPTION
## Resolves *[NA]*


## Description of changes/additions
In the original implementation of the transfer service to PPSC, we had to make assumptions about API performance and the volume of data that could be transmitted within the token's lifespan. However, recent production runs have shown that we can only send around 150 transfers before the token expires. To address this, we need to implement a mechanism that refreshes the token during the process, ensuring it remains valid if the operation exceeds the token’s expiration time.

## Tests
- [x] unit tests


