### PR TITLE
Change intake validation to match strings containing yes

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -95,7 +95,7 @@ class PPSCIntakeAPI(BaseApi):
             if not self.check_consent(req_data['participantId'].split('P')[1],
                                               self.primary_consent_types,
                                               'activity_status',
-                                              'yes'):
+                                              '%yes%'):
                 raise BadRequest("No Primary Consent record found.")
 
         # Check Enrollment Status for timestamps

--- a/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
+++ b/rdr_service/workflow_management/ppsc/ppsc_intake_to_ps_queries.py
@@ -47,7 +47,7 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND data_element_name = 'activity_status' AND rank = 1
            THEN data_element_value END) AS primary_consent,
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND rank = 1
-           THEN event_authored_time END) AS primary_consent_event_authored
+           THEN event_authored_time END) AS primary_consent_event_authored,
   MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND data_element_name = 'activity_status' AND rank = 1
            THEN data_element_value END) AS peds_primary_consent,
   MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND rank = 1

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -45,7 +45,7 @@ class PPSCIntakeAPITest(BaseTestCase):
                 name=activity
             )
 
-    def send_valid_primary_consent(self, participant, consent_type="Primary Consent"):
+    def send_valid_primary_consent(self, participant, consent_type="Primary Consent", status="yes"):
         payload = {
             "activity": "Consent",
             "eventType": consent_type,
@@ -53,7 +53,7 @@ class PPSCIntakeAPITest(BaseTestCase):
             "dataElements": [
                 {
                     "dataElementName": "activity_status",
-                    "dataElementValue": "submitted_yes"
+                    "dataElementValue": status
                 },
                 {
                     "dataElementName": "activity_date_time",
@@ -1247,7 +1247,7 @@ class PPSCIntakeAPITest(BaseTestCase):
 
     def test_intake_pediatric_permission_allowed(self):
         participant = self.ppsc_data_gen.create_database_participant()
-        self.send_valid_primary_consent(participant, consent_type="Pediatric Permission")
+        self.send_valid_primary_consent(participant, consent_type="Pediatric Permission", status="submitted_yes")
 
         payload = {
             "activity": "Profile Updates",

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -53,7 +53,7 @@ class PPSCIntakeAPITest(BaseTestCase):
             "dataElements": [
                 {
                     "dataElementName": "activity_status",
-                    "dataElementValue": "yes"
+                    "dataElementValue": "submitted_yes"
                 },
                 {
                     "dataElementName": "activity_date_time",

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -45,10 +45,10 @@ class PPSCIntakeAPITest(BaseTestCase):
                 name=activity
             )
 
-    def send_valid_primary_consent(self, participant):
+    def send_valid_primary_consent(self, participant, consent_type="Primary Consent"):
         payload = {
             "activity": "Consent",
-            "eventType": "Primary Consent",
+            "eventType": consent_type,
             "participantId": f"P{participant.id}",
             "dataElements": [
                 {
@@ -1244,6 +1244,34 @@ class PPSCIntakeAPITest(BaseTestCase):
 
         self.assertEqual('last_retention_activity_date_time', participant_status_events[3].data_element_name)
         self.assertEqual('2020-04-17T19:00:00.000Z', participant_status_events[3].data_element_value)
+
+    def test_intake_pediatric_permission_allowed(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        self.send_valid_primary_consent(participant, consent_type="Pediatric Permission")
+
+        payload = {
+            "activity": "Profile Updates",
+            "eventType": "Profile Data",
+            "participantId": f"P{participant.id}",
+            "dataElements": [
+                {
+                    "dataElementName": "first_name",
+                    "dataElementValue": "Jane"
+                },
+                {
+                    "dataElementName": "last_name",
+                    "dataElementValue": "Eyre"
+                },
+                {
+                    "dataElementName": "activity_date_time",
+                    "dataElementValue": "2024-05-20T14:30:00Z"
+                },
+            ]
+        }
+
+        test_time = datetime(2024, 6, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -341,7 +341,7 @@ SELECT
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND data_element_name = 'activity_status' AND rank = 1
            THEN data_element_value END) AS primary_consent,
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND rank = 1
-           THEN event_authored_time END) AS primary_consent_event_authored
+           THEN event_authored_time END) AS primary_consent_event_authored,
   MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND data_element_name = 'activity_status' AND rank = 1
            THEN data_element_value END) AS peds_primary_consent,
   MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND rank = 1

--- a/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
+++ b/tests/workflow_tests/test_data/ppsc_data_feed_test_data.py
@@ -342,6 +342,10 @@ SELECT
            THEN data_element_value END) AS primary_consent,
   MAX(CASE WHEN event_type_name = 'Primary Consent' AND rank = 1
            THEN event_authored_time END) AS primary_consent_event_authored
+  MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND data_element_name = 'activity_status' AND rank = 1
+           THEN data_element_value END) AS peds_primary_consent,
+  MAX(CASE WHEN event_type_name = 'Pediatric Permission' AND rank = 1
+           THEN event_authored_time END) AS peds_primary_consent_event_authored
 FROM ranked_events
 WHERE rank = 1
 GROUP BY participant_id, event_id, event_type_name


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
This PR fixes the queries in the Consent Intake to Participant Summary datafeed. This PR also also allows all strings containing "yes" to be considered valid, including `submitted_yes`.

## Tests
- [x] unit tests
- [x ] Queries tested in BigQuery


