### PR TITLE
[DA-4785]  Ensure Test PIDs Won't Go Out on AW0s Moving Forward

### DIFF
--- a/rdr_service/data_gen/generators/data_generator.py
+++ b/rdr_service/data_gen/generators/data_generator.py
@@ -386,7 +386,6 @@ class DataGenerator:
             "nphDeactivation": False,
             "hasCoreData": False,
             "hasHeightAndWeight": False,
-
         }
 
         defaults.update(kwargs)

--- a/rdr_service/data_gen/generators/data_generator.py
+++ b/rdr_service/data_gen/generators/data_generator.py
@@ -386,6 +386,7 @@ class DataGenerator:
             "nphDeactivation": False,
             "hasCoreData": False,
             "hasHeightAndWeight": False,
+
         }
 
         defaults.update(kwargs)

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -416,6 +416,7 @@ class GenomicQueryClass:
         WHERE TRUE
             AND ss.test in ('1ED04', '1ED10', '1SAL2')
             AND m.id IS NULL
+            AND p.is_test_participant != 1
         """
 
     # BEGIN Data Quality Pipeline Report Queries

--- a/rdr_service/genomic/genomic_data.py
+++ b/rdr_service/genomic/genomic_data.py
@@ -413,10 +413,14 @@ class GenomicQueryClass:
             LEFT JOIN genomic_set_member m ON m.participant_id = ps.participant_id
                     AND m.genomic_workflow_state <> :ignore_param
             LEFT JOIN biobank_mail_kit_order mk ON mk.participant_id = p.participant_id
+            LEFT JOIN ppsc.participant_status_event pse on pse.participant_id = p.participant_id
+                    AND pse.event_type_name = "Test Account"
+                    AND pse.data_element_name = "activity_status"
+                    AND pse.data_element_value = "test"
         WHERE TRUE
             AND ss.test in ('1ED04', '1ED10', '1SAL2')
             AND m.id IS NULL
-            AND p.is_test_participant != 1
+            AND pse.id IS NULL
         """
 
     # BEGIN Data Quality Pipeline Report Queries

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -6,6 +6,7 @@ import operator
 import pytz
 import random
 import time
+import http.client
 
 from copy import deepcopy
 from dateutil.parser import parse
@@ -18,6 +19,7 @@ from rdr_service.code_constants import (
 from rdr_service.config import GENOMIC_GEM_A3_MANIFEST_SUBFOLDER
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
+#from rdr_service.dao.ppsc_d
 from rdr_service.dao.genomics_dao import (
     GenomicSetDao,
     GenomicSetMemberDao,
@@ -46,6 +48,7 @@ from rdr_service.model.biobank_order import (
     BiobankOrderIdentifier,
     BiobankOrderedSample
 )
+from rdr_service.data_gen.generators.ppsc import PPSCDataGenerator
 from rdr_service.model.config_utils import get_biobank_id_prefix
 from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.consent_file import ConsentType, ConsentSyncStatus
@@ -174,6 +177,7 @@ class GenomicPipelineTest(BaseTestCase):
         self.qq_dao = QuestionnaireQuestionDao()
         self.aw1_raw_dao = GenomicAW1RawDao()
         self.aw2_raw_dao = GenomicAW2RawDao()
+        self.ppsc_data_gen = PPSCDataGenerator()
 
         self._participant_i = 1
 
@@ -1402,13 +1406,60 @@ class GenomicPipelineTest(BaseTestCase):
                 mko.stateId = ny_code.codeId
 
                 self.mk_dao.update(mko)
-        #Add one Test Participant to ensure we do not pick up test participants
-        if bid == 100010:
-            self.hpo_dao = HPODao()
-            self.hpo_dao.insert(
-                HPO(hpoId=TEST_HPO_ID, name=TEST_HPO_NAME, displayName="Test", organizationType=OrganizationType.UNSET))
-            participant = Participant(participantId=100010)
-            ParticipantDao().switch_to_test_account(None, participant,commit_update=False)
+
+            #Add one Test Participant to ensure we do not pick up test participants
+            if bid == 100010:
+
+                self.hpo_dao = HPODao()
+                self.hpo_dao.insert(
+                    HPO(hpoId=TEST_HPO_ID, name=TEST_HPO_NAME, displayName="Test", organizationType=OrganizationType.UNSET))
+                participant = Participant(participantId=p.participantId)
+                ParticipantDao().switch_to_test_account(None, participant,commit_update=False)
+
+                self.ppsc_data_gen.create_database_participant(
+                    **{
+                        'id': 10,
+                        'biobank_id': 100010,
+                    }
+                )
+                payload = {
+                    'participantId': 'P10',
+                    'biobankId': 'T100010',
+                    'registeredDate': '2024-03-26T13:24:03.935Z'
+                }
+                self.send_post('createParticipant', request_data=payload,expected_status=http.client.FORBIDDEN)
+
+                activities = [
+                    "ENROLLMENT",
+                    "Consent",
+                    "Survey Completion",
+                    "Profile Updates",
+                    "Withdrawal",
+                    "Deactivation",
+                    "Participant Status",
+                    "Attribution",
+                    "NPH Opt In",
+                    "Account Linkage"
+                ]
+                for activity in activities:
+                    self.ppsc_data_gen.create_database_activity(
+                        name=activity
+                    )
+
+                participant_event_activity_profile = self.ppsc_data_gen.create_database_participant_event_activity(
+                    participant_id=p.participantId,
+                    activity_id=7  # Participant Status
+                )
+
+                self.ppsc_data_gen.create_database_participant_status_event(
+                    participant_id=p.participantId,
+                    event_type_name='Test Account',
+                    event_id=participant_event_activity_profile.id,
+                    data_element_name='activity_status',
+                    data_element_value='test',
+                    event_authored_time=clock.CLOCK.now()
+                )
+
 
         # insert an 'already ran' workflow to test proper exclusions
         self.job_run_dao.insert(GenomicJobRun(
@@ -1428,7 +1479,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Should be a aou_wgs and aou_array for each and exclude the test participant
         new_genomic_members = self.member_dao.get_all()
-        self.assertEqual(16, len(new_genomic_members) - 2)
+        self.assertEqual(16, len(new_genomic_members) )
 
         all_ps_origins = [self.summary_dao.get_by_participant_id(obj.participantId).participantOrigin
                        for obj in new_genomic_members]
@@ -1450,6 +1501,7 @@ class GenomicPipelineTest(BaseTestCase):
         # Test GenomicMember's data
         # 100001 : Excluded, created before last run,
         # 100005 : Excluded, no DNA sample
+        # 100010 : Excluded, test participant
         member_genome_types = {_member.biobankId: list() for _member in new_genomic_members}
         for member in new_genomic_members:
             member_genome_types[member.biobankId].append(member.genomeType)

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -191,8 +191,7 @@ class GenomicPipelineTest(BaseTestCase):
         i = self._participant_i
         self._participant_i += 1
         bid = kwargs.pop('biobankId', i)
-        testParticipant = kwargs.pop('isTestParticipant', i)
-        participant = Participant(participantId=i, biobankId=bid, researchId=1000000 + i, isTestParticipant=testParticipant, **kwargs)
+        participant = Participant(participantId=i, biobankId=bid, researchId=1000000 + i, **kwargs)
         self.participant_dao.insert(participant)
         return participant
 
@@ -263,7 +262,6 @@ class GenomicPipelineTest(BaseTestCase):
             consentForStudyEnrollmentAuthored=datetime.datetime(2019, 1, 1),
             consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
             consentForGenomicsROR=QuestionnaireStatus.SUBMITTED,
-
         )
         kwargs = dict(valid_kwargs, **override_kwargs)
         summary = self.data_generator._participant_summary_with_defaults(**kwargs)
@@ -1327,10 +1325,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Setup the biobank order backend
         for i, bid in enumerate(test_biobank_ids):
-            #p = self._make_participant(biobankId=bid,  isTestParticipant =True if bid == 100002 else False,)
-            p = self._make_participant(biobankId=bid, isTestParticipant= False, )
-            # Needed by test_switch_to_test_account
-
+            p = self._make_participant(biobankId=bid)
             self._make_summary(p, sexId=intersex_code if bid == 100004 else female_code,
                                consentForStudyEnrollment=0 if bid == 100006 else 1,
                                sampleStatus1ED04=0,
@@ -1339,8 +1334,7 @@ class GenomicPipelineTest(BaseTestCase):
                                samplesToIsolateDNA=0,
                                race=Race.HISPANIC_LATINO_OR_SPANISH,
                                consentCohort=3,
-                               participantOrigin=participant_origins[0 if i % 2 == 0 else 1],
-                              )
+                               participantOrigin=participant_origins[0 if i % 2 == 0 else 1])
             # Insert participant races
             race_answer = ParticipantRaceAnswers(
                 participantId=p.participantId,
@@ -1432,7 +1426,7 @@ class GenomicPipelineTest(BaseTestCase):
         new_genomic_set = self.set_dao.get_all()
         self.assertEqual(1, len(new_genomic_set))
 
-        # Should be a aou_wgs and aou_array for each
+        # Should be a aou_wgs and aou_array for each and exclude the test participant
         new_genomic_members = self.member_dao.get_all()
         self.assertEqual(16, len(new_genomic_members) - 2)
 

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -38,6 +38,8 @@ from rdr_service.dao.questionnaire_dao import QuestionnaireDao, QuestionnaireQue
 from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao, QuestionnaireResponseAnswerDao
 from rdr_service.dao.site_dao import SiteDao
 from rdr_service.dao.code_dao import CodeDao, CodeType
+from rdr_service.dao.hpo_dao import HPODao
+from rdr_service.model.hpo import HPO
 from rdr_service.model.biobank_mail_kit_order import BiobankMailKitOrder
 from rdr_service.model.biobank_order import (
     BiobankOrder,
@@ -67,7 +69,7 @@ from rdr_service.participant_enums import (
     SampleStatus,
     Race,
     QuestionnaireStatus,
-    WithdrawalStatus
+    WithdrawalStatus, TEST_HPO_ID, TEST_HPO_NAME, OrganizationType
 )
 from rdr_service.genomic_enums import GenomicSetStatus, GenomicSetMemberStatus, GenomicJob, GenomicWorkflowState, \
     GenomicSubProcessStatus, GenomicSubProcessResult, GenomicManifestTypes, GenomicContaminationCategory, \
@@ -189,7 +191,8 @@ class GenomicPipelineTest(BaseTestCase):
         i = self._participant_i
         self._participant_i += 1
         bid = kwargs.pop('biobankId', i)
-        participant = Participant(participantId=i, biobankId=bid, researchId=1000000 + i, **kwargs)
+        testParticipant = kwargs.pop('isTestParticipant', i)
+        participant = Participant(participantId=i, biobankId=bid, researchId=1000000 + i, isTestParticipant=testParticipant, **kwargs)
         self.participant_dao.insert(participant)
         return participant
 
@@ -260,6 +263,7 @@ class GenomicPipelineTest(BaseTestCase):
             consentForStudyEnrollmentAuthored=datetime.datetime(2019, 1, 1),
             consentForStudyEnrollment=QuestionnaireStatus.SUBMITTED,
             consentForGenomicsROR=QuestionnaireStatus.SUBMITTED,
+
         )
         kwargs = dict(valid_kwargs, **override_kwargs)
         summary = self.data_generator._participant_summary_with_defaults(**kwargs)
@@ -1305,7 +1309,7 @@ class GenomicPipelineTest(BaseTestCase):
     def test_new_participant_workflow(self):
         # Test for Cohort 3 workflow
         # create test samples
-        test_biobank_ids = (100001, 100002, 100003, 100004, 100005, 100006, 100007, 100008, 100009)
+        test_biobank_ids = (100001, 100002, 100003, 100004, 100005, 100006, 100007, 100008, 100009, 100010)
         fake_datetime_old = datetime.datetime(2019, 12, 31, tzinfo=pytz.utc)
         fake_datetime_new = datetime.datetime(2020, 1, 5, tzinfo=pytz.utc)
         participant_origins = ['careevolution', 'example']
@@ -1323,7 +1327,10 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Setup the biobank order backend
         for i, bid in enumerate(test_biobank_ids):
-            p = self._make_participant(biobankId=bid)
+            #p = self._make_participant(biobankId=bid,  isTestParticipant =True if bid == 100002 else False,)
+            p = self._make_participant(biobankId=bid, isTestParticipant= False, )
+            # Needed by test_switch_to_test_account
+
             self._make_summary(p, sexId=intersex_code if bid == 100004 else female_code,
                                consentForStudyEnrollment=0 if bid == 100006 else 1,
                                sampleStatus1ED04=0,
@@ -1332,7 +1339,8 @@ class GenomicPipelineTest(BaseTestCase):
                                samplesToIsolateDNA=0,
                                race=Race.HISPANIC_LATINO_OR_SPANISH,
                                consentCohort=3,
-                               participantOrigin=participant_origins[0 if i % 2 == 0 else 1])
+                               participantOrigin=participant_origins[0 if i % 2 == 0 else 1],
+                              )
             # Insert participant races
             race_answer = ParticipantRaceAnswers(
                 participantId=p.participantId,
@@ -1400,6 +1408,13 @@ class GenomicPipelineTest(BaseTestCase):
                 mko.stateId = ny_code.codeId
 
                 self.mk_dao.update(mko)
+        #Add one Test Participant to ensure we do not pick up test participants
+        if bid == 100010:
+            self.hpo_dao = HPODao()
+            self.hpo_dao.insert(
+                HPO(hpoId=TEST_HPO_ID, name=TEST_HPO_NAME, displayName="Test", organizationType=OrganizationType.UNSET))
+            participant = Participant(participantId=100010)
+            ParticipantDao().switch_to_test_account(None, participant,commit_update=False)
 
         # insert an 'already ran' workflow to test proper exclusions
         self.job_run_dao.insert(GenomicJobRun(
@@ -1419,7 +1434,7 @@ class GenomicPipelineTest(BaseTestCase):
 
         # Should be a aou_wgs and aou_array for each
         new_genomic_members = self.member_dao.get_all()
-        self.assertEqual(16, len(new_genomic_members))
+        self.assertEqual(16, len(new_genomic_members) - 2)
 
         all_ps_origins = [self.summary_dao.get_by_participant_id(obj.participantId).participantOrigin
                        for obj in new_genomic_members]

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -6,7 +6,6 @@ import operator
 import pytz
 import random
 import time
-import http.client
 
 from copy import deepcopy
 from dateutil.parser import parse
@@ -1422,33 +1421,12 @@ class GenomicPipelineTest(BaseTestCase):
                         'biobank_id': 100010,
                     }
                 )
-                payload = {
-                    'participantId': 'P10',
-                    'biobankId': 'T100010',
-                    'registeredDate': '2024-03-26T13:24:03.935Z'
-                }
-                self.send_post('createParticipant', request_data=payload,expected_status=http.client.FORBIDDEN)
 
-                activities = [
-                    "ENROLLMENT",
-                    "Consent",
-                    "Survey Completion",
-                    "Profile Updates",
-                    "Withdrawal",
-                    "Deactivation",
-                    "Participant Status",
-                    "Attribution",
-                    "NPH Opt In",
-                    "Account Linkage"
-                ]
-                for activity in activities:
-                    self.ppsc_data_gen.create_database_activity(
-                        name=activity
-                    )
+                self.ppsc_data_gen.create_database_activity(name="Participant Status")
 
                 participant_event_activity_profile = self.ppsc_data_gen.create_database_participant_event_activity(
                     participant_id=p.participantId,
-                    activity_id=7  # Participant Status
+                    activity_id=1
                 )
 
                 self.ppsc_data_gen.create_database_participant_status_event(

--- a/tests/genomics_tests/test_genomic_pipeline.py
+++ b/tests/genomics_tests/test_genomic_pipeline.py
@@ -19,7 +19,7 @@ from rdr_service.code_constants import (
 from rdr_service.config import GENOMIC_GEM_A3_MANIFEST_SUBFOLDER
 from rdr_service.dao.biobank_order_dao import BiobankOrderDao
 from rdr_service.dao.biobank_stored_sample_dao import BiobankStoredSampleDao
-#from rdr_service.dao.ppsc_d
+
 from rdr_service.dao.genomics_dao import (
     GenomicSetDao,
     GenomicSetMemberDao,


### PR DESCRIPTION
Resolves [DA-4785](https://precisionmedicineinitiative.atlassian.net/browse/DA-4785)


## Description of changes/additions
Changed criteria when selecting new biobank participants to ensure that we do not send test participants on the AW0

## Tests
Modified unit tests to create a test participant




[DA-4785]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ