### PR TITLE
Fix awardee insite datafeed query

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -922,13 +922,22 @@ def insert_awardee_insite_data(
                 , CURRENT_TIMESTAMP() AS created
                 , *
             FROM withdrawn_update
+          ),
+          latest_datafeed_records AS (
+              SELECT * EXCEPT(rn)
+              FROM (
+                SELECT *
+                , ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY created DESC) AS rn
+                FROM `{project}.{destination_dataset}.datafeed_input_awardee_insite`
+              )
+              WHERE rn = 1
           )
 
         SELECT *
         FROM final_result_with_surrogate_key fr
         WHERE NOT EXISTS (
             SELECT 1
-            FROM `{project}.{destination_dataset}.datafeed_input_awardee_insite` staging_data
+            FROM latest_datafeed_records staging_data
             WHERE staging_data.participant_id = fr.participant_id  -- to detect new pids
                 AND staging_data.surrogate_key = fr.surrogate_key  -- to detect updated records
         );


### PR DESCRIPTION
## Resolves *[DA-NA]*


## Description of changes/additions
- Updated the query to retrieve the latest record of a participant from the datafeed input table. Used in checking if any of the participant's value has changed from the current values in the awardee insite.

## Tests
- [] unit tests (Tested in BQ)


