### PR TITLE
Fix for Package Vulnerabilities

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -23,6 +23,9 @@ security: # configuration for the `safety check` command
         70612:
           reason: jinja2 version 3.1.4 has a vulnerability
           expires: '2025-05-31'
+        77740:
+          reason: protobuf version 3.20.3 has a vulnerability
+          expires: '2026-07-31'
     continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
     security:

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -88,7 +88,7 @@ pyzmq==25.1.0             # via locust
 redis==4.5.4              # via flask-limiter
 requests-oauthlib==1.3.0  # via jira
 requests-toolbelt==0.9.1  # via jira
-requests[security]==2.32.2  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
+requests[security]==2.32.4  # via -r requirements.in, fhirclient, google-api-core, googlemaps, jira, locust, requests-oauthlib, requests-toolbelt, sphinx
 rsa==4.7.2                  # via google-auth, oauth2client
 sendgrid==6.9.1           # via -r requirements.in
 simple-geometry==0.1.4  # geometry


### PR DESCRIPTION
## Resolves *Protobuf Upgrade Failures*


## Description of changes/additions
Short term fix to temporary suppress the upgrade of protobuf from 3.20.3 to 4.25.8 to allow more time to fix dependency conflicts and other cascading errors. These changes also upgrade the requests library per Vulnerability ID: 77680.

## Tests
- [] unit tests


