### PR TITLE
[DA-4830] Updating pediatric flag in biobank received report

### DIFF
--- a/rdr_service/offline/biobank_samples_pipeline.py
+++ b/rdr_service/offline/biobank_samples_pipeline.py
@@ -514,12 +514,12 @@ def _participant_answer_subquery():
     )
 
 
-_PEDIATRIC_SELECT_CLAUSE = 'pdl.id is not null is_pediatric'
+_PEDIATRIC_SELECT_CLAUSE = 'pue.id is not null is_pediatric'
 _PEDIATRIC_JOIN_CLAUSE = '''
-left join pediatric_data_log pdl
-    on pdl.participant_id = participant.participant_id
-    and pdl.replaced_by_id is null
-    and pdl.data_type = 1  -- is AGE_RANGE data
+left join ppsc.profile_updates_event pue
+    on pue.participant_id = participant.participant_id
+    and event_type_name = 'Account Type' and data_element_name = 'activity_status'
+    and data_element_value = 'pediatric' and pue.ignore_flag = 0
 '''
 
 

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -23,6 +23,7 @@ from rdr_service.model.biobank_stored_sample import BiobankStoredSample
 from rdr_service.model.config_utils import from_client_biobank_id
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
+from rdr_service.model.ppsc import Participant as PpscParticipant, ParticipantEventActivity, ProfileUpdatesEvent
 from rdr_service.offline import biobank_samples_pipeline
 from rdr_service.participant_enums import EnrollmentStatus, SampleStatus, get_sample_status_enum_value,\
     SampleCollectionMethod
@@ -431,6 +432,100 @@ class BiobankSamplesPipelineTest(BaseTestCase):
                 None,  # order origin
                 'example',  # Participant origin
                 0,  # pediatric flag
+                'Y',  # NY flag
+                'NA',  # sex at birth flag
+            )])
+
+    def test_pediatric_flag(self):
+        # Generate data for a sample to be in the received report
+        participant = self.data_generator.create_database_participant_summary(aian=True)
+        collection_site = self.data_generator.create_database_site(state='NY')
+        order = self.data_generator.create_database_biobank_order(
+            participantId=participant.participantId,
+            collectedSiteId=collection_site.siteId
+        )
+
+        # Setup order identifiers that CE would send for Quest order
+        self.data_generator.create_database_biobank_order_identifier(
+            biobankOrderId=order.biobankOrderId,
+            value='aoeu-1234',  # CE CareTask system doesn't use the KIT numbers for identifiers
+            system=biobank_samples_pipeline._CE_QUEST_SYSTEM
+        )
+        kit_order_identifier = self.data_generator.create_database_biobank_order_identifier(
+            biobankOrderId=order.biobankOrderId,
+            value='KIT-001',
+            system=biobank_samples_pipeline._KIT_ID_SYSTEM
+        )
+
+        ordered_sample = self.data_generator.create_database_biobank_ordered_sample(
+            biobankOrderId=order.biobankOrderId,
+            collected=datetime(2020, 6, 5),
+            processed=datetime(2020, 6, 6),
+            finalized=datetime(2020, 6, 7)
+        )
+        stored_sample = self.data_generator.create_database_biobank_stored_sample(
+            test=ordered_sample.test,
+            biobankId=participant.biobankId,
+            biobankOrderIdentifier=kit_order_identifier.value,
+            confirmed=self._datetime_days_ago(7)
+        )
+
+        # set up data to show participant as pediatric
+        self.session.add(
+            PpscParticipant(
+                id=participant.participantId,
+                biobank_id=self.fake.pyint(),
+                registered_date=self.fake.date_time_this_year()
+            )
+        )
+
+        event = ParticipantEventActivity(participant_id=participant.participantId)
+        self.session.add(event)
+        self.session.flush()
+
+        self.session.add(
+            ProfileUpdatesEvent(
+                participant_id=participant.participantId,
+                event_type_name='Account Type',
+                data_element_name='activity_status',
+                data_element_value='Pediatric',
+                event_id=event.id
+            )
+        )
+        self.session.commit()
+
+        # Mocking the file writer to catch what gets exported and mocking the upload method because
+        # that isn't what this test is meant to cover
+        with mock.patch('rdr_service.offline.sql_exporter.csv.writer') as mock_writer_class,\
+                mock.patch('rdr_service.offline.sql_exporter.SqlExporter.upload_export_file'):
+            biobank_samples_pipeline.write_reconciliation_report(datetime.now())
+
+            mock_write_rows = mock_writer_class.return_value.writerows
+            mock_write_rows.assert_called_once_with([(
+                f'Z{participant.biobankId}',
+                ordered_sample.test,
+                Decimal('1'),  # sent count
+                kit_order_identifier.value,
+                self._format_datetime(ordered_sample.collected),
+                self._format_datetime(ordered_sample.processed),
+                self._format_datetime(ordered_sample.finalized),
+                None, None, None, 'UNKNOWN',  # site info: name, client_number, hpo, hpo_type
+                None, None, None, 'UNKNOWN',  # finalized site info: name, client_number, hpo, hpo_type
+                None,  # finalized username
+                ordered_sample.test,
+                1,  # received count
+                str(stored_sample.biobankStoredSampleId),
+                self._format_datetime(stored_sample.confirmed),  # received time
+                None,  # created family date
+                None,  # elapsed hours
+                'KIT-001',  # kit identifier
+                None,  # fedex tracking number
+                'Y',  # is Native American
+                None, None, None,  # notes info: collected, processed, finalized
+                None, None, None, None, None,  # cancelled_restored info: status_flag, name, name, time, reason
+                None,  # order origin
+                'example',  # Participant origin
+                1,  # pediatric flag
                 'Y',  # NY flag
                 'NA',  # sex at birth flag
             )])

--- a/tests/cron_job_tests/test_biobank_samples_pipeline.py
+++ b/tests/cron_job_tests/test_biobank_samples_pipeline.py
@@ -478,6 +478,7 @@ class BiobankSamplesPipelineTest(BaseTestCase):
                 registered_date=self.fake.date_time_this_year()
             )
         )
+        self.session.commit()
 
         event = ParticipantEventActivity(participant_id=participant.participantId)
         self.session.add(event)

--- a/tests/helpers/mysql_helper.py
+++ b/tests/helpers/mysql_helper.py
@@ -33,6 +33,7 @@ from rdr_service.model import compiler  # pylint: disable=unused-import
 from rdr_service.model.base import Base
 from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
+from rdr_service.model.ppsc import PPSCBase
 from rdr_service.model.site import Site
 from rdr_service.model.site_enums import ObsoleteStatus
 from rdr_service.participant_enums import OrganizationType, UNSET_HPO_ID
@@ -118,12 +119,17 @@ def get_table_change_listener(table_name):
 def _track_database_changes():
     for module in [member for _, member in inspect.getmembers(model) if isinstance(member, ModuleType)]:
         for _, model_class in inspect.getmembers(module):
-            if inspect.isclass(model_class) and issubclass(model_class, Base) and model_class != Base:
-                table_name = model_class.__tablename__
-                table_changed[table_name] = False
+            if inspect.isclass(model_class):
+                table_name = None
+                if issubclass(model_class, PPSCBase) and model_class != PPSCBase:
+                    table_name = f'ppsc.{model_class.__tablename__}'
+                elif issubclass(model_class, Base) and model_class != Base:
+                    table_name = model_class.__tablename__
 
-                event.listen(model_class, 'before_insert', get_table_change_listener(table_name))
-                event.listen(model_class, 'before_update', get_table_change_listener(table_name))
+                if table_name:
+                    table_changed[table_name] = False
+                    event.listen(model_class, 'before_insert', get_table_change_listener(table_name))
+                    event.listen(model_class, 'before_update', get_table_change_listener(table_name))
 
 
 def clear_table_on_next_reset(table_name):


### PR DESCRIPTION
## Resolves *[DA-4830](https://precisionmedicineinitiative.atlassian.net/browse/DA-4830)*
The pediatric flag on the Biobank received report isn’t looking at the new ppsc schema, so isn’t correctly identifying newer pediatric participants.

## Description of changes/additions
This updates the received report query to use data from the ppsc schema.

## Tests
- [x] unit tests


[DA-4830]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ