### PR TITLE
[DA-4878] Get state name from mapping table for awardee insite

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -412,7 +412,7 @@ def insert_awardee_insite_data(
               , piiname_middle AS middle_name
               , COALESCE(piiname_last,'')  AS last_name
               , streetaddress_piizip AS zip_code
-              , COALESCE(sm.display, streetaddress_piistate) AS state
+              , COALESCE(sm.state, streetaddress_piistate) AS state
               , streetaddress_piicity AS city
               , piiaddress_streetaddress AS street_address
               , piiaddress_streetaddress2 AS street_address2
@@ -443,7 +443,7 @@ def insert_awardee_insite_data(
                     )
                 )
             LEFT JOIN `{project}.{src_operational_dataset}.state_mapping` sm
-            ON sm.value = streetaddress_piistate
+            ON sm.code_value = streetaddress_piistate
           ),
           withdrawn_cte AS (
             SELECT participant_id

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -408,11 +408,11 @@ def insert_awardee_insite_data(
           ),
           profile_pivot AS (
             SELECT participant_id
-              , coalesce(piiname_first,'') AS first_name
+              , COALESCE(piiname_first,'') AS first_name
               , piiname_middle AS middle_name
-              , coalesce(piiname_last,'')  AS last_name
+              , COALESCE(piiname_last,'')  AS last_name
               , streetaddress_piizip AS zip_code
-              , streetaddress_piistate AS state
+              , COALESCE(sm.display, streetaddress_piistate) AS state
               , streetaddress_piicity AS city
               , piiaddress_streetaddress AS street_address
               , piiaddress_streetaddress2 AS street_address2
@@ -442,6 +442,8 @@ def insert_awardee_insite_data(
                       , 'piibirthinformation_birthdate'
                     )
                 )
+            LEFT JOIN `{project}.{src_operational_dataset}.state_mapping` sm
+            ON sm.value = streetaddress_piistate
           ),
           withdrawn_cte AS (
             SELECT participant_id


### PR DESCRIPTION
## Resolves *[DA-4878](https://precisionmedicineinitiative.atlassian.net/browse/DA-4878)*


## Description of changes/additions
- The `ppsc_profile_updates_event` table stores codebook values in `streetaddress_piistate` column associated with states, such as PC_STATE_LIVEHEALTH_IL for Illinois. Created a table in BQ that maps the codebook values to their corresponding state names to allow the awardee insite API to show the state names instead of the codebook values. This PR updates the query to join on the new table and display the state.

## Tests
- [] unit tests (Tested in BQ)




[DA-4878]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ