### PR TITLE
[DA-4937] Allow ppsc to call awardee insite api with awardee query param

### DIFF
--- a/rdr_service/api/awardee_insite_api.py
+++ b/rdr_service/api/awardee_insite_api.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest, InternalServerError
 from rdr_service.query import Query, Results
 from rdr_service.api.base_api import BaseApi, log_api_request
 from rdr_service.app_util import auth_required, get_validated_user_info
-from rdr_service.api_util import AWARDEE, RDR
+from rdr_service.api_util import AWARDEE, RDR, PPSC
 from rdr_service.dao.awardee_insite_dao import AwardeeInSiteDao
 
 
@@ -16,7 +16,7 @@ class AwardeeInSiteApi(BaseApi):
         super().__init__(AwardeeInSiteDao())
         self.awardee = None
 
-    @auth_required([RDR] + [AWARDEE])
+    @auth_required([RDR] + [AWARDEE] + [PPSC])
     def get(self, id_=None, participant_id=None):
         log_api_request(log=request.log_record)
 
@@ -29,8 +29,8 @@ class AwardeeInSiteApi(BaseApi):
             except KeyError:
                 raise InternalServerError("Config error for awardee")
 
-        # In case RDR needs to call the API, they can pass an awardee query param with a awardee name to get the data
-        if RDR in user_info["roles"]:
+        # RDR & PPSC can pass an awardee query param with an awardee name to get the data
+        if RDR in user_info["roles"] or PPSC in user_info["roles"]:
             self.awardee = request.args.get("awardee")
             if not self.awardee:
                 raise BadRequest(

--- a/tests/api_tests/test_awardee_insite_api.py
+++ b/tests/api_tests/test_awardee_insite_api.py
@@ -8,7 +8,7 @@ from tests.helpers.unittest_base import BaseTestCase
 from rdr_service import config
 from rdr_service.clock import FakeClock
 from rdr_service.dao.awardee_insite_dao import AwardeeInSiteDao
-from rdr_service.api_util import HEALTHPRO, AWARDEE, RDR
+from rdr_service.api_util import HEALTHPRO, AWARDEE, RDR, PPSC
 from rdr_service.model.awardee_insite import AwardeeInSite
 
 
@@ -138,6 +138,24 @@ class AwardeeInSiteApiTest(BaseTestCase):
     def test_rdr_requires_awardee_parameter(self):
         """RDR must pass awardee parameter to call the API"""
         self.overwrite_test_user_awardee(roles=[RDR])
+        response = self.send_get("AwardeeInSite?awardee=PITT")
+        results = response.get("entry")
+        results_pid = [
+            int(ele["resource"]["participantId"].replace("P", "")) for ele in results
+        ]
+        self.assertTrue(response is not None)
+        self.assertEqual(len(results), len(self.pitt_org_pids))
+        self.assertEqual(results_pid, self.pitt_org_pids)
+
+        # Not passing in an awardee query param to the endpoint
+        response = self.send_get(
+            "AwardeeInSite", expected_status=http.client.BAD_REQUEST
+        )
+        self.assertTrue(response.status_code == 400)
+
+    def test_ppsc_requires_awardee_parameter(self):
+        """PPSC must pass awardee parameter to call the API"""
+        self.overwrite_test_user_awardee(roles=[PPSC])
         response = self.send_get("AwardeeInSite?awardee=PITT")
         results = response.get("entry")
         results_pid = [


### PR DESCRIPTION
## Resolves *[DA-4937](https://precisionmedicineinitiative.atlassian.net/browse/DA-4937?actionerId=61b21fdfc15977006a4fa167&sourceType=assign)*


## Description of changes/additions
- Allowing ppsc to call the awardee insite api to get an awardee's data, e.g., calling awardee_insite/awardee=CAL_PMC will get them cal_pmc's participants.

## Tests
- ✅  unit tests




[DA-4937]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ