### PR TITLE
[DA-4800] Request log Intake API modifications

### DIFF
--- a/rdr_service/api/base_api.py
+++ b/rdr_service/api/base_api.py
@@ -70,6 +70,10 @@ def log_api_request(log: RequestsLog = None, model_obj=None):
                     log.fpk_id = int(v)
                 else:
                     log.fpk_alt_id = str(v).strip()
+    elif request.endpoint == 'ppsc.intake':
+        participant_id = log.resource.get('participantId')
+        if participant_id:
+            log.participantId = int(participant_id.split('P')[1])
 
     if model_obj:
         try:

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -11,21 +11,9 @@ from rdr_service.dao.ppsc_dao import PPSCDefaultBaseDao, PPSCNphOptEventInDao
 from rdr_service.model.ppsc import (
     ParticipantEventActivity, Activity,
     ConsentEvent, ProfileUpdatesEvent, SurveyCompletionEvent, WithdrawalEvent, DeactivationEvent,
-    AccountLinkageEvent, ParticipantStatusEvent, AttributionEvent, NPHOptInEvent
+    AccountLinkageEvent, ParticipantStatusEvent, AttributionEvent
 )
 
-
-PPSC_INTAKE_ACTIVITIES_MODELS = {
-    "Consent": ConsentEvent(),
-    "Survey Completion": SurveyCompletionEvent(),
-    "Profile Updates": ProfileUpdatesEvent(),
-    "Withdrawal": WithdrawalEvent(),
-    "Deactivation": DeactivationEvent(),
-    "Participant Status": ParticipantStatusEvent(),
-    "Attribution": AttributionEvent(),
-    "NPH Opt In": NPHOptInEvent(),
-    "Account Linkage": AccountLinkageEvent()
-}
 
 class PPSCIntakeAPI(BaseApi):
     def __init__(self):
@@ -52,7 +40,10 @@ class PPSCIntakeAPI(BaseApi):
         # Validate
         self.validate_payload(req_data=req_data)
 
-        model = PPSC_INTAKE_ACTIVITIES_MODELS[req_data['activity']]
+        # get correct [Activity]Event DAO
+        dao_str = f"{req_data['activity'].lower().replace(' ', '_')}_event_dao"
+        activity_event_dao = self.__dict__.get(dao_str)
+        model = activity_event_dao.model_type
         log_api_request(log=request.log_record, model_obj=model)
 
         # Route to correct activity and insert events

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -48,15 +48,12 @@ class PPSCIntakeAPI(BaseApi):
     @auth_required([PPSC, RDR])
     def post(self):
         req_data = self.get_request_json()
-        try:
-            model = PPSC_INTAKE_ACTIVITIES_MODELS[req_data['activity']]
-        except ValueError:
-            raise BadRequest(f'Invalid Intake API Payload: Invalid Activity: {req_data["activity"]}')
-
-        log_api_request(log=request.log_record, model_obj=model)
 
         # Validate
         self.validate_payload(req_data=req_data)
+
+        model = PPSC_INTAKE_ACTIVITIES_MODELS[req_data['activity']]
+        log_api_request(log=request.log_record, model_obj=model)
 
         # Route to correct activity and insert events
         inserted_event = self.handle_event_insert(

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -11,9 +11,21 @@ from rdr_service.dao.ppsc_dao import PPSCDefaultBaseDao, PPSCNphOptEventInDao
 from rdr_service.model.ppsc import (
     ParticipantEventActivity, Activity,
     ConsentEvent, ProfileUpdatesEvent, SurveyCompletionEvent, WithdrawalEvent, DeactivationEvent,
-    AccountLinkageEvent, ParticipantStatusEvent, AttributionEvent
+    AccountLinkageEvent, ParticipantStatusEvent, AttributionEvent, NPHOptInEvent
 )
 
+
+PPSC_INTAKE_ACTIVITIES_MODELS = {
+    "Consent": ConsentEvent(),
+    "Survey Completion": SurveyCompletionEvent(),
+    "Profile Updates": ProfileUpdatesEvent(),
+    "Withdrawal": WithdrawalEvent(),
+    "Deactivation": DeactivationEvent(),
+    "Participant Status": ParticipantStatusEvent(),
+    "Attribution": AttributionEvent(),
+    "NPH Opt In": NPHOptInEvent(),
+    "Account Linkage": AccountLinkageEvent()
+}
 
 class PPSCIntakeAPI(BaseApi):
     def __init__(self):
@@ -35,10 +47,16 @@ class PPSCIntakeAPI(BaseApi):
 
     @auth_required([PPSC, RDR])
     def post(self):
-        log_api_request(log=request.log_record)
+        req_data = self.get_request_json()
+        try:
+            model = PPSC_INTAKE_ACTIVITIES_MODELS[req_data['activity']]
+        except ValueError:
+            raise BadRequest(f'Invalid Intake API Payload: Invalid Activity: {req_data["activity"]}')
+
+        log_api_request(log=request.log_record, model_obj=model)
 
         # Validate
-        self.validate_payload(req_data=self.get_request_json())
+        self.validate_payload(req_data=req_data)
 
         # Route to correct activity and insert events
         inserted_event = self.handle_event_insert(

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -1295,7 +1295,7 @@ class PPSCIntakeAPITest(BaseTestCase):
         )
         self.assertEqual(
             log_entry.fpk_column,
-            "id"
+            "id",
             "the fpk_column in the requests log entry does not match the expected value",
         )
 

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -10,6 +10,7 @@ from rdr_service.data_gen.generators.ppsc import PPSCDataGenerator
 from rdr_service.model.ppsc import (
     Activity, ParticipantEventActivity, ConsentEvent, SurveyCompletionEvent, ProfileUpdatesEvent,
     WithdrawalEvent, DeactivationEvent, ParticipantStatusEvent, AttributionEvent, AccountLinkageEvent)
+from rdr_service.model.requests_log import RequestsLog
 from tests.helpers.unittest_base import BaseTestCase
 
 
@@ -1272,6 +1273,31 @@ class PPSCIntakeAPITest(BaseTestCase):
         test_time = datetime(2024, 6, 25, 12, 1)
         with clock.FakeClock(test_time):
             self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
+
+    def test_requests_log_generation(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        self.send_valid_primary_consent(participant)
+
+        # checking for the log in the Requests Log and verifying the fpk info
+        log_entry = (
+            self.session.query(RequestsLog).order_by(RequestsLog.id.desc()).first()
+        )
+        self.assertIsNotNone(log_entry, "No log entry found in the requests log table")
+        self.assertEqual(
+            log_entry.participantId,
+            100000000,
+            "the participant_id in the requests log entry does not match the expected value",
+        )
+        self.assertEqual(
+            log_entry.fpk_table,
+            "consent_event",
+            "the fpk_table in the requests log entry does not match the expected value",
+        )
+        self.assertEqual(
+            log_entry.fpk_column,
+            "id"
+            "the fpk_column in the requests log entry does not match the expected value",
+        )
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
## Resolves *[DA-4800](https://precisionmedicineinitiative.atlassian.net/browse/DA-4800)*


## Description of changes/additions
Added logic to populate participant_id, fpk_table, and fpk_column to intake api

## Tests
- [x] unit tests




[DA-4800]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ