### PR TITLE
Added lims_parent_sample_id to API endpoint and N1 process

### DIFF
--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1151,7 +1151,8 @@ class NphBiospecimenDao(BaseDao):
                     "biobankModified": stored_sample.get('biobankModified'),
                     "status": str(StoredSampleStatus.lookup_by_number(stored_sample.get('status'))),
                     "freezeThawCount": stored_sample.get('freezeThawCount'),
-                    "specimenVolumeUl": stored_sample.get('specimenVolumeUl')
+                    "specimenVolumeUl": stored_sample.get('specimenVolumeUl'),
+                    "limsParentSampleID": stored_sample.get('limsParentSampleID')
                 } for stored_sample in stored_samples
             ]
         return order_samples
@@ -1172,7 +1173,8 @@ class NphBiospecimenDao(BaseDao):
                             'status', StoredSample.status,
                             'orderSampleID', StoredSample.sample_id,
                             'freezeThawCount', StoredSample.freeze_thaw_count,
-                            'specimenVolumeUl', StoredSample.specimen_volume_ul
+                            'specimenVolumeUl', StoredSample.specimen_volume_ul,
+                            'limsParentSampleID', StoredSample.lims_parent_sample_id
                         )
                     ), type_=JSON
                 ).label('orders_sample_biobank_status')
@@ -1183,7 +1185,7 @@ class NphBiospecimenDao(BaseDao):
                 stored_sample_alias,
                 and_(
                     StoredSample.biobank_id == stored_sample_alias.biobank_id,
-                    stored_sample_alias.sample_id == StoredSample.sample_id,
+                    stored_sample_alias.lims_id == StoredSample.lims_id,
                     stored_sample_alias.status == StoredSample.status,
                     StoredSample.id < stored_sample_alias.id
                 )

--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -250,10 +250,6 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
             elif 'duke' in kwargs.get('recipient').lower():
                 query = query.add_columns(
                     SmsN0.lims_parent_sample_id,
-                    func.json_extract(OrderedSample.supplemental_fields, "$.bowelMovement").label('bowel_movement'),
-                    func.json_extract(
-                        OrderedSample.supplemental_fields, '$.bowelMovementQuality'
-                    ).label('bowel_movement_quality')
                 ).outerjoin(
                     SmsN1Mc1,
                     and_(

--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -187,28 +187,17 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                 SmsSample.race,
                 SmsSample.bmi,
                 SmsSample.diet,
-                func.json_extract(OrderedSample.supplemental_fields, "$.color").label('urine_color'),
-                func.json_extract(OrderedSample.supplemental_fields, "$.clarity").label('urine_clarity'),
             ).outerjoin(
                 SmsSample,
                 and_(
-                    SmsN0.sample_id == SmsSample.sample_id,
+                    SmsN0.lims_sample_id == SmsSample.lims_sample_id,
                     SmsSample.ignore_flag == 0
                 )
-            ).outerjoin(
-                OrderedSample,
-                SmsSample.sample_id == OrderedSample.nph_sample_id
             ).outerjoin(
                 SmsBlocklist,
                 and_(
                     SmsSample.sample_id == SmsBlocklist.identifier_value,
                     SmsBlocklist.identifier_type == "sample_id"
-                )
-            ).outerjoin(
-                SmsN1Mc1,
-                and_(
-                    SmsN0.sample_id == SmsN1Mc1.sample_id,
-                    SmsN1Mc1.ignore_flag == 0
                 )
             ).outerjoin(
                 sample_well,
@@ -220,13 +209,15 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
             ).outerjoin(
                 most_recent,
                 and_(
-                    SmsSample.sample_id == most_recent.c.sample_id,
+                    SmsSample.lims_sample_id == most_recent.c.lims_sample_id,
                     SmsSample.created == most_recent.c.created
                 )
             )
 
             if 'pbrc' in kwargs.get('recipient').lower():
                 query = query.add_columns(
+                    func.json_extract(OrderedSample.supplemental_fields, "$.color").label('urine_color'),
+                    func.json_extract(OrderedSample.supplemental_fields, "$.clarity").label('urine_clarity'),
                     SmsSample.body_weight_kg,
                     DlwDosage.batch_id.label('dlw_dose_batch'),
                     DlwDosage.dose_time.label('dlw_dose_date_time'),
@@ -247,6 +238,15 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                         DlwDosage.visit_period == func.regexp_substr(SmsN0.visit, "[0-9]+"),
                         DlwDosage.ignore_flag == 0,
                     )
+                ).outerjoin(
+                    OrderedSample,
+                    SmsSample.sample_id == OrderedSample.nph_sample_id
+                ).outerjoin(
+                    SmsN1Mc1,
+                    and_(
+                        SmsN0.sample_id == SmsN1Mc1.sample_id,
+                        SmsN1Mc1.ignore_flag == 0
+                    )
                 )
             elif 'duke' in kwargs.get('recipient').lower():
                 query = query.add_columns(
@@ -255,13 +255,30 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
                     func.json_extract(
                         OrderedSample.supplemental_fields, '$.bowelMovementQuality'
                     ).label('bowel_movement_quality')
+                ).outerjoin(
+                    SmsN1Mc1,
+                    and_(
+                        SmsN0.lims_sample_id == SmsN1Mc1.sample_id,
+                        SmsN1Mc1.ignore_flag == 0
+                    )
                 )
             else:
                 query = query.add_columns(
+                    func.json_extract(OrderedSample.supplemental_fields, "$.color").label('urine_color'),
+                    func.json_extract(OrderedSample.supplemental_fields, "$.clarity").label('urine_clarity'),
                     func.json_extract(OrderedSample.supplemental_fields, "$.bowelMovement").label('bowel_movement'),
                     func.json_extract(
                         OrderedSample.supplemental_fields, '$.bowelMovementQuality'
                     ).label('bowel_movement_quality')
+                ).outerjoin(
+                    OrderedSample,
+                    SmsSample.sample_id == OrderedSample.nph_sample_id
+                ).outerjoin(
+                    SmsN1Mc1,
+                    and_(
+                        SmsN0.sample_id == SmsN1Mc1.sample_id,
+                        SmsN1Mc1.ignore_flag == 0
+                    )
                 )
 
             query = query.filter(

--- a/rdr_service/dao/study_nph_sms_dao.py
+++ b/rdr_service/dao/study_nph_sms_dao.py
@@ -149,10 +149,10 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
 
         with self.session() as session:
             most_recent = session.query(
-                SmsSample.sample_id,
+                SmsSample.lims_sample_id,
                 func.max(SmsSample.created).label("created")
             ).group_by(
-                SmsSample.sample_id
+                SmsSample.lims_sample_id
             ).filter(
                 SmsSample.ignore_flag == 0
             ).subquery()
@@ -160,7 +160,6 @@ class SmsN1Mc1Dao(BaseDao, SmsManifestMixin, SmsManifestSourceMixin):
             sample_well = aliased(SmsN1Mc1)
 
             aliquot_sample = aliased(OrderedSample)
-
             query = session.query(
                 SmsSample.sample_id,
                 SmsN0.matrix_id,

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -512,9 +512,6 @@ class NphSmsWorkflowsTest(BaseTestCase):
             csv_reader = csv.DictReader(cloud_file)
             csv_rows = list(csv_reader)
 
-        for row in csv_rows:
-            print(row)
-
         self.assertEqual(csv_rows[0]['sample_id'], '10001')
         self.assertEqual(csv_rows[0]['matrix_id'], "1111")
         self.assertEqual(csv_rows[0]['urine_color'], '"Color 4"')

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -253,7 +253,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sex_at_birth="M",
             sample_identifier="test",
             sample_id=10001,
-            lims_sample_id="000200",
+            lims_sample_id="000201",
             destination=destination
         )
         sms_datagen.create_database_sms_sample(
@@ -264,7 +264,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sex_at_birth="M",
             sample_identifier="test",
             sample_id=10002,
-            lims_sample_id="000200",
+            lims_sample_id="000202",
             destination=destination
         )
         sms_datagen.create_database_sms_sample(
@@ -275,7 +275,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sex_at_birth="M",
             sample_identifier="test",
             sample_id=10003,
-            lims_sample_id="000200",
+            lims_sample_id="000203",
             destination=destination
         )
 
@@ -299,6 +299,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             manufacturer_lot='256837',
             age="22",
             biobank_id="test",
+            lims_sample_id="000201",
         )
         sms_datagen.create_database_sms_n0(
             sample_id=10002,
@@ -320,6 +321,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             manufacturer_lot='256838',
             age="22",
             biobank_id="test",
+            lims_sample_id="000202",
         )
         sms_datagen.create_database_sms_n0(
             sample_id=10003,
@@ -341,6 +343,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             manufacturer_lot='256837',
             age="22",
             biobank_id="test",
+            lims_sample_id="000203",
         )
 
         sms_datagen.create_database_sms_blocklist(
@@ -353,7 +356,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             package_id="test",
             storage_unit_id="test",
             file_path=f"{destination}_n0_test.csv",
-            well_box_position="A4"
+            well_box_position="A4",
         )
 
     @staticmethod
@@ -405,6 +408,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             manufacturer_lot='256837',
             age="22",
             biobank_id=f"T{biobank_id}",
+            lims_sample_id="000200",
         )
 
         sms_datagen.create_database_dlw_dosage(
@@ -467,6 +471,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             manufacturer_lot='256837',
             age="22",
             biobank_id=f"T{biobank_id}",
+            lims_sample_id="000200",
             lims_parent_sample_id="12345678",
         )
 
@@ -482,7 +487,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
             sex_at_birth="M",
             sample_identifier="test",
             sample_id=10002,
-            lims_sample_id="000200",
+            lims_sample_id="000202",
             destination="UNC_META"
         )
 
@@ -506,6 +511,9 @@ class NphSmsWorkflowsTest(BaseTestCase):
         with open_cloud_file(expected_csv_path, mode='r') as cloud_file:
             csv_reader = csv.DictReader(cloud_file)
             csv_rows = list(csv_reader)
+
+        for row in csv_rows:
+            print(row)
 
         self.assertEqual(csv_rows[0]['sample_id'], '10001')
         self.assertEqual(csv_rows[0]['matrix_id'], "1111")


### PR DESCRIPTION
## Resolves *[DA-4926](https://precisionmedicineinitiative.atlassian.net/browse/DA-4926)*


## Description of changes/additions
Added lims_parent_sample_id to stored_sample api endpoint
Changed N1 process to use lims_sample_id instead of sample_id in some areas
Moved recipient-dependent data fields to lower logic

## Tests
- [x] unit tests




[DA-4926]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ