### PR TITLE
[DA-4564] Migrating metrics cache queries to BigQuery

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -299,11 +299,15 @@ SENSITIVE_EHR_RELEASE_DATE = 'sensitive_ehr_release_date'
 PM_HEIGHT_CODES = 'pm_height_codes'
 PM_WEIGHT_CODES = 'pm_weight_codes'
 
-# The ParticipantCountsOverTime job runs in the AOU RDR Prod, but the job uses participant and participant_summary
-# tables from the Warehouse project BigQuery. This maps the RDR project to the correct Warehouse project.
-PUBLIC_METRICS_PROJECT_MAP = "public_metrics_project_map"
+# BigQuery tables used in the ParticipantCountsOverTime job
 PUBLIC_METRICS_PARTICIPANT_TABLE = "public_metrics_participant_table"
 PUBLIC_METRICS_PARTICIPANT_SUMMARY_TABLE = "public_metrics_participant_summary_table"
+
+PUBLIC_METRICS_HPO_TABLE = "public_metrics_hpo_table"
+PUBLIC_METRICS_CALENDAR_TABLE = "public_metrics_calendar_table"
+PUBLIC_METRICS_CODE_TABLE = "public_metrics_code_table"
+PUBLIC_METRICS_GENDER_ANSWERS_TABLE = "public_metrics_gender_answers_table"
+PUBLIC_METRICS_RACE_ANSWERS_TABLE = "public_metrics_race_answers_table"
 
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}

--- a/rdr_service/dao/metrics_cache_dao.py
+++ b/rdr_service/dao/metrics_cache_dao.py
@@ -3,7 +3,9 @@ import json
 
 import sqlalchemy
 from sqlalchemy import and_, desc, func, or_, distinct
+from typing import List, Dict
 
+from rdr_service import config
 from rdr_service.census_regions import census_regions
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
@@ -32,7 +34,40 @@ from rdr_service.participant_enums import (
     MetricsCronJobStage
 )
 
-TEMP_TABLE_PREFIX = 'metrics_tmp_participant_'
+TEMP_TABLE_QUERY = """
+  WITH temp_table AS (
+  SELECT p.participant_id, p.biobank_id, p.sign_up_time, ps.first_name, ps.last_name, ps.suspension_status, ps.deceased_status, ps.is_ehr_data_available, ps.is_participant_mediated_ehr_data_available, ps.was_participant_mediated_ehr_available, p.withdrawal_status, p.hpo_id, p.organization_id, p.site_id, p.participant_origin, ps.date_of_birth, ps.consent_for_study_enrollment_time, ps.enrollment_status, ps.enrollment_status_member_time, ps.enrollment_status_core_stored_sample_time, ps.questionnaire_on_the_basics, ps.primary_language, ps.language_id, ps.gender_identity_id, ps.gender_identity, ps.race, ps.questionnaire_on_the_basics_time, ps.questionnaire_on_lifestyle_time, ps.questionnaire_on_medications_time, ps.questionnaire_on_family_health_time, ps.questionnaire_on_overall_health_time, ps.questionnaire_on_healthcare_access_time, ps.questionnaire_on_medical_history_time, ps.clinic_physical_measurements_time, ps.self_reported_physical_measurements_authored, ps.sample_status_1ed10_time, ps.sample_status_2ed10_time, ps.sample_status_1ed04_time, ps.sample_status_1sal_time, ps.sample_status_1sal2_time, ps.state_id, ps.consent_for_electronic_health_records, ps.clinic_physical_measurements_finalized_time
+  FROM `{participant}` AS p
+  LEFT JOIN `{participant_summary}` AS ps ON p.participant_id = ps.participant_id
+  WHERE p.hpo_id != 21
+  AND (p.is_ghost_id != 1 OR p.is_ghost_id IS NULL)
+  AND p.is_test_participant != 1
+  AND (ps.email IS NULL OR NOT ps.email LIKE '%@example.com')
+  AND p.withdrawal_status = 1
+  AND p.hpo_id = @hpo_id
+  )"""
+
+PARTICIPANT_ORIGIN_SQL = """, participant_origin AS ( SELECT DISTINCT participant_origin FROM `{participant}` )"""
+
+# Save all BigQuery table names here for all metrics tables to access
+participant_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_TABLE,
+                                          'rdr_operational_datastream.rdr_participant')
+participant_summary_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_SUMMARY_TABLE,
+                                                  'rdr_operational_datastream.rdr_participant_summary')
+hpo_table = config.getSettingJson(config.PUBLIC_METRICS_HPO_TABLE, 'rdr_operational_datastream.rdr_hpo')
+calendar_table = config.getSettingJson(config.PUBLIC_METRICS_CALENDAR_TABLE,
+                                       'rdr_operational_datastream.rdr_calendar')
+code_table = config.getSettingJson(config.PUBLIC_METRICS_CODE_TABLE, 'rdr_operational_datastream.rdr_code')
+gender_answers_table = config.getSettingJson(config.PUBLIC_METRICS_GENDER_ANSWERS_TABLE,
+                                             'rdr_operational_datastream.rdr_participant_gender_answers')
+race_answers_table = config.getSettingJson(config.PUBLIC_METRICS_RACE_ANSWERS_TABLE,
+                                           'rdr_operational_datastream.rdr_participant_race_answers')
+
+class MetricsDaoMixin:
+    def insert_bulk(self, batch: List[Dict]) -> None:
+        with self.session() as session:
+            return session.bulk_insert_mappings(self.model_type, batch)
+
 
 class MetricsCacheJobStatusDao(UpdatableDao):
     def __init__(self):
@@ -80,7 +115,7 @@ class MetricsCacheJobStatusDao(UpdatableDao):
             return record
 
 
-class MetricsEnrollmentStatusCacheDao(BaseDao):
+class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
     def __init__(self, cache_type=MetricsCacheType.METRICS_V2_API, version=None):
         super(MetricsEnrollmentStatusCacheDao, self).__init__(MetricsEnrollmentStatusCache)
         self.version = version
@@ -287,14 +322,15 @@ class MetricsEnrollmentStatusCacheDao(BaseDao):
 
             return results_by_date
 
-    def get_metrics_cache_sql(self, hpo_id):
-        temp_table_name = TEMP_TABLE_PREFIX + str(hpo_id)
-        sql = """
-            insert into metrics_enrollment_status_cache
-              SELECT
-                :date_inserted AS date_inserted,
-                :hpo_id AS hpo_id,
-                (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS name,
+    def get_metrics_cache_sql(self, bq_project):
+        sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                      participant_summary=f"{bq_project}.{participant_summary_table}")
+        sql += PARTICIPANT_ORIGIN_SQL.format(participant=f"{bq_project}.{participant_table}")
+        sql += """
+              SELECT DISTINCT
+                @date_inserted AS dateInserted,
+                @hpo_id AS hpoId,
+                (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
                 c.day AS date,
                 IFNULL((
                   SELECT SUM(results.enrollment_count)
@@ -304,12 +340,12 @@ class MetricsEnrollmentStatusCacheDao(BaseDao):
                            DATE(ps.consent_for_study_enrollment_time) AS consent_for_study_enrollment_time,
                            ps.participant_origin,
                            count(*) enrollment_count
-                    FROM {temp_table_name} ps
+                    FROM temp_table ps
                     GROUP BY DATE(ps.sign_up_time), DATE(ps.consent_for_study_enrollment_time), ps.participant_origin
                   ) AS results
                   WHERE c.day>=DATE(sign_up_time) AND (consent_for_study_enrollment_time IS NULL OR DATE(consent_for_study_enrollment_time)>c.day)
                   and results.participant_origin = d.participant_origin
-                ),0) AS registered_count,
+                ),0) AS registeredCount,
                 IFNULL((
                   SELECT SUM(results.enrollment_count)
                   FROM
@@ -318,12 +354,12 @@ class MetricsEnrollmentStatusCacheDao(BaseDao):
                            DATE(ps.enrollment_status_member_time) AS enrollment_status_member_time,
                            ps.participant_origin,
                            count(*) enrollment_count
-                    FROM {temp_table_name} ps
+                    FROM temp_table ps
                     GROUP BY DATE(ps.consent_for_study_enrollment_time), DATE(ps.enrollment_status_member_time), ps.participant_origin
                   ) AS results
                   WHERE consent_for_study_enrollment_time IS NOT NULL AND c.day>=DATE(consent_for_study_enrollment_time) AND (enrollment_status_member_time IS NULL OR c.day < DATE(enrollment_status_member_time))
                   and results.participant_origin = d.participant_origin
-                ),0) AS participant_count,
+                ),0) AS participantCount,
                 IFNULL((
                   SELECT SUM(results.enrollment_count)
                   FROM
@@ -332,34 +368,34 @@ class MetricsEnrollmentStatusCacheDao(BaseDao):
                            DATE(ps.enrollment_status_core_stored_sample_time) AS enrollment_status_core_stored_sample_time,
                            ps.participant_origin,
                            count(*) enrollment_count
-                    FROM {temp_table_name} ps
+                    FROM temp_table ps
                     GROUP BY DATE(ps.enrollment_status_member_time), DATE(ps.enrollment_status_core_stored_sample_time), ps.participant_origin
                   ) AS results
                   WHERE enrollment_status_member_time IS NOT NULL AND day>=DATE(enrollment_status_member_time) AND (enrollment_status_core_stored_sample_time IS NULL OR day < DATE(enrollment_status_core_stored_sample_time))
                   and results.participant_origin = d.participant_origin
-                ),0) AS consented_count,
+                ),0) AS consentedCount,
                 IFNULL((
                   SELECT SUM(results.enrollment_count)
                   FROM
                   (
                     SELECT DATE(ps.enrollment_status_core_stored_sample_time) AS enrollment_status_core_stored_sample_time,
                            ps.participant_origin, count(*) enrollment_count
-                    FROM {temp_table_name} ps
+                    FROM temp_table ps
                     GROUP BY DATE(ps.enrollment_status_core_stored_sample_time), ps.participant_origin
                   ) AS results
                   WHERE enrollment_status_core_stored_sample_time IS NOT NULL AND day>=DATE(enrollment_status_core_stored_sample_time)
                   and results.participant_origin = d.participant_origin
-                ),0) AS core_count,
-                d.participant_origin
-              FROM calendar c, metrics_tmp_participant_origin d
-              WHERE c.day BETWEEN :start_date AND :end_date
+                ),0) AS coreCount,
+                d.participant_origin AS participantOrigin
+              FROM `{calendar}` c, participant_origin d
+              WHERE c.day BETWEEN @start_date AND @end_date
               ;
-        """.format(temp_table_name=temp_table_name)
+        """.format(calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}")
 
         return [sql]
 
 
-class MetricsGenderCacheDao(BaseDao):
+class MetricsGenderCacheDao(BaseDao, MetricsDaoMixin):
     def __init__(self, cache_type=MetricsCacheType.METRICS_V2_API, version=None):
         super(MetricsGenderCacheDao, self).__init__(MetricsGenderCache)
         try:
@@ -476,10 +512,10 @@ class MetricsGenderCacheDao(BaseDao):
 
             if self.version == MetricsAPIVersion.V2:
                 params = {'start_date': start_date, 'end_date': end_date, 'date_inserted': last_inserted_date,
-                          'cache_type': self.cache_type}
+                          'cache_type': MetricsCacheType.METRICS_V2_API}
             else:
                 params = {'start_date': start_date, 'end_date': end_date, 'date_inserted': last_inserted_date,
-                          'cache_type': MetricsCacheType.METRICS_V2_API}
+                          'cache_type': self.cache_type}
 
             cursor = session.execute(sql, params)
             try:
@@ -558,8 +594,7 @@ class MetricsGenderCacheDao(BaseDao):
             client_json.append(new_item)
         return client_json
 
-    def get_metrics_cache_sql(self, hpo_id):
-        temp_table_name = TEMP_TABLE_PREFIX + str(hpo_id)
+    def get_metrics_cache_sql(self, bq_project):
         sql_arr = []
 
         if self.cache_type == MetricsCacheType.PUBLIC_METRICS_EXPORT_API:
@@ -598,18 +633,19 @@ class MetricsGenderCacheDao(BaseDao):
                              CASE WHEN code_id = {GenderIdentity_NonBinary} THEN 1 ELSE 0 END   AS GenderIdentity_NonBinary,
                              CASE WHEN code_id = {PMI_PreferNotToAnswer} THEN 1 ELSE 0 END   AS PMI_PreferNotToAnswer,
                              CASE WHEN code_id = {PMI_Skip} THEN 1 ELSE 0 END   AS PMI_Skip
-                      FROM participant_gender_answers
-                      ) x
+                      FROM `{gender_answers}`
+                      )
                 GROUP BY participant_id)
             """.format(GenderIdentity_Woman=gender_code_dict['GenderIdentity_Woman'],
-                     GenderIdentity_Transgender=gender_code_dict['GenderIdentity_Transgender'],
-                     GenderIdentity_Man=gender_code_dict['GenderIdentity_Man'],
-                     GenderIdentity_AdditionalOptions=
-                                                     gender_code_dict['GenderIdentity_AdditionalOptions'],
-                     GenderIdentity_NonBinary=gender_code_dict['GenderIdentity_NonBinary'],
-                     PMI_PreferNotToAnswer=gender_code_dict['PMI_PreferNotToAnswer'],
-                     PMI_Skip=gender_code_dict['PMI_Skip']
-                     )
+                       GenderIdentity_Transgender=gender_code_dict['GenderIdentity_Transgender'],
+                       GenderIdentity_Man=gender_code_dict['GenderIdentity_Man'],
+                       GenderIdentity_AdditionalOptions=
+                                                       gender_code_dict['GenderIdentity_AdditionalOptions'],
+                       GenderIdentity_NonBinary=gender_code_dict['GenderIdentity_NonBinary'],
+                       PMI_PreferNotToAnswer=gender_code_dict['PMI_PreferNotToAnswer'],
+                       PMI_Skip=gender_code_dict['PMI_Skip'],
+                       gender_answers=f"{bq_project}.{gender_answers_table}"
+                       )
 
             gender_conditions = [
                 ' pga.participant_id IS NULL ',
@@ -622,17 +658,18 @@ class MetricsGenderCacheDao(BaseDao):
                 ' pga.PMI_PreferNotToAnswer=1 ',
                 ' pga.Number_of_Answer>1 AND pga.PMI_Skip=0 AND pga.PMI_PreferNotToAnswer=0 ',
             ]
-            sql = """insert into metrics_gender_cache """
+            sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                          participant_summary=f"{bq_project}.{participant_summary_table}")
             sub_queries = []
             sql_template = """
             SELECT
-              :date_inserted AS date_inserted,
+              @date_inserted AS dateInserted,
               '{cache_type}' as type,
-              'core' as enrollment_status,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+              'core' as enrollmentStatus,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
               c.day AS date,
-              '{gender_name}' AS gender_name,
+              '{gender_name}' AS genderName,
               IFNULL((
                 SELECT SUM(results.gender_count)
                 FROM
@@ -640,7 +677,7 @@ class MetricsGenderCacheDao(BaseDao):
                   SELECT DATE(ps.sign_up_time) as day,
                          DATE(ps.enrollment_status_core_stored_sample_time) as enrollment_status_core_stored_sample_time,
                          COUNT(*) gender_count
-                  FROM {temp_table_name} ps
+                  FROM temp_table ps
                   LEFT JOIN {answers_table_sql} pga ON ps.participant_id = pga.participant_id
                   WHERE {gender_condition}
                   GROUP BY DATE(ps.sign_up_time), DATE(ps.enrollment_status_core_stored_sample_time)
@@ -648,19 +685,19 @@ class MetricsGenderCacheDao(BaseDao):
                 WHERE results.day <= c.day
                 AND enrollment_status_core_stored_sample_time IS NOT NULL
                 AND DATE(enrollment_status_core_stored_sample_time) <= c.day
-              ),0) AS gender_count,
-              '' as participant_origin
-            FROM calendar c
-            WHERE c.day BETWEEN :start_date AND :end_date
-            UNION ALL
+              ),0) AS genderCount,
+              '' as participantOrigin
+            FROM `{calendar}` c
+            WHERE c.day BETWEEN @start_date AND @end_date
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
+              @date_inserted AS dateInserted,
               '{cache_type}' as type,
-              'registered' as enrollment_status,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+              'registered' as enrollmentStatus,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
               c.day AS date,
-              '{gender_name}' AS gender_name,
+              '{gender_name}' AS genderName,
               IFNULL((
                 SELECT SUM(results.gender_count)
                 FROM
@@ -668,26 +705,26 @@ class MetricsGenderCacheDao(BaseDao):
                   SELECT DATE(ps.sign_up_time) as day,
                          DATE(ps.enrollment_status_member_time) as enrollment_status_member_time,
                          COUNT(*) gender_count
-                  FROM {temp_table_name} ps
+                  FROM temp_table ps
                   LEFT JOIN {answers_table_sql} pga ON ps.participant_id = pga.participant_id
                   WHERE {gender_condition}
                   GROUP BY DATE(ps.sign_up_time), DATE(ps.enrollment_status_member_time)
                 ) AS results
                 WHERE results.day <= c.day
                 AND (enrollment_status_member_time is null or DATE(enrollment_status_member_time)>c.day)
-              ),0) AS gender_count,
-              '' as participant_origin
-            FROM calendar c
-            WHERE c.day BETWEEN :start_date AND :end_date
-            UNION ALL
+              ),0) AS genderCount,
+              '' as participantOrigin
+            FROM `{calendar}` c
+            WHERE c.day BETWEEN @start_date AND @end_date
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
+              @date_inserted AS dateInserted,
               '{cache_type}' as type,
-              'consented' as enrollment_status,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+              'consented' as enrollmentStatus,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
               c.day AS date,
-              '{gender_name}' AS gender_name,
+              '{gender_name}' AS genderName,
               IFNULL((
                 SELECT SUM(results.gender_count)
                 FROM
@@ -696,7 +733,7 @@ class MetricsGenderCacheDao(BaseDao):
                          DATE(ps.enrollment_status_member_time) as enrollment_status_member_time,
                          DATE(ps.enrollment_status_core_stored_sample_time) as enrollment_status_core_stored_sample_time,
                          COUNT(*) gender_count
-                  FROM {temp_table_name} ps
+                  FROM temp_table ps
                   LEFT JOIN {answers_table_sql} pga ON ps.participant_id = pga.participant_id
                   WHERE {gender_condition}
                   GROUP BY DATE(ps.sign_up_time), DATE(ps.enrollment_status_member_time), DATE(ps.enrollment_status_core_stored_sample_time)
@@ -705,20 +742,21 @@ class MetricsGenderCacheDao(BaseDao):
                 AND enrollment_status_member_time IS NOT NULL
                 AND DATE(enrollment_status_member_time) <= c.day
                 AND (enrollment_status_core_stored_sample_time is null or DATE(enrollment_status_core_stored_sample_time)>c.day)
-              ),0) AS gender_count,
-              '' as participant_origin
-            FROM calendar c
-            WHERE c.day BETWEEN :start_date AND :end_date
+              ),0) AS genderCount,
+              '' as participantOrigin
+            FROM `{calendar}` c
+            WHERE c.day BETWEEN @start_date AND @end_date
             """
             for gender_name, gender_condition in zip(self.gender_names, gender_conditions):
                 sub_query = sql_template.format(cache_type=self.cache_type,
-                                                temp_table_name=temp_table_name,
                                                 gender_name=gender_name,
                                                 gender_condition=gender_condition,
-                                                answers_table_sql=answers_table_sql)
+                                                answers_table_sql=answers_table_sql,
+                                                calendar=f"{bq_project}.{calendar_table}",
+                                                hpo=f"{bq_project}.{hpo_table}")
                 sub_queries.append(sub_query)
 
-            sql += ' UNION ALL '.join(sub_queries)
+            sql += ' UNION DISTINCT '.join(sub_queries)
             sql_arr.append(sql)
         else:
             enrollment_status_criteria_arr = [
@@ -749,40 +787,42 @@ class MetricsGenderCacheDao(BaseDao):
             ]
 
             for item in enrollment_status_criteria_arr:
-                sql = """insert into metrics_gender_cache """
+                sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                              participant_summary=f"{bq_project}.{participant_summary_table}")
                 sub_queries = []
                 sql_template = """
                 SELECT
-                  :date_inserted AS date_inserted,
+                  @date_inserted AS dateInserted,
                   '{cache_type}' AS type,
-                  '{enrollment_status}' AS enrollment_status,
-                  :hpo_id AS hpo_id,
-                  (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+                  '{enrollment_status}' AS enrollmentStatus,
+                  @hpo_id AS hpoId,
+                  (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
                   c.day AS date,
-                  '{gender_name}' AS gender_name,
-                  COUNT(*) as gender_count,
-                  participant_origin
-                FROM {temp_table_name} ps, calendar c
+                  '{gender_name}' AS genderName,
+                  COUNT(DISTINCT ps.participant_id) as genderCount,
+                  participant_origin AS participantOrigin
+                FROM temp_table ps, `{calendar}` c
                 WHERE {enrollment_status_criteria}
                 AND {gender_condition}
-                AND c.day BETWEEN :start_date AND :end_date
+                AND c.day BETWEEN @start_date AND @end_date
                 GROUP BY date, participant_origin
                 """
                 for gender_name, gender_condition in zip(self.gender_names, gender_conditions):
                     sub_query = sql_template.format(cache_type=self.cache_type,
-                                                    temp_table_name=temp_table_name,
                                                     enrollment_status=item[0],
                                                     gender_name=gender_name,
                                                     enrollment_status_criteria=item[1],
-                                                    gender_condition=gender_condition)
+                                                    gender_condition=gender_condition,
+                                                    calendar=f"{bq_project}.{calendar_table}",
+                                                    hpo=f"{bq_project}.{hpo_table}")
                     sub_queries.append(sub_query)
 
-                sql += ' UNION ALL '.join(sub_queries)
+                sql += ' UNION DISTINCT '.join(sub_queries)
                 sql_arr.append(sql)
         return sql_arr
 
 
-class MetricsAgeCacheDao(BaseDao):
+class MetricsAgeCacheDao(BaseDao, MetricsDaoMixin):
 
     def __init__(self, cache_type=MetricsCacheType.METRICS_V2_API):
         super(MetricsAgeCacheDao, self).__init__(MetricsAgeCache)
@@ -955,18 +995,19 @@ class MetricsAgeCacheDao(BaseDao):
             client_json.append(new_item)
         return client_json
 
-    def get_metrics_cache_sql(self, hpo_id):
-        temp_table_name = TEMP_TABLE_PREFIX + str(hpo_id)
-        sql = """
-          insert into metrics_age_cache
+    def get_metrics_cache_sql(self, bq_project):
+        sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                      participant_summary=f"{bq_project}.{participant_summary_table}")
+        sql += PARTICIPANT_ORIGIN_SQL.format(participant=f"{bq_project}.{participant_table}")
+        sql += """
             SELECT
-              :date_inserted AS date_inserted,
-              'core' as enrollment_status,
+              @date_inserted AS dateInserted,
+              'core' as enrollmentStatus,
               '{cache_type}' as type,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
               c.day AS date,
-              'UNSET' AS age_range,
+              'UNSET' AS ageRange,
               IFNULL((
                 SELECT SUM(results.age_count)
                 FROM
@@ -974,26 +1015,26 @@ class MetricsAgeCacheDao(BaseDao):
                   SELECT DATE(ps.enrollment_status_core_stored_sample_time) as enrollment_status_core_stored_sample_time,
                          participant_origin,
                          count(*) age_count
-                  FROM {temp_table_name} ps
+                  FROM temp_table ps
                   WHERE ps.date_of_birth IS NULL
                   GROUP BY DATE(ps.enrollment_status_core_stored_sample_time), participant_origin
                 ) AS results
                 WHERE enrollment_status_core_stored_sample_time IS NOT NULL
                 AND DATE(enrollment_status_core_stored_sample_time) <= c.day
                 AND results.participant_origin = d.participant_origin
-              ),0) AS age_count,
-              d.participant_origin
-            FROM calendar c, metrics_tmp_participant_origin d
-            WHERE c.day BETWEEN :start_date AND :end_date
-            UNION ALL
+              ),0) AS ageCount,
+              d.participant_origin AS participantOrigin
+            FROM `{calendar}` c, participant_origin d
+            WHERE c.day BETWEEN @start_date AND @end_date
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
-              'registered' as enrollment_status,
+              @date_inserted AS dateInserted,
+              'registered' as enrollmentStatus,
               '{cache_type}' as type,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
               c.day AS date,
-              'UNSET' AS age_range,
+              'UNSET' AS ageRange,
               IFNULL((
                 SELECT SUM(results.age_count)
                 FROM
@@ -1002,26 +1043,26 @@ class MetricsAgeCacheDao(BaseDao):
                          DATE(ps.consent_for_study_enrollment_time) as consent_for_study_enrollment_time,
                          participant_origin,
                          count(*) age_count
-                  FROM {temp_table_name} ps
+                  FROM temp_table ps
                   WHERE ps.date_of_birth IS NULL
                   GROUP BY DATE(ps.sign_up_time), DATE(ps.consent_for_study_enrollment_time), participant_origin
                 ) AS results
                 WHERE results.day <= c.day
                 AND (consent_for_study_enrollment_time is NULL OR DATE(consent_for_study_enrollment_time)>c.day)
                 AND results.participant_origin = d.participant_origin
-              ),0) AS age_count,
-              d.participant_origin
-            FROM calendar c, metrics_tmp_participant_origin d
-            WHERE c.day BETWEEN :start_date AND :end_date
-            UNION ALL
+              ),0) AS ageCount,
+              d.participant_origin AS participantOrigin
+            FROM `{calendar}` c, participant_origin d
+            WHERE c.day BETWEEN @start_date AND @end_date
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
-              'participant' as enrollment_status,
+              @date_inserted AS dateInserted,
+              'participant' as enrollmentStatus,
               '{cache_type}' as type,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
               c.day AS date,
-              'UNSET' AS age_range,
+              'UNSET' AS ageRange,
               IFNULL((
                 SELECT SUM(results.age_count)
                 FROM
@@ -1030,7 +1071,7 @@ class MetricsAgeCacheDao(BaseDao):
                          DATE(ps.enrollment_status_member_time) as enrollment_status_member_time,
                          participant_origin,
                          count(*) age_count
-                  FROM {temp_table_name} ps
+                  FROM temp_table ps
                   WHERE ps.date_of_birth IS NULL
                   GROUP BY DATE(ps.consent_for_study_enrollment_time), DATE(ps.enrollment_status_member_time), participant_origin
                 ) AS results
@@ -1038,19 +1079,19 @@ class MetricsAgeCacheDao(BaseDao):
                 AND c.day>=DATE(consent_for_study_enrollment_time)
                 AND (enrollment_status_member_time is null or DATE(enrollment_status_member_time)>c.day)
                 AND results.participant_origin = d.participant_origin
-              ),0) AS age_count,
-              d.participant_origin
-            FROM calendar c, metrics_tmp_participant_origin d
-            WHERE c.day BETWEEN :start_date AND :end_date
-            UNION ALL
+              ),0) AS ageCount,
+              d.participant_origin AS participantOrigin
+            FROM `{calendar}` c, participant_origin d
+            WHERE c.day BETWEEN @start_date AND @end_date
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
-              'consented' as enrollment_status,
+              @date_inserted AS dateInserted,
+              'consented' as enrollmentStatus,
               '{cache_type}' as type,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
               c.day AS date,
-              'UNSET' AS age_range,
+              'UNSET' AS ageRange,
               IFNULL((
                 SELECT SUM(results.age_count)
                 FROM
@@ -1059,7 +1100,7 @@ class MetricsAgeCacheDao(BaseDao):
                          DATE(ps.enrollment_status_core_stored_sample_time) as enrollment_status_core_stored_sample_time,
                          participant_origin,
                          count(*) age_count
-                  FROM {temp_table_name} ps
+                  FROM temp_table ps
                   WHERE ps.date_of_birth IS NULL
                   GROUP BY DATE(ps.enrollment_status_member_time), DATE(ps.enrollment_status_core_stored_sample_time), participant_origin
                 ) AS results
@@ -1067,34 +1108,33 @@ class MetricsAgeCacheDao(BaseDao):
                 AND DATE(enrollment_status_member_time) <= c.day
                 AND (enrollment_status_core_stored_sample_time is null or DATE(enrollment_status_core_stored_sample_time)>c.day)
                 AND results.participant_origin = d.participant_origin
-              ),0) AS age_count,
-              d.participant_origin
-            FROM calendar c, metrics_tmp_participant_origin d
-            WHERE c.day BETWEEN :start_date AND :end_date
-            UNION ALL
-        """.format(cache_type=str(self.cache_type), temp_table_name=temp_table_name)
+              ),0) AS ageCount,
+              d.participant_origin AS participantOrigin
+            FROM `{calendar}` c, participant_origin d
+            WHERE c.day BETWEEN @start_date AND @end_date
+            UNION DISTINCT
+        """.format(cache_type=str(self.cache_type), # temp_table_name=temp_table_name,
+                   calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}")
 
         age_ranges_conditions = []
         for age_range in self.age_ranges:
             age_borders = [_f for _f in age_range.split("-") if _f]
             if len(age_borders) == 2:
-                age_ranges_conditions.append(' AND (Date_format(From_Days(To_Days(c.day) - To_Days(dob)), '
-                                             '\'%Y\') + 0) BETWEEN ' + age_borders[0] + ' AND '
+                age_ranges_conditions.append(' AND DATETIME_DIFF(c.day, dob, YEAR) BETWEEN ' + age_borders[0] + ' AND '
                                              + age_borders[1], )
             else:
-                age_ranges_conditions.append(' AND (Date_format(From_Days(To_Days(c.day) - To_Days(dob)), '
-                                             '\'%Y\') + 0) >= ' + age_borders[0])
+                age_ranges_conditions.append(' AND DATETIME_DIFF(c.day, dob, YEAR) >= ' + age_borders[0])
 
         sub_queries = []
         sql_template = """
           SELECT
-            :date_inserted AS date_inserted,
-            'core' as enrollment_status,
+            @date_inserted AS dateInserted,
+            'core' as enrollmentStatus,
             '{cache_type}' as type,
-            :hpo_id AS hpo_id,
-            (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+            @hpo_id AS hpoId,
+            (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
             c.day as date,
-            '{age_range}' AS age_range,
+            '{age_range}' AS ageRange,
             IFNULL((
               SELECT SUM(results.age_count)
               FROM
@@ -1103,7 +1143,7 @@ class MetricsAgeCacheDao(BaseDao):
                        DATE(ps.enrollment_status_core_stored_sample_time) as enrollment_status_core_stored_sample_time,
                        participant_origin,
                        count(*) age_count
-                FROM {temp_table_name} ps
+                FROM temp_table ps
                 WHERE ps.date_of_birth IS NOT NULL
                 GROUP BY DATE(ps.date_of_birth), DATE(ps.enrollment_status_core_stored_sample_time), participant_origin
               ) AS results
@@ -1111,19 +1151,19 @@ class MetricsAgeCacheDao(BaseDao):
               AND DATE(enrollment_status_core_stored_sample_time) <= c.day
               AND results.participant_origin = d.participant_origin
               {age_range_condition}
-            ),0) AS age_count,
-            d.participant_origin
-          FROM calendar c, metrics_tmp_participant_origin d
-          WHERE c.day BETWEEN :start_date AND :end_date
-          UNION ALL
+            ),0) AS ageCount,
+            d.participant_origin AS participantOrigin
+          FROM `{calendar}` c, participant_origin d
+          WHERE c.day BETWEEN @start_date AND @end_date
+          UNION DISTINCT
           SELECT
-            :date_inserted AS date_inserted,
-            'registered' as enrollment_status,
+            @date_inserted AS dateInserted,
+            'registered' as enrollmentStatus,
             '{cache_type}' as type,
-            :hpo_id AS hpo_id,
-            (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+            @hpo_id AS hpoId,
+            (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
             c.day as date,
-            '{age_range}' AS age_range,
+            '{age_range}' AS ageRange,
             IFNULL((
               SELECT SUM(results.age_count)
               FROM
@@ -1133,26 +1173,26 @@ class MetricsAgeCacheDao(BaseDao):
                        DATE(ps.consent_for_study_enrollment_time) as consent_for_study_enrollment_time,
                        participant_origin,
                        count(*) age_count
-                FROM {temp_table_name} ps
+                FROM temp_table ps
                 WHERE ps.date_of_birth IS NOT NULL
                 GROUP BY DATE(ps.sign_up_time), DATE(ps.date_of_birth), DATE(ps.consent_for_study_enrollment_time), participant_origin
               ) AS results
               WHERE results.day <= c.day AND (consent_for_study_enrollment_time is NULL OR DATE(consent_for_study_enrollment_time)>c.day)
               AND results.participant_origin = d.participant_origin
               {age_range_condition}
-            ),0) AS age_count,
-            d.participant_origin
-          FROM calendar c, metrics_tmp_participant_origin d
-          WHERE c.day BETWEEN :start_date AND :end_date
-          UNION ALL
+            ),0) AS ageCount,
+            d.participant_origin AS participantOrigin
+          FROM `{calendar}` c, participant_origin d
+          WHERE c.day BETWEEN @start_date AND @end_date
+          UNION DISTINCT
           SELECT
-            :date_inserted AS date_inserted,
-            'participant' as enrollment_status,
+            @date_inserted AS dateInserted,
+            'participant' as enrollmentStatus,
             '{cache_type}' as type,
-            :hpo_id AS hpo_id,
-            (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+            @hpo_id AS hpoId,
+            (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
             c.day as date,
-            '{age_range}' AS age_range,
+            '{age_range}' AS ageRange,
             IFNULL((
               SELECT SUM(results.age_count)
               FROM
@@ -1162,7 +1202,7 @@ class MetricsAgeCacheDao(BaseDao):
                        DATE(ps.enrollment_status_member_time) as enrollment_status_member_time,
                        participant_origin,
                        count(*) age_count
-                FROM {temp_table_name} ps
+                FROM temp_table ps
                 WHERE ps.date_of_birth IS NOT NULL
                 GROUP BY DATE(ps.consent_for_study_enrollment_time), DATE(ps.date_of_birth), DATE(ps.enrollment_status_member_time), participant_origin
               ) AS results
@@ -1170,19 +1210,19 @@ class MetricsAgeCacheDao(BaseDao):
               AND (enrollment_status_member_time is null or DATE(enrollment_status_member_time)>c.day)
               AND results.participant_origin = d.participant_origin
               {age_range_condition}
-            ),0) AS age_count,
-            d.participant_origin
-          FROM calendar c, metrics_tmp_participant_origin d
-          WHERE c.day BETWEEN :start_date AND :end_date
-          UNION ALL
+            ),0) AS ageCount,
+            d.participant_origin AS participantOrigin
+          FROM `{calendar}` c, participant_origin d
+          WHERE c.day BETWEEN @start_date AND @end_date
+          UNION DISTINCT
           SELECT
-            :date_inserted AS date_inserted,
-            'consented' as enrollment_status,
+            @date_inserted AS dateInserted,
+            'consented' as enrollmentStatus,
             '{cache_type}' as type,
-            :hpo_id AS hpo_id,
-            (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
+            @hpo_id AS hpoId,
+            (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
             c.day as date,
-            '{age_range}' AS age_range,
+            '{age_range}' AS ageRange,
             IFNULL((
               SELECT SUM(results.age_count)
               FROM
@@ -1192,7 +1232,7 @@ class MetricsAgeCacheDao(BaseDao):
                        DATE(ps.enrollment_status_core_stored_sample_time) as enrollment_status_core_stored_sample_time,
                        participant_origin,
                        count(*) age_count
-                FROM {temp_table_name} ps
+                FROM temp_table ps
                 WHERE ps.date_of_birth IS NOT NULL
                 GROUP BY DATE(ps.date_of_birth), DATE(ps.enrollment_status_member_time), DATE(ps.enrollment_status_core_stored_sample_time), participant_origin
               ) AS results
@@ -1201,25 +1241,25 @@ class MetricsAgeCacheDao(BaseDao):
               AND (enrollment_status_core_stored_sample_time is null or DATE(enrollment_status_core_stored_sample_time)>c.day)
               AND results.participant_origin = d.participant_origin
               {age_range_condition}
-            ),0) AS age_count,
-            d.participant_origin
-          FROM calendar c, metrics_tmp_participant_origin d
-          WHERE c.day BETWEEN :start_date AND :end_date
+            ),0) AS ageCount,
+            d.participant_origin AS participantOrigin
+          FROM `{calendar}` c, participant_origin d
+          WHERE c.day BETWEEN @start_date AND @end_date
         """
 
         for age_range, age_range_condition in zip(self.age_ranges, age_ranges_conditions):
             sub_query = sql_template.format(cache_type=str(self.cache_type),
-                                            temp_table_name=temp_table_name,
                                             age_range=age_range,
-                                            age_range_condition=age_range_condition)
+                                            age_range_condition=age_range_condition,
+                                            calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}")
             sub_queries.append(sub_query)
 
-        sql += ' UNION ALL '.join(sub_queries)
+        sql += ' UNION DISTINCT '.join(sub_queries)
 
         return [sql]
 
 
-class MetricsRaceCacheDao(BaseDao):
+class MetricsRaceCacheDao(BaseDao, MetricsDaoMixin):
 
     def __init__(self, cache_type=MetricsCacheType.METRICS_V2_API, version=None):
         super(MetricsRaceCacheDao, self).__init__(MetricsRaceCache, read_uncommitted=True)
@@ -1291,10 +1331,10 @@ class MetricsRaceCacheDao(BaseDao):
                                       )
                 if self.version == MetricsAPIVersion.V2:
                     query = query.filter(MetricsRaceCache.dateInserted == last_inserted_date,
-                                         MetricsRaceCache.type == self.cache_type)
+                                         MetricsRaceCache.type == MetricsCacheType.METRICS_V2_API)
                 else:
                     query = query.filter(MetricsRaceCache.dateInserted == last_inserted_date,
-                                         MetricsRaceCache.type == MetricsCacheType.METRICS_V2_API)
+                                         MetricsRaceCache.type == self.cache_type)
 
                 if start_date:
                     query = query.filter(MetricsRaceCache.date >= start_date)
@@ -1453,8 +1493,7 @@ class MetricsRaceCacheDao(BaseDao):
             client_json.append(new_item)
         return client_json
 
-    def get_metrics_cache_sql(self, hpo_id):
-        temp_table_name = TEMP_TABLE_PREFIX + str(hpo_id)
+    def get_metrics_cache_sql(self, bq_project):
         race_code_dict = {
             'Race_WhatRaceEthnicity': 193,
             'WhatRaceEthnicity_Hispanic': 207,
@@ -1469,50 +1508,54 @@ class MetricsRaceCacheDao(BaseDao):
             'WhatRaceEthnicity_NHPI': 237
         }
 
+        sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                      participant_summary=f"{bq_project}.{participant_summary_table}")
+        sql += PARTICIPANT_ORIGIN_SQL.format(participant=f"{bq_project}.{participant_table}")
+
         for k in race_code_dict:
             code = CodeDao().get_code(PPI_SYSTEM, k)
             if code is not None:
                 race_code_dict[k] = code.codeId
         if self.cache_type == MetricsCacheType.METRICS_V2_API:
-            sql = """
-            insert into metrics_race_cache
+            sql += """
               SELECT
-                :date_inserted as date_inserted,
+                @date_inserted as dateInserted,
                 '{cache_type}' as type,
-                registered as registered_flag,
-                participant as participant_flag,
-                consented as consented_flag,
-                core as core_flag,
-                hpo_id,
-                (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-                day,
-                SUM(American_Indian_Alaska_Native) AS American_Indian_Alaska_Native,
-                SUM(Asian) AS Asian,
-                SUM(Black_African_American) AS Black_African_American,
-                SUM(Middle_Eastern_North_African) AS Middle_Eastern_North_African,
-                SUM(Native_Hawaiian_other_Pacific_Islander) AS Native_Hawaiian_other_Pacific_Islander,
-                SUM(White) AS White,
-                SUM(Hispanic_Latino_Spanish) AS Hispanic_Latino_Spanish,
-                SUM(None_Of_These_Fully_Describe_Me) AS None_Of_These_Fully_Describe_Me,
-                SUM(Prefer_Not_To_Answer) AS Prefer_Not_To_Answer,
-                SUM(Multi_Ancestry) AS Multi_Ancestry,
-                SUM(No_Ancestry_Checked) AS No_Ancestry_Checked,
-                participant_origin,
-                SUM(Unset_No_Basics) AS Unset_No_Basics
+                registered as registeredFlag,
+                participant as participantFlag,
+                consented as consentedFlag,
+                core as coreFlag,
+                hpo_id AS hpoId,
+                (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+                day AS date,
+                SUM(American_Indian_Alaska_Native) AS americanIndianAlaskaNative,
+                SUM(Asian) AS asian,
+                SUM(Black_African_American) AS blackAfricanAmerican,
+                SUM(Middle_Eastern_North_African) AS middleEasternNorthAfrican,
+                SUM(Native_Hawaiian_other_Pacific_Islander) AS nativeHawaiianOtherPacificIslander,
+                SUM(White) AS white,
+                SUM(Hispanic_Latino_Spanish) AS hispanicLatinoSpanish,
+                SUM(None_Of_These_Fully_Describe_Me) AS noneOfTheseFullyDescribeMe,
+                SUM(Prefer_Not_To_Answer) AS preferNotToAnswer,
+                SUM(Multi_Ancestry) AS multiAncestry,
+                SUM(No_Ancestry_Checked) AS noAncestryChecked,
+                participant_origin AS participantOrigin,
+                SUM(Unset_No_Basics) AS unsetNoBasics
                 FROM
                 (
-                  SELECT p.hpo_id,
+                  SELECT DISTINCT p.participant_id,
+                         p.hpo_id,
                          day,
                          p.participant_origin,
-                         CASE WHEN DATE(sign_up_time)<=calendar.day AND (consent_for_study_enrollment_time IS NULL OR DATE(consent_for_study_enrollment_time)>calendar.day)
+                         CASE WHEN DATE(sign_up_time)<=c.day AND (consent_for_study_enrollment_time IS NULL OR DATE(consent_for_study_enrollment_time)>c.day)
                                    THEN 1 ELSE 0 END AS registered,
-                         CASE WHEN (consent_for_study_enrollment_time IS NOT NULL AND DATE(consent_for_study_enrollment_time)<=calendar.day) AND
-                                   (enrollment_status_member_time IS NULL OR DATE(enrollment_status_member_time)>calendar.day)
+                         CASE WHEN (consent_for_study_enrollment_time IS NOT NULL AND DATE(consent_for_study_enrollment_time)<=c.day) AND
+                                   (enrollment_status_member_time IS NULL OR DATE(enrollment_status_member_time)>c.day)
                              THEN 1 ELSE 0 END AS participant,
-                         CASE WHEN (enrollment_status_member_time IS NOT NULL AND DATE(enrollment_status_member_time)<=calendar.day) AND
-                                   (enrollment_status_core_stored_sample_time IS NULL OR DATE(enrollment_status_core_stored_sample_time)>calendar.day)
+                         CASE WHEN (enrollment_status_member_time IS NOT NULL AND DATE(enrollment_status_member_time)<=c.day) AND
+                                   (enrollment_status_core_stored_sample_time IS NULL OR DATE(enrollment_status_core_stored_sample_time)>c.day)
                              THEN 1 ELSE 0 END AS consented,
-                         CASE WHEN enrollment_status_core_stored_sample_time IS NOT NULL AND DATE(enrollment_status_core_stored_sample_time)<=calendar.day
+                         CASE WHEN enrollment_status_core_stored_sample_time IS NOT NULL AND DATE(enrollment_status_core_stored_sample_time)<=c.day
                              THEN 1 ELSE 0 END AS core,
                          CASE WHEN WhatRaceEthnicity_AIAN=1 AND Number_of_Answer=1 THEN 1 ELSE 0 END AS American_Indian_Alaska_Native,
                          CASE WHEN WhatRaceEthnicity_Asian=1 AND Number_of_Answer=1 THEN 1 ELSE 0 END AS Asian,
@@ -1583,21 +1626,20 @@ class MetricsRaceCacheDao(BaseDao):
                                        CASE WHEN q.code_id = {WhatRaceEthnicity_MENA} THEN 1 ELSE 0 END   AS WhatRaceEthnicity_MENA,
                                        CASE WHEN q.code_id = {PMI_Skip} THEN 1 ELSE 0 END   AS PMI_Skip,
                                        CASE WHEN q.code_id = {WhatRaceEthnicity_NHPI} THEN 1 ELSE 0 END   AS WhatRaceEthnicity_NHPI
-                                FROM {temp_table_name} ps
-                                LEFT JOIN participant_race_answers q ON ps.participant_id = q.participant_id
+                                FROM temp_table ps
+                                LEFT JOIN `{participant_race_answers}` q ON ps.participant_id = q.participant_id
                               ) x
                          GROUP BY participant_id, hpo_id, sign_up_time, consent_for_study_enrollment_time, enrollment_status_member_time, enrollment_status_core_stored_sample_time, participant_origin
                        ) p,
-                       calendar, metrics_tmp_participant_origin po
-                  WHERE calendar.day >= :start_date
-                    AND calendar.day <= :end_date
-                    AND calendar.day >= Date(p.sign_up_time)
+                       `{calendar}` c, participant_origin po
+                  WHERE c.day >= @start_date
+                    AND c.day <= @end_date
+                    AND c.day >= Date(p.sign_up_time)
                     AND p.participant_origin = po.participant_origin
                 ) y
                 GROUP BY day, hpo_id, registered, participant, consented, core, participant_origin
                 ;
             """.format(cache_type=self.cache_type,
-                       temp_table_name=temp_table_name,
                        Race_WhatRaceEthnicity=race_code_dict['Race_WhatRaceEthnicity'],
                        WhatRaceEthnicity_Hispanic=race_code_dict['WhatRaceEthnicity_Hispanic'],
                        WhatRaceEthnicity_Black=race_code_dict['WhatRaceEthnicity_Black'],
@@ -1609,47 +1651,50 @@ class MetricsRaceCacheDao(BaseDao):
                        PMI_PreferNotToAnswer=race_code_dict['PMI_PreferNotToAnswer'],
                        WhatRaceEthnicity_MENA=race_code_dict['WhatRaceEthnicity_MENA'],
                        PMI_Skip=race_code_dict['PMI_Skip'],
-                       WhatRaceEthnicity_NHPI=race_code_dict['WhatRaceEthnicity_NHPI'])
+                       WhatRaceEthnicity_NHPI=race_code_dict['WhatRaceEthnicity_NHPI'],
+                       calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}",
+                       participant_race_answers=f"{bq_project}.{race_answers_table}"
+                       )
         else:
-            sql = """
-                  insert into metrics_race_cache
+            sql += """
                     SELECT
-                      :date_inserted as date_inserted,
+                      @date_inserted as dateInserted,
                       '{cache_type}' as type,
-                      registered as registered_flag,
-                      participant as participant_flag,
-                      consented as consented_flag,
-                      core as core_flag,
-                      hpo_id,
-                      (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-                      day,
-                      SUM(American_Indian_Alaska_Native) AS American_Indian_Alaska_Native,
-                      SUM(Asian) AS Asian,
-                      SUM(Black_African_American) AS Black_African_American,
-                      SUM(Middle_Eastern_North_African) AS Middle_Eastern_North_African,
-                      SUM(Native_Hawaiian_other_Pacific_Islander) AS Native_Hawaiian_other_Pacific_Islander,
-                      SUM(White) AS White,
-                      SUM(Hispanic_Latino_Spanish) AS Hispanic_Latino_Spanish,
-                      SUM(None_Of_These_Fully_Describe_Me) AS None_Of_These_Fully_Describe_Me,
-                      SUM(Prefer_Not_To_Answer) AS Prefer_Not_To_Answer,
-                      SUM(Multi_Ancestry) AS Multi_Ancestry,
-                      SUM(No_Ancestry_Checked) AS No_Ancestry_Checked,
-                      participant_origin,
-                      SUM(Unset_No_Basics) AS Unset_No_Basics
+                      registered as registeredFlag,
+                      participant as participantFlag,
+                      consented as consentedFlag,
+                      core as coreFlag,
+                      hpo_id AS hpoId,
+                      (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+                      day AS date,
+                      SUM(American_Indian_Alaska_Native) AS americanIndianAlaskaNative,
+                      SUM(Asian) AS asian,
+                      SUM(Black_African_American) AS blackAfricanAmerican,
+                      SUM(Middle_Eastern_North_African) AS middleEasternNorthAfrican,
+                      SUM(Native_Hawaiian_other_Pacific_Islander) AS nativeHawaiianOtherPacificIslander,
+                      SUM(White) AS white,
+                      SUM(Hispanic_Latino_Spanish) AS hispanicLatinoSpanish,
+                      SUM(None_Of_These_Fully_Describe_Me) AS noneOfTheseFullyDescribeMe,
+                      SUM(Prefer_Not_To_Answer) AS preferNotToAnswer,
+                      SUM(Multi_Ancestry) AS multiAncestry,
+                      SUM(No_Ancestry_Checked) AS noAncestryChecked,
+                      participant_origin AS participantOrigin,
+                      SUM(Unset_No_Basics) AS unsetNoBasics
                       FROM
                       (
-                        SELECT p.hpo_id,
+                        SELECT DISTINCT p.participant_id,
+                               p.hpo_id,
                                day,
                                p.participant_origin,
-                               CASE WHEN DATE(sign_up_time)<=calendar.day AND (consent_for_study_enrollment_time IS NULL OR DATE(consent_for_study_enrollment_time)>calendar.day)
+                               CASE WHEN DATE(sign_up_time)<=c.day AND (consent_for_study_enrollment_time IS NULL OR DATE(consent_for_study_enrollment_time)>c.day)
                                    THEN 1 ELSE 0 END AS registered,
-                               CASE WHEN (consent_for_study_enrollment_time IS NOT NULL AND DATE(consent_for_study_enrollment_time)<=calendar.day) AND
-                                         (enrollment_status_member_time IS NULL OR DATE(enrollment_status_member_time)>calendar.day)
+                               CASE WHEN (consent_for_study_enrollment_time IS NOT NULL AND DATE(consent_for_study_enrollment_time)<=c.day) AND
+                                         (enrollment_status_member_time IS NULL OR DATE(enrollment_status_member_time)>c.day)
                                    THEN 1 ELSE 0 END AS participant,
-                               CASE WHEN (enrollment_status_member_time IS NOT NULL AND DATE(enrollment_status_member_time)<=calendar.day) AND
-                                         (enrollment_status_core_stored_sample_time IS NULL OR DATE(enrollment_status_core_stored_sample_time)>calendar.day)
+                               CASE WHEN (enrollment_status_member_time IS NOT NULL AND DATE(enrollment_status_member_time)<=c.day) AND
+                                         (enrollment_status_core_stored_sample_time IS NULL OR DATE(enrollment_status_core_stored_sample_time)>c.day)
                                    THEN 1 ELSE 0 END AS consented,
-                               CASE WHEN enrollment_status_core_stored_sample_time IS NOT NULL AND DATE(enrollment_status_core_stored_sample_time)<=calendar.day
+                               CASE WHEN enrollment_status_core_stored_sample_time IS NOT NULL AND DATE(enrollment_status_core_stored_sample_time)<=c.day
                                    THEN 1 ELSE 0 END AS core,
                                CASE WHEN WhatRaceEthnicity_AIAN=1 THEN 1 ELSE 0 END AS American_Indian_Alaska_Native,
                                CASE WHEN WhatRaceEthnicity_Asian=1 THEN 1 ELSE 0 END AS Asian,
@@ -1720,21 +1765,20 @@ class MetricsRaceCacheDao(BaseDao):
                                              CASE WHEN q.code_id = {WhatRaceEthnicity_MENA} THEN 1 ELSE 0 END   AS WhatRaceEthnicity_MENA,
                                              CASE WHEN q.code_id = {PMI_Skip} THEN 1 ELSE 0 END   AS PMI_Skip,
                                              CASE WHEN q.code_id = {WhatRaceEthnicity_NHPI} THEN 1 ELSE 0 END   AS WhatRaceEthnicity_NHPI
-                                      FROM {temp_table_name} ps
-                                      LEFT JOIN participant_race_answers q ON ps.participant_id = q.participant_id
+                                      FROM temp_table ps
+                                      LEFT JOIN `{participant_race_answers}` q ON ps.participant_id = q.participant_id
                                     ) x
                                GROUP BY participant_id, hpo_id, sign_up_time, consent_for_study_enrollment_time, enrollment_status_member_time, enrollment_status_core_stored_sample_time, participant_origin
                              ) p,
-                             calendar, metrics_tmp_participant_origin po
-                        WHERE calendar.day >= :start_date
-                          AND calendar.day <= :end_date
-                          AND calendar.day >= Date(p.sign_up_time)
+                             `{calendar}` c, participant_origin po
+                        WHERE c.day >= @start_date
+                          AND c.day <= @end_date
+                          AND c.day >= Date(p.sign_up_time)
                           AND p.participant_origin = po.participant_origin
                       ) y
                       GROUP BY day, hpo_id, registered, participant, consented, core, participant_origin
                       ;
                 """.format(cache_type=self.cache_type,
-                           temp_table_name=temp_table_name,
                            Race_WhatRaceEthnicity=race_code_dict['Race_WhatRaceEthnicity'],
                            WhatRaceEthnicity_Hispanic=race_code_dict['WhatRaceEthnicity_Hispanic'],
                            WhatRaceEthnicity_Black=race_code_dict['WhatRaceEthnicity_Black'],
@@ -1746,11 +1790,13 @@ class MetricsRaceCacheDao(BaseDao):
                            PMI_PreferNotToAnswer=race_code_dict['PMI_PreferNotToAnswer'],
                            WhatRaceEthnicity_MENA=race_code_dict['WhatRaceEthnicity_MENA'],
                            PMI_Skip=race_code_dict['PMI_Skip'],
-                           WhatRaceEthnicity_NHPI=race_code_dict['WhatRaceEthnicity_NHPI'])
+                           WhatRaceEthnicity_NHPI=race_code_dict['WhatRaceEthnicity_NHPI'],
+                           calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}",
+                           participant_race_answers=f"{bq_project}.{race_answers_table}")
         return [sql]
 
 
-class MetricsRegionCacheDao(BaseDao):
+class MetricsRegionCacheDao(BaseDao, MetricsDaoMixin):
 
     def __init__(self, cache_type=MetricsCacheType.METRICS_V2_API, version=None):
         super(MetricsRegionCacheDao, self).__init__(MetricsRegionCache)
@@ -2016,107 +2062,109 @@ class MetricsRegionCacheDao(BaseDao):
                 client_json.append(new_item)
         return client_json
 
-    def get_metrics_cache_sql(self, hpo_id):
-        temp_table_name = TEMP_TABLE_PREFIX + str(hpo_id)
-        sql = """
-          INSERT INTO metrics_region_cache
+    def get_metrics_cache_sql(self, bq_project):
+        sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                      participant_summary=f"{bq_project}.{participant_summary_table}")
+        sql += PARTICIPANT_ORIGIN_SQL.format(participant=f"{bq_project}.{participant_table}")
+        sql += """
             SELECT
-              :date_inserted AS date_inserted,
-              'core' as enrollment_status,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-              c.day,
-              IFNULL(ps.value,'UNSET') AS state_name,
-              count(ps.participant_id) AS state_count,
-              ps.participant_origin
+              @date_inserted AS dateInserted,
+              'core' as enrollmentStatus,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+              c.day AS date,
+              IFNULL(ps.value,'UNSET') AS stateName,
+              count(DISTINCT ps.participant_id) AS stateCount,
+              ps.participant_origin AS participantOrigin
             FROM
               (
               SELECT participant_id, participant_origin, hpo_id, value, enrollment_status_core_stored_sample_time
-              FROM {temp_table_name}, code WHERE state_id=code_id
-              ) ps,
-              metrics_tmp_participant_origin po,
-              calendar c
-            WHERE ps.participant_origin = po.participant_origin
-            AND ps.enrollment_status_core_stored_sample_time IS NOT NULL
+              FROM temp_table
+              JOIN `{code}` code ON temp_table.state_id = code.code_id
+              ) ps
+              JOIN participant_origin po ON ps.participant_origin = po.participant_origin,
+              `{calendar}` c
+            WHERE ps.enrollment_status_core_stored_sample_time IS NOT NULL
             AND DATE(ps.enrollment_status_core_stored_sample_time) <= c.day
-            AND c.day BETWEEN :start_date AND :end_date
+            AND c.day BETWEEN @start_date AND @end_date
             GROUP BY c.day, ps.hpo_id, ps.value, ps.participant_origin
-            UNION ALL
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
-              'registered' as enrollment_status,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-              c.day,
-              IFNULL(ps.value,'UNSET') AS state_name,
-              count(ps.participant_id) AS state_count,
-              ps.participant_origin
+              @date_inserted AS dateInserted,
+              'registered' as enrollmentStatus,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+              c.day AS date,
+              IFNULL(ps.value,'UNSET') AS stateName,
+              count(DISTINCT ps.participant_id) AS stateCount,
+              ps.participant_origin  AS participantOrigin
             FROM
               (
               SELECT participant_id, participant_origin, hpo_id, value, sign_up_time, consent_for_study_enrollment_time
-              FROM {temp_table_name}, code WHERE state_id=code_id
-              ) ps,
-              metrics_tmp_participant_origin po,
-              calendar c
-            WHERE ps.participant_origin = po.participant_origin
-            AND ps.sign_up_time IS NOT NULL
+              FROM temp_table
+              JOIN `{code}` code ON temp_table.state_id = code.code_id
+              ) ps
+              JOIN participant_origin po ON ps.participant_origin = po.participant_origin,
+              `{calendar}` c
+            WHERE ps.sign_up_time IS NOT NULL
             AND DATE(ps.sign_up_time) <= c.day
             AND (ps.consent_for_study_enrollment_time IS NULL OR DATE(ps.consent_for_study_enrollment_time)>c.day)
-            AND c.day BETWEEN :start_date AND :end_date
+            AND c.day BETWEEN @start_date AND @end_date
             GROUP BY c.day, ps.hpo_id, ps.value, ps.participant_origin
-            UNION ALL
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
-              'participant' as enrollment_status,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-              c.day,
-              IFNULL(ps.value,'UNSET') AS state_name,
-              count(ps.participant_id) AS state_count,
-              ps.participant_origin
+              @date_inserted AS dateInserted,
+              'participant' as enrollmentStatus,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+              c.day AS date,
+              IFNULL(ps.value,'UNSET') AS stateName,
+              count(DISTINCT ps.participant_id) AS stateCount,
+              ps.participant_origin AS participantOrigin
             FROM
               (
               SELECT participant_id, participant_origin, hpo_id, value, consent_for_study_enrollment_time, enrollment_status_member_time
-              FROM {temp_table_name}, code WHERE state_id=code_id
-              ) ps,
-              metrics_tmp_participant_origin po,
-              calendar c
-            WHERE ps.participant_origin = po.participant_origin
-            AND ps.consent_for_study_enrollment_time IS NOT NULL
+              FROM temp_table
+              JOIN `{code}` code ON temp_table.state_id = code.code_id
+              ) ps
+              JOIN participant_origin po ON ps.participant_origin = po.participant_origin,
+              `{calendar}` c
+            WHERE ps.consent_for_study_enrollment_time IS NOT NULL
             AND DATE(ps.consent_for_study_enrollment_time) <= c.day
             AND (ps.enrollment_status_member_time is null or DATE(ps.enrollment_status_member_time)>c.day)
-            AND c.day BETWEEN :start_date AND :end_date
+            AND c.day BETWEEN @start_date AND @end_date
             GROUP BY c.day, ps.hpo_id, ps.value, ps.participant_origin
-            UNION ALL
+            UNION DISTINCT
             SELECT
-              :date_inserted AS date_inserted,
-              'consented' as enrollment_status,
-              :hpo_id AS hpo_id,
-              (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-              c.day,
-              IFNULL(ps.value,'UNSET') AS state_name,
-              count(ps.participant_id) AS state_count,
-              ps.participant_origin
+              @date_inserted AS dateInserted,
+              'consented' as enrollmentStatus,
+              @hpo_id AS hpoId,
+              (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+              c.day AS date,
+              IFNULL(ps.value,'UNSET') AS stateName,
+              count(DISTINCT ps.participant_id) AS stateCount,
+              ps.participant_origin AS participantOrigin
             FROM
               (
               SELECT participant_id, participant_origin, hpo_id, value, enrollment_status_member_time, enrollment_status_core_stored_sample_time
-              FROM {temp_table_name}, code WHERE state_id=code_id
-              ) ps,
-              metrics_tmp_participant_origin po,
-              calendar c
-            WHERE ps.participant_origin = po.participant_origin
-            AND ps.enrollment_status_member_time IS NOT NULL
+              FROM temp_table
+              JOIN `{code}` code ON temp_table.state_id = code.code_id
+              ) ps
+              JOIN participant_origin po ON ps.participant_origin = po.participant_origin,
+              `{calendar}` c
+            WHERE ps.enrollment_status_member_time IS NOT NULL
             AND DATE(ps.enrollment_status_member_time) <= c.day
             AND (ps.enrollment_status_core_stored_sample_time is null or DATE(ps.enrollment_status_core_stored_sample_time)>c.day)
-            AND c.day BETWEEN :start_date AND :end_date
+            AND c.day BETWEEN @start_date AND @end_date
             GROUP BY c.day, ps.hpo_id, ps.value, ps.participant_origin
             ;
-        """.format(temp_table_name=temp_table_name)
+        """.format(calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}",
+                   code=f"{bq_project}.{code_table}")
 
         return [sql]
 
 
-class MetricsLifecycleCacheDao(BaseDao):
+class MetricsLifecycleCacheDao(BaseDao, MetricsDaoMixin):
 
     def __init__(self, cache_type=MetricsCacheType.METRICS_V2_API, version=None):
         super(MetricsLifecycleCacheDao, self).__init__(MetricsLifecycleCache)
@@ -2440,8 +2488,7 @@ class MetricsLifecycleCacheDao(BaseDao):
             client_json.append(new_item)
         return client_json
 
-    def get_metrics_cache_sql(self, hpo_id):
-        temp_table_name = TEMP_TABLE_PREFIX + str(hpo_id)
+    def get_metrics_cache_sql(self, bq_project):
         sql_arr = []
         if self.cache_type == MetricsCacheType.METRICS_V2_API:
             enrollment_status_criteria_arr = [
@@ -2460,217 +2507,274 @@ class MetricsLifecycleCacheDao(BaseDao):
                          'AND calendar.day>=DATE(enrollment_status_core_stored_sample_time)')
             ]
             for item in enrollment_status_criteria_arr:
-                sql = """
-                insert into metrics_lifecycle_cache
+                sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                              participant_summary=f"{bq_project}.{participant_summary_table}")
+                sql += """
                   select
-                    :date_inserted AS date_inserted,
-                    '{enrollment_status}' as enrollment_status,
+                    @date_inserted AS dateInserted,
+                    '{enrollment_status}' as enrollmentStatus,
                     '{cache_type}' as type,
+                    ps.hpo_id AS hpoId,
+                    (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+                    ps.day AS date,
+                    SUM(CASE WHEN DATE(ps.sign_up_time) <= ps.day THEN 1 ELSE 0 END) AS registered,
+                    SUM(CASE WHEN DATE(ps.consent_for_study_enrollment_time) <= ps.day THEN 1 ELSE 0 END) AS consentEnrollment,
+                    SUM(CASE WHEN DATE(ps.enrollment_status_member_time) <= ps.day THEN 1 ELSE 0 END) AS consentComplete,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                        DATE(ps.consent_for_study_enrollment_time) <= ps.day
+                      THEN 1 ELSE 0
+                    END) AS ppiBasics,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_overall_health_time) <= ps.day AND
+                        DATE(ps.consent_for_study_enrollment_time) <= ps.day
+                      THEN 1 ELSE 0
+                    END) AS ppiOverallHealth,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_lifestyle_time) <= ps.day AND
+                        DATE(ps.consent_for_study_enrollment_time) <= ps.day
+                      THEN 1 ELSE 0
+                    END) AS ppiLifestyle,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_healthcare_access_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                        DATE_DIFF(ps.day, DATE(ps.consent_for_study_enrollment_time), DAY) > 90
+                      THEN 1 ELSE 0
+                    END) AS ppiHealthcareAccess,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_medical_history_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                        DATE_DIFF(ps.day, DATE(ps.consent_for_study_enrollment_time), DAY) > 90
+                      THEN 1 ELSE 0
+                    END) AS ppiMedicalHistory,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_medications_time) <= ps.day AND
+                        DATE(ps.consent_for_study_enrollment_time) <= ps.day
+                      THEN 1 ELSE 0
+                    END) AS ppiMedications,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_family_health_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                        DATE_DIFF(ps.day, DATE(ps.consent_for_study_enrollment_time), DAY) > 90
+                      THEN 1 ELSE 0
+                    END) AS ppiFamilyHealth,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_lifestyle_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_overall_health_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                        DATE(ps.consent_for_study_enrollment_time) <= ps.day
+                      THEN 1 ELSE 0
+                    END) AS ppiComplete,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                        DATE_DIFF(ps.day, DATE(ps.consent_for_study_enrollment_time), DAY) > 90
+                      THEN 1 ELSE 0
+                    END) AS retentionModulesEligible,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_healthcare_access_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_family_health_time) <= ps.day AND
+                        DATE(ps.questionnaire_on_medical_history_time) <= ps.day AND
+                        DATE_DIFF(ps.day, DATE(ps.consent_for_study_enrollment_time), DAY) > 90
+                      THEN 1 ELSE 0
+                    END) AS retentionModulesComplete,
+                    SUM(CASE
+                      WHEN
+                        (DATE(ps.clinic_physical_measurements_time) <= ps.day OR
+                        DATE(ps.self_reported_physical_measurements_authored) <= ps.day) AND
+                        DATE(ps.consent_for_study_enrollment_time) <= ps.day
+                      THEN 1 ELSE 0
+                    END) AS physicalMeasurement,
+                    SUM(CASE
+                      WHEN
+                        DATE(ps.sample_status_1ed10_time) <= ps.day OR
+                        DATE(ps.sample_status_2ed10_time) <= ps.day OR
+                        DATE(ps.sample_status_1ed04_time) <= ps.day OR
+                        DATE(ps.sample_status_1sal_time) <= ps.day OR
+                        DATE(ps.sample_status_1sal2_time) <= ps.day
+                      THEN 1 ELSE 0
+                    END) AS sampleReceived,
+                    0 AS ppiBaselineComplete,
+                    0 AS fullParticipant,
+                    SUM(CASE WHEN DATE(ps.enrollment_status_core_stored_sample_time) <= ps.day THEN 1 ELSE 0 END) AS coreParticipant,
+                    ps.participant_origin AS participantOrigin
+                FROM (
+                  SELECT DISTINCT
+                    ps.participant_id,
                     ps.hpo_id,
-                    (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-                    day,
-                    SUM(CASE WHEN DATE(ps.sign_up_time) <= calendar.day THEN 1 ELSE 0 END) AS registered,
-                    SUM(CASE WHEN DATE(ps.consent_for_study_enrollment_time) <= calendar.day THEN 1 ELSE 0 END) AS consent_enrollment,
-                    SUM(CASE WHEN DATE(ps.enrollment_status_member_time) <= calendar.day THEN 1 ELSE 0 END) AS consent_complete,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                        DATE(ps.consent_for_study_enrollment_time) <= calendar.day
-                      THEN 1 ELSE 0
-                    END) AS ppi_basics,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_overall_health_time) <= calendar.day AND
-                        DATE(ps.consent_for_study_enrollment_time) <= calendar.day
-                      THEN 1 ELSE 0
-                    END) AS ppi_overall_health,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_lifestyle_time) <= calendar.day AND
-                        DATE(ps.consent_for_study_enrollment_time) <= calendar.day
-                      THEN 1 ELSE 0
-                    END) AS ppi_lifestyle,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_healthcare_access_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                        DATEDIFF(calendar.day, DATE(ps.consent_for_study_enrollment_time)) > 90
-                      THEN 1 ELSE 0
-                    END) AS ppi_healthcare_access,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_medical_history_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                        DATEDIFF(calendar.day, DATE(ps.consent_for_study_enrollment_time)) > 90
-                      THEN 1 ELSE 0
-                    END) AS ppi_medical_history,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_medications_time) <= calendar.day AND
-                        DATE(ps.consent_for_study_enrollment_time) <= calendar.day
-                      THEN 1 ELSE 0
-                    END) AS ppi_medications,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_family_health_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                        DATEDIFF(calendar.day, DATE(ps.consent_for_study_enrollment_time)) > 90
-                      THEN 1 ELSE 0
-                    END) AS ppi_family_health,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_lifestyle_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_overall_health_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                        DATE(ps.consent_for_study_enrollment_time) <= calendar.day
-                      THEN 1 ELSE 0
-                    END) AS ppi_complete,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                        DATEDIFF(calendar.day, DATE(ps.consent_for_study_enrollment_time)) > 90
-                      THEN 1 ELSE 0
-                    END) AS retention_modules_eligible,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_healthcare_access_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_family_health_time) <= calendar.day AND
-                        DATE(ps.questionnaire_on_medical_history_time) <= calendar.day AND
-                        DATEDIFF(calendar.day, DATE(ps.consent_for_study_enrollment_time)) > 90
-                      THEN 1 ELSE 0
-                    END) AS retention_modules_complete,
-                    SUM(CASE
-                      WHEN
-                        (DATE(ps.clinic_physical_measurements_time) <= calendar.day OR
-                        DATE(ps.self_reported_physical_measurements_authored) <= calendar.day) AND
-                        DATE(ps.consent_for_study_enrollment_time) <= calendar.day
-                      THEN 1 ELSE 0
-                    END) AS physical_measurement,
-                    SUM(CASE
-                      WHEN
-                        DATE(ps.sample_status_1ed10_time) <= calendar.day OR
-                        DATE(ps.sample_status_2ed10_time) <= calendar.day OR
-                        DATE(ps.sample_status_1ed04_time) <= calendar.day OR
-                        DATE(ps.sample_status_1sal_time) <= calendar.day OR
-                        DATE(ps.sample_status_1sal2_time) <= calendar.day
-                      THEN 1 ELSE 0
-                    END) AS sample_received,
-                    SUM(CASE WHEN DATE(ps.enrollment_status_core_stored_sample_time) <= calendar.day THEN 1 ELSE 0 END) AS core_participant,
-                    ps.participant_origin
-                  from {temp_table_name} ps,
-                       calendar
+                    ps.sign_up_time,
+                    ps.consent_for_study_enrollment_time,
+                    ps.enrollment_status_member_time,
+                    ps.enrollment_status_core_stored_sample_time,
+                    ps.questionnaire_on_the_basics_time,
+                    ps.questionnaire_on_overall_health_time,
+                    ps.questionnaire_on_healthcare_access_time,
+                    ps.questionnaire_on_lifestyle_time,
+                    ps.questionnaire_on_medical_history_time,
+                    ps.questionnaire_on_medications_time,
+                    ps.questionnaire_on_family_health_time,
+                    ps.clinic_physical_measurements_time,
+                    ps.self_reported_physical_measurements_authored,
+                    ps.sample_status_1sal_time,
+                    ps.sample_status_1sal2_time,
+                    ps.sample_status_1ed04_time,
+                    ps.sample_status_2ed10_time,
+                    ps.sample_status_1ed10_time,
+                    ps.participant_origin,
+                    calendar.day
+                  FROM temp_table AS ps,
+                       `{calendar}` AS calendar
                   WHERE {enrollment_status_criteria}
-                  AND calendar.day BETWEEN :start_date AND :end_date
-                  GROUP BY day, ps.hpo_id, ps.participant_origin;
+                  AND calendar.day BETWEEN @start_date AND @end_date
+                ) AS ps
+                GROUP BY ps.day, ps.hpo_id, ps.participant_origin;
               """.format(enrollment_status=item[0],
                          cache_type=self.cache_type,
-                         temp_table_name=temp_table_name,
-                         enrollment_status_criteria=item[1])
+                         enrollment_status_criteria=item[1],
+                         calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}")
                 sql_arr.append(sql)
         else:
-            sql = """
-            insert into metrics_lifecycle_cache
+            sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                          participant_summary=f"{bq_project}.{participant_summary_table}")
+            sql += """
               select
-                :date_inserted AS date_inserted,
-                '' as enrollment_status,
+                @date_inserted AS dateInserted,
+                '' as enrollmentStatus,
                 '{cache_type}' as type,
-                ps.hpo_id,
-                (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-                day,
-                SUM(CASE WHEN DATE(ps.sign_up_time) <= calendar.day THEN 1 ELSE 0 END) AS registered,
-                SUM(CASE WHEN DATE(ps.consent_for_study_enrollment_time) <= calendar.day THEN 1 ELSE 0 END) AS consent_enrollment,
-                SUM(CASE WHEN DATE(ps.enrollment_status_member_time) <= calendar.day THEN 1 ELSE 0 END) AS consent_complete,
+                ps.hpo_id AS hpoId,
+                (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+                day AS date,
+                SUM(CASE WHEN DATE(ps.sign_up_time) <= ps.day THEN 1 ELSE 0 END) AS registered,
+                SUM(CASE WHEN DATE(ps.consent_for_study_enrollment_time) <= ps.day THEN 1 ELSE 0 END) AS consentEnrollment,
+                SUM(CASE WHEN DATE(ps.enrollment_status_member_time) <= ps.day THEN 1 ELSE 0 END) AS consentComplete,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_basics,
+                END) AS ppiBasics,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_overall_health_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_overall_health_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_overall_health,
+                END) AS ppiOverallHealth,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_lifestyle_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_lifestyle_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_lifestyle,
+                END) AS ppiLifestyle,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_healthcare_access_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_healthcare_access_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_healthcare_access,
+                END) AS ppiHealthcareAccess,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_medical_history_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_medical_history_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_medical_history,
+                END) AS ppiMedicalHistory,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_medications_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_medications_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_medications,
+                END) AS ppiMedications,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_family_health_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_family_health_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_family_health,
+                END) AS ppiFamilyHealth,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_lifestyle_time) <= calendar.day AND
-                    DATE(ps.questionnaire_on_overall_health_time) <= calendar.day AND
-                    DATE(ps.questionnaire_on_the_basics_time) <= calendar.day AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.questionnaire_on_lifestyle_time) <= ps.day AND
+                    DATE(ps.questionnaire_on_overall_health_time) <= ps.day AND
+                    DATE(ps.questionnaire_on_the_basics_time) <= ps.day AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS ppi_complete,
+                END) AS ppiComplete,
                 SUM(CASE
                   WHEN
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS retention_modules_eligible,
+                END) AS retentionModulesEligible,
                 SUM(CASE
                   WHEN
-                    DATE(ps.questionnaire_on_healthcare_access_time) <= calendar.day AND
-                    DATE(ps.questionnaire_on_family_health_time) <= calendar.day AND
-                    DATE(ps.questionnaire_on_medical_history_time) <= calendar.day
+                    DATE(ps.questionnaire_on_healthcare_access_time) <= ps.day AND
+                    DATE(ps.questionnaire_on_family_health_time) <= ps.day AND
+                    DATE(ps.questionnaire_on_medical_history_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS retention_modules_complete,
+                END) AS retentionModulesComplete,
                 SUM(CASE
                   WHEN
-                    (DATE(ps.clinic_physical_measurements_time) <= calendar.day OR
-                    DATE(ps.self_reported_physical_measurements_authored) <= calendar.day) AND
-                    DATE(ps.consent_for_study_enrollment_time) <= calendar.day
+                    (DATE(ps.clinic_physical_measurements_time) <= ps.day OR
+                    DATE(ps.self_reported_physical_measurements_authored) <= ps.day) AND
+                    DATE(ps.consent_for_study_enrollment_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS physical_measurement,
+                END) AS physicalMeasurement,
                 SUM(CASE
                   WHEN
-                    DATE(ps.sample_status_1ed10_time) <= calendar.day OR
-                    DATE(ps.sample_status_2ed10_time) <= calendar.day OR
-                    DATE(ps.sample_status_1ed04_time) <= calendar.day OR
-                    DATE(ps.sample_status_1sal_time) <= calendar.day OR
-                    DATE(ps.sample_status_1sal2_time) <= calendar.day
+                    DATE(ps.sample_status_1ed10_time) <= ps.day OR
+                    DATE(ps.sample_status_2ed10_time) <= ps.day OR
+                    DATE(ps.sample_status_1ed04_time) <= ps.day OR
+                    DATE(ps.sample_status_1sal_time) <= ps.day OR
+                    DATE(ps.sample_status_1sal2_time) <= ps.day
                   THEN 1 ELSE 0
-                END) AS sample_received,
-                SUM(CASE WHEN DATE(ps.enrollment_status_core_stored_sample_time) <= calendar.day THEN 1 ELSE 0 END) AS core_participant,
-                ps.participant_origin
-              from {temp_table_name} ps,
-                   calendar
-              WHERE calendar.day BETWEEN :start_date AND :end_date
-              GROUP BY day, ps.hpo_id, ps.participant_origin;
-          """.format(cache_type=self.cache_type, temp_table_name=temp_table_name)
+                END) AS sampleReceived,
+                0 AS ppiBaselineComplete,
+                0 AS fullParticipant,
+                SUM(CASE WHEN DATE(ps.enrollment_status_core_stored_sample_time) <= ps.day THEN 1 ELSE 0 END) AS coreParticipant,
+                ps.participant_origin AS participantOrigin
+            FROM (
+              SELECT DISTINCT
+                    ps.participant_id,
+                    ps.hpo_id,
+                    ps.sign_up_time,
+                    ps.consent_for_study_enrollment_time,
+                    ps.enrollment_status_member_time,
+                    ps.enrollment_status_core_stored_sample_time,
+                    ps.questionnaire_on_the_basics_time,
+                    ps.questionnaire_on_overall_health_time,
+                    ps.questionnaire_on_healthcare_access_time,
+                    ps.questionnaire_on_lifestyle_time,
+                    ps.questionnaire_on_medical_history_time,
+                    ps.questionnaire_on_medications_time,
+                    ps.questionnaire_on_family_health_time,
+                    ps.clinic_physical_measurements_time,
+                    ps.self_reported_physical_measurements_authored,
+                    ps.sample_status_1sal_time,
+                    ps.sample_status_1sal2_time,
+                    ps.sample_status_1ed04_time,
+                    ps.sample_status_2ed10_time,
+                    ps.sample_status_1ed10_time,
+                    ps.participant_origin,
+                    calendar.day
+              FROM temp_table AS ps,
+                   `{calendar}` AS calendar
+              WHERE calendar.day BETWEEN @start_date AND @end_date
+            ) AS ps
+            GROUP BY ps.day, ps.hpo_id, ps.participant_origin;
+          """.format(cache_type=self.cache_type,
+                     calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}")
             sql_arr.append(sql)
         return sql_arr
 
 
-class MetricsLanguageCacheDao(BaseDao):
+class MetricsLanguageCacheDao(BaseDao, MetricsDaoMixin):
 
     def __init__(self, cache_type=MetricsCacheType.METRICS_V2_API):
         super(MetricsLanguageCacheDao, self).__init__(MetricsLanguageCache)
@@ -2803,11 +2907,9 @@ class MetricsLanguageCacheDao(BaseDao):
                 client_json.append(new_item)
         return client_json
 
-    def get_metrics_cache_sql(self, hpo_id):
-        temp_table_name = TEMP_TABLE_PREFIX + str(hpo_id)
-        sql = """
-          insert into metrics_language_cache
-        """
+    def get_metrics_cache_sql(self, bq_project):
+        sql = TEMP_TABLE_QUERY.format(participant=f"{bq_project}.{participant_table}",
+                                      participant_summary=f"{bq_project}.{participant_summary_table}")
 
         enrollment_status_and_criteria_list = [
             ['registered', ' c.day>=DATE(sign_up_time) AND (enrollment_status_member_time IS NULL '
@@ -2827,12 +2929,12 @@ class MetricsLanguageCacheDao(BaseDao):
 
         sql_template = """
           select
-          :date_inserted AS date_inserted,
-          '{enrollment_status}' as enrollment_status,
-          :hpo_id AS hpo_id,
-          (SELECT name FROM hpo WHERE hpo_id=:hpo_id) AS hpo_name,
-          c.day,
-          '{language_name}' AS language_name,
+          @date_inserted AS dateInserted,
+          '{enrollment_status}' as enrollmentStatus,
+          @hpo_id AS hpoId,
+          (SELECT name FROM `{hpo}` WHERE hpo_id=@hpo_id) AS hpoName,
+          c.day AS date,
+          '{language_name}' AS languageName,
           IFNULL((
               SELECT SUM(results.count)
               FROM
@@ -2841,14 +2943,14 @@ class MetricsLanguageCacheDao(BaseDao):
                        DATE(ps.enrollment_status_member_time) AS enrollment_status_member_time,
                        DATE(ps.enrollment_status_core_stored_sample_time) AS enrollment_status_core_stored_sample_time,
                        count(*) count
-                FROM {temp_table_name} ps
+                FROM temp_table ps
                 WHERE {language_criteria}
                 GROUP BY DATE(ps.sign_up_time), DATE(ps.enrollment_status_member_time), DATE(ps.enrollment_status_core_stored_sample_time)
               ) AS results
               WHERE {enrollment_status_criteria}
-            ),0) AS language_count
-          FROM calendar c
-          WHERE c.day BETWEEN :start_date AND :end_date
+            ),0) AS languageCount
+          FROM `{calendar}` c
+          WHERE c.day BETWEEN @start_date AND @end_date
         """
 
         sub_queries = []
@@ -2859,10 +2961,11 @@ class MetricsLanguageCacheDao(BaseDao):
                                                 language_name=language_pairs[0],
                                                 language_criteria=language_pairs[1],
                                                 enrollment_status_criteria=status_pairs[1],
-                                                temp_table_name=temp_table_name)
+                                                calendar=f"{bq_project}.{calendar_table}",
+                                                hpo=f"{bq_project}.{hpo_table}")
                 sub_queries.append(sub_query)
 
-        sql = sql + ' UNION ALL '.join(sub_queries)
+        sql = sql + ' UNION DISTINCT '.join(sub_queries)
 
         return [sql]
 

--- a/rdr_service/dao/participant_counts_over_time_service.py
+++ b/rdr_service/dao/participant_counts_over_time_service.py
@@ -1,10 +1,10 @@
 import datetime
 import logging
 import time
-import warnings
 
 from werkzeug.exceptions import BadRequest
 from google.cloud import bigquery
+from typing import List, Dict
 
 from rdr_service import config
 from rdr_service.dao.base_dao import BaseDao
@@ -33,52 +33,11 @@ from rdr_service.participant_enums import (
     WithdrawalStatus,
     MetricsCronJobStage
 )
-from rdr_service.dao.metrics_cache_dao import TEMP_TABLE_PREFIX
 
 
 class ParticipantCountsOverTimeService(BaseDao):
-    QUERIES = {
-        "participant_sql": """
-            SELECT {columns} FROM `{participant_bq_table}` AS p
-            LEFT JOIN `{participant_summary_bq_table}` AS ps
-            ON p.participant_id = ps.participant_id
-            WHERE p.hpo_id != @test_hpo_id
-            AND (p.is_ghost_id != 1 OR p.is_ghost_id IS NULL)
-            AND p.is_test_participant != 1
-            AND (ps.email IS NULL OR NOT ps.email LIKE @test_email_pattern)
-            AND p.withdrawal_status = @not_withdraw
-            AND p.hpo_id = @hpo_id
-            ;""",
-    }
 
-    PARTICIPANT_FIELDS = ['participant_id', 'biobank_id', 'sign_up_time', 'withdrawal_status',
-                          'hpo_id', 'organization_id', 'site_id', 'participant_origin']
-
-    TEMP_FIELDS = [('participant_id','int'), ('biobank_id', 'int'), ('sign_up_time', 'datetime'),
-                   ('first_name', 'varchar(255)'), ('last_name', 'varchar(255)'), ('suspension_status', 'smallint'),
-                   ('deceased_status', 'smallint'), ('is_ehr_data_available', 'tinyint(1)'),
-                   ('is_participant_mediated_ehr_data_available', 'tinyint(1)'),
-                   ('was_participant_mediated_ehr_available', 'tinyint(1)'), ('withdrawal_status', 'smallint'),
-                   ('hpo_id', 'int'), ('organization_id', 'int'), ('site_id', 'int'),
-                   ('participant_origin', 'varchar(80)'), ('date_of_birth', 'date'),
-                   ('consent_for_study_enrollment_time', 'datetime'), ('enrollment_status', 'smallint'),
-                   ('enrollment_status_member_time', 'datetime'),
-                   ('enrollment_status_core_stored_sample_time', 'datetime'),
-                   ('questionnaire_on_the_basics', 'smallint'), ('primary_language', 'varchar(80)'),
-                   ('language_id', 'int'), ('gender_identity_id', 'int'), ('gender_identity', 'smallint'),
-                   ('race', 'smallint'), ('questionnaire_on_the_basics_time', 'datetime'),
-                   ('questionnaire_on_lifestyle_time', 'datetime'), ('questionnaire_on_medications_time', 'datetime'),
-                   ('questionnaire_on_family_health_time', 'datetime'),
-                   ('questionnaire_on_overall_health_time', 'datetime'),
-                   ('questionnaire_on_healthcare_access_time', 'datetime'),
-                   ('questionnaire_on_medical_history_time', 'datetime'),
-                   ('clinic_physical_measurements_time', 'datetime'),
-                   ('self_reported_physical_measurements_authored', 'datetime'),
-                   ('sample_status_1ed10_time', 'datetime'), ('sample_status_2ed10_time', 'datetime'),
-                   ('sample_status_1ed04_time', 'datetime'), ('sample_status_1sal_time', 'datetime'),
-                   ('sample_status_1sal2_time', 'datetime'), ('state_id', 'int'),
-                   ('consent_for_electronic_health_records', 'int'),
-                   ('clinic_physical_measurements_finalized_time', 'datetime')]
+    JOB_TIME = None
 
     def __init__(self):
         super(ParticipantCountsOverTimeService, self).__init__(ParticipantSummary, alembic=True)
@@ -87,91 +46,8 @@ class ParticipantCountsOverTimeService(BaseDao):
         self.start_date = datetime.datetime.strptime("2017-05-30", "%Y-%m-%d").date()
         self.end_date = datetime.datetime.now().date() + datetime.timedelta(days=10)
         self.stage_number = MetricsCronJobStage.STAGE_ONE
-        self.cronjob_time = datetime.datetime.now().replace(microsecond=0)
-
-        public_metrics_project_map = config.getSettingJson(config.PUBLIC_METRICS_PROJECT_MAP, {})
-
+        self.job_time = self.JOB_TIME if self.JOB_TIME else datetime.datetime.now().replace(microsecond=0)
         self.client = bigquery.Client(project=config.GAE_PROJECT)
-        self.bq_project = public_metrics_project_map.get(self.client.project)
-        self.participant_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_TABLE,
-                                                       'lake_operational_data.rdr_participant')
-        self.participant_summary_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_SUMMARY_TABLE,
-                                                               'lake_operational_data.rdr_participant_summary')
-
-    def init_tmp_table(self):
-        with self.session() as session:
-            hpo_dao = HPODao()
-            hpo_list = hpo_dao.get_all()
-            for hpo in hpo_list:
-                if hpo.hpoId == self.test_hpo_id:
-                    continue
-                temp_table_name = TEMP_TABLE_PREFIX + str(hpo.hpoId)
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')
-                    session.execute('DROP TABLE IF EXISTS {};'.format(temp_table_name))
-
-                temp_table_columns = ", ".join([a + ' ' + b for a, b in self.TEMP_FIELDS])
-
-                sql_string = 'CREATE TABLE {} ({}) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'.format(
-                    temp_table_name, temp_table_columns)
-                session.execute(sql_string)
-                logging.info('temp table created for hpo_id: ' + str(hpo.hpoId))
-
-                indexes_cursor = session.execute('SHOW INDEX FROM {}'.format(temp_table_name))
-
-                index_name_list = []
-                for index in indexes_cursor:
-                    index_name_list.append(index[2])
-                index_name_list = list(set(index_name_list))
-
-                for index_name in index_name_list:
-                    if index_name != 'PRIMARY':
-                        session.execute('ALTER TABLE {} DROP INDEX  {}'.format(temp_table_name, index_name))
-
-                columns_str = ", ".join(['p.' + a if a in self.PARTICIPANT_FIELDS else 'ps.' + a for a, b in
-                                         self.TEMP_FIELDS])
-
-                params = [
-                    bigquery.ScalarQueryParameter("test_hpo_id", "INT64", self.test_hpo_id),
-                    bigquery.ScalarQueryParameter("test_email_pattern", "STRING", self.test_email_pattern),
-                    bigquery.ScalarQueryParameter("not_withdraw", "INT64", int(WithdrawalStatus.NOT_WITHDRAWN)),
-                    bigquery.ScalarQueryParameter("hpo_id", "INT64", hpo.hpoId),
-                ]
-
-                session.execute('CREATE INDEX idx_sign_up_time ON {} (sign_up_time)'.format(temp_table_name))
-                session.execute('CREATE INDEX idx_date_of_birth ON {} (date_of_birth)'.format(temp_table_name))
-                session.execute('CREATE INDEX idx_consent_time ON {} (consent_for_study_enrollment_time)'
-                                .format(temp_table_name))
-                session.execute('CREATE INDEX idx_member_time ON {} (enrollment_status_member_time)'
-                                .format(temp_table_name))
-                session.execute('CREATE INDEX idx_sample_time ON {} (enrollment_status_core_stored_sample_time)'
-                                .format(temp_table_name))
-                session.execute('CREATE INDEX idx_participant_origin ON {} (participant_origin)'
-                                .format(temp_table_name))
-
-                participant_data = self.build_participant_sql(params, columns_str)
-                self.batch_insert_results(session, temp_table_name, participant_data)
-
-                logging.info('data inserted into temp table for hpo_id: ' + str(hpo.hpoId))
-
-            session.execute('DROP TABLE IF EXISTS metrics_tmp_participant_origin;')
-            session.execute('CREATE TABLE metrics_tmp_participant_origin (participant_origin VARCHAR(50))')
-            participant_origin_sql = """
-                INSERT INTO metrics_tmp_participant_origin
-                SELECT DISTINCT participant_origin FROM participant
-            """
-            session.execute(participant_origin_sql)
-
-            logging.info('Init temp table for metrics cron job.')
-
-    def build_participant_sql(self, params, columns):
-        p_table_path = f"{self.bq_project}.{self.participant_table}"
-        ps_table_path = f"{self.bq_project}.{self.participant_summary_table}"
-        job_config = bigquery.QueryJobConfig(query_parameters=params)
-        sql = self.QUERIES['participant_sql'].format(participant_bq_table=p_table_path,
-                                                     participant_summary_bq_table=ps_table_path,
-                                                     columns=columns)
-        return self.run_bq_query(sql, job_config)
 
     def run_bq_query(self, sql: str, job_config=None):
         # Run the job with exponential backoff to avoid 403: rateLimitExceeded Error
@@ -186,38 +62,21 @@ class ParticipantCountsOverTimeService(BaseDao):
                     raise Exception
                 time.sleep(2 ** n)
 
-    def batch_insert_results(self, session, temp_table_name, results):
+    def batch_insert_results(self, dao, results: List[Dict]):
         # Insert results into RDR table, implement batching of the results
         records_to_insert, batch_size = [], 100
-
-        columns_str = ", ".join([a for a, b in self.TEMP_FIELDS])
-        values_str = ",".join([':' + a for a, b in self.TEMP_FIELDS])
-        batch_insert_stmt = ('insert into `{temp_table_name}` ({columns_str}) values ({values_str});'
-                             .format(temp_table_name=temp_table_name, columns_str=columns_str, values_str=values_str))
 
         for record in results:
             x = dict(record.items())
             records_to_insert.append(x)
 
             if len(records_to_insert) == batch_size:
-                session.execute(batch_insert_stmt, records_to_insert)
+                dao.insert_bulk(records_to_insert)
                 records_to_insert.clear()
 
         if records_to_insert:
-            session.execute(batch_insert_stmt, records_to_insert)
+            dao.insert_bulk(records_to_insert)
             records_to_insert.clear()
-
-    def clean_tmp_tables(self):
-        with self.session() as session:
-            hpo_dao = HPODao()
-            hpo_list = hpo_dao.get_all()
-            for hpo in hpo_list:
-                if hpo.hpoId == self.test_hpo_id:
-                    continue
-                temp_table_name = TEMP_TABLE_PREFIX + str(hpo.hpoId)
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')
-                    session.execute('DROP TABLE IF EXISTS {};'.format(temp_table_name))
 
     def refresh_metrics_cache_data(self, start_date, end_date, stage_number):
         self.start_date = start_date
@@ -264,7 +123,7 @@ class ParticipantCountsOverTimeService(BaseDao):
                 inProgress=True,
                 stage_one_complete=False,
                 stage_two_complete=False,
-                dateInserted=self.cronjob_time,
+                dateInserted=self.job_time,
             )
             job_status_obj = MetricsCacheJobStatus(**kwargs)
             status_dao.insert(job_status_obj)
@@ -276,7 +135,7 @@ class ParticipantCountsOverTimeService(BaseDao):
                 continue
             self.insert_cache_by_hpo(dao, hpo.hpoId)
 
-        status_dao.set_to_complete(dao.cache_type, dao.table_name, self.cronjob_time, self.stage_number)
+        status_dao.set_to_complete(dao.cache_type, dao.table_name, self.job_time, self.stage_number)
         if self.stage_number == MetricsCronJobStage.STAGE_TWO:
             dao.delete_old_records()
 
@@ -290,19 +149,26 @@ class ParticipantCountsOverTimeService(BaseDao):
             logging.info(f'No last success stage two found for {dao.table_name}, calculate new data for stage two')
             self.refresh_data_for_metrics_cache(dao)
         else:
-            dao.update_historical_cache_data(self.cronjob_time, last_success_stage_two.dateInserted,
+            dao.update_historical_cache_data(self.job_time, last_success_stage_two.dateInserted,
                                              self.start_date, self.end_date)
-            status_dao.set_to_complete(dao.cache_type, dao.table_name, self.cronjob_time, self.stage_number)
+            status_dao.set_to_complete(dao.cache_type, dao.table_name, self.job_time, self.stage_number)
             dao.delete_old_records(n_days_ago=30)
 
     def insert_cache_by_hpo(self, dao, hpo_id):
-        sql_arr = dao.get_metrics_cache_sql(hpo_id)
+        # Generate participant_origin table
+        sql_arr = dao.get_metrics_cache_sql(self.client.project)
 
-        params = {'hpo_id': hpo_id, 'start_date': self.start_date, 'end_date': self.end_date,
-                  'date_inserted': self.cronjob_time}
-        with dao.session() as session:
-            for sql in sql_arr:
-                session.execute(sql, params)
+        params = [
+            bigquery.ScalarQueryParameter("hpo_id", "INT64", hpo_id),
+            bigquery.ScalarQueryParameter("start_date", "DATE", self.start_date),
+            bigquery.ScalarQueryParameter("end_date", "DATE", self.end_date),
+            bigquery.ScalarQueryParameter("date_inserted", "DATETIME", self.job_time),
+        ]
+
+        for sql in sql_arr:
+            job_config = bigquery.QueryJobConfig(query_parameters=params)
+            results = self.run_bq_query(sql, job_config)
+            self.batch_insert_results(dao, results)
 
     def get_filtered_results(
         self, stratification, start_date, end_date, history, awardee_ids, enrollment_statuses, sample_time_def,

--- a/rdr_service/researchers_offline/main.py
+++ b/rdr_service/researchers_offline/main.py
@@ -24,6 +24,7 @@ def test_job():
 
 @app_util.auth_required_scheduler
 def participant_counts_over_time():
+    logging.info('Starting participant metrics calculation...')
     calculate_participant_metrics()
     return '{"success": "true"}'
 

--- a/rdr_service/researchers_offline/participant_counts_over_time.py
+++ b/rdr_service/researchers_offline/participant_counts_over_time.py
@@ -15,7 +15,6 @@ def calculate_participant_metrics():
 
     # call metrics functions
     service = ParticipantCountsOverTimeService()
-    service.init_tmp_table()
     # calculate data in last 30 days
     service.refresh_metrics_cache_data(stage_one_start_date, stage_one_end_date, MetricsCronJobStage.STAGE_ONE)
     logging.info('calculate participant metrics stage one is done.')

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -2,33 +2,23 @@ import datetime
 import time
 import mock
 
-from rdr_service import config
 from rdr_service.clock import FakeClock
-from rdr_service.code_constants import (
-    PMI_SKIP_CODE,
-    PPI_SYSTEM,
-    RACE_AIAN_CODE,
-    RACE_HISPANIC_CODE,
-    RACE_MENA_CODE,
-    RACE_NONE_OF_THESE_CODE,
-    RACE_WHITE_CODE,
-)
+from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.concepts import Concept
 from rdr_service.dao.calendar_dao import CalendarDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.hpo_dao import HPODao
 from rdr_service.researchers_offline.participant_counts_over_time import calculate_participant_metrics
 from rdr_service.dao.organization_dao import OrganizationDao
-from rdr_service.dao.participant_counts_over_time_service import ParticipantCountsOverTimeService
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.site_dao import SiteDao
-from rdr_service.dao.participant_summary_dao import ParticipantGenderAnswersDao, ParticipantSummaryDao
+from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.model.calendar import Calendar
 from rdr_service.model.code import Code, CodeType
 from rdr_service.model.hpo import HPO
 from rdr_service.model.site import Site
 from rdr_service.model.participant import Participant
-from rdr_service.model.participant_summary import ParticipantGenderAnswers, ParticipantSummary
+from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.participant_enums import (
     EnrollmentStatus,
     OrganizationType,
@@ -46,43 +36,6 @@ TIME_3 = datetime.datetime(2018, 2, 10)
 
 def _questionnaire_response_url(participant_id):
     return "Participant/%s/QuestionnaireResponse" % participant_id
-
-
-def generate_mock_results(participant, summary, the_basics=None):
-    expected_bq_results = dict()
-
-    for field, _ in ParticipantCountsOverTimeService.TEMP_FIELDS:
-        temp = field.split('_')
-        camel_field = temp[0] + ''.join(f.title() for f in temp[1:])
-
-        try:
-            value = getattr(summary, camel_field)
-
-            if field in ParticipantCountsOverTimeService.PARTICIPANT_FIELDS:
-                value = getattr(participant, camel_field)
-        except Exception:  # pylint: disable=broad-except
-            value = None
-
-        expected_bq_results[field] = value
-
-    expected_bq_results['sample_status_1ed10_time'] = getattr(summary, 'sampleStatus1ED10Time')
-    expected_bq_results['sample_status_2ed10_time'] = getattr(summary, 'sampleStatus2ED10Time')
-    expected_bq_results['sample_status_1ed04_time'] = getattr(summary, 'sampleStatus1ED04Time')
-    expected_bq_results['sample_status_1sal_time'] = getattr(summary, 'sampleStatus1SALTime')
-    expected_bq_results['sample_status_1sal2_time'] = getattr(summary, 'sampleStatus1SAL2Time')
-
-    expected_bq_results['withdrawal_status'] = 1
-    expected_bq_results['suspension_status'] = 1
-    expected_bq_results['enrollment_status'] = 3
-    expected_bq_results['deceased_status'] = 0
-    expected_bq_results['race'] = 0
-    expected_bq_results['questionnaire_on_the_basics'] = 1
-    expected_bq_results['consent_for_electronic_health_records'] = 0
-
-    if the_basics is not None:
-        expected_bq_results['questionnaire_on_the_basics'] = 0
-
-    return expected_bq_results
 
 
 class PublicMetricsApiTest(BaseTestCase):
@@ -104,6 +57,8 @@ class PublicMetricsApiTest(BaseTestCase):
     )
 
     string_link_ids = ("firstName", "middleName", "lastName", "streetAddress", "city", "phoneNumber", "zipCode")
+
+    test_job_time = datetime.datetime.now().replace(microsecond=0)
 
     def setUp(self):
         super(PublicMetricsApiTest, self).setUp()
@@ -132,24 +87,15 @@ class PublicMetricsApiTest(BaseTestCase):
             CalendarDao().insert(calendar_day)
             curr_date = curr_date + datetime.timedelta(days=1)
 
-        self.clear_table_after_test('metrics_enrollment_status_cache')
-        self.clear_table_after_test('metrics_gender_cache')
-        self.clear_table_after_test('metrics_age_cache')
-        self.clear_table_after_test('metrics_race_cache')
-        self.clear_table_after_test('metrics_region_cache')
-        self.clear_table_after_test('metrics_lifecycle_cache')
-        self.clear_table_after_test('metrics_language_cache')
-
-        self.temporarily_override_config_setting(config.PUBLIC_METRICS_PROJECT_MAP, {
-            "localhost": "aou-warehouse-test",
-            "all-of-us-rdr-sandbox": "aou-warehouse-test",
-            "all-of-us-rdr-staging": "aou-warehouse-test",
-            "all-of-us-rdr-stable": "aou-warehouse-test",
-            "all-of-us-rdr-prod": "aou-warehouse-test",
-        })
-
     def tearDown(self):
         self.clear_table_after_test("rdr.metrics_enrollment_status_cache")
+        self.clear_table_after_test("rdr.metrics_gender_cache")
+        self.clear_table_after_test("rdr.metrics_age_cache")
+        self.clear_table_after_test("rdr.metrics_race_cache")
+        self.clear_table_after_test("rdr.metrics_region_cache")
+        self.clear_table_after_test("rdr.metrics_lifecycle_cache")
+        self.clear_table_after_test("rdr.metrics_language_cache")
+
         super().tearDown()
 
     def _insert(
@@ -185,8 +131,6 @@ class PublicMetricsApiTest(BaseTestCase):
     :return: Participant object
     """
 
-        expected_bq_results = dict()
-
         if unconsented is True:
             enrollment_status = None
         elif time_mem is None:
@@ -202,23 +146,6 @@ class PublicMetricsApiTest(BaseTestCase):
         participant.providerLink = make_primary_provider_link_for_name(hpo_name)
         with FakeClock(time_mem):
             self.dao.update(participant)
-
-        if enrollment_status is None:
-            for field, _ in ParticipantCountsOverTimeService.TEMP_FIELDS:
-                temp = field.split('_')
-                camel_field = temp[0] + ''.join(f.title() for f in temp[1:])
-
-                try:
-                    value = getattr(participant, camel_field)
-                except Exception:  # pylint: disable=broad-except
-                    value = None
-
-                expected_bq_results[field] = value
-
-            expected_bq_results['withdrawal_status'] = 1
-            expected_bq_results['suspension_status'] = 1
-
-            return None, expected_bq_results
 
         summary = self.participant_summary(participant)
 
@@ -281,10 +208,10 @@ class PublicMetricsApiTest(BaseTestCase):
 
         self.ps_dao.insert(summary)
 
-        return summary, generate_mock_results(participant, summary)
+        return summary
 
     def update_participant_summary(
-        self, participant_id, time_mem=None, time_fp=None, time_fp_stored=None, time_study=None, the_basics=None
+        self, participant_id, time_mem=None, time_fp=None, time_fp_stored=None, time_study=None
     ):
 
         participant = self.dao.get(participant_id)
@@ -332,38 +259,2228 @@ class PublicMetricsApiTest(BaseTestCase):
 
         self.ps_dao.update(summary)
 
-        return summary, generate_mock_results(participant, summary, the_basics)
+        return summary
 
+    def get_mock_data(self):
+        insert_time = self.test_job_time
+
+        enrollment_results_az = [
+            {
+                "dateInserted": insert_time,
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "registeredCount": "0",
+                "participantCount": "1",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "registeredCount": "0",
+                "participantCount": "2",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "registeredCount": "0",
+                "participantCount": "1",
+                "consentedCount": "1",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "registeredCount": "0",
+                "participantCount": "1",
+                "consentedCount": "0",
+                "coreCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "registeredCount": "0",
+                "participantCount": "1",
+                "consentedCount": "0",
+                "coreCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-07",
+                "registeredCount": "0",
+                "participantCount": "1",
+                "consentedCount": "0",
+                "coreCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-08",
+                "registeredCount": "0",
+                "participantCount": "1",
+                "consentedCount": "0",
+                "coreCount": "1",
+                "participantOrigin": "example"
+            },
+        ]
+        enrollment_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "registeredCount": "1",
+                "participantCount": "0",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-01",
+                "registeredCount": "1",
+                "participantCount": "0",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "registeredCount": "1",
+                "participantCount": "0",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-03",
+                "registeredCount": "1",
+                "participantCount": "0",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-07",
+                "registeredCount": "1",
+                "participantCount": "0",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-08",
+                "registeredCount": "1",
+                "participantCount": "0",
+                "consentedCount": "0",
+                "coreCount": "0",
+                "participantOrigin": "example"
+            }
+        ]
+        age_results_az = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "18-29",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "18-29",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "18-29",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "18-29",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "18-29",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "18-29",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "18-29",
+                "ageCount": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "30-39",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "30-39",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "30-39",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "30-39",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {"dateInserted": insert_time,
+             "type": "PUBLIC_METRICS_EXPORT_API",
+             "enrollment_status": "consented",
+             "hpoId": 4,
+             "hpoName": "AZ_TUCSON",
+             "date": "2017-12-31",
+             "ageRange": "40-49",
+             "ageCount": "0",
+             "participantOrigin": "example"
+             },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "50-59",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "60-69",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "70-79",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "80-89",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "90-",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "ageRange": "UNSET",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "40-49",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "50-59",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "60-69",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "70-79",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "80-89",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "90-",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "ageRange": "UNSET",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "40-49",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "50-59",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "60-69",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "70-79",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "80-89",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "90-",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "ageRange": "UNSET",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "40-49",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "50-59",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "60-69",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "70-79",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "80-89",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "90-",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "ageRange": "UNSET",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "18-29",
+                "ageCount": "3",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "30-39",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "40-49",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "50-59",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "60-69",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "70-79",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "80-89",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "90-",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "ageRange": "UNSET",
+                "ageCount": "0",
+                "participantOrigin": "example"
+            }
+        ]
+        age_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "ageRange": "30-39",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-01",
+                "ageRange": "30-39",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "ageRange": "30-39",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-03",
+                "ageRange": "30-39",
+                "ageCount": "1",
+                "participantOrigin": "example"
+            },
+        ]
+        lang_results_az = [
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-30",
+                "languageName": "ES",
+                "languageCount": "0",
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "languageName": "UNSET",
+                "languageCount": "2",
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "languageName": "ES",
+                "languageCount": "0",
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "languageName": "ES",
+                "languageCount": "1",
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "languageName": "UNSET",
+                "languageCount": "2",
+            }
+        ]
+        lang_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-30",
+                "languageName": "UNSET",
+                "languageCount": "0",
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-30",
+                "languageName": "EN",
+                "languageCount": "0",
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "languageName": "EN",
+                "languageCount": "1",
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "registered",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-03",
+                "languageName": "EN",
+                "languageCount": "1",
+            }
+        ]
+        region_results_az = [
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "stateName": "PIIState_IN",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "stateName": "PIIState_IN",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "stateName": "PIIState_IN",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "stateName": "PIIState_CA",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            }
+        ]
+        region_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "stateName": "PIIState_IL",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-01",
+                "stateName": "PIIState_IL",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "stateName": "PIIState_IL",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+        ]
+        region_results_pitt = [
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2017-12-31",
+                "stateName": "PIIState_PR",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-01",
+                "stateName": "PIIState_PR",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-01",
+                "stateName": "PIIState_IN",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-02",
+                "stateName": "PIIState_IN",
+                "stateCount": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "enrollmentStatus": "consented",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-02",
+                "stateName": "PIIState_PR",
+                "stateCount": "1",
+                "participantOrigin": "example"
+            }
+        ]
+        lifecycle_results_az = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "registered": "0",
+                "consentEnrollment": "0",
+                "consentComplete": "0",
+                "ppiBasics": "0",
+                "ppiOverallHealth": "0",
+                "ppiLifestyle": "0",
+                "ppiHealthcareAccess": "0",
+                "ppiMedicalHistory": "0",
+                "ppiMedications": "0",
+                "ppiFamilyHealth": "0",
+                "ppiBaselineComplete": "0",
+                "retentionModulesEligible": "0",
+                "retentionModulesComplete": "0",
+                "physicalMeasurement": "0",
+                "sampleReceived": "0",
+                "fullParticipant": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "registered": "1",
+                "consentEnrollment": "1",
+                "consentComplete": "1",
+                "ppiBasics": "1",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "1",
+                "retentionModulesComplete": "1",
+                "physicalMeasurement": "1",
+                "sampleReceived": "1",
+                "fullParticipant": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "registered": "2",
+                "consentEnrollment": "2",
+                "consentComplete": "2",
+                "ppiBasics": "2",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "1",
+                "retentionModulesComplete": "1",
+                "physicalMeasurement": "1",
+                "sampleReceived": "2",
+                "fullParticipant": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-06",
+                "registered": "2",
+                "consentEnrollment": "2",
+                "consentComplete": "2",
+                "ppiBasics": "2",
+                "ppiOverallHealth": "2",
+                "ppiLifestyle": "2",
+                "ppiHealthcareAccess": "2",
+                "ppiMedicalHistory": "2",
+                "ppiMedications": "2",
+                "ppiFamilyHealth": "2",
+                "ppiBaselineComplete": "2",
+                "retentionModulesEligible": "2",
+                "retentionModulesComplete": "2",
+                "physicalMeasurement": "2",
+                "sampleReceived": "2",
+                "fullParticipant": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-08",
+                "registered": "2",
+                "consentEnrollment": "2",
+                "consentComplete": "2",
+                "ppiBasics": "2",
+                "ppiOverallHealth": "2",
+                "ppiLifestyle": "2",
+                "ppiHealthcareAccess": "2",
+                "ppiMedicalHistory": "2",
+                "ppiMedications": "2",
+                "ppiFamilyHealth": "2",
+                "ppiBaselineComplete": "2",
+                "retentionModulesEligible": "2",
+                "retentionModulesComplete": "2",
+                "physicalMeasurement": "2",
+                "sampleReceived": "2",
+                "fullParticipant": "2",
+                "participantOrigin": "example"
+            }
+        ]
+        lifecycle_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-03",
+                "registered": "1",
+                "consentEnrollment": "1",
+                "consentComplete": "1",
+                "ppiBasics": "1",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "1",
+                "retentionModulesComplete": "1",
+                "physicalMeasurement": "1",
+                "sampleReceived": "1",
+                "fullParticipant": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-08",
+                "registered": "1",
+                "consentEnrollment": "1",
+                "consentComplete": "1",
+                "ppiBasics": "1",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "1",
+                "retentionModulesComplete": "1",
+                "physicalMeasurement": "1",
+                "sampleReceived": "1",
+                "fullParticipant": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "registered": "1",
+                "consentEnrollment": "1",
+                "consentComplete": "1",
+                "ppiBasics": "1",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "1",
+                "retentionModulesComplete": "1",
+                "physicalMeasurement": "1",
+                "sampleReceived": "1",
+                "fullParticipant": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "registered": "1",
+                "consentEnrollment": "1",
+                "consentComplete": "1",
+                "ppiBasics": "1",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "1",
+                "retentionModulesComplete": "1",
+                "physicalMeasurement": "1",
+                "sampleReceived": "1",
+                "fullParticipant": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "consented",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-06",
+                "registered": "1",
+                "consentEnrollment": "1",
+                "consentComplete": "1",
+                "ppiBasics": "1",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "1",
+                "retentionModulesComplete": "1",
+                "physicalMeasurement": "1",
+                "sampleReceived": "1",
+                "fullParticipant": "1",
+                "participantOrigin": "example"
+            }
+        ]
+        lifecycle_results_pitt = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-03",
+                "registered": "2",
+                "consentEnrollment": "2",
+                "consentComplete": "1",
+                "ppiBasics": "0",
+                "ppiOverallHealth": "1",
+                "ppiLifestyle": "1",
+                "ppiHealthcareAccess": "1",
+                "ppiMedicalHistory": "1",
+                "ppiMedications": "1",
+                "ppiFamilyHealth": "1",
+                "ppiBaselineComplete": "1",
+                "retentionModulesEligible": "0",
+                "retentionModulesComplete": "0",
+                "physicalMeasurement": "1",
+                "sampleReceived": "0",
+                "fullParticipant": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "consented",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-08",
+                "registered": "2",
+                "consentEnrollment": "2",
+                "consentComplete": "2",
+                "ppiBasics": "2",
+                "ppiOverallHealth": "2",
+                "ppiLifestyle": "2",
+                "ppiHealthcareAccess": "2",
+                "ppiMedicalHistory": "2",
+                "ppiMedications": "2",
+                "ppiFamilyHealth": "2",
+                "ppiBaselineComplete": "2",
+                "retentionModulesEligible": "2",
+                "retentionModulesComplete": "2",
+                "physicalMeasurement": "2",
+                "sampleReceived": "2",
+                "fullParticipant": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2017-12-31",
+                "registered": "0",
+                "consentEnrollment": "0",
+                "consentComplete": "0",
+                "ppiBasics": "0",
+                "ppiOverallHealth": "0",
+                "ppiLifestyle": "0",
+                "ppiHealthcareAccess": "0",
+                "ppiMedicalHistory": "0",
+                "ppiMedications": "0",
+                "ppiFamilyHealth": "0",
+                "ppiBaselineComplete": "0",
+                "retentionModulesEligible": "0",
+                "retentionModulesComplete": "0",
+                "physicalMeasurement": "0",
+                "sampleReceived": "0",
+                "fullParticipant": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "registered",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-02",
+                "registered": "0",
+                "consentEnrollment": "0",
+                "consentComplete": "0",
+                "ppiBasics": "0",
+                "ppiOverallHealth": "0",
+                "ppiLifestyle": "0",
+                "ppiHealthcareAccess": "0",
+                "ppiMedicalHistory": "0",
+                "ppiMedications": "0",
+                "ppiFamilyHealth": "0",
+                "ppiBaselineComplete": "0",
+                "retentionModulesEligible": "0",
+                "retentionModulesComplete": "0",
+                "physicalMeasurement": "0",
+                "sampleReceived": "0",
+                "fullParticipant": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollmentStatus": "consented",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-06",
+                "registered": "2",
+                "consentEnrollment": "2",
+                "consentComplete": "2",
+                "ppiBasics": "2",
+                "ppiOverallHealth": "2",
+                "ppiLifestyle": "2",
+                "ppiHealthcareAccess": "2",
+                "ppiMedicalHistory": "2",
+                "ppiMedications": "2",
+                "ppiFamilyHealth": "2",
+                "ppiBaselineComplete": "2",
+                "retentionModulesEligible": "2",
+                "retentionModulesComplete": "2",
+                "physicalMeasurement": "2",
+                "sampleReceived": "2",
+                "fullParticipant": "2",
+                "participantOrigin": "example"
+            }
+        ]
+        gender_results_az = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "genderName": "Man",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "genderName": "Man",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "genderName": "Transgender",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "genderName": "Man",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "genderName": "Transgender",
+                "genderCount": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "genderName": "Man",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "genderName": "Transgender",
+                "genderCount": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "genderName": "More than one gender identity",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+        ]
+        gender_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-01",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-03",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-04",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            }
+        ]
+        gender_v2_results_az = [
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "genderName": "Man",
+                "genderCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "genderName": "Woman",
+                "genderCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "genderName": "Man",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "genderName": "Woman",
+                "genderCount": "0",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "genderName": "Man",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "genderName": "Transgender",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "genderName": "Man",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-03",
+                "genderName": "Transgender",
+                "genderCount": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "genderName": "Man",
+                "genderCount": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "genderName": "Transgender",
+                "genderCount": "2",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "consented",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-04",
+                "genderName": "More than one gender identity",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+        ]
+        gender_v2_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-01",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-03",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "enrollment_status": "",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-04",
+                "genderName": "Woman",
+                "genderCount": "1",
+                "participantOrigin": "example"
+            }
+        ]
+        race_results_az = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            }
+        ]
+        race_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-01",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "1",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "1",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "1"
+            }
+        ]
+        race_results_pitt = [
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2017-12-31",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-01",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-02",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-03",
+                "registeredFlag": 1,
+                "participantFlag": 1,
+                "consentedFlag": 1,
+                "coreFlag": 1,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "1",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "2",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "PUBLIC_METRICS_EXPORT_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-04",
+                "registeredFlag": 1,
+                "participantFlag": 1,
+                "consentedFlag": 1,
+                "coreFlag": 1,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "1",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            }
+        ]
+        race_v2_results_az = [
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2017-12-31",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-01",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 4,
+                "hpoName": "AZ_TUCSON",
+                "date": "2018-01-02",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "2",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "1",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            }
+        ]
+        race_v2_results_unst = [
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2017-12-31",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-01",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 0,
+                "hpoName": "UNSET",
+                "date": "2018-01-02",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "0",
+                "hispanicLatinoSpanish": "0",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "1"
+            }
+        ]
+        race_v2_results_pitt = [
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2017-12-31",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "1",
+                "hispanicLatinoSpanish": "1",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-01",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "1",
+                "hispanicLatinoSpanish": "1",
+                "noneOfTheseFullyDescribeMe": "1",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-02",
+                "registeredFlag": 0,
+                "participantFlag": 0,
+                "consentedFlag": 0,
+                "coreFlag": 0,
+                "americanIndianAlaskaNative": "0",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "1",
+                "hispanicLatinoSpanish": "1",
+                "noneOfTheseFullyDescribeMe": "1",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "0",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-03",
+                "registeredFlag": 1,
+                "participantFlag": 1,
+                "consentedFlag": 1,
+                "coreFlag": 1,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "2",
+                "hispanicLatinoSpanish": "2",
+                "noneOfTheseFullyDescribeMe": "1",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "2",
+                "noAncestryChecked": "0",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            },
+            {
+                "dateInserted": insert_time,
+                "type": "METRICS_V2_API",
+                "hpoId": 2,
+                "hpoName": "PITT",
+                "date": "2018-01-04",
+                "registeredFlag": 1,
+                "participantFlag": 1,
+                "consentedFlag": 1,
+                "coreFlag": 1,
+                "americanIndianAlaskaNative": "1",
+                "asian": "0",
+                "blackAfricanAmerican": "0",
+                "middleEasternNorthAfrican": "0",
+                "nativeHawaiianOtherPacificIslander": "0",
+                "white": "1",
+                "hispanicLatinoSpanish": "1",
+                "noneOfTheseFullyDescribeMe": "0",
+                "preferNotToAnswer": "0",
+                "multiAncestry": "1",
+                "noAncestryChecked": "1",
+                "participantOrigin": "example",
+                "unsetNoBasics": "0"
+            }
+        ]
+
+        return [lifecycle_results_unst, lifecycle_results_pitt, lifecycle_results_az,
+                gender_results_unst, [], gender_results_az,
+                age_results_unst, [], age_results_az,
+                race_results_unst, race_results_pitt, race_results_az,
+                enrollment_results_unst, [], enrollment_results_az,
+                region_results_unst, region_results_pitt, region_results_az,
+                lang_results_unst, [], lang_results_az,
+                gender_v2_results_unst, [], gender_v2_results_az,  [],
+                [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [],
+                [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [],
+                [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [],
+                [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [],
+                race_v2_results_unst, race_v2_results_pitt, race_v2_results_az]
+
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_enrollment_status_api(self, big_query):
-
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", unconsented=True, time_int=self.time1, time_study=self.time1)
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2, "Bob", "Builder", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time2, time_study=self.time2
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time3,
-            time_fp_stored=self.time4,
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = self.get_mock_data()
 
         calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 3)
+        self.assertEqual(big_query().query.call_count, 72)
 
         qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08"
 
@@ -379,144 +2496,16 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 1}}, results)
         self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 1}}, results)
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_gender_api(self, big_query):
-
-        self.init_gender_codes()
-        gender_code_dict = {
-            "GenderIdentity_Woman": 1,
-            "GenderIdentity_Transgender": 2,
-            "GenderIdentity_Man": 3,
-            "GenderIdentity_AdditionalOptions": 4,
-            "GenderIdentity_NonBinary": 5,
-            "PMI_PreferNotToAnswer": 6,
-            "PMI_Skip": 7,
-        }
-
-        participant_gender_answer_dao = ParticipantGenderAnswersDao()
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1,
-                                                gender_identity=3)
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=1,
-                    created=self.time1,
-                    modified=self.time1,
-                    codeId=gender_code_dict["GenderIdentity_Woman"],
-                )
-            )
-        )
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2,
-            "Bob",
-            "Builder",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time2,
-            time_study=self.time2,
-            time_mem=self.time3,
-            gender_identity=2
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=2,
-                    created=self.time2,
-                    modified=self.time2,
-                    codeId=gender_code_dict["GenderIdentity_Man"],
-                )
-            )
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time3,
-            time_mem=self.time5,
-            gender_identity=5
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=3,
-                    created=self.time3,
-                    modified=self.time3,
-                    codeId=gender_code_dict["GenderIdentity_Transgender"],
-                )
-            )
-        )
-
-        p4 = Participant(participantId=4, biobankId=7)
-        _, expected_bq_results_4 = self._insert(
-            p4,
-            "Chad2",
-            "Caterpillar2",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time4,
-            time_study=self.time4,
-            time_mem=self.time5,
-            gender_identity=5
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=4,
-                    created=self.time4,
-                    modified=self.time4,
-                    codeId=gender_code_dict["GenderIdentity_Transgender"],
-                )
-            )
-        )
-
-        p6 = Participant(participantId=6, biobankId=9)
-        _, expected_bq_results_6 = self._insert(
-            p6,
-            "Chad3",
-            "Caterpillar3",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time5,
-            time_study=self.time5,
-            time_mem=self.time5,
-            gender_identity=7
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=6,
-                    created=self.time5,
-                    modified=self.time5,
-                    codeId=gender_code_dict["GenderIdentity_Woman"],
-                )
-            )
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=6,
-                    created=self.time5,
-                    modified=self.time5,
-                    codeId=gender_code_dict["GenderIdentity_Man"],
-                )
-            )
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
-                                                                       expected_bq_results_4, expected_bq_results_6]]
+        big_query().query.side_effect = self.get_mock_data()
 
         calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 3)
+        self.assertEqual(big_query().query.call_count, 72)
 
         qs = "&stratification=GENDER_IDENTITY" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -734,136 +2723,11 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_gender_api_v2(self, big_query):
-
-        self.init_gender_codes()
-        gender_code_dict = {
-            "GenderIdentity_Woman": 1,
-            "GenderIdentity_Transgender": 2,
-            "GenderIdentity_Man": 3,
-            "GenderIdentity_AdditionalOptions": 4,
-            "GenderIdentity_NonBinary": 5,
-            "PMI_PreferNotToAnswer": 6,
-            "PMI_Skip": 7,
-        }
-
-        participant_gender_answer_dao = ParticipantGenderAnswersDao()
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1,
-                                                gender_identity=3)
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=1,
-                    created=self.time1,
-                    modified=self.time1,
-                    codeId=gender_code_dict["GenderIdentity_Woman"],
-                )
-            )
-        )
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2,
-            "Bob",
-            "Builder",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time2,
-            time_mem=self.time3,
-            gender_identity=2,
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=2,
-                    created=self.time2,
-                    modified=self.time2,
-                    codeId=gender_code_dict["GenderIdentity_Man"],
-                )
-            )
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time3,
-            time_mem=self.time5,
-            gender_identity=5,
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=3,
-                    created=self.time3,
-                    modified=self.time3,
-                    codeId=gender_code_dict["GenderIdentity_Transgender"],
-                )
-            )
-        )
-
-        p4 = Participant(participantId=4, biobankId=7)
-        _, expected_bq_results_4 = self._insert(
-            p4,
-            "Chad2",
-            "Caterpillar2",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time4,
-            time_mem=self.time5,
-            gender_identity=5,
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=4,
-                    created=self.time4,
-                    modified=self.time4,
-                    codeId=gender_code_dict["GenderIdentity_Transgender"],
-                )
-            )
-        )
-        p6 = Participant(participantId=6, biobankId=9)
-        _, expected_bq_results_6 = self._insert(
-            p6,
-            "Chad3",
-            "Caterpillar3",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time5,
-            time_mem=self.time5,
-            gender_identity=7,
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=6,
-                    created=self.time5,
-                    modified=self.time5,
-                    codeId=gender_code_dict["GenderIdentity_Woman"],
-                )
-            )
-        )
-        participant_gender_answer_dao.insert(
-            ParticipantGenderAnswers(
-                **dict(
-                    participantId=6,
-                    created=self.time5,
-                    modified=self.time5,
-                    codeId=gender_code_dict["GenderIdentity_Man"],
-                )
-            )
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
-                                                                       expected_bq_results_4, expected_bq_results_6],
-                                         [expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
-                                                                       expected_bq_results_4, expected_bq_results_6]]
+        big_query().query.side_effect = self.get_mock_data()
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -875,7 +2739,7 @@ class PublicMetricsApiTest(BaseTestCase):
             calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 6)
+        self.assertEqual(big_query().query.call_count, 132)
 
         qs = "&stratification=GENDER_IDENTITY" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -1154,57 +3018,11 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_age_range_api(self, big_query):
-        dob1 = datetime.date(1978, 10, 10)
-        dob2 = datetime.date(1988, 10, 10)
-        dob3 = datetime.date(1988, 10, 10)
-        dob4 = datetime.date(1998, 10, 10)
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", time_int=self.time1, dob=dob1)
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2,
-            "Bob",
-            "Builder",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time2,
-            time_study=self.time2,
-            time_mem=self.time3,
-            dob=dob2
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_study=self.time3,
-            time_int=self.time3,
-            time_mem=self.time5,
-            dob=dob3
-        )
-
-        p4 = Participant(participantId=4, biobankId=7)
-        _, expected_bq_results_4 = self._insert(
-            p4,
-            "Chad2",
-            "Caterpillar2",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_study=self.time4,
-            time_int=self.time4,
-            time_mem=self.time5,
-            dob=dob4
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [],
-                                         [expected_bq_results_2, expected_bq_results_3, expected_bq_results_4],
-                                         [expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = self.get_mock_data()
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -1216,7 +3034,7 @@ class PublicMetricsApiTest(BaseTestCase):
             calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 6)
+        self.assertEqual(big_query().query.call_count, 132)
 
         qs = "&stratification=AGE_RANGE" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -1459,120 +3277,47 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_total_api(self, big_query):
-
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET", unconsented=True, time_int=self.time1,
-                                                time_study=self.time1)
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2, "Bob", "Builder", "AZ_TUCSON", "AZ_TUCSON_BANNER_HEALTH", time_int=self.time2, time_study=self.time2
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time3,
-            time_mem=self.time4,
-            time_fp_stored=self.time5,
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = self.get_mock_data()
 
         calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 3)
+        self.assertEqual(big_query().query.call_count, 72)
 
-        qs = "&stratification=TOTAL" "&startDate=2018-01-01" "&endDate=2018-01-08"
+        qs = "&stratification=TOTAL" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
         response = self.send_get("PublicMetrics", query_string=qs)
 
-        self.assertIn({"date": "2018-01-01", "metrics": {"TOTAL": 2}}, response)
+        self.assertIn({"date": "2017-12-31", "metrics": {"TOTAL": 2}}, response)
+        self.assertIn({"date": "2018-01-01", "metrics": {"TOTAL": 3}}, response)
         self.assertIn({"date": "2018-01-02", "metrics": {"TOTAL": 3}}, response)
         self.assertIn({"date": "2018-01-07", "metrics": {"TOTAL": 3}}, response)
         self.assertIn({"date": "2018-01-08", "metrics": {"TOTAL": 3}}, response)
 
-        qs = "&stratification=TOTAL" "&startDate=2018-01-01" "&endDate=2018-01-08" "&awardee=AZ_TUCSON"
+        qs = "&stratification=TOTAL" "&startDate=2017-12-31" "&endDate=2018-01-08" "&awardee=AZ_TUCSON"
 
         response = self.send_get("PublicMetrics", query_string=qs)
 
-        self.assertIn({"date": "2018-01-01", "metrics": {"TOTAL": 1}}, response)
+        self.assertIn({"date": "2017-12-31", "metrics": {"TOTAL": 1}}, response)
+        self.assertIn({"date": "2018-01-01", "metrics": {"TOTAL": 2}}, response)
         self.assertIn({"date": "2018-01-02", "metrics": {"TOTAL": 2}}, response)
         self.assertIn({"date": "2018-01-07", "metrics": {"TOTAL": 2}}, response)
         self.assertIn({"date": "2018-01-08", "metrics": {"TOTAL": 2}}, response)
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_race_api(self, big_query):
-
-        questionnaire_id = self.create_demographics_questionnaire()
-
-        def setup_participant(when, race_code_list, providerLink=self.provider_link, no_demographic=False):
-            # Set up participant, questionnaire, and consent
-            with FakeClock(when):
-                participant = self.send_post("Participant", {"providerLink": [providerLink]})
-                participant_id = participant["participantId"]
-                self.send_consent(participant_id)
-                if no_demographic:
-                    return participant
-                # Populate some answers to the questionnaire
-                answers = {
-                    "race": race_code_list,
-                    "genderIdentity": PMI_SKIP_CODE,
-                    "firstName": self.fake.first_name(),
-                    "middleName": self.fake.first_name(),
-                    "lastName": self.fake.last_name(),
-                    "zipCode": "78751",
-                    "state": PMI_SKIP_CODE,
-                    "streetAddress": "1234 Main Street",
-                    "city": "Austin",
-                    "sex": PMI_SKIP_CODE,
-                    "sexualOrientation": PMI_SKIP_CODE,
-                    "phoneNumber": "512-555-5555",
-                    "recontactMethod": PMI_SKIP_CODE,
-                    "language": PMI_SKIP_CODE,
-                    "education": PMI_SKIP_CODE,
-                    "income": PMI_SKIP_CODE,
-                    "dateOfBirth": datetime.date(1978, 10, 9),
-                    "CABoRSignature": "signature.pdf",
-                }
-            self.post_demographics_questionnaire(participant_id, questionnaire_id, time=when, **answers)
-            return participant
-
-        p1 = setup_participant(self.time1, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        _, expected_bq_results_1 = self.update_participant_summary(p1["participantId"][1:], time_mem=self.time2)
-        p2 = setup_participant(self.time2, [RACE_NONE_OF_THESE_CODE], self.provider_link)
-        _, expected_bq_results_2 = self.update_participant_summary(p2["participantId"][1:], time_mem=self.time3,
-                                                                   time_fp_stored=self.time5)
-        p3 = setup_participant(self.time3, [RACE_AIAN_CODE], self.provider_link)
-        p6 = setup_participant(self.time3, [PMI_SKIP_CODE], self.provider_link, no_demographic=True)
-        _, expected_bq_results_3 = self.update_participant_summary(p3["participantId"][1:], time_mem=self.time4)
-        _, expected_bq_results_6 = self.update_participant_summary(p6["participantId"][1:], the_basics=0)
-        p4 = setup_participant(self.time4, [PMI_SKIP_CODE], self.provider_link)
-        _, expected_bq_results_4 = self.update_participant_summary(p4["participantId"][1:], time_mem=self.time5)
-        p5 = setup_participant(self.time4, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        _, expected_bq_results_5 = self.update_participant_summary(p5["participantId"][1:], time_mem=self.time4,
-                                                                   time_fp_stored=self.time5)
-        p7 = setup_participant(self.time2, [RACE_AIAN_CODE], self.az_provider_link)
-        p8 = setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
-        _, expected_bq_results_7 = self.update_participant_summary(p7["participantId"][1:])
-        _, expected_bq_results_8 = self.update_participant_summary(p8["participantId"][1:])
-
-        big_query().query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
-                                              expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                         [expected_bq_results_7, expected_bq_results_8]]
+        big_query().query.side_effect = self.get_mock_data()
 
         calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 3)
+        self.assertEqual(big_query().query.call_count, 72)
 
         qs = "&stratification=RACE" "&startDate=2017-12-31" "&endDate=2018-01-08"
 
@@ -1732,70 +3477,11 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_race_api_v2(self, big_query):
-
-        questionnaire_id = self.create_demographics_questionnaire()
-
-        def setup_participant(when, race_code_list, providerLink=self.provider_link, no_demographic=False):
-            # Set up participant, questionnaire, and consent
-            with FakeClock(when):
-                participant = self.send_post("Participant", {"providerLink": [providerLink]})
-                participant_id = participant["participantId"]
-                self.send_consent(participant_id)
-                if no_demographic:
-                    return participant
-                # Populate some answers to the questionnaire
-                answers = {
-                    "race": race_code_list,
-                    "genderIdentity": PMI_SKIP_CODE,
-                    "firstName": self.fake.first_name(),
-                    "middleName": self.fake.first_name(),
-                    "lastName": self.fake.last_name(),
-                    "zipCode": "78751",
-                    "state": PMI_SKIP_CODE,
-                    "streetAddress": "1234 Main Street",
-                    "city": "Austin",
-                    "sex": PMI_SKIP_CODE,
-                    "sexualOrientation": PMI_SKIP_CODE,
-                    "phoneNumber": "512-555-5555",
-                    "recontactMethod": PMI_SKIP_CODE,
-                    "language": PMI_SKIP_CODE,
-                    "education": PMI_SKIP_CODE,
-                    "income": PMI_SKIP_CODE,
-                    "dateOfBirth": datetime.date(1978, 10, 9),
-                    "CABoRSignature": "signature.pdf",
-                }
-            self.post_demographics_questionnaire(participant_id, questionnaire_id, time=when, **answers)
-            return participant
-
-        p1 = setup_participant(self.time1, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        _, expected_bq_results_1 = self.update_participant_summary(p1["participantId"][1:], time_mem=self.time2)
-        p2 = setup_participant(self.time2, [RACE_NONE_OF_THESE_CODE], self.provider_link)
-        _, expected_bq_results_2 = self.update_participant_summary(p2["participantId"][1:], time_mem=self.time3,
-                                                                   time_fp_stored=self.time5)
-        p3 = setup_participant(self.time3, [RACE_AIAN_CODE], self.provider_link)
-        _, expected_bq_results_3 = self.update_participant_summary(p3["participantId"][1:], time_mem=self.time4)
-        # Setup participant with no demographic questionnaire.
-        p6 = setup_participant(self.time3, [PMI_SKIP_CODE], self.provider_link, no_demographic=True)
-        _, expected_bq_results_6 = self.update_participant_summary(p6["participantId"][1:], the_basics=0)
-
-        p4 = setup_participant(self.time4, [PMI_SKIP_CODE], self.provider_link)
-        _, expected_bq_results_4 = self.update_participant_summary(p4["participantId"][1:], time_mem=self.time5)
-        p5 = setup_participant(self.time4, [RACE_WHITE_CODE, RACE_HISPANIC_CODE], self.provider_link)
-        _, expected_bq_results_5 = self.update_participant_summary(p5["participantId"][1:], time_mem=self.time4,
-                                                                   time_fp_stored=self.time5)
-        p7 = setup_participant(self.time2, [RACE_AIAN_CODE], self.az_provider_link)
-        p8 = setup_participant(self.time3, [RACE_AIAN_CODE, RACE_MENA_CODE], self.az_provider_link)
-        _, expected_bq_results_7 = self.update_participant_summary(p7["participantId"][1:])
-        _, expected_bq_results_8 = self.update_participant_summary(p8["participantId"][1:])
-
-        big_query().query.side_effect = [[], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
-                                              expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                         [expected_bq_results_7, expected_bq_results_8],
-                                         [], [expected_bq_results_1, expected_bq_results_2, expected_bq_results_3,
-                                              expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                         [expected_bq_results_7, expected_bq_results_8]]
+        big_query().query.side_effect = self.get_mock_data()
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -1807,7 +3493,7 @@ class PublicMetricsApiTest(BaseTestCase):
             calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 6)
+        self.assertEqual(big_query().query.call_count, 132)
 
         qs = "&stratification=RACE" "&startDate=2017-12-31" "&endDate=2018-01-08" "&version=2"
 
@@ -1968,143 +3654,16 @@ class PublicMetricsApiTest(BaseTestCase):
             results,
         )
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_region_api(self, big_query):
-
-        code1 = Code(
-            codeId=1,
-            system="a",
-            value="PIIState_IL",
-            display="PIIState_IL",
-            topic="a",
-            codeType=CodeType.MODULE,
-            mapped=True,
-        )
-        code2 = Code(
-            codeId=2,
-            system="b",
-            value="PIIState_IN",
-            display="PIIState_IN",
-            topic="b",
-            codeType=CodeType.MODULE,
-            mapped=True,
-        )
-        code3 = Code(
-            codeId=3,
-            system="c",
-            value="PIIState_CA",
-            display="PIIState_CA",
-            topic="c",
-            codeType=CodeType.MODULE,
-            mapped=True,
-        )
-
-        code4 = Code(
-            codeId=4,
-            system="c",
-            value="PIIState_PR",
-            display="PIIState_PR",
-            topic="c",
-            codeType=CodeType.MODULE,
-            mapped=True,
-        )
-
-        self.code_dao.insert(code1)
-        self.code_dao.insert(code2)
-        self.code_dao.insert(code3)
-        self.code_dao.insert(code4)
-
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(
-            p1,
-            "Alice",
-            "Aardvark",
-            "UNSET",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time1,
-            time_fp_stored=self.time1,
-            state_id=1,
-        )
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2,
-            "Bob",
-            "Builder",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time2,
-            time_study=self.time2,
-            time_mem=self.time2,
-            time_fp_stored=self.time2,
-            state_id=2,
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time3,
-            time_mem=self.time3,
-            time_fp_stored=self.time3,
-            state_id=3,
-        )
-
-        p4 = Participant(participantId=4, biobankId=7)
-        _, expected_bq_results_4 = self._insert(
-            p4,
-            "Chad2",
-            "Caterpillar2",
-            "PITT",
-            "PITT_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time3,
-            time_mem=self.time3,
-            time_fp_stored=self.time3,
-            state_id=2,
-        )
-
-        p5 = Participant(participantId=6, biobankId=9)
-        _, expected_bq_results_5 = self._insert(
-            p5,
-            "Chad3",
-            "Caterpillar3",
-            "PITT",
-            "PITT_BANNER_HEALTH",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time2,
-            time_fp_stored=self.time3,
-            state_id=2,
-        )
-
-        p6 = Participant(participantId=7, biobankId=10)
-        _, expected_bq_results_6 = self._insert(
-            p6,
-            "Angela",
-            "Alligator",
-            "PITT",
-            "PITT_BANNER_HEALTH",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time2,
-            time_fp_stored=self.time3,
-            state_id=4,
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1],
-                                         [expected_bq_results_4, expected_bq_results_5, expected_bq_results_6],
-                                         [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = self.get_mock_data()
 
         calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 3)
+        self.assertEqual(big_query().query.call_count, 72)
 
         qs1 = "&stratification=GEO_STATE" "&endDate=2017-12-31"
 
@@ -2193,82 +3752,11 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertIn({"date": "2018-01-02", "count": 3, "hpo": "PITT"}, results3)
         self.assertIn({"date": "2018-01-02", "count": 2, "hpo": "AZ_TUCSON"}, results3)
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_lifecycle_api(self, big_query):
-
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(
-            p1,
-            "Alice",
-            "Aardvark",
-            "UNSET",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time1,
-            time_fp=self.time1,
-            time_fp_stored=self.time1,
-        )
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2,
-            "Bob",
-            "Builder",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time2,
-            time_study=self.time2,
-            time_mem=self.time2,
-            time_fp=self.time3,
-            time_fp_stored=self.time3,
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time4,
-            time_mem=self.time4,
-            time_fp=self.time5,
-            time_fp_stored=self.time5,
-        )
-
-        p4 = Participant(participantId=4, biobankId=7)
-        _, expected_bq_results_4 = self._insert(
-            p4,
-            "Chad2",
-            "Caterpillar2",
-            "PITT",
-            "PITT_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time4,
-            time_mem=self.time5,
-            time_fp=self.time5,
-            time_fp_stored=self.time5,
-        )
-
-        p4 = Participant(participantId=6, biobankId=9)
-        _, expected_bq_results_5 = self._insert(
-            p4,
-            "Chad3",
-            "Caterpillar3",
-            "PITT",
-            "PITT_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time4,
-            time_mem=self.time4,
-            time_fp=self.time4,
-            time_fp_stored=self.time5,
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
-                                         [expected_bq_results_2, expected_bq_results_3],
-                                         [expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
-                                         [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = self.get_mock_data()
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -2280,7 +3768,7 @@ class PublicMetricsApiTest(BaseTestCase):
             calculate_participant_metrics()
 
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 6)
+        self.assertEqual(big_query().query.call_count, 132)
 
         qs1 = "&stratification=LIFECYCLE" "&endDate=2018-01-03"
 
@@ -2374,132 +3862,27 @@ class PublicMetricsApiTest(BaseTestCase):
             ],
         )
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_language_api(self, big_query):
-
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(p1, "Alice", "Aardvark", "UNSET",
-                                                unconsented=True, time_int=self.time1, primary_language="en")
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(p2, "Bob", "Builder", "AZ_TUCSON",
-                                                "AZ_TUCSON_BANNER_HEALTH", time_int=self.time2, primary_language="es"
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time1,
-            time_mem=self.time3,
-            time_fp_stored=self.time4,
-            primary_language="en",
-        )
-
-        p4 = Participant(participantId=5, biobankId=7)
-        _, expected_bq_results_4 = self._insert(
-            p4,
-            "Chad2",
-            "Caterpillar2",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time1,
-            time_mem=self.time2,
-            time_fp_stored=self.time4,
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [], [expected_bq_results_2, expected_bq_results_3,
-                                                                       expected_bq_results_4]]
+        big_query().query.side_effect = self.get_mock_data()
 
         calculate_participant_metrics()
         qs = "&stratification=LANGUAGE" "&startDate=2017-12-30" "&endDate=2018-01-03"
 
         results = self.send_get("PublicMetrics", query_string=qs)
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 3)
+        self.assertEqual(big_query().query.call_count, 72)
         self.assertIn({"date": "2017-12-30", "metrics": {"EN": 0, "UNSET": 0, "ES": 0}}, results)
         self.assertIn({"date": "2017-12-31", "metrics": {"EN": 1, "UNSET": 2, "ES": 0}}, results)
         self.assertIn({"date": "2018-01-03", "metrics": {"EN": 1, "UNSET": 2, "ES": 1}}, results)
 
+    @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
+                test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
     def test_public_metrics_get_primary_consent_api(self, big_query):
-
-        p1 = Participant(participantId=1, biobankId=4)
-        _, expected_bq_results_1 = self._insert(
-            p1,
-            "Alice",
-            "Aardvark",
-            "UNSET",
-            time_int=self.time1,
-            time_study=self.time1,
-            time_mem=self.time1,
-            time_fp=self.time1,
-            time_fp_stored=self.time1,
-        )
-
-        p2 = Participant(participantId=2, biobankId=5)
-        _, expected_bq_results_2 = self._insert(
-            p2,
-            "Bob",
-            "Builder",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time2,
-            time_study=self.time2,
-            time_mem=self.time2,
-            time_fp=self.time3,
-            time_fp_stored=self.time3,
-        )
-
-        p3 = Participant(participantId=3, biobankId=6)
-        _, expected_bq_results_3 = self._insert(
-            p3,
-            "Chad",
-            "Caterpillar",
-            "AZ_TUCSON",
-            "AZ_TUCSON_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time4,
-            time_mem=self.time4,
-            time_fp=self.time5,
-            time_fp_stored=self.time5,
-        )
-
-        p4 = Participant(participantId=4, biobankId=7)
-        _, expected_bq_results_4 = self._insert(
-            p4,
-            "Chad2",
-            "Caterpillar2",
-            "PITT",
-            "PITT_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time4,
-            time_mem=self.time5,
-            time_fp=self.time5,
-            time_fp_stored=self.time5,
-        )
-
-        p5 = Participant(participantId=6, biobankId=9)
-        _, expected_bq_results_5 = self._insert(
-            p5,
-            "Chad3",
-            "Caterpillar3",
-            "PITT",
-            "PITT_BANNER_HEALTH",
-            time_int=self.time3,
-            time_study=self.time4,
-            time_mem=self.time4,
-            time_fp=self.time4,
-            time_fp_stored=self.time5,
-        )
-
-        big_query().query.side_effect = [[expected_bq_results_1], [expected_bq_results_4, expected_bq_results_5],
-                                         [expected_bq_results_2, expected_bq_results_3], [expected_bq_results_1],
-                                         [expected_bq_results_4, expected_bq_results_5],
-                                         [expected_bq_results_2, expected_bq_results_3]]
+        big_query().query.side_effect = self.get_mock_data()
 
         with FakeClock(TIME_2):
             calculate_participant_metrics()
@@ -2514,7 +3897,7 @@ class PublicMetricsApiTest(BaseTestCase):
 
         results = self.send_get("PublicMetrics", query_string=qs)
         self.assertTrue(big_query().query.called)
-        self.assertEqual(big_query().query.call_count, 6)
+        self.assertEqual(big_query().query.call_count, 132)
         self.assertIn({"date": "2017-12-31", "metrics": {"Primary_Consent": 1}}, results)
         self.assertIn({"date": "2018-01-02", "metrics": {"Primary_Consent": 2}}, results)
         self.assertIn({"date": "2018-01-06", "metrics": {"Primary_Consent": 5}}, results)


### PR DESCRIPTION
## Resolves *[DA-4564](https://precisionmedicineinitiative.atlassian.net/browse/DA-4564)*


## Description of changes/additions
These changes update the Participant Counts Over Time job to run all metric cache queries in BigQuery and update the MySQL tables with the results. The metric `temp_tables` are no longer used. 

The base config will be updated with the BigQuery table names before release.

base-config:
```
"public_metrics_participant_table": "rdr_operational_datastream.rdr_participant"
"public_metrics_participant_summary_table": "rdr_operational_datastream.rdr_participant_summary"
"public_metrics_hpo_table": "rdr_operational_datastream.rdr_hpo"
"public_metrics_calendar_table": "rdr_operational_datastream.rdr_calendar"
"public_metrics_code_table": "rdr_operational_datastream.rdr_code"
"public_metrics_gender_answers_table": "rdr_operational_datastream.rdr_participant_gender_answers"
"public_metrics_race_answers_table": "rdr_operational_datastream.rdr_participant_race_answers"
```

## Tests
- [X] unit tests
- Tested on Sandbox
- New queries manually run in BigQuery and counts compared to old query counts in the RDR




[DA-4564]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ