### PR TITLE
[DA-4660] Intake to PS - Update datafeed to write `hpo_id` for org attribution

### DIFF
--- a/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
@@ -415,17 +415,24 @@ WITH ranked_events AS (
   and se.event_type_name IN ('Org Attribution')
   and data_element_name IN ("activity_status", '​activity_status')
   and se.ignore_flag = 0
-)
-SELECT
-  participant_id,
-  event_id,
-  event_type_name,
-  MAX(CASE WHEN event_type_name = 'Org Attribution'
-    AND data_element_name IN ("activity_status", '​activity_status') AND rank = 1
-           THEN data_element_value END) AS organization
-FROM ranked_events
-WHERE rank = 1
-GROUP BY participant_id, event_id, event_type_name
+),
+    org_event_details AS (
+      SELECT
+      participant_id,
+      event_id,
+      event_type_name,
+      MAX(CASE WHEN event_type_name = 'Org Attribution'
+        AND data_element_name IN ("activity_status", '​activity_status') AND rank = 1
+               THEN data_element_value END) AS organization
+      FROM ranked_events
+      WHERE rank = 1
+      GROUP BY participant_id, event_id, event_type_name
+    )
+SELECT oed.*
+  , o.hpo_id
+FROM org_event_details oed
+LEFT JOIN `{project}.{source_dataset}.rdr_organization` o
+ON oed.organization = o.external_id
     """
 
 

--- a/rdr_service/workflow_management/ppsc/ppsc_to_legacy_de_mappings.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_to_legacy_de_mappings.py
@@ -150,6 +150,7 @@ def lookup_state(value):
     }
     return states.get(value)
 
+
 def map_source_to_summary(record: dict, data_element_mapping: dict, **kwargs) -> ParticipantSummary:
     """
         Maps source data to a ParticipantSummary object using the data_element_mapping definition.
@@ -634,5 +635,9 @@ attribution_data_elements = {
     "organization": {
         "field": ParticipantSummary.organizationId,
         "value": "org_lookup"
+    },
+    "hpo_id": {
+        "field": ParticipantSummary.hpoId,
+        "value": "integer"
     }
 }

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -827,7 +827,8 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         # Mock intake data
         activity_rows = [{
             "participant_id": ppsc_participant.id,
-            "organization": "PITT_BANNER_HEALTH"
+            "organization": "PITT_BANNER_HEALTH",
+            "hpo_id": 2
         }]
 
         # Mock make_datafeed_job to return the mocked intake data
@@ -850,6 +851,7 @@ class Intake2SummaryDataFeedTest(GenomicDataGenMixin):
         # Assertions for Attribution Data
         self.assertEqual(actual_rows[0].participantId, activity_rows[0]['participant_id'])
         self.assertEqual(actual_rows[0].organizationId, 3)
+        self.assertEqual(actual_rows[0].hpoId, 2)
 
         # Verify the "insert records sent" query was called
         calls = [call[0][0] for call in mock_make_datafeed_job.call_args_list if "INSERT INTO" in call[0][0]]


### PR DESCRIPTION
## Resolves *[DA-4660](https://precisionmedicineinitiative.atlassian.net/browse/DA-4660)*


## Description of changes/additions
- To continue to support Awardee filtering in the Participant Summary API until its decommission, attribution data from PPSC should include an update to the participant_summary.hpo_id to match the associated organization’s HPO ID. This PR updates participant_summary.hpo_id when PPSC Intake Org Attribution events are received.

## Tests
- [] unit tests (updated existing unit test)




[DA-4660]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ