### PR TITLE
[DA-4657] fix for bug when setting clinic PM fields after canceled PM

### DIFF
--- a/rdr_service/dao/physical_measurements_dao.py
+++ b/rdr_service/dao/physical_measurements_dao.py
@@ -365,12 +365,11 @@ class PhysicalMeasurementsDao(UpdatableDao):
                 and obj.status == PhysicalMeasurementsStatus.CANCELLED
                 and self.has_uncancelled_pm(session, participant)
             ):
-
-                get_latest_pm = self.get_latest_pm(session, participant)
-                participant_summary.clinicPhysicalMeasurementsFinalizedTime = get_latest_pm.finalized
-                participant_summary.clinicPhysicalMeasurementsTime = get_latest_pm.created
-                participant_summary.clinicPhysicalMeasurementsCreatedSiteId = get_latest_pm.createdSiteId
-                participant_summary.clinicPhysicalMeasurementsFinalizedSiteId = get_latest_pm.finalizedSiteId
+                latest_clinic_pm = self.get_latest_clinic_pm(session, participant)
+                participant_summary.clinicPhysicalMeasurementsFinalizedTime = latest_clinic_pm.finalized
+                participant_summary.clinicPhysicalMeasurementsTime = latest_clinic_pm.created
+                participant_summary.clinicPhysicalMeasurementsCreatedSiteId = latest_clinic_pm.createdSiteId
+                participant_summary.clinicPhysicalMeasurementsFinalizedSiteId = latest_clinic_pm.finalizedSiteId
         else:
             participant_summary.selfReportedPhysicalMeasurementsStatus = \
                 SelfReportedPhysicalMeasurementsStatus.COMPLETED
@@ -386,12 +385,14 @@ class PhysicalMeasurementsDao(UpdatableDao):
         )
         ParticipantSummaryDao().update_enrollment_status(summary, session=session)
 
-    def get_latest_pm(self, session, participant):
+    def get_latest_clinic_pm(self, session, participant):
         return (
             session.query(PhysicalMeasurements)
             .filter_by(participantId=participant.participantId)
-            .filter(PhysicalMeasurements.finalized != None)
-            .order_by(PhysicalMeasurements.finalized.desc())
+            .filter(
+                PhysicalMeasurements.finalized != None,
+                PhysicalMeasurements.collectType == PhysicalMeasurementsCollectType.SITE
+            ).order_by(PhysicalMeasurements.finalized.desc())
             .first()
         )
 
@@ -400,8 +401,10 @@ class PhysicalMeasurementsDao(UpdatableDao):
         query = (
             session.query(PhysicalMeasurements.status)
             .filter_by(participantId=participant.participantId)
-            .filter(PhysicalMeasurements.finalized != None)
-            .all()
+            .filter(
+                PhysicalMeasurements.finalized != None,
+                PhysicalMeasurements.collectType == PhysicalMeasurementsCollectType.SITE
+            ).all()
         )
         valid_pm = False
         for pm in query:

--- a/tests/api_tests/test_physical_measurements_api.py
+++ b/tests/api_tests/test_physical_measurements_api.py
@@ -3,7 +3,7 @@ import http.client
 import json
 from copy import deepcopy
 
-from rdr_service import main, config
+from rdr_service import main, config, participant_enums
 from rdr_service.api_util import PPSC, REDCAP
 from rdr_service.clock import FakeClock
 from rdr_service.dao.participant_dao import ParticipantDao
@@ -11,6 +11,8 @@ from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.model.measurements import Measurement
 from rdr_service.model.organization import Organization
 from rdr_service.model.participant import Participant
+from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.measurements import PhysicalMeasurements
 from rdr_service.model.utils import from_client_participant_id
 from rdr_service.participant_enums import UNSET_HPO_ID
 from tests.test_data import data_path, load_measurement_json, load_measurement_json_amendment
@@ -345,7 +347,6 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
                 return entry['resource']
         return None
 
-
     def test_cancel_a_physical_measurement(self):
         _id = self.participant_id.strip("P")
         self.send_consent(self.participant_id)
@@ -387,6 +388,43 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
         self.assertEqual(ps["entry"][0]["resource"]["clinicPhysicalMeasurementsStatus"], "COMPLETED")
         self.assertEqual(ps["entry"][0]["resource"]["clinicPhysicalMeasurementsCreatedSite"], "hpo-site-monroeville")
         self.assertEqual(ps["entry"][0]["resource"]["clinicPhysicalMeasurementsFinalizedSite"], "hpo-site-bannerphoenix")
+
+    def test_canceling_measurement_ignores_self_reported(self):
+        participant_id = self.participant_id.strip("P")
+        self.send_consent(self.participant_id)
+
+        # set up a self-reported measurement
+        log_position = self.data_generator.create_database_log_position()
+        self_reported_measurement = PhysicalMeasurements(
+            participantId=participant_id,
+            created=datetime.datetime.now(),
+            finalized=datetime.datetime.now(),
+            collectType=participant_enums.PhysicalMeasurementsCollectType.SELF_REPORTED,
+            final=True,
+            logPositionId=log_position.logPositionId,
+            physicalMeasurementsId=1234567,
+            resource={}
+        )
+        self.session.add(self_reported_measurement)
+        self.session.commit()
+
+        # send a clinic physical measurement
+        measurement = load_measurement_json(self.participant_id)
+        response = self.send_post(f'Participant/P{participant_id}/PhysicalMeasurements', measurement)
+
+        # cancel the clinic measurement
+        pm_id = response['id']
+        cancel_info = BaseTestCase.get_restore_or_cancel_info()
+        self.send_patch(f'Participant/P{participant_id}/PhysicalMeasurements/{pm_id}', cancel_info)
+
+        # make sure the participant summary didn't get the self-reported data set in the clinic fields
+        summary: ParticipantSummary = self.session.query(ParticipantSummary).filter(
+            ParticipantSummary.participantId == participant_id
+        ).one()
+        self.assertEqual(
+            participant_enums.PhysicalMeasurementsStatus.CANCELLED, summary.clinicPhysicalMeasurementsStatus
+        )
+        self.assertEqual(None, summary.clinicPhysicalMeasurementsFinalizedTime)
 
     def test_make_pm_after_cancel_first_pm(self):
         _id = self.participant_id.strip("P")


### PR DESCRIPTION
## Partially Resolves *[DA-4657](https://precisionmedicineinitiative.atlassian.net/browse/DA-4657)*
Investigating some differences between data in the physical measurements table and the participant summary data showed a bug that happens when measurements are cancelled. When an on-site measurement is cancelled, any previous on-site measurement should be used to set the clinic fields.

The code for finding the previous on-site measurements was implemented before self-reported measurements were used, and the code wasn't updated to filter them out. So some participant summary records were incorrectly updated with self-reported values (a SQL statement will be used in the ticket to correct them).


## Tests
- [x] unit tests




[DA-4657]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ