### PR TITLE
[DA-4658] Fix ehr datetime column name

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -521,7 +521,7 @@ def insert_awardee_insite_data(
           ehr_cte AS (
               SELECT participant_id
                 , event_id
-                , MAX(CASE WHEN data_element_name = 'activity_date_time' THEN data_element_value END) AS activity_date_time
+                , MAX(event_authored_time) AS activity_date_time
                 , MAX(CASE WHEN REPLACE(data_element_name, '\u200B', '') = 'activity_status' THEN data_element_value END) AS activity_status
               FROM `{project}.{src_operational_dataset}.ppsc_consent_event`
               WHERE event_type_name ='EHR Authorization' AND ignore_flag = 0


### PR DESCRIPTION
## Resolves *[DA-4658](https://precisionmedicineinitiative.atlassian.net/browse/DA-4658)*


## Description of changes/additions
- Using `event_authored_time` column to get date for ehr data in Awardee InSite.


## Tests
- [] unit tests (Tested in BQ)




[DA-4658]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ