### PR TITLE
[DA-4797] Update Read-me doc for Awardee InSite API for Withdrawal Time

### DIFF
--- a/rdr_service/model/awardee_insite.py
+++ b/rdr_service/model/awardee_insite.py
@@ -62,7 +62,7 @@ class AwardeeInSite(PPSCBase):
     * withdrawn
     """
     withdrawalTime = Column("withdrawal_time", UTCDateTime, nullable=True)
-    """The date and time at which the participant withdrew from the study."""
+    """The actual date and time at which the participant chose to stop participating in the Participant Portal."""
 
     deactivationStatus = Column(
         "deactivation_status", String(32), nullable=False, default="not_deactivated"

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -48,7 +48,7 @@ idna==3.7                 # via requests
 isodate==0.6.0            # via fhirclient
 isort==4.3.21             # via pylint
 itsdangerous==2.1.2       # via flask
-jinja2==3.1.5             # via flask, sphinx
+jinja2==3.1.6             # via flask, sphinx
 jira==2.0.0               # via -r requirements.in
 lazy-object-proxy==1.4.3  # via astroid
 locust==1.3.2             # via -r requirements.in


### PR DESCRIPTION
## Resolves *[DA-4797](https://precisionmedicineinitiative.atlassian.net/browse/DA-4797)*


## Description of changes/additions
- Update read-me for awardee insite for withdrawal time and replace it with withdrawal authored
- Bumping jinja so that safety check passes

## Tests
- [] unit tests




[DA-4797]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ