### PR TITLE
[DA-4807] Updating method of releasing memory for gunicorn

### DIFF
--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -47,12 +47,8 @@ def post_request(worker, request, environment, response):  # pylint: disable=unu
         worker.log.info(f"Restarting worker found to be using {memory_used_megabytes} megabytes (pid: {os.getpid()})")
 
         # This will safely start shutting down a worker: letting it continue with the request it is
-        # currently processing, but closing it off from further requests (as was seen with thread workers when we
-        # set alive to False).
-        # WARNING: As of now the parameters sig and frame aren't used by the thread worker (our current default). If
-        # we change to another worker type, or if Gunicorn updates the handle_quit code to do something with them,
-        # then we may need to pass something in.
-        worker.handle_abort(None, None)
+        # currently processing, but closing it off from further requests.
+        worker.handle_exit(None, None)
 
 # The below function is useful for debugging settings.
 # Leaving in but disabled in case future modifications need to be tested.


### PR DESCRIPTION
## Partially Resolves *[DA-4807](https://precisionmedicineinitiative.atlassian.net/browse/DA-4807)*
We’ve been seeing 502 status code errors logged intermittently, especially during times of higher traffic. When looking at the logs, there seems to be a pattern: any time a 502 is logged, the start time for that request coincides with a gunicorn worker reaching it’s memory limit and beginning to shutdown.

When the code detects that we’re getting closer to GAE’s memory limit, we call `handle_abort` on the worker process. This starts shutting down the worker. Any requests that are being handled by other threads continue until they’re complete, then the process is killed, memory is returned to the OS, and the main gunicorn process boots a new worker.

This was implemented when we were on gunicorn version 20.0.4 and seemed to work well (no exceptions were raised and a worker that was shutting down wouldn’t try to handle any future requests). Testing this process locally with our current version of gunicorn (23.0.0) shows that an exception is raised when calling `handle_abort` and a request can be accepted by the worker that is shutting down. That request doesn’t seem to start processing, and then the connection is closed when the worker is killed (causing the load balancer to respond with a 502).


## Description of changes/additions

This PR changes the code to use handle_exit instead, which does the same thing we’ve done previously (set the workers alive flag to False). Testing locally shows that the exception no longer occurs, and almost all future requests are handled by other workers. We do still see an issue with this that we’ve seen before: there seems to be a short window of time that the worker will accept a new connection just before exiting. But that happens alot less frequently than it does when we’re calling handle_abort.

[DA-4807]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ