### PR TITLE
[DA-4720] Remediate Empty Biobank Monthly Withdrawal Reports

### DIFF
--- a/rdr_service/data_gen/generators/data_generator.py
+++ b/rdr_service/data_gen/generators/data_generator.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from rdr_service.code_constants import PPI_SYSTEM, WITHDRAWAL_CEREMONY_QUESTION_CODE, WITHDRAWAL_CEREMONY_YES, \
     WITHDRAWAL_CEREMONY_NO
+from rdr_service.data_gen.generators.ppsc import PPSCDataGenerator
 from rdr_service.model.api_user import ApiUser
 from rdr_service.model.biobank_mail_kit_order import BiobankMailKitOrder
 from rdr_service.model.biobank_order import BiobankSpecimen, BiobankSpecimenAttribute, BiobankOrderHistory, \
@@ -47,6 +48,7 @@ from rdr_service.participant_enums import PatientStatusFlag, QuestionnaireRespon
 
 class DataGenerator:
     def __init__(self, session, faker):
+        self.ppsc_data_gen = PPSCDataGenerator()
         self.session = session
         self.faker = faker
         self._next_unique_participant_id = 900000000
@@ -1083,6 +1085,7 @@ class DataGenerator:
             participantOrigin=participant.participantOrigin,
             withdrawalAuthored=withdrawal_time,
             withdrawalStatus=WithdrawalStatus.NO_USE,
+            withdrawalReasonJustification=withdrawal_reason_justification,
             **(summary_kwargs or {})
         )
 
@@ -1110,6 +1113,15 @@ class DataGenerator:
             questionnaireVersion=questionnaire.version,
             answers=answers,
             participantId=participant.participantId
+        )
+
+        # Create a withdrawal event that satisfies the parameters for the test participant
+        ppsc_participant = self.ppsc_data_gen.create_database_participant(id=participant.participantId,
+                                                                          biobank_id=participant.biobankId)
+        self.ppsc_data_gen.create_database_withdrawal_event(
+            data_element_name='aian_ceremony_status',
+            data_element_value=requests_ceremony,
+            participant_id=ppsc_participant.id
         )
 
         return participant

--- a/rdr_service/data_gen/generators/data_generator.py
+++ b/rdr_service/data_gen/generators/data_generator.py
@@ -1074,12 +1074,17 @@ class DataGenerator:
             withdrawalStatus=WithdrawalStatus.NO_USE,
             withdrawalReasonJustification=withdrawal_reason_justification
         )
-        if summary_kwargs or is_native_american:
-            self.create_database_participant_summary(
-                participant=participant,
-                aian=is_native_american,
-                **(summary_kwargs or {})
-            )
+        self.create_database_participant_summary(
+            participant=participant,
+            biobankId=participant.biobankId,
+            siteId=participant.siteId,
+            organizationId=participant.organizationId,
+            aian=is_native_american,
+            participantOrigin=participant.participantOrigin,
+            withdrawalAuthored=withdrawal_time,
+            withdrawalStatus=WithdrawalStatus.NO_USE,
+            **(summary_kwargs or {})
+        )
 
         # Withdrawal report only includes participants that have stored samples
         self.create_database_biobank_stored_sample(biobankId=participant.biobankId, test='test')

--- a/rdr_service/data_gen/generators/ppsc.py
+++ b/rdr_service/data_gen/generators/ppsc.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from rdr_service import clock
 from rdr_service.dao import database_factory
 from rdr_service.model.ppsc import Participant, Activity, EnrollmentEventType, ConsentEvent, ProfileUpdatesEvent, \
-    SurveyCompletionEvent, PartnerActivity, Site, ParticipantEventActivity, NPHOptInEvent, ParticipantStatusEvent
+    SurveyCompletionEvent, PartnerActivity, Site, ParticipantEventActivity, NPHOptInEvent, ParticipantStatusEvent, \
+    WithdrawalEvent
 from rdr_service.model.ppsc_partner_data_transfer import (
     PPSCDataTransferAuth, PPSCDataTransferEndpoint,
     PPSCDataTransferRecord, PPSCHealthData, PPSCBiobankSample, PPSCEHR, PPSCCore, RTINphOptIn, RTIDataTransferEndpoint
@@ -224,3 +225,12 @@ class PPSCDataGenerator(PPSCBaseDataGenerator):
         participant_status_event = self._participant_status_event(**kwargs)
         self._commit_to_database(participant_status_event)
         return participant_status_event
+
+    @staticmethod
+    def _withdrawal_event(**kwargs):
+        return WithdrawalEvent(**kwargs)
+
+    def create_database_withdrawal_event(self, **kwargs):
+        withdrawal_event = self._withdrawal_event(**kwargs)
+        self._commit_to_database(withdrawal_event)
+        return withdrawal_event

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -206,10 +206,10 @@ def get_withdrawal_report_query(start_date: datetime):
     (as biobank samples for Native Americans are disposed of differently)
     """
     ceremony_answer_subquery = _participant_answer_subquery(WITHDRAWAL_CEREMONY_QUESTION_CODE)
-    return (
+    query = (
         Query([
-            func.concat(get_biobank_id_prefix(), Participant.biobankId).label('biobank_id'),
-            func.date_format(Participant.withdrawalTime, MYSQL_ISO_DATE_FORMAT).label('withdrawal_time'),
+            func.concat(get_biobank_id_prefix(), ParticipantSummary.biobankId).label('biobank_id'),
+            func.date_format(ParticipantSummary.withdrawalAuthored, MYSQL_ISO_DATE_FORMAT).label('withdrawal_time'),
             case([(ParticipantSummary.aian, 'Y')], else_='N').label('is_native_american'),
             case(
                 [
@@ -218,28 +218,35 @@ def get_withdrawal_report_query(start_date: datetime):
                 ],
                 else_=case([(ParticipantSummary.aian, 'U')], else_='NA')
             ).label('needs_disposal_ceremony'),
-            Participant.participantOrigin.label('participant_origin'),
+            ParticipantSummary.participantOrigin.label('participant_origin'),
             HPO.name.label('paired_hpo'),
             coalesce(Organization.externalId, 'UNSET').label('paired_org'),
             coalesce(Site.googleGroup, 'UNSET').label('paired_site'),
             Participant.withdrawalReasonJustification.label('withdrawal_reason_justification'),
-            coalesce(ParticipantSummary.deceasedStatus, 0).label('deceased_status')
+            case(
+                [
+                    (ParticipantSummary.deceasedStatus == 1, 'PENDING'),
+                    (ParticipantSummary.deceasedStatus == 2, 'APPROVED'),
+                ],
+                else_='UNSET'
+            ).label('deceased_status'),
         ])
-        .select_from(Participant)
-        .outerjoin(ceremony_answer_subquery, ceremony_answer_subquery.c.participant_id == Participant.participantId)
-        .join(BiobankStoredSample, BiobankStoredSample.biobankId == Participant.biobankId)
-        .outerjoin(ParticipantSummary, ParticipantSummary.participantId == Participant.participantId)
-        .outerjoin(HPO, HPO.hpoId == Participant.hpoId)
-        .outerjoin(Organization, Organization.organizationId == Participant.organizationId)
-        .outerjoin(Site, Site.siteId == Participant.siteId)
+        .select_from(ParticipantSummary)
+        .outerjoin(ceremony_answer_subquery,
+                   ceremony_answer_subquery.c.participant_id == ParticipantSummary.participantId)
+        .join(BiobankStoredSample, BiobankStoredSample.biobankId == ParticipantSummary.biobankId)
+        .outerjoin(HPO, HPO.hpoId == ParticipantSummary.hpoId)
+        .outerjoin(Organization, Organization.organizationId == ParticipantSummary.organizationId)
+        .outerjoin(Site, Site.siteId == ParticipantSummary.siteId)
         .filter(
-            Participant.withdrawalStatus != WithdrawalStatus.NOT_WITHDRAWN,
+            ParticipantSummary.withdrawalStatus != WithdrawalStatus.NOT_WITHDRAWN,
             or_(
-                Participant.withdrawalTime > start_date,
+                ParticipantSummary.withdrawalAuthored > start_date,
                 BiobankStoredSample.created > start_date
             )
         ).distinct()
     )
+    return query
 
 
 def _build_query_params(start_date: datetime):
@@ -513,7 +520,7 @@ def _participant_answer_subquery(question_code_value):
         .join(question_code, question_code.codeId == QuestionnaireQuestion.codeId)
         .join(answer_code, answer_code.codeId == QuestionnaireResponseAnswer.valueCodeId)
         .filter(
-            QuestionnaireResponse.participantId == Participant.participantId,
+            QuestionnaireResponse.participantId == ParticipantSummary.participantId,
             question_code.value == question_code_value,
             QuestionnaireResponseAnswer.endTime.is_(None)
         )

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -10,28 +10,22 @@ import logging
 import math
 import pytz
 from sqlalchemy import case
-from sqlalchemy.orm import aliased, Query
+from sqlalchemy.orm import Query
 from sqlalchemy.sql import func, or_
 from sqlalchemy.sql.functions import coalesce
 from typing import Dict
 
 from rdr_service import clock, config
 from rdr_service.api_util import list_blobs
-from rdr_service.code_constants import (
-    WITHDRAWAL_CEREMONY_YES, WITHDRAWAL_CEREMONY_NO, WITHDRAWAL_CEREMONY_QUESTION_CODE
-)
 from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN, \
     BIOBANK_SAMPLES_MONTHLY_INVENTORY_FILE_PATTERN, RDR_SLACK_WEBHOOKS
 from rdr_service.dao.database_utils import MYSQL_ISO_DATE_FORMAT, parse_datetime, replace_isodate
+from rdr_service.model import ppsc
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
-from rdr_service.model.code import Code
 from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
-from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
-from rdr_service.model.questionnaire import QuestionnaireQuestion
-from rdr_service.model.questionnaire_response import QuestionnaireResponse, QuestionnaireResponseAnswer
 from rdr_service.model.site import Site
 from rdr_service.offline.bigquery_sync import dispatch_participant_rebuild_tasks
 from rdr_service.offline.sql_exporter import SqlExporter
@@ -205,7 +199,7 @@ def get_withdrawal_report_query(start_date: datetime):
     including their biobank ID, withdrawal time, their origin, and whether they are Native American
     (as biobank samples for Native Americans are disposed of differently)
     """
-    ceremony_answer_subquery = _participant_answer_subquery(WITHDRAWAL_CEREMONY_QUESTION_CODE)
+    ceremony_answer_subquery = _participant_answer_subquery()
     return (
         Query([
             func.concat(get_biobank_id_prefix(), ParticipantSummary.biobankId).label('biobank_id'),
@@ -213,8 +207,8 @@ def get_withdrawal_report_query(start_date: datetime):
             case([(ParticipantSummary.aian, 'Y')], else_='N').label('is_native_american'),
             case(
                 [
-                    (ceremony_answer_subquery.c.value == WITHDRAWAL_CEREMONY_YES, 'Y'),
-                    (ceremony_answer_subquery.c.value == WITHDRAWAL_CEREMONY_NO, 'N'),
+                    (ceremony_answer_subquery.c.data_element_value == 'yes', 'Y'),
+                    (ceremony_answer_subquery.c.data_element_value == 'no', 'N'),
                 ],
                 else_=case([(ParticipantSummary.aian, 'U')], else_='NA')
             ).label('needs_disposal_ceremony'),
@@ -222,7 +216,7 @@ def get_withdrawal_report_query(start_date: datetime):
             HPO.name.label('paired_hpo'),
             coalesce(Organization.externalId, 'UNSET').label('paired_org'),
             coalesce(Site.googleGroup, 'UNSET').label('paired_site'),
-            Participant.withdrawalReasonJustification.label('withdrawal_reason_justification'),
+            ParticipantSummary.withdrawalReasonJustification.label('withdrawal_reason_justification'),
             case(
                 [
                     (ParticipantSummary.deceasedStatus == 1, 'PENDING'),
@@ -508,20 +502,13 @@ _NATIVE_AMERICAN_SQL = """
   (CASE WHEN participant_summary.aian THEN 'Y' ELSE 'N' END) is_native_american"""
 
 
-def _participant_answer_subquery(question_code_value):
-    question_code = aliased(Code)
-    answer_code = aliased(Code)
+def _participant_answer_subquery():
     return (
-        Query([QuestionnaireResponse.participantId, answer_code.value])
-        .select_from(QuestionnaireResponse)
-        .join(QuestionnaireResponseAnswer)
-        .join(QuestionnaireQuestion)
-        .join(question_code, question_code.codeId == QuestionnaireQuestion.codeId)
-        .join(answer_code, answer_code.codeId == QuestionnaireResponseAnswer.valueCodeId)
+        Query([ppsc.WithdrawalEvent.participant_id, ppsc.WithdrawalEvent.data_element_value])
+        .select_from(ppsc.WithdrawalEvent)
+        .join(ParticipantSummary, ppsc.WithdrawalEvent.participant_id == ParticipantSummary.participantId)
         .filter(
-            QuestionnaireResponse.participantId == ParticipantSummary.participantId,
-            question_code.value == question_code_value,
-            QuestionnaireResponseAnswer.endTime.is_(None)
+            ppsc.WithdrawalEvent.data_element_name == 'aian_ceremony_status'
         )
         .subquery()
     )

--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -206,7 +206,7 @@ def get_withdrawal_report_query(start_date: datetime):
     (as biobank samples for Native Americans are disposed of differently)
     """
     ceremony_answer_subquery = _participant_answer_subquery(WITHDRAWAL_CEREMONY_QUESTION_CODE)
-    query = (
+    return (
         Query([
             func.concat(get_biobank_id_prefix(), ParticipantSummary.biobankId).label('biobank_id'),
             func.date_format(ParticipantSummary.withdrawalAuthored, MYSQL_ISO_DATE_FORMAT).label('withdrawal_time'),
@@ -246,7 +246,6 @@ def get_withdrawal_report_query(start_date: datetime):
             )
         ).distinct()
     )
-    return query
 
 
 def _build_query_params(start_date: datetime):

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -5,7 +5,7 @@ import mock
 import random
 import os
 
-from rdr_service import clock, config, participant_enums
+from rdr_service import clock, config
 from rdr_service.api_util import open_cloud_file, get_blob
 from rdr_service.code_constants import BIOBANK_TESTS
 from rdr_service.config import BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN,\
@@ -437,10 +437,9 @@ class BiobankSamplesPipelineTest(BaseTestCase):
 
     def test_withdrawal_report(self):
         withdrawal_time = datetime(2024, 2, 17)
-        participant = self.data_generator.create_database_participant(
-            withdrawalStatus=participant_enums.WithdrawalStatus.NO_USE,
-            withdrawalTime=withdrawal_time,
-            withdrawalReasonJustification='testing report'
+        participant = self.data_generator.create_withdrawn_participant(
+            withdrawal_time=withdrawal_time,
+            withdrawal_reason_justification='testing report'
         )
         self.data_generator.create_database_biobank_stored_sample(
             biobankId=participant.biobankId
@@ -463,7 +462,7 @@ class BiobankSamplesPipelineTest(BaseTestCase):
                 'UNSET',    # paired_org
                 'UNSET',    # paired_site
                 'testing report',
-                participant_enums.DeceasedStatus.UNSET
+                'UNSET'
             )])
             mock_upload.assert_called_with(mock.ANY, 'reconciliation/report_2024-02_withdrawals.csv', None)
 

--- a/tests/tool_tests/test_biobank_report_tool.py
+++ b/tests/tool_tests/test_biobank_report_tool.py
@@ -3,7 +3,7 @@ import mock
 
 from rdr_service import clock, config
 from rdr_service.model.participant import Participant
-from rdr_service.participant_enums import DeceasedStatus, WithdrawalAIANCeremonyStatus
+from rdr_service.participant_enums import DeceasedStatus
 from rdr_service.tools.tool_libs.biobank_report import BiobankReportTool
 from tests.helpers.tool_test_mixin import ToolTestMixin
 from tests.helpers.unittest_base import BaseTestCase
@@ -18,13 +18,13 @@ class BiobankReportToolTest(ToolTestMixin, BaseTestCase):
         no_ceremony_native_american_participant = self.data_generator.create_withdrawn_participant(
             withdrawal_reason_justification=withdrawal_reason_justification,
             is_native_american=True,
-            requests_ceremony=WithdrawalAIANCeremonyStatus.DECLINED,
+            requests_ceremony='no',
             withdrawal_time=two_days_ago
         )
         ceremony_native_american_participant = self.data_generator.create_withdrawn_participant(
             withdrawal_reason_justification=withdrawal_reason_justification,
             is_native_american=True,
-            requests_ceremony=WithdrawalAIANCeremonyStatus.REQUESTED,
+            requests_ceremony='yes',
             withdrawal_time=two_days_ago
         )
         native_american_participant_without_answer = self.data_generator.create_withdrawn_participant(
@@ -226,3 +226,8 @@ class BiobankReportToolTest(ToolTestMixin, BaseTestCase):
     def _datetime_n_days_ago(self, days_ago: int) -> datetime:
         # Clearing microseconds to avoid rounding time up in database and causing test to fail
         return datetime.today().replace(microsecond=0) - timedelta(days=days_ago)
+
+    def tearDown(self):
+        self.clear_table_after_test("ppsc.participant")
+        self.clear_table_after_test("rdr.participant")
+        self.clear_table_after_test("ppsc.withdrawal_event")

--- a/tests/tool_tests/test_biobank_report_tool.py
+++ b/tests/tool_tests/test_biobank_report_tool.py
@@ -3,7 +3,7 @@ import mock
 
 from rdr_service import clock, config
 from rdr_service.model.participant import Participant
-from rdr_service.participant_enums import DeceasedStatus, WithdrawalAIANCeremonyStatus, WithdrawalStatus
+from rdr_service.participant_enums import DeceasedStatus, WithdrawalAIANCeremonyStatus
 from rdr_service.tools.tool_libs.biobank_report import BiobankReportTool
 from tests.helpers.tool_test_mixin import ToolTestMixin
 from tests.helpers.unittest_base import BaseTestCase
@@ -87,10 +87,9 @@ class BiobankReportToolTest(ToolTestMixin, BaseTestCase):
         five_days_ago = self._datetime_n_days_ago(5)
 
         # Create a participant that has a withdrawal time outside of the report range, but recently had a sample created
-        withdrawn_participant = self.data_generator.create_database_participant(
-            withdrawalTime=twenty_days_ago,
-            withdrawalStatus=WithdrawalStatus.NO_USE,
-            withdrawalReasonJustification='withdraw before delivery'
+        withdrawn_participant = self.data_generator.create_withdrawn_participant(
+            withdrawal_time=twenty_days_ago,
+            withdrawal_reason_justification='withdraw before delivery'
         )
         self.data_generator.create_database_biobank_stored_sample(
             biobankId=withdrawn_participant.biobankId,


### PR DESCRIPTION
## Resolves *[DA-4720](https://precisionmedicineinitiative.atlassian.net/browse/DA-4720)*


## Description of changes/additions
The monthly withdrawal reports from RDR to Biobank were empty (no data in the report) in the months of January & February. The report is generated using data from the Participant table; however, since the PPSC migration, the Participant table is not being updated with all the data necessary for the report, only the Participant Summary table is being updated. 

These changes update the monthly report to pull data from the Participant Summary table instead of the Participant table.

## Tests
- [X] unit tests




[DA-4720]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ