### PR TITLE
Hot-fix for Pediatric Permission

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -19,6 +19,7 @@ class PPSCIntakeAPI(BaseApi):
     def __init__(self):
         self.participant_event_activity_dao = PPSCDefaultBaseDao(model_type=ParticipantEventActivity)
         self.intake_activities = config.getSettingJson("ppsc_intake_activities")
+        self.primary_consent_types = config.getSettingJson("ppsc_primary_consent_types")
         self.activity_records = PPSCDefaultBaseDao(model_type=Activity).get_all()
         self.consent_event_dao = PPSCDefaultBaseDao(model_type=ConsentEvent)
         self.profile_updates_event_dao = PPSCDefaultBaseDao(model_type=ProfileUpdatesEvent)
@@ -90,9 +91,9 @@ class PPSCIntakeAPI(BaseApi):
                 raise BadRequest("No activity_date_time_value provided.")
 
         # Check for Primary Consent
-        if req_data['eventType'] != "Primary Consent":
+        if req_data['eventType'] not in self.primary_consent_types:
             if not self.check_consent(req_data['participantId'].split('P')[1],
-                                              'Primary Consent',
+                                              self.primary_consent_types,
                                               'activity_status',
                                               'yes'):
                 raise BadRequest("No Primary Consent record found.")
@@ -163,11 +164,11 @@ class PPSCIntakeAPI(BaseApi):
 
         return participant_event_activity.resource
 
-    def check_consent(self, participant_id, event_type, data_element_name, data_element_value):
+    def check_consent(self, participant_id, event_types, data_element_name, data_element_value):
         with self.dao.session() as session:
             return session.query(ConsentEvent).filter(
                 ConsentEvent.participant_id == participant_id,
-                ConsentEvent.event_type_name == event_type,
+                ConsentEvent.event_type_name.in_(event_types),
                 ConsentEvent.data_element_name == data_element_name,
                 ConsentEvent.data_element_value.ilike(data_element_value)
             ).first()

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -210,7 +210,11 @@
     "NPH Opt In",
     "Account Linkage"
   ],
-  "ppsc_intake_consent_event_types": ["Primary Consent", "Adult EHR Authorization"],
+  "ppsc_primary_consent_types": [
+    "Primary Consent",
+    "Pediatric Permission"
+  ],
+  "ppsc_intake_consent_event_types": ["Primary Consent", "Adult EHR Authorization", "Pediatric Permission"],
   "ppsc_intake_survey_completion_event_types": [
     "The Basics",
     "Basics Data",

--- a/rdr_service/config/config_dev.json
+++ b/rdr_service/config/config_dev.json
@@ -209,7 +209,11 @@
     "NPH Opt In",
     "Account Linkage"
   ],
-  "ppsc_intake_consent_event_types": ["Primary Consent", "Adult EHR Authorization"],
+  "ppsc_primary_consent_types": [
+    "Primary Consent",
+    "Pediatric Permission"
+  ],
+  "ppsc_intake_consent_event_types": ["Primary Consent", "Adult EHR Authorization", "Pediatric Permission"],
   "ppsc_intake_survey_completion_event_types": [
     "The Basics",
     "Basics Data",

--- a/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
@@ -48,6 +48,10 @@ SELECT
            THEN data_element_value END) AS primary_consent,
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND rank = 1
            THEN event_authored_time END) AS primary_consent_event_authored
+  MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND data_element_name = 'activity_status' AND rank = 1
+           THEN data_element_value END) AS peds_primary_consent,
+  MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND rank = 1
+           THEN event_authored_time END) AS peds_primary_consent_event_authored
 FROM ranked_events
 WHERE rank = 1
 GROUP BY participant_id, event_id, event_type_name

--- a/rdr_service/workflow_management/ppsc/ppsc_to_legacy_de_mappings.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_to_legacy_de_mappings.py
@@ -252,7 +252,18 @@ consent_data_elements = {
     "ehr_authorization_event_authored": {
         "field": ParticipantSummary.consentForElectronicHealthRecordsAuthored,
         "value": "date_string"
-    }
+    },
+    "peds_primary_consent": {
+        "field": ParticipantSummary.consentForStudyEnrollment,
+        "value": {
+            "yes": QuestionnaireStatus.SUBMITTED,
+            "no": QuestionnaireStatus.SUBMITTED_NO_CONSENT
+        }
+    },
+    "peds_primary_consent_event_authored": {
+        "field": ParticipantSummary.consentForStudyEnrollmentAuthored,
+        "value": "date_string"
+    },
 }
 
 profile_updates_data_elements = {


### PR DESCRIPTION
## Resolves *[DA-4826](https://precisionmedicineinitiative.atlassian.net/browse/DA-4826)*


## Description of changes/additions
This PR allows multiple Intake API event types to be used as the primary consent. Specifically, this implements "Pediatric Permission" as a primary consent. The `event_type_name` values can be set in the base-config moving forward. 
Additionally, this PR updates the intake-to-summary datafeed to write pediatric permission to the `consent_for_study_enrollment` field in the `participant_summary`.

## Tests
- [x] unit tests




[DA-4826]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ