### PR TITLE
[DA-4926] Add method to default Duke's null sample_ids to parent

### DIFF
--- a/rdr_service/offline/study_nph_biobank_import_inventory_file.py
+++ b/rdr_service/offline/study_nph_biobank_import_inventory_file.py
@@ -93,10 +93,26 @@ def _convert_csv_row_to_stored_sample_object(csv_obj: Dict[str, Union[str, int]]
 
 def import_biobank_inventory_into_stored_samples(csv_filepath: str):
     nph_stored_sample_dao = NphStoredSampleDao()
-    for row in read_nph_biobank_inventory_file(csv_filepath):
+    rows = read_nph_biobank_inventory_file(csv_filepath)
+    parent_fields = {}
+
+    for row in rows:
+        parent_id = row.get('LIMS_PARENT_SAMPLE_ID')
+        if row['SAMPLE_ID'] is None and parent_id is not None and parent_id not in parent_fields.keys():
+            row['SAMPLE_ID'] = check_for_parent(rows, parent_id)
+            parent_fields[parent_id] = row['SAMPLE_ID']
+
+        elif row['SAMPLE_ID'] is None and parent_id is not None and parent_id in parent_fields.keys():
+            row['SAMPLE_ID'] = parent_fields[parent_id]
+
         stored_sample = _convert_csv_row_to_stored_sample_object(row)
         nph_stored_sample_dao.insert(stored_sample)
 
+
+def check_for_parent(rows, parent_id):
+    for row in rows:
+        if row['LIMS_ID'] == parent_id:
+            return row['SAMPLE_ID']
 
 def main():
     bucket_name = config.getSetting(config.NPH_SAMPLE_DATA_BIOBANK_NIGHTLY_FILE_DROP)

--- a/rdr_service/offline/study_nph_biobank_import_inventory_file.py
+++ b/rdr_service/offline/study_nph_biobank_import_inventory_file.py
@@ -95,14 +95,15 @@ def import_biobank_inventory_into_stored_samples(csv_filepath: str):
     nph_stored_sample_dao = NphStoredSampleDao()
     rows = read_nph_biobank_inventory_file(csv_filepath)
     parent_fields = {}
+    nulls = [None, '']
 
     for row in rows:
         parent_id = row.get('LIMS_PARENT_SAMPLE_ID')
-        if row['SAMPLE_ID'] is None and parent_id is not None and parent_id not in parent_fields.keys():
+        if row['SAMPLE_ID'] in nulls and parent_id not in nulls and parent_id not in parent_fields.keys():
             row['SAMPLE_ID'] = check_for_parent(rows, parent_id)
             parent_fields[parent_id] = row['SAMPLE_ID']
 
-        elif row['SAMPLE_ID'] is None and parent_id is not None and parent_id in parent_fields.keys():
+        elif row['SAMPLE_ID'] in nulls and parent_id not in nulls and parent_id in parent_fields.keys():
             row['SAMPLE_ID'] = parent_fields[parent_id]
 
         stored_sample = _convert_csv_row_to_stored_sample_object(row)


### PR DESCRIPTION
## Resolves *[DA-4926](https://precisionmedicineinitiative.atlassian.net/browse/DA-4926)*


## Description of changes/additions
Added method to stored_sample intake process that gives child samples their parent's sample_id if not provided.

## Tests
- [x] unit tests




[DA-4926]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ