### PR TITLE
 [DA-4942] Remediate RH PublicMetrics API Registered and Core Counts

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -308,6 +308,7 @@ PUBLIC_METRICS_CALENDAR_TABLE = "public_metrics_calendar_table"
 PUBLIC_METRICS_CODE_TABLE = "public_metrics_code_table"
 PUBLIC_METRICS_GENDER_ANSWERS_TABLE = "public_metrics_gender_answers_table"
 PUBLIC_METRICS_RACE_ANSWERS_TABLE = "public_metrics_race_answers_table"
+PUBLIC_METRICS_PARTICIPANT_STATUS_EVENT_TABLE = "public_metrics_participant_status_event_table"
 
 # Overrides for testing scenarios
 CONFIG_OVERRIDES = {}

--- a/rdr_service/dao/metrics_cache_dao.py
+++ b/rdr_service/dao/metrics_cache_dao.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+from google.cloud import bigquery
 import sqlalchemy
 from sqlalchemy import and_, desc, func, or_, distinct
 from typing import List, Dict
@@ -39,6 +40,8 @@ TEMP_TABLE_QUERY = """
   SELECT ps.participant_id,
     p.sign_up_time,
     p.participant_origin,
+    p.is_test_participant,
+    p.is_ghost_id,
     ps.hpo_id,
     ps.date_of_birth,
     ps.primary_language,
@@ -87,6 +90,8 @@ gender_answers_table = config.getSettingJson(config.PUBLIC_METRICS_GENDER_ANSWER
                                              'rdr_operational_datastream.rdr_participant_gender_answers')
 race_answers_table = config.getSettingJson(config.PUBLIC_METRICS_RACE_ANSWERS_TABLE,
                                            'rdr_operational_datastream.rdr_participant_race_answers')
+participant_status_event_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_STATUS_EVENT_TABLE,
+                                           'rdr_operational_datastream.ppsc_participant_status_event')
 
 class MetricsDaoMixin:
     def insert_bulk(self, batch: List[Dict]) -> None:
@@ -145,6 +150,7 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
         super(MetricsEnrollmentStatusCacheDao, self).__init__(MetricsEnrollmentStatusCache)
         self.version = version
         self.table_name = MetricsEnrollmentStatusCache.__tablename__
+        self.client = bigquery.Client(project=config.GAE_PROJECT)
         try:
             self.cache_type = MetricsCacheType(str(cache_type))
         except TypeError:
@@ -213,9 +219,85 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
 
                 return query.group_by(MetricsEnrollmentStatusCache.date, MetricsEnrollmentStatusCache.hpoName).all()
 
+    def get_enrollment_status_counts(self, start_date=None, end_date=None, hpo_ids=None):
+        bq_project = self.client.project
+        hpo_id_params = ""
+
+        if hpo_ids:
+            hpos = ",".join(str(item) for item in hpo_ids)
+            hpo_id_params = f"AND results.hpo_id IN ({hpos})"
+
+        sql = """
+                SELECT DISTINCT
+                    c.day AS date,
+                    IFNULL((
+                        SELECT SUM(results.enrollment_count)
+                        FROM (
+                            SELECT
+                                DATE(pse.data_element_value) AS registered_date,
+                                p.hpo_id AS hpo_id,
+                                COUNT(DISTINCT pse.participant_id) AS enrollment_count
+                            FROM (
+                                SELECT
+                                    participant_id,
+                                    MIN(data_element_value) AS data_element_value
+                                FROM `{participant_status_event}` pse
+                                WHERE pse.data_element_name = 'registered_date_time'
+                                    AND pse.event_type_name = 'Enrollment Status'
+                                    AND pse.data_element_value IS NOT NULL
+                                    AND pse.ignore_flag = 0
+                                GROUP BY participant_id
+                            ) AS pse
+                            LEFT JOIN `{participant}` p ON p.participant_id = pse.participant_id
+                            WHERE (p.is_test_participant != 1 OR p.is_test_participant IS NULL)
+                                AND (p.is_ghost_id != 1 OR p.is_ghost_id IS NULL)
+                            GROUP BY DATE(pse.data_element_value), p.hpo_id
+                        ) AS results
+                        WHERE registered_date IS NOT NULL AND c.day>=DATE(registered_date)
+                        {hpo_filter}
+                    ),0) AS registeredCount,
+                    IFNULL((
+                        SELECT SUM(results.enrollment_count)
+                        FROM (
+                            SELECT
+                                DATE(pse.data_element_value) AS core_date,
+                                p.hpo_id AS hpo_id,
+                                COUNT(DISTINCT pse.participant_id) AS enrollment_count
+                            FROM `{participant_status_event}` pse
+                            LEFT JOIN `{participant}` p ON p.participant_id = pse.participant_id
+                            WHERE pse.data_element_name = 'core_participant_date_time'
+                                AND pse.event_type_name = 'Enrollment Status'
+                                AND pse.data_element_value IS NOT NULL
+                                AND pse.ignore_flag = 0
+                                AND (p.is_test_participant != 1 OR p.is_test_participant IS NULL)
+                                AND (p.is_ghost_id != 1 OR p.is_ghost_id IS NULL)
+                            GROUP BY DATE(pse.data_element_value), p.hpo_id
+                        ) AS results
+                        WHERE core_date IS NOT NULL AND c.day>=DATE(core_date)
+                        {hpo_filter}
+                    ),0) AS coreCount,
+                FROM `{calendar}` c WHERE c.day BETWEEN @start_date AND @end_date
+                GROUP BY c.day
+                ;
+                """.format(calendar=f"{bq_project}.{calendar_table}", participant=f"{bq_project}.{participant_table}",
+                           participant_status_event=f"{bq_project}.{participant_status_event_table}",
+                           hpo_filter=hpo_id_params)
+
+        params = [
+            bigquery.ScalarQueryParameter("start_date", "DATE", start_date),
+            bigquery.ScalarQueryParameter("end_date", "DATE", end_date),
+        ]
+
+        job_config = bigquery.QueryJobConfig(query_parameters=params)
+        results = self.client.query(sql, job_config)
+        return results
+
     def get_latest_version_from_cache(self, start_date, end_date, hpo_ids=None,
                                       enrollment_statuses=None, participant_origins=None):
-        buckets = self.get_active_buckets(start_date, end_date, hpo_ids, participant_origins)
+        buckets = self.get_enrollment_status_counts(start_date, end_date, hpo_ids)
+        if participant_origins:
+            buckets = self.get_active_buckets(start_date, end_date, hpo_ids, participant_origins)
+
         if buckets is None:
             return []
         operation_funcs = {
@@ -277,7 +359,7 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
                 'date': record.date.isoformat(),
                 'metrics': {
                     # research hub still use 3 tiers status
-                    'registered': int(record.registeredCount) + int(record.participantCount),
+                    'registered': int(record.registeredCount),
                     'consented': int(record.consentedCount),
                     'core': int(record.coreCount)
                 }
@@ -361,15 +443,28 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
                   SELECT SUM(results.enrollment_count)
                   FROM
                   (
-                    SELECT DATE(ps.sign_up_time) AS sign_up_time,
-                           DATE(ps.consent_for_study_enrollment_authored) AS consent_for_study_enrollment_authored,
-                           ps.participant_origin,
-                           count(*) enrollment_count
-                    FROM temp_table ps
-                    GROUP BY DATE(ps.sign_up_time), DATE(ps.consent_for_study_enrollment_authored), ps.participant_origin
+                    SELECT
+                        DATE(pse.data_element_value) AS registered_date,
+                        ps.participant_origin AS participant_origin,
+                        COUNT(DISTINCT pse.participant_id) AS enrollment_count
+                    FROM (
+                        SELECT
+                            participant_id,
+                            MIN(data_element_value) AS data_element_value
+                        FROM `{participant_status_event}` pse
+                        WHERE pse.data_element_name = 'registered_date_time'
+                            AND pse.event_type_name = 'Enrollment Status'
+                            AND pse.data_element_value IS NOT NULL
+                            AND pse.ignore_flag = 0
+                        GROUP BY participant_id
+                    ) AS pse
+                    LEFT JOIN temp_table ps ON ps.participant_id = pse.participant_id
+                    WHERE (ps.is_test_participant != 1 OR ps.is_test_participant IS NULL)
+                        AND (ps.is_ghost_id != 1 OR ps.is_ghost_id IS NULL)
+                    GROUP BY DATE(pse.data_element_value), ps.participant_origin
                   ) AS results
-                  WHERE c.day>=DATE(sign_up_time) AND (consent_for_study_enrollment_authored IS NULL OR DATE(consent_for_study_enrollment_authored)>c.day)
-                  and results.participant_origin = d.participant_origin
+                  WHERE registered_date IS NOT NULL AND c.day>=DATE(registered_date)
+                  AND results.participant_origin = d.participant_origin
                 ),0) AS registeredCount,
                 IFNULL((
                   SELECT SUM(results.enrollment_count)
@@ -403,19 +498,30 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
                   SELECT SUM(results.enrollment_count)
                   FROM
                   (
-                    SELECT DATE(ps.enrollment_status_participant_plus_ehr_v_3_2_time) AS enrollment_status_participant_plus_ehr_v_3_2_time,
-                           ps.participant_origin, count(*) enrollment_count
-                    FROM temp_table ps
-                    GROUP BY DATE(ps.enrollment_status_participant_plus_ehr_v_3_2_time), ps.participant_origin
+                    SELECT
+                        DATE(pse.data_element_value) AS core_date,
+                        ps.participant_origin AS participant_origin,
+                        COUNT(DISTINCT pse.participant_id) AS enrollment_count
+                    FROM `{participant_status_event}` pse
+                    LEFT JOIN temp_table ps ON ps.participant_id = pse.participant_id
+                    WHERE pse.data_element_name = 'core_participant_date_time'
+                        AND pse.event_type_name = 'Enrollment Status'
+                        AND pse.data_element_value IS NOT NULL
+                        AND pse.ignore_flag = 0
+                        AND ps.is_test_participant != 1
+                        AND (ps.is_test_participant != 1 OR ps.is_test_participant IS NULL)
+                        AND (ps.is_ghost_id != 1 OR ps.is_ghost_id IS NULL)
+                    GROUP BY DATE(pse.data_element_value), ps.participant_origin
                   ) AS results
-                  WHERE enrollment_status_participant_plus_ehr_v_3_2_time IS NOT NULL AND day>=DATE(enrollment_status_participant_plus_ehr_v_3_2_time)
-                  and results.participant_origin = d.participant_origin
+                  WHERE core_date IS NOT NULL AND day>=DATE(core_date)
+                  AND results.participant_origin = d.participant_origin
                 ),0) AS coreCount,
                 d.participant_origin AS participantOrigin
               FROM `{calendar}` c, participant_origin d
               WHERE c.day BETWEEN @start_date AND @end_date
               ;
-        """.format(calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}")
+        """.format(calendar=f"{bq_project}.{calendar_table}", hpo=f"{bq_project}.{hpo_table}",
+                   participant_status_event=f"{bq_project}.{participant_status_event_table}")
 
         return [sql]
 

--- a/rdr_service/dao/metrics_cache_dao.py
+++ b/rdr_service/dao/metrics_cache_dao.py
@@ -360,7 +360,6 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
                 'metrics': {
                     # research hub still use 3 tiers status
                     'registered': int(record.registeredCount),
-                    'consented': int(record.consentedCount),
                     'core': int(record.coreCount)
                 }
             }

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -2490,16 +2490,16 @@ class PublicMetricsApiTest(BaseTestCase):
         qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08"
         big_query().query.side_effect = [self.get_api_mock_data('2018-01-01', '2018-01-08')]
         results = self.send_get("PublicMetrics", query_string=qs)
-        self.assertIn({"date": "2018-01-01", "metrics": {"consented": 0, "core": 0, "registered": 1}}, results)
-        self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 1}}, results)
-        self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 1}}, results)
+        self.assertIn({"date": "2018-01-01", "metrics": {"core": 0, "registered": 1}}, results)
+        self.assertIn({"date": "2018-01-02", "metrics": {"core": 0, "registered": 1}}, results)
+        self.assertIn({"date": "2018-01-03", "metrics": {"core": 1, "registered": 1}}, results)
 
         qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08" "&awardee=AZ_TUCSON"
         big_query().query.side_effect = [self.get_api_mock_data('2018-01-01', '2018-01-08', [4])]
         results = self.send_get("PublicMetrics", query_string=qs)
-        self.assertIn({"date": "2018-01-01", "metrics": {"consented": 0, "core": 0, "registered": 0}}, results)
-        self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 0}}, results)
-        self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 0}}, results)
+        self.assertIn({"date": "2018-01-01", "metrics": {"core": 0, "registered": 0}}, results)
+        self.assertIn({"date": "2018-01-02", "metrics": {"core": 0, "registered": 0}}, results)
+        self.assertIn({"date": "2018-01-03", "metrics": {"core": 1, "registered": 0}}, results)
 
     @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
                 test_job_time)

--- a/tests/api_tests/test_public_metrics.py
+++ b/tests/api_tests/test_public_metrics.py
@@ -8,6 +8,7 @@ from rdr_service.concepts import Concept
 from rdr_service.dao.calendar_dao import CalendarDao
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.hpo_dao import HPODao
+from rdr_service.dao.metrics_cache_dao import MetricsEnrollmentStatusCacheDao
 from rdr_service.researchers_offline.participant_counts_over_time import calculate_participant_metrics
 from rdr_service.dao.organization_dao import OrganizationDao
 from rdr_service.dao.participant_dao import ParticipantDao
@@ -24,7 +25,7 @@ from rdr_service.participant_enums import (
     OrganizationType,
     TEST_HPO_ID,
     TEST_HPO_NAME,
-    make_primary_provider_link_for_name,
+    make_primary_provider_link_for_name, MetricsCacheType,
 )
 from tests.helpers.unittest_base import BaseTestCase
 from tests.helpers.mysql_helper_data import PITT_HPO_ID
@@ -2471,6 +2472,10 @@ class PublicMetricsApiTest(BaseTestCase):
                 [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [],
                 race_v2_results_unst, race_v2_results_pitt, race_v2_results_az]
 
+    def get_api_mock_data(self, start_date, end_date, hpo_ids=None, participant_origins=None):
+        test_dao = MetricsEnrollmentStatusCacheDao(MetricsCacheType.PUBLIC_METRICS_EXPORT_API)
+        return test_dao.get_active_buckets(start_date, end_date, hpo_ids, participant_origins)
+
     @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
                 test_job_time)
     @mock.patch('google.cloud.bigquery.Client')
@@ -2483,18 +2488,18 @@ class PublicMetricsApiTest(BaseTestCase):
         self.assertEqual(big_query().query.call_count, 72)
 
         qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08"
-
+        big_query().query.side_effect = [self.get_api_mock_data('2018-01-01', '2018-01-08')]
         results = self.send_get("PublicMetrics", query_string=qs)
-        self.assertIn({"date": "2018-01-01", "metrics": {"consented": 0, "core": 0, "registered": 3}}, results)
-        self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 2}}, results)
-        self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 2}}, results)
-
-        qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08" "&awardee=AZ_TUCSON"
-
-        results = self.send_get("PublicMetrics", query_string=qs)
-        self.assertIn({"date": "2018-01-01", "metrics": {"consented": 0, "core": 0, "registered": 2}}, results)
+        self.assertIn({"date": "2018-01-01", "metrics": {"consented": 0, "core": 0, "registered": 1}}, results)
         self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 1}}, results)
         self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 1}}, results)
+
+        qs = "&stratification=ENROLLMENT_STATUS" "&startDate=2018-01-01" "&endDate=2018-01-08" "&awardee=AZ_TUCSON"
+        big_query().query.side_effect = [self.get_api_mock_data('2018-01-01', '2018-01-08', [4])]
+        results = self.send_get("PublicMetrics", query_string=qs)
+        self.assertIn({"date": "2018-01-01", "metrics": {"consented": 0, "core": 0, "registered": 0}}, results)
+        self.assertIn({"date": "2018-01-02", "metrics": {"consented": 1, "core": 0, "registered": 0}}, results)
+        self.assertIn({"date": "2018-01-03", "metrics": {"consented": 0, "core": 1, "registered": 0}}, results)
 
     @mock.patch('rdr_service.dao.participant_counts_over_time_service.ParticipantCountsOverTimeService.JOB_TIME',
                 test_job_time)


### PR DESCRIPTION
## Resolves *[DA-4942](https://precisionmedicineinitiative.atlassian.net/browse/DA-4942)*


## Description of changes/additions
Participant Status values in Research Hub (RH) were found to be inaccurate. This was due to the RDR system using old definitions for registered and core participants (For example, the registered value returned by the API was actually the statuses registered + participants), as well as the structure of the Participant Counts Over Time Job storing historical data and then returning sums from that data (i.e. If historical counts are off for some reason, the total count will always be off).

To remediate this issue short-term, these changes update the API to calculate registered and core participant counts using PPSC tables in BigQuery. This PR also updates the Participant Counts Over Time Job to use the PPSC tables directly; however, even with this update, the total counts are still off due to the historical data issue. In the short term, the API will not reference any data from the Participant Counts Over Time Job but only use data received from PPSC. These changes also update the definition used to calculate the metrics.

## Tests
- [X] unit tests
- Manually ran new queries on BigQuery and checked metric counts
- Tested API return values locally 



[DA-4942]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ