### PR TITLE
NPH Biospecimen API - BigQuery Refactor

### DIFF
--- a/rdr_service/api/nph_biospecimen_api.py
+++ b/rdr_service/api/nph_biospecimen_api.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import NotFound
 from rdr_service.api.base_api import BaseApi, log_api_request
 from rdr_service.api_util import RTI, RDR_AND_HEALTHPRO
 from rdr_service.app_util import auth_required
-from rdr_service.dao.study_nph_dao import NphBiospecimenDao, NphParticipantDao
+from rdr_service.dao.study_nph_dao import NphBiospecimenDao
 
 
 class NphBiospecimenAPI(BaseApi):
@@ -14,31 +14,24 @@ class NphBiospecimenAPI(BaseApi):
     @auth_required(RDR_AND_HEALTHPRO + [RTI])
     def get(self, nph_participant_id=None):
         log_api_request(log=request.log_record)
-        if nph_participant_id:
-            nph_participant_dao = NphParticipantDao()
-            with nph_participant_dao.session() as session:
-                if nph_participant_dao.get_participant_by_id(
-                    nph_participant_id,
-                    session
-                ):
-                    biospecimen_data = self.dao.get_orders_samples_subquery(
-                        nph_participant_id=nph_participant_id
-                    )
-                    return self._make_response(biospecimen_data)
-                raise NotFound(f'NPH participant {nph_participant_id} was not found')
-        return self._query("nph_participant_id")
 
-    def _make_response(self, payload):
-        payload_response, payload = [], [payload] if type(payload) is not list else payload
-        for participant_obj in payload:
-            updated_payload = {
-                'nph_participant_id': participant_obj.orders_samples_pid,
-                'biospecimens': self.dao.update_biospeciman_stored_samples(
-                    order_samples=participant_obj.orders_sample_status,
-                    order_biobank_samples=participant_obj.orders_sample_biobank_status,
-                )}
-            payload_response.append(updated_payload)
-        return self.dao.to_client_json(payload_response)
+        # Lookup single participant from BigQuery Snapshot
+        if nph_participant_id:
+            rows = self.dao.get_by_participant(int(nph_participant_id))
+            if not rows:
+                raise NotFound(f'NPH participant {nph_participant_id} was not found')
+            return self.dao.to_client_json(rows)
+
+        # list all (paginated)
+        count = int(request.args.get("count", 100))
+        token = request.args.get("token")
+        result = self.dao.get_all(count=count, token=token)
+        return {
+            "items": result.items,
+            "next_token": result.token,
+            "more_available": result.more_available,
+            "total": result.total,
+        }
 
     @classmethod
     def _make_resource_url(cls, response_json, id_field, participant_id):

--- a/rdr_service/api/nph_biospecimen_api.py
+++ b/rdr_service/api/nph_biospecimen_api.py
@@ -28,7 +28,7 @@ class NphBiospecimenAPI(BaseApi):
         result = self.dao.get_all(count=count, token=token)
         return {
             "items": result.items,
-            "next_token": result.token,
+            "pagination_token": result.pagination_token,
             "more_available": result.more_available,
             "total": result.total,
         }

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1,19 +1,21 @@
 import logging
 import json
 
-from datetime import datetime
+from datetime import datetime, date
 from types import SimpleNamespace as Namespace
-from typing import Tuple, Dict, List, Any, Optional, Union
+from typing import Tuple, Dict, List, Any, Optional
 
 from protorpc import messages
 from werkzeug.exceptions import BadRequest, NotFound
 
+from google.cloud import bigquery
+
 from sqlalchemy.orm import Query, aliased
-from sqlalchemy import exc, func, case, and_, literal
+from sqlalchemy import exc, func, and_, literal
 from sqlalchemy.dialects.mysql import JSON
 
 from rdr_service import config
-from rdr_service.ancillary_study_resources.nph.enums import StoredSampleStatus, VisitPeriod, ModuleTypes
+from rdr_service.ancillary_study_resources.nph.enums import VisitPeriod, ModuleTypes
 from rdr_service.model.study_nph import (
     StudyCategory, Participant, Site, Order, OrderedSample,
     Activity, ParticipantEventActivity, EnrollmentEventType,
@@ -23,8 +25,8 @@ from rdr_service.model.study_nph import (
     DlwDosage, EligibleParticipants
 )
 from rdr_service.dao.base_dao import BaseDao, UpdatableDao
-from rdr_service.config import NPH_MIN_BIOBANK_ID, NPH_MAX_BIOBANK_ID
-from rdr_service.query import FieldFilter, Operator, Results
+from rdr_service.config import NPH_MIN_BIOBANK_ID, NPH_MAX_BIOBANK_ID, GAE_PROJECT
+from rdr_service.query import Results
 
 _logger = logging.getLogger("rdr_logger")
 
@@ -1045,11 +1047,11 @@ class NphIntakeDao(BaseDao):
 
 
 class NphBiospecimenDao(BaseDao):
+    SNAPSHOT_TABLE = f"{GAE_PROJECT}.operational_datastream.biospecimens_snapshots"
+
     def __init__(self):
         super().__init__(Order, order_by_ending=["participant_id"])
-
-    def get_id(self, obj):
-        return obj.id
+        self.bq = bigquery.Client()
 
     def from_client_json(self):
         pass
@@ -1057,262 +1059,85 @@ class NphBiospecimenDao(BaseDao):
     def to_client_json(self, payload):
         return payload
 
-    def _initialize_query(self, session, query_def):
-        return self.get_orders_samples_subquery(query_def=query_def)
+    def get_by_participant(self, nph_participant_id: int) -> List[Dict[str, Any]]:
+        """
+        Returns a single participant's biospecimens array
+        """
+        sql = f"""
+            SELECT nph_participant_id, biospecimens
+            FROM `{self.SNAPSHOT_TABLE}`
+            WHERE run_date = (SELECT MAX(run_date) FROM `{self.SNAPSHOT_TABLE}`)
+              AND nph_participant_id = @pid
+        """
+        cfg = bigquery.QueryJobConfig(
+            query_parameters=[bigquery.ScalarQueryParameter("pid", "INT64", nph_participant_id)]
+        )
+        rows = list(self.bq.query(sql, job_config=cfg).result())
+        return [
+            {
+                "nph_participant_id": r["nph_participant_id"],
+                "biospecimens": r["biospecimens"] or [],
+            }
+            for r in rows
+        ]
 
-    def make_query_filter(self, field_name, value):
-        if field_name == 'last_modified':
-            return FieldFilter(
-                'modified',
-                Operator.GREATER_THAN_OR_EQUALS,
-                value
+    def get_all(self, count: int = 100, token: Optional[str] = None) -> Results:
+        """
+        Returns Results(items, next_token, more_available, total=None).
+        Pagination is locked to a single snapshot partition via run_date.
+        """
+        # Get the run_date for this paging session
+        if token:
+            cursor, run_date_str = self._parse_pagination_data(
+                self._unpack_page_token(token),
+                ["participant_id", "run_date"],
             )
-        if field_name == 'nph_paired_site':
-            return FieldFilter(
-                'Site.external_id',
-                Operator.EQUALS,
-                value
-            )
-        if field_name == 'nph_paired_org':
-            return FieldFilter(
-                'Site.organization_external_id',
-                Operator.EQUALS,
-                value
-            )
-        if field_name == 'nph_paired_awardee':
-            return FieldFilter(
-                'Site.awardee_external_id',
-                Operator.EQUALS,
-                value
-            )
-        return super().make_query_filter(field_name, value)
-
-    def query(self, query_definition):
-        if query_definition.invalid_filters and not query_definition.field_filters:
-            raise BadRequest("No valid fields were provided")
-        if not self.order_by_ending:
-            raise BadRequest(f"Can't query on type {self.model_type} -- no order by ending specified")
-        with self.session() as session:
-            total = None
-            query, field_names = self._make_query(session, query_definition)
-            items = query.with_session(session).all()
-            if query_definition.include_total:
-                total = self._count_query(session, query_definition)
-            if not items:
-                return Results([], total=total)
-        if len(items) > query_definition.max_results:
-            page = items[0: query_definition.max_results]
-            token = self._make_pagination_token(
-                item_dict={'participant_id': items[query_definition.max_results - 1].orders_samples_pid},
-                field_names=['participant_id']
-            )
-            return Results(page, token, more_available=True, total=total)
+            run_date = date.fromisoformat(run_date_str)  # keep paging on same partition
         else:
-            token = (
-                self._make_pagination_token(
-                    items[-1].asdict(),
-                    field_names) if query_definition.always_return_token else None
+            run_date = self._get_latest_run_date()
+            cursor = None
+
+        # Capping to 1000 to prevent accidentally huge page pulls.
+        limit = max(1, min(int(count), 1000))
+
+        sql = f"""
+                SELECT nph_participant_id, biospecimens
+                    FROM `{self.SNAPSHOT_TABLE}`
+                WHERE run_date = @run_date
+                    AND (@cursor IS NULL OR nph_participant_id > @cursor)
+                ORDER BY nph_participant_id
+                LIMIT @limit_and_1
+                """
+        cfg = bigquery.QueryJobConfig(query_parameters=[
+            bigquery.ScalarQueryParameter("run_date", "DATE", run_date),
+            bigquery.ScalarQueryParameter("cursor", "INT64", cursor),
+            bigquery.ScalarQueryParameter("limit_and_1", "INT64", limit + 1),
+        ])
+        rows = list(self.bq.query(sql, job_config=cfg).result())
+
+        more = len(rows) > limit
+        page_rows = rows[:limit]
+
+        items = [
+            {"nph_participant_id": row["nph_participant_id"], "biospecimens": row["biospecimens"] or []}
+            for row in page_rows
+        ]
+
+        # Token contains participant_id cursor and the locked run_date
+        next_token = None
+        if items and more:
+            last_id = items[-1]["nph_participant_id"]
+            raw = self._make_pagination_token(
+                item_dict={"participant_id": last_id, "run_date": str(run_date)},
+                field_names=["participant_id", "run_date"],
             )
-            return Results(items, token, more_available=False, total=total)
+            next_token = raw.decode("ascii") if isinstance(raw, (bytes, bytearray)) else raw
 
-    def _set_filters(self, query, filters, model_type=None):
-        model_filter_map = {'Order': Order, 'Site': Site}
-        for field_filter in filters:
-            updated_model_list: List = field_filter.field_name.split('.')
-            model_type, field_name = (model_type or self.model_type), field_filter.field_name
-            if len(updated_model_list) > 1:
-                model_type, field_name = model_filter_map.get(updated_model_list[0]), updated_model_list[-1]
-            try:
-                filter_attribute = getattr(model_type, field_name)
-            except AttributeError:
-                raise BadRequest(f"No field named {field_filter.field_name} found on {model_type}.")
-            query = self._add_filter(query, field_filter, filter_attribute)
-        return query
+        return Results(items, next_token, more_available=more, total=None)
 
-    @classmethod
-    def update_biospeciman_stored_samples(
-        cls,
-        order_samples: dict,
-        order_biobank_samples: dict
-    ) -> Union[Optional[str], Any]:
-        if not order_samples:
-            return []
-        order_samples = order_samples.get('orders_sample_json')
-        for sample in order_samples:
-            sample['biobankStatus'] = []
-            if not order_biobank_samples:
-                continue
-            stored_samples = list(filter(lambda x: x.get('orderSampleID') == sample.get('sampleID'),
-                                         order_biobank_samples.get('orders_sample_biobank_json')))
-
-            sample['biobankStatus'] = [
-                {
-                    "limsID": stored_sample.get('limsID'),
-                    "biobankModified": stored_sample.get('biobankModified'),
-                    "status": str(StoredSampleStatus.lookup_by_number(stored_sample.get('status'))),
-                    "freezeThawCount": stored_sample.get('freezeThawCount'),
-                    "specimenVolumeUl": stored_sample.get('specimenVolumeUl'),
-                    "limsParentSampleID": stored_sample.get('limsParentSampleID')
-                } for stored_sample in stored_samples
-            ]
-        return order_samples
-
-    def get_stored_samples_subquery(
-        self, *, nph_participant_id=None, **kwargs
-    ):
-        stored_sample_alias = aliased(StoredSample)
-        with self.session() as session:
-            stored_samples_subquery = session.query(
-                Participant.id.label('stored_sample_pid'),
-                func.json_object(
-                    'orders_sample_biobank_json',
-                    func.json_arrayagg(
-                        func.json_object(
-                            'limsID', StoredSample.lims_id,
-                            'biobankModified', StoredSample.biobank_modified,
-                            'status', StoredSample.status,
-                            'orderSampleID', StoredSample.sample_id,
-                            'freezeThawCount', StoredSample.freeze_thaw_count,
-                            'specimenVolumeUl', StoredSample.specimen_volume_ul,
-                            'limsParentSampleID', StoredSample.lims_parent_sample_id
-                        )
-                    ), type_=JSON
-                ).label('orders_sample_biobank_status')
-            ).join(
-                StoredSample,
-                StoredSample.biobank_id == Participant.biobank_id
-            ).outerjoin(
-                stored_sample_alias,
-                and_(
-                    StoredSample.biobank_id == stored_sample_alias.biobank_id,
-                    stored_sample_alias.lims_id == StoredSample.lims_id,
-                    stored_sample_alias.status == StoredSample.status,
-                    StoredSample.id < stored_sample_alias.id
-                )
-            ).filter(
-                stored_sample_alias.id.is_(None)
-            ).group_by(Participant.id)
-
-            if nph_participant_id:
-                return stored_samples_subquery.filter(Participant.id == nph_participant_id)
-
-            if query_def := kwargs.get('query_def'):
-                if applicable_filters := [
-                    filter_obj for filter_obj
-                    in query_def.field_filters
-                    if filter_obj.field_name in ['modified']
-                ]:
-                    stored_samples_subquery = self._set_filters(
-                        query=stored_samples_subquery,
-                        filters=applicable_filters,
-                        model_type=StoredSample
-                    )
-
-            return stored_samples_subquery.subquery()
-
-    def get_orders_samples_subquery(self, *, nph_participant_id=None, **kwargs):
-        parent_study_category = aliased(StudyCategory)
-        parent_study_category_module = aliased(StudyCategory)
-        parent_ordered_sample = aliased(OrderedSample)
-        stored_samples_subquery = self.get_stored_samples_subquery(**kwargs)
-        with self.session() as session:
-            sample_orders = session.query(
-                Order.participant_id.label('orders_samples_pid'),
-                func.json_object(
-                    'orders_sample_json',
-                    func.json_arrayagg(
-                        func.json_object(
-                            'orderID', Order.nph_order_id,
-                            'visitID', parent_study_category.name,
-                            'studyID', parent_study_category_module.name,
-                            'timepointID', StudyCategory.name,
-                            'clientID', Order.client_id,
-                            'specimenCode', case(
-                                [
-                                    (OrderedSample.identifier.isnot(None), OrderedSample.identifier),
-                                ],
-                                else_=OrderedSample.test
-                            ),
-                            'volume', OrderedSample.volume,
-                            'volumeUOM', OrderedSample.volumeUnits,
-                            'orderedSampleStatus', case(
-                                [
-                                    (Order.status == 'cancelled', 'Cancelled'),
-                                    (OrderedSample.status.ilike('cancelled'), 'Cancelled'),
-                                ],
-                                else_='Active'
-                            ),
-                            'collectionDateUTC', case(
-                                [
-                                    (OrderedSample.parent_sample_id.isnot(None), parent_ordered_sample.collected),
-                                ],
-                                else_=OrderedSample.collected
-                            ),
-                            'processingDateUTC', case(
-                                [
-                                    (OrderedSample.test.startswith("ST"), OrderedSample.supplemental_fields["freezed"]),
-                                    (OrderedSample.parent_sample_id.isnot(None), OrderedSample.collected),
-                                ],
-                                else_=None
-                            ),
-                            'finalizedDateUTC', case(
-                                [
-                                    (OrderedSample.finalized.isnot(None), OrderedSample.finalized),
-                                ],
-                                else_=None
-                            ),
-                            'sampleID', case(
-                                [
-                                    (OrderedSample.aliquot_id.isnot(None), OrderedSample.aliquot_id),
-                                ],
-                                else_=OrderedSample.nph_sample_id
-                            ),
-                            'kitID', case(
-                                [
-                                    (OrderedSample.identifier.ilike("ST%"), Order.nph_order_id),
-                                    (OrderedSample.test.ilike("ST%"), Order.nph_order_id),
-                                ],
-                                else_=None
-                            ),
-                        )
-                    ), type_=JSON
-                ).label('orders_sample_status'),
-                stored_samples_subquery.c.orders_sample_biobank_status
-            ).join(
-                OrderedSample,
-                OrderedSample.order_id == Order.id
-            ).join(
-                StudyCategory,
-                StudyCategory.id == Order.category_id
-            ).join(
-                PairingEvent,
-                PairingEvent.participant_id == Order.participant_id
-            ).join(
-                Site,
-                Site.id == PairingEvent.site_id
-            ).outerjoin(
-                parent_study_category,
-                parent_study_category.id == StudyCategory.parent_id
-            ).outerjoin(
-                parent_study_category_module,
-                parent_study_category_module.id == parent_study_category.parent_id
-            ).outerjoin(
-                parent_ordered_sample,
-                parent_ordered_sample.id == OrderedSample.parent_sample_id
-            ).outerjoin(
-                stored_samples_subquery,
-                stored_samples_subquery.c.stored_sample_pid == Order.participant_id
-            ).group_by(Order.participant_id)
-
-            if nph_participant_id:
-                sample_orders = sample_orders.filter(
-                    Order.participant_id == nph_participant_id
-                )
-                return sample_orders.all()
-
-            if query_def := kwargs.get('query_def'):
-                if query_def.field_filters:
-                    return sample_orders
+    def _get_latest_run_date(self) -> date:
+        sql = f"SELECT MAX(run_date) AS d FROM `{self.SNAPSHOT_TABLE}`"
+        return list(self.bq.query(sql).result())[0]["d"]  # BigQuery returns a Python date
 
 
 class NphSampleUpdateDao(BaseDao):

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1075,10 +1075,10 @@ class NphBiospecimenDao(BaseDao):
         rows = list(self.bq.query(sql, job_config=cfg).result())
         return [
             {
-                "nph_participant_id": r["nph_participant_id"],
-                "biospecimens": r["biospecimens"] or [],
+                "nph_participant_id": row["nph_participant_id"],
+                "biospecimens": row["biospecimens"] or [],
             }
-            for r in rows
+            for row in rows
         ]
 
     def get_all(self, count: int = 100, token: Optional[str] = None) -> Results:

--- a/rdr_service/dao/study_nph_dao.py
+++ b/rdr_service/dao/study_nph_dao.py
@@ -1047,7 +1047,7 @@ class NphIntakeDao(BaseDao):
 
 
 class NphBiospecimenDao(BaseDao):
-    SNAPSHOT_TABLE = f"{GAE_PROJECT}.operational_datastream.biospecimens_snapshots"
+    SNAPSHOT_TABLE = f"{GAE_PROJECT}.rdr_operational_datastream.biospecimens_snapshots"
 
     def __init__(self):
         super().__init__(Order, order_by_ending=["participant_id"])

--- a/tests/api_tests/test_nph_biospecimen_api.py
+++ b/tests/api_tests/test_nph_biospecimen_api.py
@@ -89,7 +89,3 @@ class NphBiospecimenAPITest(BaseTestCase):
         self.assertEqual([item["nph_participant_id"] for item in response_2["items"]], [3])
         self.assertFalse(response_2["more_available"])
         self.assertIsNone(response_2["pagination_token"])
-
-    def tearDown(self):
-        self.tearDown()
-        self.clear_table_after_test("nph.participant")

--- a/tests/api_tests/test_nph_biospecimen_api.py
+++ b/tests/api_tests/test_nph_biospecimen_api.py
@@ -90,3 +90,6 @@ class NphBiospecimenAPITest(BaseTestCase):
         self.assertFalse(response_2["more_available"])
         self.assertIsNone(response_2["pagination_token"])
 
+    def tearDown(self):
+        self.tearDown()
+        self.clear_table_after_test("nph.participant")

--- a/tests/api_tests/test_nph_biospecimen_api.py
+++ b/tests/api_tests/test_nph_biospecimen_api.py
@@ -1,264 +1,92 @@
-from dateutil import parser
-from datetime import datetime
+from datetime import date
+from unittest.mock import patch
 
-from rdr_service import clock
-from rdr_service.ancillary_study_resources.nph.enums import StoredSampleStatus
-from rdr_service.dao.study_nph_dao import NphParticipantDao, NphSiteDao, NphOrderDao, NphOrderedSampleDao
-from rdr_service.data_gen.generators.nph import NphDataGenerator, NphSmsDataGenerator
+from rdr_service.dao.study_nph_dao import NphBiospecimenDao
 
 from tests.helpers.unittest_base import BaseTestCase
+from tests.helpers.fake_bq import FakeBQClient
 
 
 class NphBiospecimenAPITest(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.nph_data_gen = NphDataGenerator()
-        self.sms_data_gen = NphSmsDataGenerator()
-        self.nph_participant = NphParticipantDao()
-        self.nph_site_dao = NphSiteDao()
-        self.nph_order_dao = NphOrderDao()
-        self.nph_order_sample_dao = NphOrderedSampleDao()
 
-        # nph activities
-        for activity_name in ['ENROLLMENT', 'PAIRING']:
-            self.nph_data_gen.create_database_activity(
-                name=activity_name
-            )
+    def make_fake_rows(self, ids):
+        # Minimal to test API functionality. BigQuery results should be verified independently
+        return [{"nph_participant_id": i, "biospecimens": [{"orderID": str(i)}]} for i in ids]
 
-        # nph pairing event type
-        self.nph_data_gen.create_database_pairing_event_type(name="INITIAL")
+    @patch("rdr_service.dao.study_nph_dao.bigquery.Client")
+    def test_get_by_participant_404(self, bq_mock):
+        bq_mock.return_value = FakeBQClient({date(2025, 9, 3): self.make_fake_rows([1, 2])})
+        dao = NphBiospecimenDao()
+        response = dao.get_by_participant(999)
+        self.assertEqual(response, [])
 
-        for _ in range(2):
-            self.nph_data_gen.create_database_participant()
+    @patch("rdr_service.dao.study_nph_dao.bigquery.Client")
+    def test_get_by_participant(self, bq_mock):
+        bq_mock.return_value = FakeBQClient({date(2025, 9, 3): self.make_fake_rows([1, 2])})
+        dao = NphBiospecimenDao()
+        result = dao.get_by_participant(2)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0]["biospecimens"], list)
 
-        for i in range(1, 3):
-            self.nph_data_gen.create_database_site(
-                external_id=f"nph-test-site-{i}",
-                name=f"nph-test-site-name-{i}",
-                awardee_external_id=f"nph-test-hpo-{i}",
-                organization_external_id=f"nph-test-org-{i}"
-            )
+    @patch("rdr_service.dao.study_nph_dao.bigquery.Client")
+    def test_get_page_with_token(self, bq_mock):
+        bq_mock.return_value = FakeBQClient({date(2025, 9, 3): self.make_fake_rows([1, 2, 3, 4, 5, 6])})
+        dao = NphBiospecimenDao()
+        result = dao.get_all(count=5, token=None)
+        self.assertEqual(len(result.items), 5)
+        self.assertTrue(result.more_available)
+        self.assertIsNotNone(result.pagination_token)
+        self.assertEqual(result.items[-1]["nph_participant_id"], 5)
 
-    def create_nph_biospecimen_data(self, **kwargs):
-        num_orders = kwargs.get('num_orders', 2)
-        num_ordered_samples = kwargs.get('num_order_samples', 4)
-        num_stored_samples = kwargs.get('num_stored_samples', 1)
-        created_date = kwargs.get('created_dates', clock.CLOCK.now())
+    @patch("rdr_service.dao.study_nph_dao.bigquery.Client")
+    def test_get_all_second_page(self, bq_mock):
+        bq_mock.return_value = FakeBQClient({date(2025, 9, 3): self.make_fake_rows([1, 2, 3, 4, 5, 6])})
+        dao = NphBiospecimenDao()
+        result_1 = dao.get_all(count=5)
+        result_2 = dao.get_all(count=5, token=result_1.pagination_token)
+        self.assertEqual(len(result_2.items), 1)
+        self.assertFalse(result_2.more_available)
+        self.assertEqual(result_2.items[0]["nph_participant_id"], 6)
 
-        category = self.sms_data_gen.create_database_study_category(
-            type_label="Test",
-        )
+    @patch("rdr_service.dao.study_nph_dao.bigquery.Client")
+    def test_pagination_locks_run_date(self, bq_mock):
+        # First partition
+        partitions = {date(2025, 9, 3): self.make_fake_rows([1, 2, 3, 4, 5, 6])}
+        fake = FakeBQClient(partitions)
+        bq_mock.return_value = fake
 
-        for num, participant in enumerate(self.nph_participant.get_all()):
+        dao = NphBiospecimenDao()
+        result_1 = dao.get_all(count=3)  # token should contain run_date=2025-09-03
 
-            # create pairing data / should be only 2 sites for pairing
-            self.nph_data_gen.create_database_pairing_event(
-                participant_id=participant.id,
-                event_authored_time=datetime(2023, 1, 1, 12, 1),
-                site_id=2 if num % 2 != 0 else 1
-            )
+        # New partition arrives
+        partitions[date(2025, 9, 4)] = self.make_fake_rows([10, 11, 12])
 
-            for i in range(num_orders):
-                order = self.sms_data_gen.create_database_order(
-                    nph_order_id=f"10{participant.id + (i + 1) + participant.biobank_id}",
-                    participant_id=participant.id,
-                    notes="Test",
-                    category_id=category.id,
-                    created=created_date,
-                    modified=created_date
-                )
-                for _ in range(num_ordered_samples):
-                    self.sms_data_gen.create_database_ordered_sample(
-                        order_id=order.id,
-                        nph_sample_id=f'11{participant.id}'
-                    )
-                    for _ in range(num_stored_samples):
-                        self.sms_data_gen.create_database_stored_sample(
-                            biobank_id=participant.biobank_id,
-                            sample_id=f'11{participant.id}',
-                            lims_id=f"33{participant.id}",
-                            status=StoredSampleStatus.RECEIVED,
-                            freeze_thaw_count=3,
-                            specimen_volume_ul=79
-                        )
+        # Page 2 should still read from 2025-09-03 partition
+        result_2 = dao.get_all(count=3, token=result_1.pagination_token)
+        self.assertEqual([i["nph_participant_id"] for i in result_2.items], [4, 5, 6])
 
-    def test_biospecimen_non_existent_participant_id(self):
-        non_existent_id = 22222222
-        response = self.send_get(f'nph/Biospecimen/{non_existent_id}', expected_status=404)
-        self.assertIsNotNone(response)
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json.get('message'), f'NPH participant {non_existent_id} was not found')
+    @patch("rdr_service.dao.study_nph_dao.bigquery.Client")
+    def test_api_get_single_participant(self, bq_mock):
+        bq_mock.return_value = FakeBQClient({date(2025, 9, 3): self.make_fake_rows([1001])})
+        response = self.send_get("nph/Biospecimen/1001")
+        self.assertIsInstance(response, list)
+        self.assertEqual(response[0]["nph_participant_id"], 1001)
 
-    def test_biospecimen_by_participant_id(self):
-        self.create_nph_biospecimen_data()
-        first_nph_participant = self.nph_participant.get_all()[0]
-        response = self.send_get(f'nph/Biospecimen/{first_nph_participant.id}')
-        self.assertIsNotNone(response)
-        self.assertEqual(len(response), 1)
+    @patch("rdr_service.dao.study_nph_dao.bigquery.Client")
+    def test_api_get_all_with_pages(self, bq_mock):
+        bq_mock.return_value = FakeBQClient({date(2025, 9, 3): self.make_fake_rows([1, 2, 3])})
 
-        response_data = response[0]
-        self.assertEqual(len(response_data.keys()), 2)
-        self.assertEqual(list(response_data.keys()), ['nph_participant_id', 'biospecimens'])
-        self.assertEqual(response_data.get('nph_participant_id'), first_nph_participant.id)
+        # Page 1
+        response_1 = self.send_get("nph/Biospecimen?count=2")
+        self.assertEqual(len(response_1["items"]), 2)
+        self.assertTrue(response_1["more_available"])
+        self.assertIsNotNone(response_1["pagination_token"])
 
-        current_participant_orders = self.nph_order_dao.get_orders_by_participant_id(first_nph_participant.id)
-        self.assertEqual(len(current_participant_orders), 2)
+        # Page 2
+        response_2 = self.send_get("nph/Biospecimen", query_string={"count": 2, "token": response_1["pagination_token"]})
+        self.assertEqual([item["nph_participant_id"] for item in response_2["items"]], [3])
+        self.assertFalse(response_2["more_available"])
+        self.assertIsNone(response_2["pagination_token"])
 
-        current_order_ids = {obj.nph_order_id for obj in current_participant_orders}
-        response_order_ids = {obj.get('orderID') for obj in response_data.get('biospecimens')}
-        self.assertEqual(current_order_ids, response_order_ids)
-
-        for response_order_id in response_order_ids:
-            response_ordered_samples = [obj for obj in response_data.get('biospecimens') if obj.get('orderID') == response_order_id]
-            # should have four ordered sample(s) for each order
-            self.assertEqual(len(response_ordered_samples), 4)
-
-            for response_ordered_sample in response_ordered_samples:
-                self.assertIsNotNone(response_ordered_sample.get('biobankStatus'))
-                # should have for stored sample(s) for each ordered sample
-                stored_sample_list = response_ordered_sample.get('biobankStatus')
-                self.assertEqual(len(stored_sample_list), 1)
-                self.assertEqual(3, stored_sample_list[0]['freezeThawCount'])
-                self.assertEqual(79, stored_sample_list[0]['specimenVolumeUl'])
-
-    def test_biospecimen_by_last_modified_returns_correctly(self):
-        fake_date_one = parser.parse('2020-05-28T08:00:01-05:00')
-        fake_date_two = parser.parse('2020-05-30T08:00:01-05:00')
-        fake_date_three = parser.parse('2020-05-31T08:00:01-05:00')
-
-        with clock.FakeClock(fake_date_two):
-            self.create_nph_biospecimen_data(
-                num_orders=1,
-                created_date=fake_date_two
-            )
-
-        response = self.send_get(f'nph/Biospecimen?last_modified={fake_date_three}')
-        self.assertIsNotNone(response)
-        self.assertEqual(response.get('entry'), [])
-
-        response = self.send_get(f'nph/Biospecimen?last_modified={fake_date_one}')
-        self.assertIsNotNone(response)
-        self.assertIsNotNone(response.get('entry'))
-        self.assertEqual(len(response.get('entry')), 2)
-
-    def test_biospecimen_last_modified_pagination(self):
-        fake_date_one = parser.parse('2020-05-28T08:00:01-05:00')
-        fake_date_two = parser.parse('2020-05-30T08:00:01-05:00')
-        first_nph_participant = self.nph_participant.get_all()[0]
-        second_nph_participant = self.nph_participant.get_all()[1]
-        num_count = 1
-
-        with clock.FakeClock(fake_date_two):
-            self.create_nph_biospecimen_data(
-                created_date=fake_date_two
-            )
-
-        response = self.send_get(f'nph/Biospecimen?last_modified={fake_date_one}&_count={num_count}')
-        self.assertIsNotNone(response)
-        self.assertIsNotNone(response.get('entry'))
-        self.assertEqual(len(response.get('entry')), num_count)
-
-        response_data = response.get('entry')[0]['resource'][0]
-        self.assertEqual(list(response_data.keys()), ['nph_participant_id', 'biospecimens'])
-        self.assertEqual(response_data.get('nph_participant_id'), first_nph_participant.id)
-
-        # should have next link
-        self.assertIsNotNone(response.get('link'))
-        self.assertEqual(response['link'][0]['relation'], 'next')
-
-        self.assertEqual(len(response['entry']), 1)
-        self.assertIsNotNone(response['entry'][0]['fullUrl'])
-
-        current_response_nph_pid = response['entry'][0]['resource'][0]['nph_participant_id']
-        self.assertEqual(current_response_nph_pid, first_nph_participant.id)
-        self.assertTrue(f'rdr/v1/nph/Biospecimen/{current_response_nph_pid}'
-                        in response['entry'][0]['fullUrl'])
-
-        next_pagination_link = response['link'][0]['url'].split('v1/')[-1]
-
-        next_response = self.send_get(next_pagination_link)
-        self.assertIsNotNone(next_response.get('entry'))
-        self.assertEqual(len(next_response.get('entry')), num_count)
-
-        response_data = next_response.get('entry')[0]['resource'][0]
-        self.assertEqual(list(response_data.keys()), ['nph_participant_id', 'biospecimens'])
-        self.assertEqual(response_data.get('nph_participant_id'), second_nph_participant.id)
-
-        # should not have next link
-        self.assertIsNone(next_response.get('link'))
-
-        self.assertEqual(len(next_response['entry']), 1)
-        self.assertIsNotNone(next_response['entry'][0]['fullUrl'])
-
-        current_response_nph_pid = next_response['entry'][0]['resource'][0]['nph_participant_id']
-        self.assertEqual(current_response_nph_pid, second_nph_participant.id)
-        self.assertTrue(f'rdr/v1/nph/Biospecimen/{current_response_nph_pid}'
-                        in next_response['entry'][0]['fullUrl'])
-
-    # FILTER DB ATTRIBUTE MAPPING FOR NPH SITE = {
-    #     'nph_paired_site': 'external_id',
-    #     'nph_paired_org': 'organization_external_id',
-    #     'nph_paired_awardee': 'awardee_external_id'
-    # }
-
-    def test_filter_by_nph_paired_site(self):
-        self.create_nph_biospecimen_data()
-        first_nph_site = self.nph_site_dao.get_all()[0]
-        first_nph_participant = self.nph_participant.get_all()[0]
-        response = self.send_get(f'nph/Biospecimen?nph_paired_site={first_nph_site.external_id}')
-
-        self.assertIsNotNone(response)
-        self.assertIsNotNone(response.get('entry'))
-        self.assertEqual(len(response.get('entry')), 1)
-
-        response_data = response.get('entry')[0]['resource'][0]
-        self.assertEqual(list(response_data.keys()), ['nph_participant_id', 'biospecimens'])
-
-        # should be first participant linked to first site external_id
-        self.assertEqual(response_data.get('nph_participant_id'), first_nph_participant.id)
-
-    def test_filter_by_nph_paired_org(self):
-        self.create_nph_biospecimen_data()
-        first_nph_site = self.nph_site_dao.get_all()[0]
-        first_nph_participant = self.nph_participant.get_all()[0]
-
-        response = self.send_get(f'nph/Biospecimen?nph_paired_org={first_nph_site.organization_external_id}')
-
-        self.assertIsNotNone(response)
-        self.assertIsNotNone(response.get('entry'))
-        self.assertEqual(len(response.get('entry')), 1)
-
-        response_data = response.get('entry')[0]['resource'][0]
-        self.assertEqual(list(response_data.keys()), ['nph_participant_id', 'biospecimens'])
-
-        # should be first participant linked to first site organization_external_id
-        self.assertEqual(response_data.get('nph_participant_id'), first_nph_participant.id)
-
-    def test_filter_by_nph_paired_awardee(self):
-        self.create_nph_biospecimen_data()
-        first_nph_site = self.nph_site_dao.get_all()[0]
-        first_nph_participant = self.nph_participant.get_all()[0]
-
-        response = self.send_get(f'nph/Biospecimen?nph_paired_awardee={first_nph_site.awardee_external_id}')
-
-        self.assertIsNotNone(response)
-        self.assertIsNotNone(response.get('entry'))
-        self.assertEqual(len(response.get('entry')), 1)
-
-        response_data = response.get('entry')[0]['resource'][0]
-        self.assertEqual(list(response_data.keys()), ['nph_participant_id', 'biospecimens'])
-
-        # should be first participant linked to first site awardee_external_id
-        self.assertEqual(response_data.get('nph_participant_id'), first_nph_participant.id)
-
-    def tearDown(self):
-        super().tearDown()
-        self.clear_table_after_test("nph.participant")
-        self.clear_table_after_test("nph.site")
-        self.clear_table_after_test("nph.order")
-        self.clear_table_after_test("nph.ordered_sample")
-        self.clear_table_after_test("nph.stored_sample")
-        self.clear_table_after_test("nph.activity")
-        self.clear_table_after_test("nph.pairing_event_type")
-        self.clear_table_after_test("nph.participant_event_activity")
-        self.clear_table_after_test("nph.pairing_event")

--- a/tests/helpers/fake_bq.py
+++ b/tests/helpers/fake_bq.py
@@ -1,0 +1,63 @@
+# This file is for faking a BigQuery client for unit tests
+
+from datetime import date
+from typing import Dict, List, Any
+
+
+class Row(dict):
+    __getattr__ = dict.get
+
+
+class FakeBQJob:
+    def __init__(self, rows): self._rows = rows
+
+    def result(self): return self._rows
+
+
+class FakeBQClient:
+    """
+    This is currently only used for the Biospecimen API.
+    Future iterations should generalize this if usage become widespread
+    """
+
+    def __init__(self, partitions: Dict[date, List[Dict[str, Any]]]):
+        self.partitions = partitions  # {date: [rows...]}
+
+    def _max_run_date(self):
+        return max(self.partitions) if self.partitions else None
+
+    def query(self, sql: str, job_config=None):
+        # Parameters used in the query to fake
+        params = {}
+        if job_config and getattr(job_config, "query_parameters", None):
+            params = {p.name: p.value for p in job_config.query_parameters}
+
+        # Handle SELECT MAX(run_date) AS d
+        if "SELECT MAX(run_date) AS d" in sql:
+            return FakeBQJob([Row({"d": self._max_run_date()})])
+
+        # Determine run_date
+        run_date = params.get("run_date", None)
+        if run_date is None:
+            run_date = self._max_run_date()
+
+        # Base rows from chosen partition
+        rows = [Row(r) for r in sorted(
+            self.partitions.get(run_date, []),
+            key=lambda r: r["nph_participant_id"]
+        )]
+
+        # Single participant path
+        if "AND nph_participant_id = @pid" in sql:
+            pid = params["pid"]
+            rows = [r for r in rows if r["nph_participant_id"] == pid]
+            return FakeBQJob(rows)
+
+        # List path (cursor + limit)
+        cursor = params.get("cursor", None)
+        if cursor is not None:
+            rows = [r for r in rows if r["nph_participant_id"] > cursor]
+
+        limit_and_1 = params.get("limit_and_1") or params.get("limit_plus1") or 1000
+        rows = rows[: int(limit_and_1)]
+        return FakeBQJob(rows)

--- a/tests/workflow_tests/test_nph_sms_workflows.py
+++ b/tests/workflow_tests/test_nph_sms_workflows.py
@@ -31,6 +31,7 @@ class NphSmsWorkflowsTest(BaseTestCase):
         self.clear_table_after_test("nph.sms_sample")
         self.clear_table_after_test("nph.sms_n0")
         self.clear_table_after_test("nph.sms_n1_mc1")
+        self.clear_table_after_test("nph.participant")
 
     def create_cloud_csv(self, test_data_filename, file_name, bucket=None, prefix=None):
 


### PR DESCRIPTION
## Resolves *[DA-4990](https://precisionmedicineinitiative.atlassian.net/browse/DA-4990)*


## Description of changes/additions
This PR refactors the NPH Biospecimen API. The API now retrieves data from a BigQuery snapshot table rather than the MySQL `nph` database. 

**Snapshot Table:** `rdr_operational_datastream.biospecimens_snapshots` 

The snapshot table is updated daily via a scheduled query: 
[Biospecimen Scheduled Snapshot Query](https://console.cloud.google.com/bigquery?sq=106251944765:92827f4dac37493493f7e7cbc84f9c70)

The previous iteration of this API ran out of resources while compiling the query results into the output data structure. This is now compiled in the BQ snapshot table via the query linked above. The table is partitioned by `run_date`.

RTI always pulls all data from all time. They have never applied any other filtering. There are no other users of this API. Because this is a MVP for RTI's use case, filtering on `last_modified`, Org, Awardee, and Site have been removed. Filtering on a single NPH Participant has been retained.

The complicated ORM query and related functions have been removed, replaced with a straight-forward SQL statement to retrieve the latest snapshot.
Pagination has been somewhat re-worked to allow it to work outside of the previous MySQL model framework. Existing BaseDAO code was used where possible.

Unit tests were created to ensure pre- and post-BigQuery logic aligned with expectations. A `fake_bq` module was created to allow for mocking BQ results in unit tests, though this is currently specific to this implementation. Further testing of the API's integration with BigQuery was performed successfully on Sandbox.

## Tests
- [x] unit tests
- [x] BigQuery integration testing on Sandbox 




[DA-4990]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ