### PR TITLE
[DA-4644] Decommission API Endpoints No Longer Needed

### DIFF
--- a/rdr_service/api/check_ppi_data_api.py
+++ b/rdr_service/api/check_ppi_data_api.py
@@ -3,7 +3,7 @@ import re
 
 from flask import request
 
-from rdr_service.api_util import PTC_AND_HEALTHPRO
+from rdr_service.api_util import RDR
 from rdr_service.app_util import auth_required
 from rdr_service.code_constants import EMAIL_QUESTION_CODE, PPI_SYSTEM
 from rdr_service.dao.code_dao import CodeDao
@@ -13,7 +13,7 @@ from rdr_service.model.code import Code, CodeType
 from rdr_service.model.participant_summary import ParticipantSummary
 
 
-@auth_required(PTC_AND_HEALTHPRO)
+@auth_required(RDR)
 def check_ppi_data():
     """
     Validates the questions/responses for test participants.

--- a/rdr_service/api/deceased_report_api.py
+++ b/rdr_service/api/deceased_report_api.py
@@ -2,7 +2,7 @@ from flask import request
 from werkzeug.exceptions import BadRequest
 
 from rdr_service.api.base_api import BaseApi, UpdatableApi
-from rdr_service.api_util import HEALTHPRO, PTC_AND_HEALTHPRO
+from rdr_service.api_util import RDR, HEALTHPRO
 from rdr_service.app_util import auth_required, check_auth
 from rdr_service.dao.deceased_report_dao import DeceasedReportDao
 from rdr_service.model.utils import from_client_participant_id
@@ -21,7 +21,7 @@ class DeceasedReportApi(DeceasedReportApiMixin, BaseApi):
     one or more participants.
     """
 
-    @auth_required(PTC_AND_HEALTHPRO)
+    @auth_required(RDR)
     def list(self, participant_id=None):
         search_kwargs = {key: value for key, value in request.args.items()}
 
@@ -39,7 +39,7 @@ class DeceasedReportApi(DeceasedReportApiMixin, BaseApi):
 
         return response
 
-    @auth_required(PTC_AND_HEALTHPRO)
+    @auth_required(RDR)
     def post(self, participant_id=None):
         resource = request.get_json(force=True)
         if 'code' not in resource or\
@@ -52,7 +52,7 @@ class DeceasedReportApi(DeceasedReportApiMixin, BaseApi):
 
 
 class DeceasedReportReviewApi(DeceasedReportApiMixin, UpdatableApi):
-    @auth_required(HEALTHPRO)
+    @auth_required(RDR)
     def post(self, participant_id, report_id):
         participant_id = from_client_participant_id(participant_id)
 

--- a/rdr_service/api/genomic_api.py
+++ b/rdr_service/api/genomic_api.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import NotFound, BadRequest, Forbidden
 
 from rdr_service import clock, config
 from rdr_service.api.base_api import BaseApi, log_api_request, UpdatableApi
-from rdr_service.api_util import GEM, RDR_AND_PTC, RDR
+from rdr_service.api_util import RDR
 from rdr_service.app_util import auth_required, restrict_to_gae_project, get_validated_user_info
 from rdr_service.config import GENOMIC_CLIENT_IDS
 from rdr_service.dao.genomics_dao import GenomicPiiDao, GenomicSetMemberDao, GenomicOutreachDao, GenomicOutreachDaoV2, \
@@ -140,7 +140,7 @@ class GenomicPiiApi(BaseApi):
     def __init__(self):
         super(GenomicPiiApi, self).__init__(GenomicPiiDao())
 
-    @auth_required([GEM, RDR])
+    @auth_required(RDR)
     def get(self, mode=None, pii_id=None):
         if mode not in ('GP', 'RHP'):
             raise BadRequest("GenomicPII Mode required to be \"GP\" or \"RHP\".")
@@ -172,7 +172,7 @@ class GenomicOutreachApi(BaseApi):
         self.report_state_dao = GenomicMemberReportStateDao()
         self.participant_origin: List[str] = GenomicOrigin.set_participant_origin(lookup_type='GenomicOutreach')
 
-    @auth_required([GEM] + RDR_AND_PTC)
+    @auth_required(RDR)
     def get(self, mode=None):
         self._check_mode(mode)
         if mode.lower() == "gem":
@@ -180,7 +180,7 @@ class GenomicOutreachApi(BaseApi):
 
         return BadRequest
 
-    @auth_required(RDR_AND_PTC)
+    @auth_required(RDR)
     @restrict_to_gae_project(PTC_ALLOWED_ENVIRONMENTS)
     def post(self, p_id, mode=None):
         """
@@ -290,7 +290,7 @@ class GenomicOutreachApiV2(UpdatableApi):
         self.validate_outreach_params()
         self.participant_origin: List[str] = GenomicOrigin.set_participant_origin(lookup_type='GenomicOutreach')
 
-    @auth_required(RDR_AND_PTC)
+    @auth_required(RDR)
     def get(self):
         self._check_global_args(
             request.args.get('module'),
@@ -298,7 +298,7 @@ class GenomicOutreachApiV2(UpdatableApi):
         )
         return self.get_outreach()
 
-    @auth_required(RDR_AND_PTC)
+    @auth_required(RDR)
     @restrict_to_gae_project(PTC_ALLOWED_ENVIRONMENTS)
     def post(self):
         participant_id, request_data = self.validate_post_data()
@@ -308,7 +308,7 @@ class GenomicOutreachApiV2(UpdatableApi):
             self.participant_origin[0]
         )
 
-    @auth_required(RDR_AND_PTC)
+    @auth_required(RDR)
     @restrict_to_gae_project(PTC_ALLOWED_ENVIRONMENTS)
     def put(self):
         participant_id, request_data = self.validate_post_data()
@@ -490,7 +490,7 @@ class GenomicSchedulingApi(BaseApi):
         self.validate_scheduling_params()
         self.participant_origin: List[str] = GenomicOrigin.set_participant_origin(lookup_type='GenomicScheduling')
 
-    @auth_required(RDR_AND_PTC)
+    @auth_required(RDR)
     def get(self):
         self._check_global_args(
             request.args.get('module')

--- a/rdr_service/api/message_broker_api.py
+++ b/rdr_service/api/message_broker_api.py
@@ -1,6 +1,6 @@
 from rdr_service import app_util
 from rdr_service.api.base_api import BaseApi
-from rdr_service.api_util import PTC_AND_GEM
+from rdr_service.api_util import RDR
 from rdr_service.dao.message_broker_dao import MessageBrokerDao
 
 
@@ -8,6 +8,6 @@ class MessageBrokerApi(BaseApi):
     def __init__(self):
         super().__init__(MessageBrokerDao())
 
-    @app_util.auth_required(PTC_AND_GEM)
+    @app_util.auth_required(RDR)
     def post(self):
         return super(MessageBrokerApi, self).post()

--- a/rdr_service/api/metrics_ehr_api.py
+++ b/rdr_service/api/metrics_ehr_api.py
@@ -3,7 +3,7 @@ from flask_restful import Resource
 from werkzeug.exceptions import BadRequest
 
 from rdr_service import app_util, clock
-from rdr_service.api_util import HEALTHPRO, parse_date
+from rdr_service.api_util import RDR, parse_date
 from rdr_service.dao.metrics_ehr_service import MetricsEhrService
 from rdr_service.dao.organization_dao import OrganizationDao
 
@@ -61,7 +61,7 @@ class MetricsEhrApi(MetricsEhrApiBaseResource):
   - Organization Participant Status Counts
   """
 
-    @app_util.auth_required(HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self):
         valid_arguments = self.parse_input()
         return MetricsEhrService().get_current_metrics(organization_ids=valid_arguments["organization"])
@@ -72,7 +72,7 @@ class ParticipantEhrMetricsOverTimeApi(MetricsEhrApiBaseResource):
   Participant EHR Consented vs EHR Received
   """
 
-    @app_util.auth_required(HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self):
         valid_arguments = self.parse_input()
         return MetricsEhrService().get_current_ehr_data(organization_ids=valid_arguments["organization"])
@@ -89,7 +89,7 @@ class OrganizationMetricsApi(MetricsEhrApiBaseResource):
             end_date=self._make_parse_with_default(self._parse_date, clock.CLOCK.now()),
         )
 
-    @app_util.auth_required(HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self):
         valid_arguments = self.parse_input()
         return MetricsEhrService().get_organization_metrics_data(

--- a/rdr_service/api/metrics_fields_api.py
+++ b/rdr_service/api/metrics_fields_api.py
@@ -1,13 +1,13 @@
 from flask_restful import Resource
 
 from rdr_service import app_util
-from rdr_service.api_util import HEALTHPRO
+from rdr_service.api_util import RDR
 from rdr_service.offline import metrics_config
 
 
 class MetricsFieldsApi(Resource):
     """API that returns the names and valid values for metric fields."""
 
-    @app_util.auth_required(HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self):
         return metrics_config.get_fields()

--- a/rdr_service/api/onsite_verification_api.py
+++ b/rdr_service/api/onsite_verification_api.py
@@ -2,7 +2,7 @@ from werkzeug.exceptions import BadRequest
 
 from rdr_service import app_util
 from rdr_service.api.base_api import BaseApi
-from rdr_service.api_util import RDR_AND_HEALTHPRO
+from rdr_service.api_util import RDR
 from rdr_service.dao.onsite_verification_dao import OnsiteVerificationDao
 
 
@@ -10,11 +10,11 @@ class OnsiteVerificationApi(BaseApi):
     def __init__(self):
         super().__init__(OnsiteVerificationDao())
 
-    @app_util.auth_required(RDR_AND_HEALTHPRO)
+    @app_util.auth_required(RDR)
     def post(self):
         return super(OnsiteVerificationApi, self).post()
 
-    @app_util.auth_required(RDR_AND_HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self, p_id=None):
         if p_id is None:
             raise BadRequest("Request must include participant id")

--- a/rdr_service/api/organization_hierarchy_api.py
+++ b/rdr_service/api/organization_hierarchy_api.py
@@ -1,6 +1,6 @@
 from rdr_service.api.base_api import UpdatableApi
 from rdr_service.app_util import auth_required
-from rdr_service.api_util import PTC
+from rdr_service.api_util import RDR
 from rdr_service.dao.organization_hierarchy_sync_dao import OrganizationHierarchySyncDao
 
 
@@ -8,7 +8,7 @@ class OrganizationHierarchyApi(UpdatableApi):
     def __init__(self):
         super(OrganizationHierarchyApi, self).__init__(OrganizationHierarchySyncDao())
 
-    @auth_required(PTC)
+    @auth_required(RDR)
     def put(self):
         return super(OrganizationHierarchyApi, self).put(None, skip_etag=True)
 

--- a/rdr_service/api/participant_api.py
+++ b/rdr_service/api/participant_api.py
@@ -3,7 +3,7 @@ from werkzeug.exceptions import NotFound
 from flask import request
 
 from rdr_service.api.base_api import UpdatableApi, BaseApi
-from rdr_service.api_util import dispatch_task, PTC, PTC_AND_HEALTHPRO, HEALTHPRO
+from rdr_service.api_util import dispatch_task, PTC_AND_HEALTHPRO, RDR
 from rdr_service.dao.base_dao import _MIN_ID, _MAX_ID
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.pediatric_data_log_dao import PediatricDataLogDao
@@ -21,7 +21,7 @@ class ParticipantApi(UpdatableApi):
             raise NotFound(f"Participant with ID {p_id} is not found.")
         return super().get(p_id)
 
-    @app_util.auth_required(PTC)
+    @app_util.auth_required(RDR)
     def post(self):
         response, *_ = super(ParticipantApi, self).post()
 
@@ -31,7 +31,7 @@ class ParticipantApi(UpdatableApi):
 
         return response, *_
 
-    @app_util.auth_required(PTC)
+    @app_util.auth_required(RDR)
     def put(self, p_id):
         response = super(ParticipantApi, self).put(p_id)
         self._check_for_pediatric_update(p_id)
@@ -54,7 +54,7 @@ class ParticipantResearchIdApi(BaseApi):
     def __init__(self):
         super(ParticipantResearchIdApi, self).__init__(ParticipantDao())
 
-    @app_util.auth_required(HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self):
         kwargs = {
             'sign_up_after': request.args.get('signUpAfter'),

--- a/rdr_service/api/participant_incentives.py
+++ b/rdr_service/api/participant_incentives.py
@@ -3,7 +3,7 @@ from flask import request
 
 from rdr_service.app_util import auth_required
 from rdr_service.api.base_api import UpdatableApi, log_api_request
-from rdr_service.api_util import RDR_AND_HEALTHPRO
+from rdr_service.api_util import RDR
 from rdr_service.dao.participant_incentives_dao import ParticipantIncentivesDao
 from rdr_service.dao.participant_summary_dao import ParticipantSummaryDao
 from rdr_service.dao.site_dao import SiteDao
@@ -16,7 +16,7 @@ class ParticipantIncentivesApi(UpdatableApi):
         self.site_dao = SiteDao()
         self.site_id = None
 
-    @auth_required(RDR_AND_HEALTHPRO)
+    @auth_required(RDR)
     def post(self, p_id):
         participant = self.ps_dao.get_by_participant_id(p_id)
 
@@ -36,7 +36,7 @@ class ParticipantIncentivesApi(UpdatableApi):
         log_api_request(log=request.log_record)
         return self._make_response(obj)
 
-    @auth_required(RDR_AND_HEALTHPRO)
+    @auth_required(RDR)
     def put(self, p_id):
         participant = self.ps_dao.get_by_participant_id(p_id)
 

--- a/rdr_service/api/participant_summary_api.py
+++ b/rdr_service/api/participant_summary_api.py
@@ -281,7 +281,7 @@ class ParticipantSummaryCheckLoginApi(BaseApi):
     def __init__(self):
         super(ParticipantSummaryCheckLoginApi, self).__init__(ParticipantSummaryDao())
 
-    @auth_required(RDR_AND_PTC)
+    @auth_required(RDR)
     def post(self):
         """
         Return status of IN_USE / NOT_IN_USE if participant found / not found

--- a/rdr_service/api/patient_status.py
+++ b/rdr_service/api/patient_status.py
@@ -1,5 +1,5 @@
 from rdr_service.api.base_api import BaseApi, UpdatableApi
-from rdr_service.api_util import HEALTHPRO
+from rdr_service.api_util import RDR
 from rdr_service.app_util import auth_required
 from rdr_service.dao.patient_status_dao import PatientStatusDao
 
@@ -8,15 +8,15 @@ class PatientStatusApi(UpdatableApi):
     def __init__(self):
         super(PatientStatusApi, self).__init__(PatientStatusDao(), get_returns_children=True)
 
-    @auth_required(HEALTHPRO)
+    @auth_required(RDR)
     def post(self, p_id, org_id=None):  # pylint: disable=unused-argument
         return super(PatientStatusApi, self).post(participant_id=p_id), 201
 
-    @auth_required(HEALTHPRO)
+    @auth_required(RDR)
     def get(self, p_id, org_id):  # pylint: disable=unused-argument
         return self.dao.get(p_id, org_id)
 
-    @auth_required(HEALTHPRO)
+    @auth_required(RDR)
     def put(self, p_id, org_id):  # pylint: disable=unused-argument
         return super(PatientStatusApi, self).put(org_id, participant_id=p_id, skip_etag=True)
 
@@ -29,6 +29,6 @@ class PatientStatusHistoryApi(BaseApi):
     def __init__(self):
         super(PatientStatusHistoryApi, self).__init__(PatientStatusDao(), get_returns_children=True)
 
-    @auth_required(HEALTHPRO)
+    @auth_required(RDR)
     def get(self, p_id, org_id):
         return self.dao.get_history(p_id, org_id)

--- a/rdr_service/api/questionnaire_api.py
+++ b/rdr_service/api/questionnaire_api.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from rdr_service import app_util
 from rdr_service.api.base_api import UpdatableApi
 from rdr_service.api.etm_api import EtmApi
-from rdr_service.api_util import PTC, PTC_AND_HEALTHPRO
+from rdr_service.api_util import RDR
 from rdr_service.code_constants import PPI_SYSTEM
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.questionnaire_dao import QuestionnaireDao
@@ -14,7 +14,7 @@ class QuestionnaireApi(UpdatableApi):
     def __init__(self):
         super(QuestionnaireApi, self).__init__(QuestionnaireDao())
 
-    @app_util.auth_required(PTC_AND_HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self, id_=None):
         if id_:
             return super(QuestionnaireApi, self).get(id_)
@@ -30,7 +30,7 @@ class QuestionnaireApi(UpdatableApi):
                 raise NotFound(f"Could not find questionnaire with concept: {concept}")
             return self._make_response(questionnaire)
 
-    @app_util.auth_required(PTC)
+    @app_util.auth_required(RDR)
     def post(self):
         # Detect if this is an EtM Questionnaire
         request_json = self.get_request_json()
@@ -40,7 +40,7 @@ class QuestionnaireApi(UpdatableApi):
         else:
             return super(QuestionnaireApi, self).post()
 
-    @app_util.auth_required(PTC)
+    @app_util.auth_required(RDR)
     def put(self, id_):
         return super(QuestionnaireApi, self).put(id_)
 

--- a/rdr_service/api/questionnaire_response_api.py
+++ b/rdr_service/api/questionnaire_response_api.py
@@ -6,7 +6,7 @@ from rdr_service.config import GAE_PROJECT
 from rdr_service.dao.bq_questionnaire_dao import bq_questionnaire_update_task
 from rdr_service.api.base_api import BaseApi
 from rdr_service.api.etm_api import EtmApi
-from rdr_service.api_util import PTC, PTC_AND_HEALTHPRO
+from rdr_service.api_util import RDR
 from rdr_service.dao.code_dao import CodeDao
 from rdr_service.dao.participant_dao import ParticipantDao, raise_if_withdrawn
 from rdr_service.dao.questionnaire_response_dao import QuestionnaireResponseDao
@@ -24,12 +24,12 @@ class QuestionnaireResponseApi(BaseApi):
     def __init__(self):
         super(QuestionnaireResponseApi, self).__init__(QuestionnaireResponseDao())
 
-    @app_util.auth_required(PTC_AND_HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self, p_id, id_):
         # pylint: disable=unused-argument
         return super(QuestionnaireResponseApi, self).get(id_)
 
-    @app_util.auth_required(PTC)
+    @app_util.auth_required(RDR)
     def post(self, p_id):
         # Reject any questionnaire response POSTs for participants that are withdrawn
         participant = ParticipantDao().get(p_id)
@@ -62,7 +62,7 @@ class QuestionnaireResponseApi(BaseApi):
 
 
 class ParticipantQuestionnaireAnswers(Resource):
-    @app_util.auth_required(PTC_AND_HEALTHPRO)
+    @app_util.auth_required(RDR)
     def get(self, p_id=None, module=None):
         """
     Return questionnaire answers for a participant

--- a/tests/api_tests/test_deceased_report_api.py
+++ b/tests/api_tests/test_deceased_report_api.py
@@ -3,7 +3,6 @@ from datetime import date, datetime, timedelta
 import pytz
 
 from rdr_service import config
-from rdr_service.api_util import HEALTHPRO, PTC
 from rdr_service.model.api_user import ApiUser
 from rdr_service.model.deceased_report import DeceasedReport
 from rdr_service.model.participant_summary import ParticipantSummary

--- a/tests/api_tests/test_deceased_report_api.py
+++ b/tests/api_tests/test_deceased_report_api.py
@@ -342,16 +342,6 @@ class DeceasedReportApiTest(DeceasedReportTestBase):
         self.overwrite_test_user_roles(['testing'])
         self.post_report(report_json, expected_status=403)
 
-    def test_health_pro_can_create(self):
-        report_json = self.build_deceased_report_json()
-        self.overwrite_test_user_roles([HEALTHPRO])
-        self.post_report(report_json)
-
-    def test_ptsc_can_create(self):
-        report_json = self.build_deceased_report_json()
-        self.overwrite_test_user_roles([PTC])
-        self.post_report(report_json)
-
     def test_report_auto_approve(self):
         # Deceased reports made for unpaired participants don't need second approval.
         # So these reports should be approved upon creation.
@@ -436,19 +426,6 @@ class DeceasedReportApiTest(DeceasedReportTestBase):
 
         participant_summary = self.get_participant_summary_from_db(participant_id=participant_id)
         self.assertEqual(date(2019, 6, 1), participant_summary.dateOfDeath)
-
-    def test_only_healthpro_can_review(self):
-        report = self.create_pending_deceased_report()
-        review_json = self.build_report_review_json()
-
-        self.overwrite_test_user_roles(['testing'])
-        self.post_report_review(review_json, report.id, report.participantId, expected_status=403)
-
-        self.overwrite_test_user_roles([PTC])
-        self.post_report_review(review_json, report.id, report.participantId, expected_status=403)
-
-        self.overwrite_test_user_roles([HEALTHPRO])
-        self.post_report_review(review_json, report.id, report.participantId, expected_status=200)
 
     def test_report_denial(self):
         report = self.create_pending_deceased_report(
@@ -774,23 +751,3 @@ class SearchDeceasedReportApiTest(DeceasedReportTestBase):
             self.unpaired_3_report_id,  # Authored 02/18
             self.unpaired_2_report_id   # Authored 01/05
         ], self.send_get(f'DeceasedReports?org_id=UNSET'))
-
-    def test_searching_api_by_org_and_status(self):
-        self.assertListResponseMatches(
-            [],
-            self.send_get(f'DeceasedReports?org_id=OTHER&status=preliminary'))
-
-        self.assertListResponseMatches([
-            self.unpaired_1_report_id,  # Authored 04/01
-            self.unpaired_3_report_id  # Authored 02/18
-        ], self.send_get(f'DeceasedReports?org_id=UNSET&status=preliminary'))
-
-    def test_searching_api_by_org_and_status(self):
-        self.overwrite_test_user_roles(['TEST'])
-        self.send_get(f'DeceasedReports', expected_status=403)
-
-        self.overwrite_test_user_roles([PTC])
-        self.send_get(f'DeceasedReports', expected_status=403)
-
-        self.overwrite_test_user_roles([HEALTHPRO])
-        self.send_get(f'DeceasedReports', expected_status=200)

--- a/tests/api_tests/test_genomic_api.py
+++ b/tests/api_tests/test_genomic_api.py
@@ -1,13 +1,11 @@
 import datetime
 import http.client
 import pytz
-import random
 
 from copy import deepcopy
 from dateutil import parser
 from unittest import mock
 
-from rdr_service.api_util import PTC, HEALTHPRO, GEM, RDR
 from rdr_service.dao.database_utils import format_datetime
 from rdr_service.model.consent_file import ConsentType, ConsentSyncStatus
 from rdr_service.services.system_utils import JSONObject
@@ -628,43 +626,6 @@ class GenomicOutreachApiTest(GenomicApiTestBase):
         }
 
         self.send_post(local_path, request_data=payload, expected_status=404)
-
-    def test_get_roles_return_response(self):
-        participant = self._make_participant()
-
-        fake_date = parser.parse('2020-05-29T08:00:01-05:00')
-        self._make_summary(
-            participant,
-            consentForGenomicsRORAuthored=fake_date,
-            consentForStudyEnrollmentAuthored=fake_date
-        )
-        self._make_set_member(
-            participant,
-            genomicWorkflowState=GenomicWorkflowState.GEM_RPT_READY
-        )
-
-        accepted_roles = [PTC, GEM, RDR]
-
-        self.overwrite_test_user_roles(
-            [random.choice(accepted_roles)]
-        )
-
-        resp = self.send_get(
-            f'GenomicOutreach/GEM?participant_id=P{participant.participantId}'
-        )
-
-        self.assertTrue(resp.get('participant_report_statuses') is not None)
-
-        self.overwrite_test_user_roles([HEALTHPRO])
-
-        resp = self.send_get(
-            f'GenomicOutreach/GEM?participant_id=P{participant.participantId}',
-            expected_status=403
-        )
-
-        self.assertTrue(resp.status_code == 403)
-
-
 class GenomicOutreachApiV2Test(GenomicApiTestBase, GenomicDataGenMixin):
     def setUp(self):
         super(GenomicOutreachApiV2Test, self).setUp()


### PR DESCRIPTION
## Resolves *[DA-4644](https://precisionmedicineinitiative.atlassian.net/browse/DA-4644)*


## Description of changes/additions
Removed permissions to access several endpoints, now for internal use only

## Tests
- [x] unit tests




[DA-4644]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ