### PR TITLE
[DA-4658] Get latest profile update data for Awardee InSite

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -586,7 +586,6 @@ def insert_awardee_insite_data(
           primary_consent_latest_submitted AS (
               SELECT participant_id
                   , activity_status_cleaned AS consent_for_study_enrollment
-                  , activity_date_time AS consent_for_study_enrollment_authored
               FROM (
                 SELECT participant_id
                   , activity_status_cleaned
@@ -644,6 +643,8 @@ def insert_awardee_insite_data(
               participant_id
               , ehr_receipt_time AS first_ehr_receipt_time
               , ehr_update_time AS latest_ehr_receipt_time
+              , consent_for_electronic_health_records_first_yes_authored
+              , consent_for_study_enrollment_authored
               , map.status AS enrollment_status
               , clinic_physical_measurements_status
               , clinic_physical_measurements_finalized_time
@@ -761,8 +762,6 @@ def insert_awardee_insite_data(
             LEFT JOIN latest_deceased
             USING (participant_id)
             LEFT JOIN ehr_latest_submitted
-            USING (participant_id)
-            LEFT JOIN ehr_first_yes_submitted
             USING (participant_id)
             LEFT JOIN primary_consent_latest_submitted
             USING (participant_id)

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -437,27 +437,6 @@ def insert_awardee_insite_data(
                     )
                 )
           ),
-          organization_cte AS (
-            SELECT participant_id
-                , event_id
-                , MAX(event_authored_time) AS activity_date_time
-                , MAX(CASE WHEN REPLACE(data_element_name, '\u200B', '') = 'activity_status' THEN data_element_value END) AS activity_status
-            FROM `{project}.{src_operational_dataset}.ppsc_attribution_event`
-            WHERE event_type_name = 'Org Attribution' AND ignore_flag = 0
-            GROUP BY 1, 2
-          ),
-          latest_organization AS (
-            SELECT participant_id
-                , activity_status AS organization
-            FROM (
-              SELECT participant_id
-                , activity_status
-                , activity_date_time
-                , ROW_NUMBER() OVER(PARTITION BY participant_id ORDER BY activity_date_time DESC) AS rn
-              FROM organization_cte
-            )
-            WHERE rn = 1
-          ),
           withdrawn_cte AS (
             SELECT participant_id
             , event_id
@@ -557,13 +536,6 @@ def insert_awardee_insite_data(
             )
             WHERE rn = 1
           ),
-          ehr_first_yes_submitted AS (
-            SELECT participant_id
-                , MIN(activity_date_time) AS consent_for_electronic_health_records_first_yes_authored
-            FROM ehr_transformed_values
-            WHERE LOWER(activity_status_cleaned) = 'yes'
-            GROUP BY 1
-          ),
           primary_consent_cte AS (
             SELECT participant_id
                 , event_id
@@ -659,6 +631,7 @@ def insert_awardee_insite_data(
               , sample_status_1sal2
               , sample_order_status_1sal2
               , sample_order_status_1sal2_time
+              , o.external_id AS organization
             FROM `{project}.{src_operational_dataset}.rdr_participant_summary` ps
             LEFT JOIN `{project}.{src_operational_dataset}.rdr_site` s1
             ON ps.clinic_physical_measurements_finalized_site_id = s1.site_id
@@ -666,6 +639,8 @@ def insert_awardee_insite_data(
             ON ps.biospecimen_source_site_id = s2.site_id
             LEFT JOIN enrollment_status_mapping map
             ON ps.enrollment_status_v_3_2 = map.enrollment_status
+            LEFT JOIN `{project}.{src_operational_dataset}.rdr_organization` o
+            ON ps.organization_id = o.organization_id
           ),
           default_filled_columns AS (
             SELECT
@@ -752,8 +727,6 @@ def insert_awardee_insite_data(
               , sample_order_status_1sal2_time
             FROM participant_cte
             LEFT JOIN profile_pivot
-            USING (participant_id)
-            LEFT JOIN latest_organization
             USING (participant_id)
             LEFT JOIN latest_withdrawn
             USING (participant_id)

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -489,7 +489,7 @@ def insert_awardee_insite_data(
               WHERE LOWER(event_type_name) = 'deactivation' AND ignore_flag = 0
               GROUP BY 1, 2
           ),
-          latest_deactivation AS (
+          earliest_deactivation AS (
               SELECT participant_id
                 , activity_status AS deactivation_status
                 , activity_date_time AS deactivation_time
@@ -497,7 +497,7 @@ def insert_awardee_insite_data(
                 SELECT participant_id
                   , activity_status
                   , activity_date_time
-                  , ROW_NUMBER() OVER(PARTITION BY participant_id ORDER BY activity_date_time DESC) AS rn
+                  , ROW_NUMBER() OVER(PARTITION BY participant_id ORDER BY activity_date_time ASC) AS rn
                 FROM deactivation_cte
               )
               WHERE rn = 1
@@ -756,7 +756,7 @@ def insert_awardee_insite_data(
             USING (participant_id)
             LEFT JOIN latest_withdrawn
             USING (participant_id)
-            LEFT JOIN latest_deactivation
+            LEFT JOIN earliest_deactivation
             USING (participant_id)
             LEFT JOIN latest_deceased
             USING (participant_id)

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -394,6 +394,12 @@ def insert_awardee_insite_data(
             FROM `{project}.{src_operational_dataset}.ppsc_participant`
             WHERE ignore_flag = 0
           ),
+          latest_profile_update_events AS (
+            SELECT *
+            , ROW_NUMBER() OVER(PARTITION BY participant_id, data_element_name ORDER BY event_authored_time DESC) AS rn
+          FROM `{project}.{src_operational_dataset}.ppsc_profile_updates_event`
+          WHERE ignore_flag = 0
+          ),
           profile_pivot AS (
             SELECT participant_id
               , piiname_first AS first_name
@@ -412,8 +418,8 @@ def insert_awardee_insite_data(
                 SELECT participant_id
                   , data_element_name
                   , data_element_value
-                FROM `{project}.{src_operational_dataset}.ppsc_profile_updates_event`
-                WHERE ignore_flag = 0
+                FROM latest_profile_update_events
+                WHERE rn = 1
               )
             PIVOT(ANY_VALUE(data_element_value)
                 FOR data_element_name IN


### PR DESCRIPTION
## Resolves *[DA-4658](https://precisionmedicineinitiative.atlassian.net/browse/DA-4658)*


## Description of changes/additions
- Fixing the query to get recent participant profile data, like name, email, zipcode, etc. 
- Reading `consent_for_electronic_health_records_first_yes_authored`, `consent_for_study_enrollment_authored` from PS
- Fixing deactivation CTE
- Reading org from PS since some participants are missing org attribution event in ppsc table

## Tests
- [] unit tests (Tested in BQ)




[DA-4658]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ