### PR TITLE
[PDR-2786] PDR generator fix for participant_history (PPSC)

### DIFF
--- a/rdr_service/cron_default.yaml
+++ b/rdr_service/cron_default.yaml
@@ -42,7 +42,7 @@ cron:
 - description: BigQuery Sync
   url: /offline/BigQuerySync
   timezone: America/New_York
-  schedule: every 15 minutes
+  schedule: every 8 hours
   target: offline
 - description: Clean up request logs
   url: /offline/CleanUpRequestLogs

--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -12,7 +12,7 @@ cron:
 - description: BigQuery Sync
   url: /offline/BigQuerySync
   timezone: America/New_York
-  schedule: every 3 minutes
+  schedule: every 3 hours
   target: offline
 - description: Genomic AW2F Manifest Workflow
   url: /offline/GenomicAW2FManifestWorkflow

--- a/rdr_service/resource/generators/participant.py
+++ b/rdr_service/resource/generators/participant.py
@@ -473,7 +473,7 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         }
 
         # Collect participant pairing history
-        pairing_history = None
+        pairing_history = list()
         query = ro_session.query(ParticipantHistory.lastModified, ParticipantHistory.hpoId, HPO.name.label('hpo'),
                                    ParticipantHistory.organizationId, Organization.externalId.label('organization'),
                                    ParticipantHistory.siteId, Site.googleGroup.label('site'),
@@ -485,7 +485,6 @@ class ParticipantSummaryGenerator(generators.BaseGenerator):
         # sql = self.ro_dao.query_to_text(query)
         pairing = query.all()
         if pairing:
-            pairing_history = list()
             for item in pairing:
                 pairing_history.append({
                     'last_modified': item.lastModified,


### PR DESCRIPTION
## Resolves *[PDR-2786](https://precisionmedicineinitiative.atlassian.net/browse/PDR-2786)*


## Description of changes/additions
RDR codebase still contains a PDR generator that builds `pdr_participant` records, as a way to transfer a participant's biobank order/sample history as nested record content.  Future deactivation is still planned in the PDR backlog.  

Post-PPSC launch, the BigQuerySync job began hitting errors for "Field value of pairing_history cannot be empty" during the transferring of recently built `pdr_participant` records.  This is likely due to changes in what content can be expected in the `participant_history` table related to newly enrolled `ppsc` origin pids.

Make sure the `pairing_history` is never None/NULL by always initializing to an empty list instead.  Also, reduce the frequency of the BigQuerySync cron job since we no longer get most of our "live" data updates through this pipeline flow.  Instead of every 3 minutes, it will run every 3 hours.

## Test ##
- [x] unit tests (confirm all remaining tests passing)




[PDR-2786]: https://precisionmedicineinitiative.atlassian.net/browse/PDR-2786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ