### PR TITLE
[DA-4782] Add Date Range and Batching to EHR Datafeed Job

### DIFF
--- a/rdr_service/ppsc_pipeline/main.py
+++ b/rdr_service/ppsc_pipeline/main.py
@@ -1,6 +1,7 @@
 """The main API definition file for ppsc-pipeline service endpoints."""
 import logging
 import traceback
+import datetime
 
 from flask import Flask, got_request_exception, request
 from sqlalchemy.exc import DBAPIError
@@ -38,8 +39,11 @@ def awardee_insite_input_feed():
 @app_util.auth_required_scheduler
 def ppsc_data_transfer_input_feed():
     datafeed = request.get_json().get("datafeed")
+    start_date = request.get_json().get("earliest_date", '2025-03-28')
+    end_date = request.get_json().get("latest_date", datetime.datetime.utcnow().strftime('%Y-%m-%d'))
+    batch_size = request.get_json().get("batch_size", 800)
     input_feed = InputFeed(project=GAE_PROJECT)
-    input_feed.run_datafeed(datafeed)
+    input_feed.run_datafeed(datafeed, start_date, end_date, batch_size)
     return '{ "success": "true" }'
 
 

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -278,7 +278,8 @@ def get_ppsc_biospecimen_to_stream(project: str, destination_dataset: str) -> st
         )
     ;"""
 
-def get_ppsc_ehr_to_stream(project: str, destination_dataset: str, start_date: str, end_date: str, batch_size: int) -> str:
+def get_ppsc_ehr_to_stream(project: str, destination_dataset: str, start_date: str,
+                           end_date: str, batch_size: int) -> str:
     return f"""
 SELECT distinct participant_id, ignore_flag, created, modified, event_date_time
 FROM `{project}.{destination_dataset}.datafeed_input_ehr` s

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -246,6 +246,7 @@ WHERE TRUE
 ;
 """
 
+
 def get_ppsc_core_to_stream(project: str, destination_dataset: str) -> str:
     return f"""
     SELECT distinct participant_id, ignore_flag, event_date_time, created, modified, has_core_data
@@ -260,6 +261,7 @@ def get_ppsc_core_to_stream(project: str, destination_dataset: str) -> str:
                 AND t.ignore_flag = 0
         )
     ;"""
+
 
 def get_ppsc_biospecimen_to_stream(project: str, destination_dataset: str) -> str:
     return f"""
@@ -276,7 +278,7 @@ def get_ppsc_biospecimen_to_stream(project: str, destination_dataset: str) -> st
         )
     ;"""
 
-def get_ppsc_ehr_to_stream(project: str, destination_dataset: str) -> str:
+def get_ppsc_ehr_to_stream(project: str, destination_dataset: str, start_date: str, end_date: str, batch_size: int) -> str:
     return f"""
 SELECT distinct participant_id, ignore_flag, created, modified, event_date_time
 FROM `{project}.{destination_dataset}.datafeed_input_ehr` s
@@ -289,6 +291,9 @@ where TRUE
             AND t.event_date_time = s.event_date_time
             AND t.ignore_flag = 0
     )
+  AND event_date_time >= {start_date}
+  AND event_date_time <= {end_date}
+LIMIT {batch_size}
 ;"""
 
 def get_health_data_to_stream(project: str, destination_dataset: str) -> str:

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -292,8 +292,8 @@ where TRUE
             AND t.event_date_time = s.event_date_time
             AND t.ignore_flag = 0
     )
-  AND event_date_time >= {start_date}
-  AND event_date_time <= {end_date}
+  AND event_date_time >= '{start_date}'
+  AND event_date_time <= '{end_date}'
 LIMIT {batch_size}
 ;"""
 

--- a/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_data_transfer_input_feed.py
@@ -54,7 +54,7 @@ class InputFeed(PPSCBigQueryDatafeedBase):
     def make_datafeed_job(self, job_def):
         return self.bq_client.query(job_def)
 
-    def get_datafeed_definition(self, datafeed):
+    def get_datafeed_definition(self, datafeed, start_date=None, end_date=None, batch_size=None):
         src = config.getSettingJson(config.PPSC_DATAFEED_SRC_DATASET)[0]
         destination = config.getSettingJson(config.PPSC_DATAFEED_DEST_DATASET)[0]
 
@@ -80,7 +80,8 @@ class InputFeed(PPSCBigQueryDatafeedBase):
 
         elif datafeed == "ehr":
             job_def['staging_data'] = data_feed_queries.insert_ehr_receipt(self.project, src, destination)
-            job_def['streaming_data'] = data_feed_queries.get_ppsc_ehr_to_stream(self.project, destination)
+            job_def['streaming_data'] = data_feed_queries.get_ppsc_ehr_to_stream(self.project, destination, start_date,
+                                                                                 end_date, batch_size)
             job_def['output_model'] = PPSCEHR
             return job_def
 
@@ -88,11 +89,11 @@ class InputFeed(PPSCBigQueryDatafeedBase):
             # Raise error
             raise BadRequest(f"Invalid Datafeed: {datafeed}")
 
-    def run_datafeed(self, datafeed):
+    def run_datafeed(self, datafeed, start_date=None, end_date=None, batch_size=None):
         """
         Loads datafeed results in batches and commits updates to database per batch.
         """
-        job_def = self.get_datafeed_definition(datafeed)
+        job_def = self.get_datafeed_definition(datafeed, start_date, end_date, batch_size)
 
         # Stage the Data
         job = self.make_datafeed_job(job_def['staging_data'])

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -237,6 +237,9 @@ where TRUE
             AND t.event_date_time = s.event_date_time
             AND t.ignore_flag = 0
     )
+  AND event_date_time >= '2025-03-28'
+  AND event_date_time <= '2025-04-01'
+LIMIT 800
 ;"""
 
 health_data_sharing_expected_sql = """

--- a/tests/workflow_tests/test_ppsc_data_transfer_input.py
+++ b/tests/workflow_tests/test_ppsc_data_transfer_input.py
@@ -100,7 +100,7 @@ class DataTransferInputTest(GenomicDataGenMixin):
 
         self.assertEqual(staging_data_expected_sql, query)
 
-        feed.run_datafeed("ehr")
+        feed.run_datafeed("ehr", '2025-03-28', '2025-04-01', 800)
 
         self.assertEqual(mock_bq_instance.query.call_count, 2)
 


### PR DESCRIPTION
## Resolves *[DA-4782](https://precisionmedicineinitiative.atlassian.net/browse/DA-4782)*


## Description of changes/additions
Added date range and batching as optional parameters to EHR datafeed job. If left blank, will default to a range from 2024-03-28 to now, and a batch size limit of 800.


## Tests
- updated tests.workflow_tests.test_ppsc_data_transfer_input.DataTransferInputTest.test_ehr_datafeed to support




[DA-4782]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ