### PR TITLE
[DA-4964] Remove pairing from PM dao & use `organization` for AwardeeInsite from attribution table

### DIFF
--- a/rdr_service/dao/participant_dao.py
+++ b/rdr_service/dao/participant_dao.py
@@ -518,7 +518,7 @@ class ParticipantDao(UpdatableDao):
             self.switch_to_test_account(None, participant, commit_update=False)
         return participant
 
-    def add_missing_hpo_from_site(self, session, participant_id, site_id):
+    def add_missing_hpo_from_site(self, session, participant_id, site_id, pairing=True):
         if site_id is None:
             raise BadRequest("No site ID given for auto-pairing participant.")
         site = SiteDao().get_with_session(session, site_id)
@@ -531,13 +531,15 @@ class ParticipantDao(UpdatableDao):
 
         if participant.siteId == site.siteId:
             return
-        participant.hpoId = site.hpoId
-        participant.organizationId = site.organizationId
-        participant.siteId = site.siteId
+
         participant.providerLink = make_primary_provider_link_for_id(site.hpoId)
         if participant.participantSummary is None:
             raise RuntimeError(f"No ParticipantSummary available for P{participant_id}.")
-        participant.participantSummary.hpoId = site.hpoId
+        if pairing:
+            participant.hpoId = site.hpoId
+            participant.organizationId = site.organizationId
+            participant.siteId = site.siteId
+            participant.participantSummary.hpoId = site.hpoId
         participant.lastModified = clock.CLOCK.now()
         # Update the version and add history row
         self._do_update(session, participant, participant)

--- a/rdr_service/dao/physical_measurements_dao.py
+++ b/rdr_service/dao/physical_measurements_dao.py
@@ -279,9 +279,9 @@ class PhysicalMeasurementsDao(UpdatableDao):
                 is_amendment = True
                 break
         if obj.collectType == PhysicalMeasurementsCollectType.SELF_REPORTED:
-            self._update_participant_summary(session, obj, is_amendment, is_self_reported=True)
+            participant_summary = self._update_participant_summary(session, obj, is_amendment, is_self_reported=True)
         else:
-            self._update_participant_summary(session, obj, is_amendment)
+            participant_summary = self._update_participant_summary(session, obj, is_amendment)
         existing_measurements = (
             session.query(PhysicalMeasurements).filter(PhysicalMeasurements.participantId == obj.participantId).all()
         )
@@ -300,7 +300,11 @@ class PhysicalMeasurementsDao(UpdatableDao):
         PhysicalMeasurementsDao.set_measurement_ids(obj)
 
         inserted_obj = super(PhysicalMeasurementsDao, self).insert_with_session(session, obj)
-
+        if not is_amendment:  # Amendments aren't expected to have site ID extensions.
+            if participant_summary.biospecimenCollectedSiteId is None:
+                ParticipantDao().add_missing_hpo_from_site(
+                    session, inserted_obj.participantId, inserted_obj.finalizedSiteId
+                )
         # Commit before recalculating the enrollment status-related details so DB queries to retrieve measurements
         # data during the calculation will return what was just inserted
         session.commit()

--- a/rdr_service/dao/physical_measurements_dao.py
+++ b/rdr_service/dao/physical_measurements_dao.py
@@ -303,7 +303,7 @@ class PhysicalMeasurementsDao(UpdatableDao):
         if not is_amendment:  # Amendments aren't expected to have site ID extensions.
             if participant_summary.biospecimenCollectedSiteId is None:
                 ParticipantDao().add_missing_hpo_from_site(
-                    session, inserted_obj.participantId, inserted_obj.finalizedSiteId
+                    session, inserted_obj.participantId, inserted_obj.finalizedSiteId, pairing=False
                 )
         # Commit before recalculating the enrollment status-related details so DB queries to retrieve measurements
         # data during the calculation will return what was just inserted

--- a/rdr_service/dao/physical_measurements_dao.py
+++ b/rdr_service/dao/physical_measurements_dao.py
@@ -258,7 +258,6 @@ class PhysicalMeasurementsDao(UpdatableDao):
         return super(PhysicalMeasurementsDao, self).insert_with_session(session, obj)
 
     def insert_with_session(self, session, obj):
-        participant_summary = None
         is_amendment = False
         obj.logPosition = LogPosition()
         obj.final = True
@@ -280,9 +279,9 @@ class PhysicalMeasurementsDao(UpdatableDao):
                 is_amendment = True
                 break
         if obj.collectType == PhysicalMeasurementsCollectType.SELF_REPORTED:
-            participant_summary = self._update_participant_summary(session, obj, is_amendment, is_self_reported=True)
+            self._update_participant_summary(session, obj, is_amendment, is_self_reported=True)
         else:
-            participant_summary = self._update_participant_summary(session, obj, is_amendment)
+            self._update_participant_summary(session, obj, is_amendment)
         existing_measurements = (
             session.query(PhysicalMeasurements).filter(PhysicalMeasurements.participantId == obj.participantId).all()
         )
@@ -301,11 +300,6 @@ class PhysicalMeasurementsDao(UpdatableDao):
         PhysicalMeasurementsDao.set_measurement_ids(obj)
 
         inserted_obj = super(PhysicalMeasurementsDao, self).insert_with_session(session, obj)
-        if not is_amendment:  # Amendments aren't expected to have site ID extensions.
-            if participant_summary.biospecimenCollectedSiteId is None:
-                ParticipantDao().add_missing_hpo_from_site(
-                    session, inserted_obj.participantId, inserted_obj.finalizedSiteId
-                )
 
         # Commit before recalculating the enrollment status-related details so DB queries to retrieve measurements
         # data during the calculation will return what was just inserted

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -446,6 +446,27 @@ def insert_awardee_insite_data(
             LEFT JOIN `{project}.{src_operational_dataset}.state_mapping` sm
             ON sm.code_value = streetaddress_piistate
           ),
+          organization_cte AS (
+              SELECT participant_id
+                  , event_id
+                  , MAX(event_authored_time) AS activity_date_time
+                  , MAX(CASE WHEN REPLACE(data_element_name, '\u200B', '') = 'activity_status' THEN data_element_value END) AS activity_status
+              FROM `{project}.{src_operational_dataset}.ppsc_attribution_event`
+              WHERE event_type_name = 'Org Attribution' AND ignore_flag = 0
+              GROUP BY 1, 2
+          ),
+          latest_organization_cte AS (
+              SELECT participant_id
+                  , activity_status AS latest_organization
+              FROM (
+                SELECT participant_id
+                  , activity_status
+                  , activity_date_time
+                  , ROW_NUMBER() OVER(PARTITION BY participant_id ORDER BY activity_date_time DESC) AS rn
+                FROM organization_cte
+              )
+              WHERE rn = 1
+          ),
           withdrawn_cte AS (
             SELECT participant_id
             , event_id
@@ -734,7 +755,7 @@ def insert_awardee_insite_data(
               , sample_status_1sal2
               , sample_order_status_1sal2
               , sample_order_status_1sal2_time
-              , o.external_id AS organization
+              , o.external_id AS ps_organization
             FROM `{project}.{src_operational_dataset}.rdr_participant_summary` ps
             LEFT JOIN `{project}.{src_operational_dataset}.rdr_site` s2
             ON ps.biospecimen_source_site_id = s2.site_id
@@ -755,7 +776,7 @@ def insert_awardee_insite_data(
               , phone_number
               , email
               , date_of_birth
-              , organization
+              , COALESCE(latest_organization, ps_organization) AS organization
               , COALESCE(withdrawal_status, 'not_withdrawn') AS withdrawal_status
               , withdrawal_time
               , COALESCE(deactivation_status, 'not_deactivated') AS deactivation_status
@@ -847,6 +868,8 @@ def insert_awardee_insite_data(
             USING (participant_id)
             LEFT JOIN latest_ehr_receipt_time_cte lertc
             ON participant_cte.participant_id = lertc.person_id
+            LEFT JOIN latest_organization_cte
+            USING(participant_id)
           ),
           withdrawn_update AS (
               SELECT

--- a/tests/api_tests/test_physical_measurements_api.py
+++ b/tests/api_tests/test_physical_measurements_api.py
@@ -9,6 +9,7 @@ from rdr_service.clock import FakeClock
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.model.measurements import Measurement
+from rdr_service.model.organization import Organization
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.measurements import PhysicalMeasurements
@@ -339,15 +340,14 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
         self.assertEqual(1, len(sync_response_2["entry"]))
         self.assertNotEqual(sync_response["entry"][0], sync_response_2["entry"][0])
 
-    def test_no_auto_pairing(self):
+    def test_auto_pair_called(self):
         pid_numeric = from_client_participant_id(self.participant_id)
         participant_dao = ParticipantDao()
         self.send_consent(self.participant_id)
         self.send_consent(self.participant_id_2)
         self.assertEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
         self._insert_measurements(datetime.datetime.utcnow().isoformat())
-        # should not pair participant
-        self.assertEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
+        self.assertNotEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
 
     def get_composition_resource_from_fhir_doc(self, data):
         """
@@ -653,7 +653,15 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
                 count += 1
         self.assertEqual(count, 4)
 
-    def test_pairing_doesnt_update(self):
+    def test_pairing_update(self):
+        """
+        There's a bug when PM updates pairing and then the enrollment status is recalculated.
+        Merging the participant summary seems to be resetting the paired organization back to what
+        it was.
+
+        This checks that when pairing gets changed, the organization doesn't revert back.
+        """
+
         # Create a participant summary that has no pairing
         summary = self.data_generator.create_database_participant_summary()
 
@@ -662,11 +670,16 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
             f'Participant/P{summary.participantId}/PhysicalMeasurements',
             load_measurement_json(summary.participantId)
         )
+
+        # The participant's organization should be set to PITT on the summary and participant tables
+        # (PITT is the org used in the PM json)
+        pitt_org = self.session.query(Organization).filter(Organization.externalId == 'PITT_BANNER_HEALTH').one()
+
         self.session.refresh(summary)
-        self.assertEqual(None, summary.organizationId)
+        self.assertEqual(pitt_org.organizationId, summary.organizationId)
 
         participant = self.session.query(Participant).filter(Participant.participantId == summary.participantId).one()
-        self.assertEqual(None, participant.organizationId)
+        self.assertEqual(pitt_org.organizationId, participant.organizationId)
 
     def test_ppsc_roles(self):
         self.overwrite_test_user_roles([PPSC])

--- a/tests/api_tests/test_physical_measurements_api.py
+++ b/tests/api_tests/test_physical_measurements_api.py
@@ -9,7 +9,6 @@ from rdr_service.clock import FakeClock
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.model.measurements import Measurement
-from rdr_service.model.organization import Organization
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.measurements import PhysicalMeasurements
@@ -340,14 +339,15 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
         self.assertEqual(1, len(sync_response_2["entry"]))
         self.assertNotEqual(sync_response["entry"][0], sync_response_2["entry"][0])
 
-    def test_auto_pair_called(self):
+    def test_no_auto_pairing(self):
         pid_numeric = from_client_participant_id(self.participant_id)
         participant_dao = ParticipantDao()
         self.send_consent(self.participant_id)
         self.send_consent(self.participant_id_2)
         self.assertEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
         self._insert_measurements(datetime.datetime.utcnow().isoformat())
-        self.assertNotEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
+        # should not pair participant
+        self.assertEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
 
     def get_composition_resource_from_fhir_doc(self, data):
         """
@@ -653,15 +653,7 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
                 count += 1
         self.assertEqual(count, 4)
 
-    def test_pairing_update(self):
-        """
-        There's a bug when PM updates pairing and then the enrollment status is recalculated.
-        Merging the participant summary seems to be resetting the paired organization back to what
-        it was.
-
-        This checks that when pairing gets changed, the organization doesn't revert back.
-        """
-
+    def test_pairing_doesnt_update(self):
         # Create a participant summary that has no pairing
         summary = self.data_generator.create_database_participant_summary()
 
@@ -670,16 +662,11 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
             f'Participant/P{summary.participantId}/PhysicalMeasurements',
             load_measurement_json(summary.participantId)
         )
-
-        # The participant's organization should be set to PITT on the summary and participant tables
-        # (PITT is the org used in the PM json)
-        pitt_org = self.session.query(Organization).filter(Organization.externalId == 'PITT_BANNER_HEALTH').one()
-
         self.session.refresh(summary)
-        self.assertEqual(pitt_org.organizationId, summary.organizationId)
+        self.assertEqual(None, summary.organizationId)
 
         participant = self.session.query(Participant).filter(Participant.participantId == summary.participantId).one()
-        self.assertEqual(pitt_org.organizationId, participant.organizationId)
+        self.assertEqual(None, participant.organizationId)
 
     def test_ppsc_roles(self):
         self.overwrite_test_user_roles([PPSC])

--- a/tests/api_tests/test_physical_measurements_api.py
+++ b/tests/api_tests/test_physical_measurements_api.py
@@ -9,7 +9,6 @@ from rdr_service.clock import FakeClock
 from rdr_service.dao.participant_dao import ParticipantDao
 from rdr_service.dao.physical_measurements_dao import PhysicalMeasurementsDao
 from rdr_service.model.measurements import Measurement
-from rdr_service.model.organization import Organization
 from rdr_service.model.participant import Participant
 from rdr_service.model.participant_summary import ParticipantSummary
 from rdr_service.model.measurements import PhysicalMeasurements
@@ -152,7 +151,6 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
 
     def test_insert_with_qualifiers(self):
         self.send_consent(self.participant_id)
-        now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         now = self.time2
         with open(data_path("physical_measurements_2.json")) as measurements_file:
             json_text = measurements_file.read() % {
@@ -341,14 +339,15 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
         self.assertEqual(1, len(sync_response_2["entry"]))
         self.assertNotEqual(sync_response["entry"][0], sync_response_2["entry"][0])
 
-    def test_auto_pair_called(self):
+    def test_no_auto_pairing(self):
         pid_numeric = from_client_participant_id(self.participant_id)
         participant_dao = ParticipantDao()
         self.send_consent(self.participant_id)
         self.send_consent(self.participant_id_2)
         self.assertEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
         self._insert_measurements(datetime.datetime.utcnow().isoformat())
-        self.assertNotEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
+        # should not pair participant
+        self.assertEqual(participant_dao.get(pid_numeric).hpoId, UNSET_HPO_ID)
 
     def get_composition_resource_from_fhir_doc(self, data):
         """
@@ -654,15 +653,7 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
                 count += 1
         self.assertEqual(count, 4)
 
-    def test_pairing_update(self):
-        """
-        There's a bug when PM updates pairing and then the enrollment status is recalculated.
-        Merging the participant summary seems to be resetting the paired organization back to what
-        it was.
-
-        This checks that when pairing gets changed, the organization doesn't revert back.
-        """
-
+    def test_pairing_doesnt_update(self):
         # Create a participant summary that has no pairing
         summary = self.data_generator.create_database_participant_summary()
 
@@ -671,16 +662,11 @@ class PhysicalMeasurementsApiTest(BaseTestCase):
             f'Participant/P{summary.participantId}/PhysicalMeasurements',
             load_measurement_json(summary.participantId)
         )
-
-        # The participant's organization should be set to PITT on the summary and participant tables
-        # (PITT is the org used in the PM json)
-        pitt_org = self.session.query(Organization).filter(Organization.externalId == 'PITT_BANNER_HEALTH').one()
-
         self.session.refresh(summary)
-        self.assertEqual(pitt_org.organizationId, summary.organizationId)
+        self.assertEqual(None, summary.organizationId)
 
         participant = self.session.query(Participant).filter(Participant.participantId == summary.participantId).one()
-        self.assertEqual(pitt_org.organizationId, participant.organizationId)
+        self.assertEqual(None, participant.organizationId)
 
     def test_ppsc_roles(self):
         self.overwrite_test_user_roles([PPSC])

--- a/tests/dao_tests/test_physical_measurements_dao.py
+++ b/tests/dao_tests/test_physical_measurements_dao.py
@@ -237,6 +237,7 @@ class PhysicalMeasurementsDaoTest(BaseTestCase):
     def testInsert_getFailsForWithdrawnParticipant(self):
         self._make_summary()
         self.dao.insert(self._make_physical_measurements())
+        self.participant.version += 1
         self.participant.withdrawalStatus = WithdrawalStatus.NO_USE
         ParticipantDao().update(self.participant)
         with self.assertRaises(Forbidden):

--- a/tests/dao_tests/test_physical_measurements_dao.py
+++ b/tests/dao_tests/test_physical_measurements_dao.py
@@ -237,7 +237,6 @@ class PhysicalMeasurementsDaoTest(BaseTestCase):
     def testInsert_getFailsForWithdrawnParticipant(self):
         self._make_summary()
         self.dao.insert(self._make_physical_measurements())
-        self.participant.version += 1
         self.participant.withdrawalStatus = WithdrawalStatus.NO_USE
         ParticipantDao().update(self.participant)
         with self.assertRaises(Forbidden):


### PR DESCRIPTION
## Resolves *[DA-4964](https://precisionmedicineinitiative.atlassian.net/browse/DA-4964)*


## Description of changes/additions
- When doing the investigation on why some participants have `TEST_PROD` set as their organization in awardee_insite & participant_summary, I found that the PhysicalMeasurements endpoint might be the one setting a participant's HPO to `TEST`. Looking at the payload of what we get in the POST request to that endpoint, I notice we get a part that looks like this `{"url":"http://terminology.pmi-ops.org/StructureDefinition/finalized-location","valueReference":"Location/hpo-site-a"}]`. It then looks at the 'hpo-site-a' and then update the participant summary table's hpo_id, organization_id, and site_id to whatever is linked with 'hpo-site-a'. Currently hpo-site-a is linked to TEST hpo in our tables. This PR disables pairing a participant with the finalized site received in the physical_measurement payload.

- This PR also updates the awardee insite query to read `organization` from ppsc attribution table, and if that value is `None` for a participant, then reads `organization` from PS table.


## Tests
- ✅  unit tests




[DA-4964]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ