### PR TITLE
[DA-4854] Add Pediatric Permission to Primary Consent check in awardee_insite

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -549,7 +549,7 @@ def insert_awardee_insite_data(
                 , MAX(event_authored_time) AS activity_date_time
                 , MAX(CASE WHEN REPLACE(data_element_name, '\u200B', '') = 'activity_status' THEN data_element_value END) AS activity_status
             FROM `{project}.{src_operational_dataset}.ppsc_consent_event`
-            WHERE event_type_name ='Primary Consent' AND ignore_flag = 0
+            WHERE event_type_name IN ('Primary Consent', 'Pediatric Permission') AND ignore_flag = 0
             GROUP BY 1, 2
           ),
           primary_consent_cleaned_values AS (


### PR DESCRIPTION
## Resolves *[DA-4854](https://precisionmedicineinitiative.atlassian.net/browse/DA-4854)*


## Description of changes/additions
Add a clause to check for either Primary Consent or Pediatric Permission when sending Primary Consent status to awardee insite.

## Tests
- [x] unit tests




[DA-4854]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ