### PR TITLE
[DA-4807] Adding a new Gunicorn worker class

### DIFF
--- a/rdr_service/rdr_thread_worker.py
+++ b/rdr_service/rdr_thread_worker.py
@@ -1,0 +1,10 @@
+
+from gunicorn.workers.gthread import ThreadWorker
+
+
+class RdrThreadWorker(ThreadWorker):
+    def accept(self, server, listener):
+        if not self.alive:
+            return
+
+        super().accept(server, listener)

--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -2,9 +2,13 @@ import multiprocessing
 import os
 import resource
 
+from rdr_service.rdr_thread_worker import RdrThreadWorker
+
+
 _port = 8080 # local dev/testing.
 workers = 1
 threads = 1
+worker_class = RdrThreadWorker
 
 max_requests = 1000
 max_requests_jitter = 50


### PR DESCRIPTION
## Resolves *[DA-4807](https://precisionmedicineinitiative.atlassian.net/browse/DA-4807)*
The current thread worker checks if it's still alive, checks if the max number of connections has been reached, and then waits up to a second before checking those conditions again. If a request tries to close the worker (setting alive to False), there's a good chance that the main thread of the worker is already through the alive check and waiting for another request.

## Description of changes/additions
This creates a new worker class that inherits gunicorn's thread class and adds another check for whether the worker is alive just before accepting a connection for a request. If the worker isn't alive, the function returns and the new request is left waiting for another worker to pick it up. It's still possible that the worker would be set to not alive just after this check, but it atleast narrows the window of a closing worker taking a new request by alot.

## Tests
- [ ] unit tests
Ran manual testing locally and on sandbox.




[DA-4807]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ