### PR TITLE
[DA-4658] Use enrollment status from PS for AwardeeInSite

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -571,6 +571,7 @@ def insert_awardee_insite_data(
             SELECT *
               , CASE
                   WHEN LOWER(activity_status) = 'submitted_yes' THEN 'yes'
+                  WHEN LOWER(activity_status) = 'submitted_complete' THEN 'yes'
                   WHEN LOWER(activity_status) = 'submitted_no' THEN 'no'
                   ELSE LOWER(activity_status)
                 END AS activity_status_cleaned
@@ -619,11 +620,25 @@ def insert_awardee_insite_data(
             FROM enrollment_status_recent_yes_ranked
             WHERE rn = 1
           ),
+          enrollment_status_mapping AS (
+            SELECT 1 AS enrollment_status, "participant" AS status
+            UNION ALL
+            SELECT 2 AS enrollment_status, "participant_ehr_consent" AS status
+            UNION ALL
+            SELECT 3 AS enrollment_status, "enrolled" AS status
+            UNION ALL
+            SELECT 4 AS enrollment_status, "core_minus_pm" AS status
+            UNION ALL
+            SELECT 5 AS enrollment_status, "core_participant" AS status
+            UNION ALL
+            SELECT 6 AS enrollment_status, "pmb_eligible" AS status
+          ),
           participant_summary_cte AS (
             SELECT
               participant_id
               , ehr_receipt_time AS first_ehr_receipt_time
               , ehr_update_time AS latest_ehr_receipt_time
+              , map.status AS enrollment_status
               , clinic_physical_measurements_status
               , clinic_physical_measurements_finalized_time
               , s1.google_group AS clinic_physical_measurements_finalized_site
@@ -642,6 +657,8 @@ def insert_awardee_insite_data(
             ON ps.clinic_physical_measurements_finalized_site_id = s1.site_id
             LEFT JOIN `{project}.{src_operational_dataset}.rdr_site` s2
             ON ps.biospecimen_source_site_id = s2.site_id
+            LEFT JOIN enrollment_status_mapping map
+            ON ps.enrollment_status_v_3_2 = map.enrollment_status
           ),
           default_filled_columns AS (
             SELECT
@@ -742,8 +759,6 @@ def insert_awardee_insite_data(
             LEFT JOIN ehr_first_yes_submitted
             USING (participant_id)
             LEFT JOIN primary_consent_latest_submitted
-            USING (participant_id)
-            LEFT JOIN enrollment_status_recent_yes
             USING (participant_id)
             LEFT JOIN participant_summary_cte
             USING (participant_id)


### PR DESCRIPTION
## Resolves *[DA-4658](https://precisionmedicineinitiative.atlassian.net/browse/DA-4658)*


## Description of changes/additions
- Using enrollment status field from PS for now. WIll do the backfill later.
- There was `submitted_complete` value for 2 participants for `consent_for_study_enrollment`. Changing that value to 'yes',  just like we do for `submitted_yes`


## Tests
- [] unit tests (tested the query in BQ)




[DA-4658]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ