### PR TITLE
[DA-4961] updating request log foreign key tracking for intake api

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -40,17 +40,13 @@ class PPSCIntakeAPI(BaseApi):
         # Validate
         self.validate_payload(req_data=req_data)
 
-        # get correct [Activity]Event DAO
-        dao_str = f"{req_data['activity'].lower().replace(' ', '_')}_event_dao"
-        activity_event_dao = self.__dict__.get(dao_str)
-        model = activity_event_dao.model_type
-        log_api_request(log=request.log_record, model_obj=model)
 
         # Route to correct activity and insert events
         inserted_event = self.handle_event_insert(
             req_data=self.get_request_json(),
         )
-        return self._make_response(obj=inserted_event)
+        log_api_request(log=request.log_record, model_obj=inserted_event)
+        return self._make_response(obj=inserted_event.resource)
 
     def validate_payload(self, *, req_data: dict):
         required_keys = ['activity', 'eventType', 'participantId', 'dataElements']
@@ -112,7 +108,7 @@ class PPSCIntakeAPI(BaseApi):
                     if not name+'_date_time' in data_element_names:
                         raise BadRequest(f"Enrollment Status {name} is missing {name+'_date_time'}.")
 
-    def handle_event_insert(self, *, req_data: dict) -> dict:
+    def handle_event_insert(self, *, req_data: dict):
         activity_record = list(filter(lambda x: x.name.lower() == req_data['activity'].lower(),
                                       self.activity_records))
 
@@ -168,7 +164,7 @@ class PPSCIntakeAPI(BaseApi):
 
         activity_event_dao.insert_bulk(records_to_insert)
 
-        return participant_event_activity.resource
+        return participant_event_activity
 
     def check_consent(self, participant_id, event_types, data_element_name, data_element_value):
         with self.dao.session() as session:

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -1279,25 +1279,14 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.send_valid_primary_consent(participant)
 
         # checking for the log in the Requests Log and verifying the fpk info
-        log_entry = (
-            self.session.query(RequestsLog).order_by(RequestsLog.id.desc()).first()
-        )
+        log_entry = self.session.query(RequestsLog).order_by(
+            RequestsLog.id.desc()
+        ).first()
         self.assertIsNotNone(log_entry, "No log entry found in the requests log table")
-        self.assertEqual(
-            log_entry.participantId,
-            100000000,
-            "the participant_id in the requests log entry does not match the expected value",
-        )
-        self.assertEqual(
-            log_entry.fpk_table,
-            "consent_event",
-            "the fpk_table in the requests log entry does not match the expected value",
-        )
-        self.assertEqual(
-            log_entry.fpk_column,
-            "id",
-            "the fpk_column in the requests log entry does not match the expected value",
-        )
+        self.assertEqual(log_entry.participantId, 100000000)
+        self.assertEqual(log_entry.fpk_table, "participant_event_activity")
+        self.assertEqual(log_entry.fpk_column, "id")
+        self.assertIsNotNone(log_entry.fpk_id)
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
## Resolves *[DA-4961](https://precisionmedicineinitiative.atlassian.net/browse/DA-4961)*
The `log_api_request` method expects an instance of a mapped object to be able to store the foreign key id in the request log table. This updates the Intake API a bit so we can pass an instanced object.

## Description of changes/additions
Ideally we would have the request log point to the most low-level-detail table (like consent_event or participant_status_event) but for that we'd need to set up some kind of new mapping system (since the request log is only set up to point at one specific record, and each of the detailed tables has multple records for one event).

But each request only generates one participant_event_activity record, and sql queries can be set up to get any other records needed from the data in that table. So these changes store the participant_event_activity id.

## Tests
- [x] unit tests




[DA-4961]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ