### PR TITLE
[DA-4829] Remove suspension as an exclusion criteria for AW3 array and AW3 WGS workflows

### DIFF
--- a/rdr_service/dao/genomics_dao.py
+++ b/rdr_service/dao/genomics_dao.py
@@ -3863,7 +3863,6 @@ class GenomicQueriesDao(BaseDao):
                     GenomicGCValidationMetrics.processingStatus.ilike('pass'),
                     GenomicGCValidationMetrics.ignoreFlag != 1,
                     ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
-                    ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
                     or_(
                         idat_red_path.file_type.is_(None),
                         idat_red_md5_path.file_type.is_(None),
@@ -3963,7 +3962,6 @@ class GenomicQueriesDao(BaseDao):
                     GenomicGCValidationMetrics.processingStatus.ilike('pass'),
                     GenomicGCValidationMetrics.ignoreFlag != 1,
                     ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
-                    ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
                     or_(
                         hard_filtered_vcf_gz.file_type.is_(None),
                         hard_filtered_vcf_gz_tbi.file_type.is_(None),
@@ -4257,7 +4255,6 @@ class GenomicShortReadDao(BaseDao):
                 GenomicGCValidationMetrics.processingStatus.ilike('pass'),
                 GenomicGCValidationMetrics.ignoreFlag != 1,
                 ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
-                ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
                 GenomicAW3Raw.id.is_(None)
             )
             return aw3_rows.distinct().all()
@@ -4450,7 +4447,6 @@ class GenomicShortReadDao(BaseDao):
                         GenomicGCValidationMetrics.processingStatus.ilike('pass'),
                         GenomicGCValidationMetrics.ignoreFlag != 1,
                         ParticipantSummary.withdrawalStatus == WithdrawalStatus.NOT_WITHDRAWN,
-                        ParticipantSummary.suspensionStatus == SuspensionStatus.NOT_SUSPENDED,
                         GenomicGCValidationMetrics.pipelineId == pipeline_id
                     ),
                     GenomicGCValidationMetrics.aw3ReadyFlag == 1


### PR DESCRIPTION
Resolves *[DA-4829] (https://precisionmedicineinitiative.atlassian.net/browse/DA-####)*
Background:  During AW2 and AW3 reconciliation, we found that suspended/deactivated participants were excluded in AW3 array and AW3 wgs workflows.  Back in September, 2022, DRC was given approval from NIH to remove suspension as an exclusion criteria in AW3 workflow.  So it becomes urgent we remove suspension as an exclusion criteria for AW3 to meet program’s requirement and make sure suspended samples that meet all other AW3 criteria can go downstream  in DRC QC pipelines.

Task:

Remove suspension as an exclusion criteria for AW3 array

Remove suspension as an exclusion criteria for AW3 wgs
## Tests
- [] unit tests




[DA-4829]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ