### PR TITLE
[DA-4954] Update RH API Enrollment Data to be Chronological

### DIFF
--- a/rdr_service/dao/metrics_cache_dao.py
+++ b/rdr_service/dao/metrics_cache_dao.py
@@ -278,6 +278,7 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
                     ),0) AS coreCount,
                 FROM `{calendar}` c WHERE c.day BETWEEN @start_date AND @end_date
                 GROUP BY c.day
+                ORDER BY c.day ASC
                 ;
                 """.format(calendar=f"{bq_project}.{calendar_table}", participant=f"{bq_project}.{participant_table}",
                            participant_status_event=f"{bq_project}.{participant_status_event_table}",


### PR DESCRIPTION
## Resolves *[DA-4954](https://precisionmedicineinitiative.atlassian.net/browse/DA-4954)*


## Description of changes/additions
RH API is returning values in non-chronological order order currently causing issues on the website. This PR updates the results for enrollment status metrics to be ordered chronologically

## Tests
- [X] unit tests
- Manually ran query on BigQuery to check results




[DA-4954]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ