### PR TITLE
[DA-4998] Allow Test Account payloads for participants without primary consent

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -98,7 +98,7 @@ class PPSCIntakeAPI(BaseApi):
                                               self.primary_consent_types,
                                               'activity_status',
                                               '%yes%'):
-                raise BadRequest(f"No Primary Consent record found. event type is: {req_data['eventType']}, list is: {self.primary_consent_types}")
+                raise BadRequest("No Primary Consent record found.")
 
         # Check Enrollment Status for timestamps
         if req_data['eventType'] == "Enrollment Status":

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -98,7 +98,7 @@ class PPSCIntakeAPI(BaseApi):
                                               self.primary_consent_types,
                                               'activity_status',
                                               '%yes%'):
-                raise BadRequest("No Primary Consent record found.")
+                raise BadRequest(f"No Primary Consent record found. event type is: {req_data['eventType']}, list is: {self.primary_consent_types}")
 
         # Check Enrollment Status for timestamps
         if req_data['eventType'] == "Enrollment Status":

--- a/rdr_service/config/base_config.json
+++ b/rdr_service/config/base_config.json
@@ -212,7 +212,8 @@
   ],
   "ppsc_primary_consent_types": [
     "Primary Consent",
-    "Pediatric Permission"
+    "Pediatric Permission",
+    "Test Flag"
   ],
   "ppsc_intake_consent_event_types": ["Primary Consent", "Adult EHR Authorization", "Pediatric Permission"],
   "ppsc_intake_survey_completion_event_types": [

--- a/rdr_service/config/config_dev.json
+++ b/rdr_service/config/config_dev.json
@@ -211,7 +211,8 @@
   ],
   "ppsc_primary_consent_types": [
     "Primary Consent",
-    "Pediatric Permission"
+    "Pediatric Permission",
+    "Test Flag"
   ],
   "ppsc_intake_consent_event_types": ["Primary Consent", "Adult EHR Authorization", "Pediatric Permission"],
   "ppsc_intake_survey_completion_event_types": [

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -1310,6 +1310,28 @@ class PPSCIntakeAPITest(BaseTestCase):
         with clock.FakeClock(test_time):
             self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
 
+    def test_intake_test_account_allowed(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        payload = {
+            "activity": "Participant Status",
+            "eventType": "Test Flag",
+            "participantId": f"P{participant.id}",
+            "dataElements": [
+                {
+                    "dataElementName": "activity_status",
+                    "dataElementValue": "test"
+                },
+                {
+                    "dataElementName": "activity_date_time",
+                    "dataElementValue": "2024-05-20T14:30:00.000Z"
+                },
+            ]
+        }
+
+        test_time = datetime(2024, 6, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.OK)
+
     def test_requests_log_generation(self):
         participant = self.ppsc_data_gen.create_database_participant()
         self.send_valid_primary_consent(participant)


### PR DESCRIPTION
## Resolves *[DA-4998](https://precisionmedicineinitiative.atlassian.net/browse/DA-4998)*


## Description of changes/additions
Added Test Flag event type to primary consent check

## Tests
- [x] unit tests




[DA-4998]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ