### PR TITLE
[DA-4970] Morehouse org updates: Intake and Site Attribution

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -140,6 +140,15 @@ class PPSCIntakeAPI(BaseApi):
 
         # Iterate through data elements, add to bulk insert
         for data_element in req_data['dataElements']:
+
+            # DA-4970: Transforming SEEC_MOREHOUSE to DREF_MOREHOUSE
+            if (
+                req_data['activity'].lower() == 'attribution' and
+                data_element.get('dataElementName').lower() == 'activity_status' and
+                data_element.get('dataElementValue').lower() == 'seec_morehouse'
+            ):
+                data_element['dataElementValue'] = 'DREF_MOREHOUSE'
+
             now = clock.CLOCK.now()  # event_listener doesn't work with bulk inserts
             event_dict = {
                 'event_id': participant_event_activity.id,

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -6,6 +6,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from rdr_service.api.base_api import BaseApi, log_api_request
 from rdr_service.api_util import RDR, PPSC
 from rdr_service.app_util import auth_required
+from rdr_service.ppsc_transform_org_map import TRANSFORM_ORG_MAP
 from rdr_service import config, clock
 from rdr_service.dao.ppsc_dao import PPSCDefaultBaseDao, PPSCNphOptEventInDao
 from rdr_service.model.ppsc import (
@@ -39,7 +40,6 @@ class PPSCIntakeAPI(BaseApi):
 
         # Validate
         self.validate_payload(req_data=req_data)
-
 
         # Route to correct activity and insert events
         inserted_event = self.handle_event_insert(
@@ -145,9 +145,9 @@ class PPSCIntakeAPI(BaseApi):
             if (
                 req_data['activity'].lower() == 'attribution' and
                 data_element.get('dataElementName').lower() == 'activity_status' and
-                data_element.get('dataElementValue').lower() == 'seec_morehouse'
+                data_element.get('dataElementValue').upper() in TRANSFORM_ORG_MAP
             ):
-                data_element['dataElementValue'] = 'DREF_MOREHOUSE'
+                data_element['dataElementValue'] = TRANSFORM_ORG_MAP[data_element.get('dataElementValue').upper()]
 
             now = clock.CLOCK.now()  # event_listener doesn't work with bulk inserts
             event_dict = {

--- a/rdr_service/api/ppsc_site_api.py
+++ b/rdr_service/api/ppsc_site_api.py
@@ -75,7 +75,9 @@ class PPSCSiteAPI(BaseApi):
             raise BadRequest(f'Payload for Site is invalid: Required keys - {response_string}')
 
     def handle_site_updates(self, *, site_data: dict) -> Site:
-        # site data
+        if site_data.get("org_id").upper() == "SEEC_MOREHOUSE":
+            site_data["org_id"] = "DREF_MOREHOUSE"
+
         site_record = self.dao.upsert(self.dao.model_type(**site_data))
 
         # event tracking

--- a/rdr_service/api/ppsc_site_api.py
+++ b/rdr_service/api/ppsc_site_api.py
@@ -9,7 +9,7 @@ from rdr_service.app_util import auth_required
 from rdr_service.dao.ppsc_dao import SiteDao, PPSCDefaultBaseDao
 from rdr_service.model.ppsc import PartnerActivity, Site, PartnerEventActivity
 from rdr_service.ppsc.ppsc_legacy_data_sync import SiteDataSync
-
+from rdr_service.ppsc_transform_org_map import TRANSFORM_ORG_MAP
 
 # pylint: disable=broad-except
 class PPSCSiteAPI(BaseApi):
@@ -75,8 +75,9 @@ class PPSCSiteAPI(BaseApi):
             raise BadRequest(f'Payload for Site is invalid: Required keys - {response_string}')
 
     def handle_site_updates(self, *, site_data: dict) -> Site:
-        if site_data.get("org_id").upper() == "SEEC_MOREHOUSE":
-            site_data["org_id"] = "DREF_MOREHOUSE"
+        org_id = site_data.get("org_id")
+        if org_id and org_id.upper() in TRANSFORM_ORG_MAP:
+            site_data["org_id"] = TRANSFORM_ORG_MAP[site_data.get("org_id")]
 
         site_record = self.dao.upsert(self.dao.model_type(**site_data))
 

--- a/rdr_service/ppsc_transform_org_map.py
+++ b/rdr_service/ppsc_transform_org_map.py
@@ -1,0 +1,4 @@
+# Dict that transforms incoming organizations to a different string
+TRANSFORM_ORG_MAP = {
+    "SEEC_MOREHOUSE": "DREF_MOREHOUSE"
+}

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -816,6 +816,42 @@ class PPSCIntakeAPITest(BaseTestCase):
         response = self.send_post('Intake', request_data=payload, expected_status=http.client.BAD_REQUEST)
         self.assertEqual(response.status_code, 400)
 
+    def test_morehouse_attribution_payload_is_updated(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        self.send_valid_primary_consent(participant)
+
+        payload = {
+            "activity": "Attribution",
+            "eventType": "Org Attribution",
+            "participantId": f"P{participant.id}",
+            "dataElements": [
+                {
+                    "dataElementName": "activity_status",
+                    "dataElementValue": "SEEC_MOREHOUSE"
+                },
+                {
+                    "dataElementName": "activity_date_time",
+                    "dataElementValue": "2025-05-20T12:38:00.000Z"
+                },
+            ]
+        }
+
+        test_time = datetime(2025, 5, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
+
+        participant_event_activities = self.ppsc_participant_activity_dao.get_all()
+        original_org = payload.get("dataElements")[0].get("dataElementValue")
+        # Verify that sent data stored in the participant_even_activities as is
+        self.assertEqual(original_org, participant_event_activities[1].resource["dataElements"][0]["dataElementValue"])
+
+        attribution_events = self.attribution_event_dao.get_all()
+        self.assertEqual('Org Attribution', attribution_events[0].event_type_name)
+        # Verify value is transformed
+        self.assertEqual('DREF_MOREHOUSE', attribution_events[0].data_element_value)
+
+
+
     def test_intake_attribution_insert(self):
         participant = self.ppsc_data_gen.create_database_participant()
         self.send_valid_primary_consent(participant)


### PR DESCRIPTION
## Resolves *[DA-4970](https://precisionmedicineinitiative.atlassian.net/browse/DA-4970)*


## Description of changes/additions
Morehouse org was historically paired to Awardee SEEC, however this is no longer going to be the case and Morehouse is now going to be under awardee DREF. However due to limitations in PPSC systems, they cannot make a change to send us the right naming conventions. 

This PR updates the the Intake API. When PPSC sends us participant attribution events with `SEEC_MOREHOUSE` as the org pairing, we will transform this so we instead insert `DREF_MOREHOUSE` for the Org pairing.

Also when PPSC sends us Site hierarchy payloads in site API, `SEEC_MOREHOUSE` will be transformed to `DREF_MOREHOUSE`

## Tests
✅  unit tests




[DA-4970]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ