### PR TITLE
Removing ci steps to deploy to deleted test environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,20 +96,6 @@ jobs:
           project-id: all-of-us-rdr-staging
           git-target: << pipeline.git.tag >>
 
-  job_deploy_to_ptsc_1:
-    <<: *job_defaults
-    steps:
-      - deploy-app-steps:
-          project-id: all-of-us-rdr-ptsc-1-test
-          git-target: << pipeline.git.tag >>
-
-  job_deploy_to_ce:
-    <<: *job_defaults
-    steps:
-      - deploy-app-steps:
-          project-id: all-of-us-rdr-careevo-test
-          git-target: << pipeline.git.tag >>
-
 workflows:
 
   test_commits_workflow:
@@ -145,18 +131,6 @@ workflows:
   release_workflow:
     jobs:
       - job_deploy_to_staging:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d\.\d+\.\d+$/
-      - job_deploy_to_ptsc_1:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d\.\d+\.\d+$/
-      - job_deploy_to_ce:
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Resolves *no ticket*
CE and PTSC test environments no longer exist.

## Description of changes/additions
This updates the CI steps so we don't run steps to try to deploy to them anymore.
