### PR TITLE
[DA-4974]Update EHR latest receipt time in Awardee Insite

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -155,6 +155,7 @@ GENOMIC_GC_SITE_BUCKET_MAP = 'gc_site_bucket_map'
 CONFIG_BUCKET = "all-of-us-rdr-sequestered-config-test"
 EHR_STATUS_BIGQUERY_VIEW_PARTICIPANT = "ehr_status_bigquery_view_participant"
 EHR_STATUS_BIGQUERY_VIEW_ORGANIZATION = "ehr_status_bigquery_view_organization"
+CURATION_PROD_PROJECT = "curation_prod_project"
 HPO_REPORT_CONFIG_MIXIN_PATH = "hpo_report_config_mixin_path"
 LOCALHOST_DEFAULT_BUCKET_NAME = 'local_bucket'
 BIOBANK_SAMPLES_DAILY_INVENTORY_FILE_PATTERN = 'biobank_samples_daily_inventory_file_pattern'

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -712,6 +712,9 @@ def insert_awardee_insite_data(
               )
             WHERE rn = 1
           ),
+          -- 2 BQ jobs are run daily in curation project."materialize_ehr_uploads_pids_view_into_table" changes the view
+          -- to a table & "copy_rdr_operational_across_regions" moves the dataset from US to uscentral1 so it can be
+          -- queried here
           latest_ehr_receipt_time_cte AS (
             SELECT person_id
             , CAST(FORMAT_TIMESTAMP("%Y-%m-%dT%H:%M:%S", latest_upload_time) AS DATETIME) AS latest_ehr_receipt_time

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -347,7 +347,7 @@ def insert_awardee_insite_data(
     project: str, src_operational_dataset: str, destination_dataset: str
 ) -> str:
     """Insert data into `datafeed_input_awardee_insite` table. Also takes care of withdrawn participants"""
-    curation_project = config.getSettingJson(config.CURATION_PROD_PROJECT)
+    curation_project = config.getSettingJson(config.CURATION_PROD_PROJECT)[0]
 
     return f"""
         INSERT INTO `{project}.{destination_dataset}.datafeed_input_awardee_insite`

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -347,6 +347,7 @@ def insert_awardee_insite_data(
     project: str, src_operational_dataset: str, destination_dataset: str
 ) -> str:
     """Insert data into `datafeed_input_awardee_insite` table. Also takes care of withdrawn participants"""
+    curation_project = config.getSettingJson(config.CURATION_PROD_PROJECT)
 
     return f"""
         INSERT INTO `{project}.{destination_dataset}.datafeed_input_awardee_insite`
@@ -711,11 +712,15 @@ def insert_awardee_insite_data(
               )
             WHERE rn = 1
           ),
+          latest_ehr_receipt_time_cte AS (
+            SELECT person_id
+            , CAST(FORMAT_TIMESTAMP("%Y-%m-%dT%H:%M:%S", latest_upload_time) AS DATETIME) AS latest_ehr_receipt_time
+            FROM `{curation_project}.rdr_operational_us_central.ehr_upload_pids`
+          ),
           participant_summary_cte AS (
             SELECT
               participant_id
               , ehr_receipt_time AS first_ehr_receipt_time
-              , ehr_update_time AS latest_ehr_receipt_time
               , consent_for_electronic_health_records_first_yes_authored
               , consent_for_study_enrollment_authored
               , patient_status
@@ -837,6 +842,8 @@ def insert_awardee_insite_data(
             USING (participant_id)
             LEFT JOIN latest_enrollement_status
             USING (participant_id)
+            LEFT JOIN latest_ehr_receipt_time_cte lertc
+            ON participant_cte.participant_id = lertc.person_id
           ),
           withdrawn_update AS (
               SELECT


### PR DESCRIPTION
## Resolves *[DA-4974]*


## Description of changes/additions
- Copied the `ehr_upload_pids` table from US to us-central1, so I can use that table for joining. This PR updates the awardee insite query to read `ehr_latest_receipt_time` from curation's ehr_upload_pids.


## Tests
- [] unit tests (Tested in BQ)




[DA-4974]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ