### PR TITLE
Change ehr date to file_timestamp

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -188,7 +188,7 @@ INSERT INTO `{project}.{destination_dataset}.datafeed_input_ehr` (
 SELECT DISTINCT
     p.id,
     0 as ignore_flag,
-    participant_ehr.last_seen,
+    participant_ehr.file_timestamp,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
 FROM `{project}.{src_operational_dataset}.ppsc_participant` p
@@ -201,7 +201,7 @@ WHERE TRUE
         SELECT 1
         FROM `{project}.{destination_dataset}.datafeed_input_ehr` t
         WHERE t.participant_id = p.id
-            AND t.event_date_time = participant_ehr.last_seen
+            AND t.event_date_time = participant_ehr.file_timestamp
             AND t.ignore_flag = 0
     )
 ;

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -206,7 +206,7 @@ INSERT INTO `test.rdr_operational_datastream.datafeed_input_ehr` (
 SELECT DISTINCT
     p.id,
     0 as ignore_flag,
-    participant_ehr.last_seen,
+    participant_ehr.file_timestamp,
     CURRENT_TIMESTAMP() AS created,
     CURRENT_TIMESTAMP() AS modified
 FROM `test.rdr_operational_datastream.ppsc_participant` p
@@ -219,7 +219,7 @@ WHERE TRUE
         SELECT 1
         FROM `test.rdr_operational_datastream.datafeed_input_ehr` t
         WHERE t.participant_id = p.id
-            AND t.event_date_time = participant_ehr.last_seen
+            AND t.event_date_time = participant_ehr.file_timestamp
             AND t.ignore_flag = 0
     )
 ;


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
The EHR datafeed to PPSC was using the "last_seen" field, not the "file_timestamp" field, from the `participant_ehr_receipt` table. This PR updates the EHR datafeed to PPSC to use the correct field for the EHR receipt time.

## Tests
- [x] unit tests


