### PR TITLE
[DA-4795] Update validation for new PPSC payloads

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -104,7 +104,7 @@ class PPSCIntakeAPI(BaseApi):
                 if name in ['registered', 'participant', 'participant_ehr_consent', 'enrolled',
                                                'pmb_eligible', 'core_minus_pm', 'core_participant']:
                     if not name+'_date_time' in data_element_names:
-                        raise BadRequest("Timestamp required for Enrollment Status.")
+                        raise BadRequest(f"Enrollment Status {name} is missing {name+'_date_time'}.")
 
     def handle_event_insert(self, *, req_data: dict) -> dict:
         activity_record = list(filter(lambda x: x.name.lower() == req_data['activity'].lower(),

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -101,8 +101,7 @@ class PPSCIntakeAPI(BaseApi):
         if req_data['eventType'] == "Enrollment Status":
             data_element_names = [item['dataElementName'].lower() for item in req_data['dataElements']]
             for name in data_element_names:
-                if name in ['registered', 'participant', 'participant_ehr_consent', 'enrolled',
-                                               'pmb_eligible', 'core_minus_pm', 'core_participant']:
+                if '_date_time' not in name:
                     if not name+'_date_time' in data_element_names:
                         raise BadRequest(f"Enrollment Status {name} is missing {name+'_date_time'}.")
 

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -84,7 +84,10 @@ class PPSCIntakeAPI(BaseApi):
             except ValueError:
                 raise BadRequest("The activity_date_time_value is not valid.")
         else:
-            raise BadRequest("No activity_date_time_value provided.")
+            if req_data['eventType'] in ['Enrollment Status', 'UBR Status'] :
+                pass
+            else:
+                raise BadRequest("No activity_date_time_value provided.")
 
         # Check for Primary Consent
         if req_data['eventType'] != "Primary Consent":
@@ -93,6 +96,15 @@ class PPSCIntakeAPI(BaseApi):
                                               'activity_status',
                                               'yes'):
                 raise BadRequest("No Primary Consent record found.")
+
+        # Check Enrollment Status for timestamps
+        if req_data['eventType'] == "Enrollment Status":
+            data_element_names = [item['dataElementName'].lower() for item in req_data['dataElements']]
+            for name in data_element_names:
+                if name in ['registered', 'participant', 'participant_ehr_consent', 'enrolled',
+                                               'pmb_eligible', 'core_minus_pm', 'core_participant']:
+                    if not name+'_date_time' in data_element_names:
+                        raise BadRequest("Timestamp required for Enrollment Status.")
 
     def handle_event_insert(self, *, req_data: dict) -> dict:
         activity_record = list(filter(lambda x: x.name.lower() == req_data['activity'].lower(),

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -1105,11 +1105,11 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual('participant_ehr_consent_date_time', participant_status_events[5].data_element_name)
         self.assertEqual('2024-10-28T19:20:42.000Z', participant_status_events[5].data_element_value)
 
-        self.assertEqual('outdoors', participant_status_events[2].data_element_name)
-        self.assertEqual('yes', participant_status_events[2].data_element_value)
+        self.assertEqual('outdoors', participant_status_events[6].data_element_name)
+        self.assertEqual('yes', participant_status_events[6].data_element_value)
 
-        self.assertEqual('outdoors_date_time', participant_status_events[3].data_element_name)
-        self.assertEqual('2024-10-31T19:20:42.000Z', participant_status_events[3].data_element_value)
+        self.assertEqual('outdoors_date_time', participant_status_events[7].data_element_name)
+        self.assertEqual('2024-10-31T19:20:42.000Z', participant_status_events[7].data_element_value)
 
     def test_intake_ubr_status_insert(self):
         participant = self.ppsc_data_gen.create_database_participant()
@@ -1161,7 +1161,7 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual(7, participant_event_activities.activity_id)
 
         participant_status_events = self.participant_status_event_dao.get_all()
-        self.assertEqual(12, len(participant_status_events))
+        self.assertEqual(6, len(participant_status_events))
         self.assertEqual(test_time, participant_status_events[0].created)
         self.assertEqual(test_time, participant_status_events[0].modified)
         self.assertEqual(participant_event_activities.id, participant_status_events[0].event_id)
@@ -1176,14 +1176,14 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual('ubr_healthcare_access_and_utilization', participant_status_events[2].data_element_name)
         self.assertEqual('Unknown', participant_status_events[2].data_element_value)
 
-        self.assertEqual('ubr_racial_identity', participant_status_events[1].data_element_name)
-        self.assertEqual('UBR', participant_status_events[1].data_element_value)
+        self.assertEqual('ubr_racial_identity', participant_status_events[3].data_element_name)
+        self.assertEqual('UBR', participant_status_events[3].data_element_value)
 
-        self.assertEqual('ubr_gender_identity', participant_status_events[1].data_element_name)
-        self.assertEqual('RBR', participant_status_events[1].data_element_value)
+        self.assertEqual('ubr_gender_identity', participant_status_events[4].data_element_name)
+        self.assertEqual('RBR', participant_status_events[4].data_element_value)
 
-        self.assertEqual('ubr_sex_at_birth', participant_status_events[1].data_element_name)
-        self.assertEqual('RBR', participant_status_events[1].data_element_value)
+        self.assertEqual('ubr_sex_at_birth', participant_status_events[5].data_element_name)
+        self.assertEqual('RBR', participant_status_events[5].data_element_value)
 
     def test_intake_retention_status_insert(self):
         participant = self.ppsc_data_gen.create_database_participant()

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -1005,6 +1005,269 @@ class PPSCIntakeAPITest(BaseTestCase):
         response = self.send_post('Intake', request_data=payload, expected_status=http.client.BAD_REQUEST)
         self.assertTrue(response is not None)
 
+    def test_intake_enrollment_status_validation(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+
+        payload = {
+            "activity": "Participant Status",
+            "eventType": "Enrollment Status",
+            "participantId": f"P{participant.id}",
+            "dataElements": [
+                {
+                    "dataElementName": "registered",
+                    "dataElementValue": "yes"
+                }
+            ]
+        }
+
+        response = self.send_post('Intake', request_data=payload, expected_status=http.client.BAD_REQUEST)
+        self.assertEqual(response.status_code, 400)
+
+    def test_intake_enrollment_status_insert(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        self.send_valid_primary_consent(participant)
+
+        payload = {
+            "activity": "Participant Status",
+            "eventType": "Enrollment Status",
+            "participantId": f"P{participant.id}",
+            "dataElements": [
+                {
+                    "dataElementName": "registered",
+                    "dataElementValue": "yes"
+                },
+                {
+                    "dataElementName": "registered_date_time",
+                    "dataElementValue": "2024-04-21T18:06:04.356Z"
+                },
+                {
+                    "dataElementName": "participant",
+                    "dataElementValue": "yes"
+                },
+                {
+                    "dataElementName": "participant_date_time",
+                    "dataElementValue": "2024-10-28T19:20:42.000Z"
+                },
+                {
+                    "dataElementName": "participant_ehr_consent",
+                    "dataElementValue": "yes"
+                },
+                {
+                    "dataElementName": "participant_ehr_consent_date_time",
+                    "dataElementValue": "2024-10-28T19:20:42.000Z"
+                },
+                {
+                    "dataElementName": "enrolled",
+                    "dataElementValue": "yes"
+                },
+                {
+                    "dataElementName": "enrolled_date_time",
+                    "dataElementValue": "2024-10-28T19:20:42.000Z"
+                },
+                {
+                    "dataElementName": "pmb_eligible",
+                    "dataElementValue": "yes"
+                },
+                {
+                    "dataElementName": "pmb_eligible_date_time",
+                    "dataElementValue": "2024-10-28T19:20:42.000Z"
+                },
+                {
+                    "dataElementName": "core_minus_pm",
+                    "dataElementValue": "yes"
+                },
+                {
+                    "dataElementName": "core_minus_pm_date_time",
+                    "dataElementValue": "2024-10-28T19:20:42.000Z"
+                },
+                {
+                    "dataElementName": "core_participant",
+                    "dataElementValue": "yes"
+                },
+                {
+                    "dataElementName": "core_participant_date_time",
+                    "dataElementValue": "2024-10-28T19:20:42.000Z"
+                }
+            ]
+        }
+
+        test_time = datetime(2024, 6, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
+
+        participant_event_activities = self.ppsc_participant_activity_dao.get_all()
+        participant_event_activities = self.filter_events_by_type(participant_event_activities, 7)
+
+        self.assertEqual(test_time, participant_event_activities.created)
+        self.assertEqual(test_time, participant_event_activities.modified)
+        self.assertEqual(participant.id, participant_event_activities.participant_id)
+        self.assertEqual(payload, participant_event_activities.resource)
+        self.assertEqual(7, participant_event_activities.activity_id)
+
+        participant_status_events = self.participant_status_event_dao.get_all()
+        self.assertEqual(14, len(participant_status_events))
+        self.assertEqual(test_time, participant_status_events[0].created)
+        self.assertEqual(test_time, participant_status_events[0].modified)
+        self.assertEqual(participant_event_activities.id, participant_status_events[0].event_id)
+        self.assertEqual(participant.id, participant_status_events[0].participant_id)
+        self.assertEqual('Enrollment Status', participant_status_events[0].event_type_name)
+        self.assertEqual('registered', participant_status_events[0].data_element_name)
+        self.assertEqual('yes', participant_status_events[0].data_element_value)
+
+        self.assertEqual('registered_date_time', participant_status_events[1].data_element_name)
+        self.assertEqual('2024-04-21T18:06:04.356Z', participant_status_events[1].data_element_value)
+
+        self.assertEqual('participant', participant_status_events[2].data_element_name)
+        self.assertEqual('yes', participant_status_events[2].data_element_value)
+
+    def test_intake_ubr_status_insert(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        self.send_valid_primary_consent(participant)
+
+        payload = {
+             "activity": "Participant Status",
+             "eventType": "UBR Status",
+             "participantId": f"P{participant.id}",
+             "dataElements": [
+               {
+                 "dataElementName": "ubr_overall",
+                 "dataElementValue": "UBR"
+               },
+               {
+                 "dataElementName": "ubr_geography",
+                 "dataElementValue": "RBR"
+               },
+               {
+                 "dataElementName": "ubr_healthcare_access_and_utilization",
+                 "dataElementValue": "Unknown"
+               },
+               {
+                 "dataElementName": "ubr_racial_identity",
+                 "dataElementValue": "UBR"
+               },
+               {
+                 "dataElementName": "ubr_gender_identity",
+                 "dataElementValue": "RBR"
+               },
+               {
+                 "dataElementName": "ubr_sex_at_birth",
+                 "dataElementValue": "RBR"
+               },
+               {
+                 "dataElementName": "ubr_sexual_orientation",
+                 "dataElementValue": "RBR"
+               },
+               {
+                 "dataElementName": "ubr_sexual_and_gender_minority",
+                 "dataElementValue": "UBR"
+               },
+               {
+                 "dataElementName": "ubr_education",
+                 "dataElementValue": "RBR"
+               },
+               {
+                 "dataElementName": "ubr_disability",
+                 "dataElementValue": "RBR"
+               },
+               {
+                 "dataElementName": "ubr_income",
+                 "dataElementValue": "RBR"
+               },
+               {
+                 "dataElementName": "ubr_age",
+                 "dataElementValue": "UBR"
+               }
+             ]
+            }
+
+        test_time = datetime(2024, 6, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
+
+        participant_event_activities = self.ppsc_participant_activity_dao.get_all()
+        participant_event_activities = self.filter_events_by_type(participant_event_activities, 7)
+
+        self.assertEqual(test_time, participant_event_activities.created)
+        self.assertEqual(test_time, participant_event_activities.modified)
+        self.assertEqual(participant.id, participant_event_activities.participant_id)
+        self.assertEqual(payload, participant_event_activities.resource)
+        self.assertEqual(7, participant_event_activities.activity_id)
+
+        participant_status_events = self.participant_status_event_dao.get_all()
+        self.assertEqual(12, len(participant_status_events))
+        self.assertEqual(test_time, participant_status_events[0].created)
+        self.assertEqual(test_time, participant_status_events[0].modified)
+        self.assertEqual(participant_event_activities.id, participant_status_events[0].event_id)
+        self.assertEqual(participant.id, participant_status_events[0].participant_id)
+        self.assertEqual('UBR Status', participant_status_events[0].event_type_name)
+        self.assertEqual('ubr_overall', participant_status_events[0].data_element_name)
+        self.assertEqual('UBR', participant_status_events[0].data_element_value)
+
+        self.assertEqual('ubr_geography', participant_status_events[1].data_element_name)
+        self.assertEqual('RBR', participant_status_events[1].data_element_value)
+
+        self.assertEqual('ubr_healthcare_access_and_utilization', participant_status_events[2].data_element_name)
+        self.assertEqual('Unknown', participant_status_events[2].data_element_value)
+
+    def test_intake_retention_status_insert(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        self.send_valid_primary_consent(participant)
+
+        payload = {
+         "activity": "Participant Status",
+         "eventType": "Retention Status",
+         "participantId": f"P{participant.id}",
+         "dataElements": [
+          {
+           "dataElementName": "activity_date_time",
+           "dataElementValue": "2020-04-17T19:00:00.000Z"
+          },
+          {
+           "dataElementName": "activity_status",
+           "dataElementValue": "eligible"
+          },
+          {
+           "dataElementName": "retention_type",
+           "dataElementValue": "Active"
+          },
+          {
+           "dataElementName": "last_retention_activity_date_time",
+           "dataElementValue": "2020-04-17T19:00:00.000Z"
+          }
+         ]
+        }
+
+        test_time = datetime(2024, 6, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
+
+        participant_event_activities = self.ppsc_participant_activity_dao.get_all()
+        participant_event_activities = self.filter_events_by_type(participant_event_activities, 7)
+
+        self.assertEqual(test_time, participant_event_activities.created)
+        self.assertEqual(test_time, participant_event_activities.modified)
+        self.assertEqual(participant.id, participant_event_activities.participant_id)
+        self.assertEqual(payload, participant_event_activities.resource)
+        self.assertEqual(7, participant_event_activities.activity_id)
+
+        participant_status_events = self.participant_status_event_dao.get_all()
+        self.assertEqual(4, len(participant_status_events))
+        self.assertEqual(test_time, participant_status_events[0].created)
+        self.assertEqual(test_time, participant_status_events[0].modified)
+        self.assertEqual(participant_event_activities.id, participant_status_events[0].event_id)
+        self.assertEqual(participant.id, participant_status_events[0].participant_id)
+        self.assertEqual('Retention Status', participant_status_events[0].event_type_name)
+        self.assertEqual('activity_date_time', participant_status_events[0].data_element_name)
+        self.assertEqual('2020-04-17T19:00:00.000Z', participant_status_events[0].data_element_value)
+
+        self.assertEqual('activity_status', participant_status_events[1].data_element_name)
+        self.assertEqual('eligible', participant_status_events[1].data_element_value)
+
+        self.assertEqual('retention_type', participant_status_events[2].data_element_name)
+        self.assertEqual('Active', participant_status_events[2].data_element_value)
+
+        self.assertEqual('last_retention_activity_date_time', participant_status_events[3].data_element_name)
+        self.assertEqual('2020-04-17T19:00:00.000Z', participant_status_events[3].data_element_value)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -1016,7 +1016,7 @@ class PPSCIntakeAPITest(BaseTestCase):
                 {
                     "dataElementName": "registered",
                     "dataElementValue": "yes"
-                }
+                },
             ]
         }
 
@@ -1057,37 +1057,13 @@ class PPSCIntakeAPITest(BaseTestCase):
                     "dataElementValue": "2024-10-28T19:20:42.000Z"
                 },
                 {
-                    "dataElementName": "enrolled",
+                    "dataElementName": "outdoors",
                     "dataElementValue": "yes"
                 },
                 {
-                    "dataElementName": "enrolled_date_time",
-                    "dataElementValue": "2024-10-28T19:20:42.000Z"
+                    "dataElementName": "outdoors_date_time",
+                    "dataElementValue": "2024-10-31T19:20:42.000Z"
                 },
-                {
-                    "dataElementName": "pmb_eligible",
-                    "dataElementValue": "yes"
-                },
-                {
-                    "dataElementName": "pmb_eligible_date_time",
-                    "dataElementValue": "2024-10-28T19:20:42.000Z"
-                },
-                {
-                    "dataElementName": "core_minus_pm",
-                    "dataElementValue": "yes"
-                },
-                {
-                    "dataElementName": "core_minus_pm_date_time",
-                    "dataElementValue": "2024-10-28T19:20:42.000Z"
-                },
-                {
-                    "dataElementName": "core_participant",
-                    "dataElementValue": "yes"
-                },
-                {
-                    "dataElementName": "core_participant_date_time",
-                    "dataElementValue": "2024-10-28T19:20:42.000Z"
-                }
             ]
         }
 
@@ -1105,7 +1081,7 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual(7, participant_event_activities.activity_id)
 
         participant_status_events = self.participant_status_event_dao.get_all()
-        self.assertEqual(14, len(participant_status_events))
+        self.assertEqual(8, len(participant_status_events))
         self.assertEqual(test_time, participant_status_events[0].created)
         self.assertEqual(test_time, participant_status_events[0].modified)
         self.assertEqual(participant_event_activities.id, participant_status_events[0].event_id)
@@ -1119,6 +1095,21 @@ class PPSCIntakeAPITest(BaseTestCase):
 
         self.assertEqual('participant', participant_status_events[2].data_element_name)
         self.assertEqual('yes', participant_status_events[2].data_element_value)
+
+        self.assertEqual('participant_date_time', participant_status_events[3].data_element_name)
+        self.assertEqual('2024-10-28T19:20:42.000Z', participant_status_events[3].data_element_value)
+
+        self.assertEqual('participant_ehr_consent', participant_status_events[4].data_element_name)
+        self.assertEqual('yes', participant_status_events[4].data_element_value)
+
+        self.assertEqual('participant_ehr_consent_date_time', participant_status_events[5].data_element_name)
+        self.assertEqual('2024-10-28T19:20:42.000Z', participant_status_events[5].data_element_value)
+
+        self.assertEqual('outdoors', participant_status_events[2].data_element_name)
+        self.assertEqual('yes', participant_status_events[2].data_element_value)
+
+        self.assertEqual('outdoors_date_time', participant_status_events[3].data_element_name)
+        self.assertEqual('2024-10-31T19:20:42.000Z', participant_status_events[3].data_element_value)
 
     def test_intake_ubr_status_insert(self):
         participant = self.ppsc_data_gen.create_database_participant()
@@ -1153,30 +1144,6 @@ class PPSCIntakeAPITest(BaseTestCase):
                  "dataElementName": "ubr_sex_at_birth",
                  "dataElementValue": "RBR"
                },
-               {
-                 "dataElementName": "ubr_sexual_orientation",
-                 "dataElementValue": "RBR"
-               },
-               {
-                 "dataElementName": "ubr_sexual_and_gender_minority",
-                 "dataElementValue": "UBR"
-               },
-               {
-                 "dataElementName": "ubr_education",
-                 "dataElementValue": "RBR"
-               },
-               {
-                 "dataElementName": "ubr_disability",
-                 "dataElementValue": "RBR"
-               },
-               {
-                 "dataElementName": "ubr_income",
-                 "dataElementValue": "RBR"
-               },
-               {
-                 "dataElementName": "ubr_age",
-                 "dataElementValue": "UBR"
-               }
              ]
             }
 
@@ -1209,6 +1176,15 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual('ubr_healthcare_access_and_utilization', participant_status_events[2].data_element_name)
         self.assertEqual('Unknown', participant_status_events[2].data_element_value)
 
+        self.assertEqual('ubr_racial_identity', participant_status_events[1].data_element_name)
+        self.assertEqual('UBR', participant_status_events[1].data_element_value)
+
+        self.assertEqual('ubr_gender_identity', participant_status_events[1].data_element_name)
+        self.assertEqual('RBR', participant_status_events[1].data_element_value)
+
+        self.assertEqual('ubr_sex_at_birth', participant_status_events[1].data_element_name)
+        self.assertEqual('RBR', participant_status_events[1].data_element_value)
+
     def test_intake_retention_status_insert(self):
         participant = self.ppsc_data_gen.create_database_participant()
         self.send_valid_primary_consent(participant)
@@ -1233,7 +1209,7 @@ class PPSCIntakeAPITest(BaseTestCase):
           {
            "dataElementName": "last_retention_activity_date_time",
            "dataElementValue": "2020-04-17T19:00:00.000Z"
-          }
+          },
          ]
         }
 


### PR DESCRIPTION
## Resolves *[DA-4795](https://precisionmedicineinitiative.atlassian.net/browse/DA-4795)*


## Description of changes/additions
Updates PPSC Intake API validation to allow Enrollment Status and UBR Status payloads to be received.

## Tests
- [x] unit tests




[DA-4795]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ