### PR TITLE
[DA-4616] Update query for ehr and primary consents for Awardee InSite

### DIFF
--- a/rdr_service/model/awardee_insite.py
+++ b/rdr_service/model/awardee_insite.py
@@ -324,7 +324,7 @@ class AwardeeInSite(PPSCBase):
                 (
                     f"COALESCE(CAST({key} AS STRING), ''), '|' "
                     if key != "patient_status"
-                    else "CAST(TO_JSON_STRING(patient_status) AS BYTES), '|' "
+                    else "TO_BASE64(CAST(TO_JSON_STRING(patient_status) AS BYTES)), '|' "
                 )
                 for key in keys
             ).rstrip(", '|' ")

--- a/rdr_service/model/awardee_insite.py
+++ b/rdr_service/model/awardee_insite.py
@@ -324,7 +324,7 @@ class AwardeeInSite(PPSCBase):
                 (
                     f"COALESCE(CAST({key} AS STRING), ''), '|' "
                     if key != "patient_status"
-                    else "COALESCE(CAST(TO_JSON_STRING(patient_status) AS BYTES), '[]'), '|' "
+                    else "CAST(TO_JSON_STRING(patient_status) AS BYTES), '|' "
                 )
                 for key in keys
             ).rstrip(", '|' ")

--- a/rdr_service/model/awardee_insite.py
+++ b/rdr_service/model/awardee_insite.py
@@ -324,7 +324,7 @@ class AwardeeInSite(PPSCBase):
                 (
                     f"COALESCE(CAST({key} AS STRING), ''), '|' "
                     if key != "patient_status"
-                    else "COALESCE(TO_JSON_STRING(patient_status), '[]'), '|' "
+                    else "COALESCE(CAST(TO_JSON_STRING(patient_status) AS BYTES), '[]'), '|' "
                 )
                 for key in keys
             ).rstrip(", '|' ")

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -493,6 +493,7 @@ def insert_awardee_insite_data(
                   , activity_date_time
                   , ROW_NUMBER() OVER(PARTITION BY participant_id ORDER BY activity_date_time DESC) AS rn
                 FROM ehr_cte
+                WHERE LOWER(activity_status) IN ('yes', 'no')
               )
               WHERE rn = 1
           ),
@@ -500,7 +501,7 @@ def insert_awardee_insite_data(
               SELECT participant_id
                 , MIN(activity_date_time) AS consent_for_electronic_health_records_first_yes_authored
               FROM ehr_cte
-              WHERE activity_status = 'Yes'
+              WHERE LOWER(activity_status) = 'yes'
               GROUP BY 1
           ),
           ehr_receipt AS (
@@ -529,6 +530,7 @@ def insert_awardee_insite_data(
                 , activity_date_time
                 , ROW_NUMBER() OVER(PARTITION BY participant_id ORDER BY activity_date_time DESC) AS rn
               FROM primary_consent_cte
+              WHERE LOWER(activity_status) IN ('yes', 'no')
             )
             WHERE rn = 1
           ),


### PR DESCRIPTION
## Resolves *[DA-4616](https://precisionmedicineinitiative.atlassian.net/browse/DA-4616)*


## Description of changes/additions
- Adding condition to only look at `yes` and `no` values and to ignore `submitted_yes`, `submitted_no` for `consent_for_electronic_health_records` and `consent_for_study_enrollment` columns for Awardee InSite.

## Tests
- [] unit tests (Tested the query by running it in Prod BQ)




[DA-4616]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ