### PR TITLE
[DA-4933] Validate Date of Birth in Profile Update payloads

### DIFF
--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -115,9 +115,9 @@ class PPSCIntakeAPI(BaseApi):
                 if item['dataElementName'].lower() == 'piibirthinformation_birthdate':
                     dob_present = True
                     if item.get('dataElementValue', None) is None:
-                        raise BadRequest(f"Invalid Date of Birth")
+                        raise BadRequest("Invalid Date of Birth")
             if not dob_present:
-                raise BadRequest(f"Profile Data payload missing Date of Birth")
+                raise BadRequest("Profile Data payload missing Date of Birth")
 
     def handle_event_insert(self, *, req_data: dict):
         activity_record = list(filter(lambda x: x.name.lower() == req_data['activity'].lower(),

--- a/rdr_service/api/ppsc_intake_api.py
+++ b/rdr_service/api/ppsc_intake_api.py
@@ -108,6 +108,17 @@ class PPSCIntakeAPI(BaseApi):
                     if not name+'_date_time' in data_element_names:
                         raise BadRequest(f"Enrollment Status {name} is missing {name+'_date_time'}.")
 
+        # Check profile data for date of birth
+        if req_data['eventType'] == 'Profile Data':
+            dob_present = False
+            for item in req_data['dataElements']:
+                if item['dataElementName'].lower() == 'piibirthinformation_birthdate':
+                    dob_present = True
+                    if item.get('dataElementValue', None) is None:
+                        raise BadRequest(f"Invalid Date of Birth")
+            if not dob_present:
+                raise BadRequest(f"Profile Data payload missing Date of Birth")
+
     def handle_event_insert(self, *, req_data: dict):
         activity_record = list(filter(lambda x: x.name.lower() == req_data['activity'].lower(),
                                       self.activity_records))

--- a/tests/api_tests/test_ppsc_intake_api.py
+++ b/tests/api_tests/test_ppsc_intake_api.py
@@ -513,6 +513,10 @@ class PPSCIntakeAPITest(BaseTestCase):
                     "dataElementName": "activity_date_time",
                     "dataElementValue": "2024-05-20T14:30:00.000Z"
                 },
+                {
+                    "dataElementName": "piibirthinformation_birthdate",
+                    "dataElementValue": "2000-01-01"
+                }
             ]
         }
 
@@ -530,7 +534,7 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual(4, participant_event_activities.activity_id)
 
         profile_updates_events = self.profile_updates_event_dao.get_all()
-        self.assertEqual(3, len(profile_updates_events))
+        self.assertEqual(4, len(profile_updates_events))
 
         self.assertEqual(test_time, profile_updates_events[0].created)
         self.assertEqual(test_time, profile_updates_events[0].modified)
@@ -555,6 +559,14 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.assertEqual('Profile Data', profile_updates_events[2].event_type_name)
         self.assertEqual('activity_date_time', profile_updates_events[2].data_element_name)
         self.assertEqual("2024-05-20T14:30:00.000Z", profile_updates_events[2].data_element_value)
+
+        self.assertEqual(test_time, profile_updates_events[3].created)
+        self.assertEqual(test_time, profile_updates_events[3].modified)
+        self.assertEqual(participant_event_activities.id, profile_updates_events[3].event_id)
+        self.assertEqual(participant.id, profile_updates_events[3].participant_id)
+        self.assertEqual('Profile Data', profile_updates_events[3].event_type_name)
+        self.assertEqual('piibirthinformation_birthdate', profile_updates_events[3].data_element_name)
+        self.assertEqual("2000-01-01", profile_updates_events[3].data_element_value)
 
     def test_intake_withdrawal_event_type_validation(self):
         participant = self.ppsc_data_gen.create_database_participant()
@@ -1303,6 +1315,10 @@ class PPSCIntakeAPITest(BaseTestCase):
                     "dataElementName": "activity_date_time",
                     "dataElementValue": "2024-05-20T14:30:00.000Z"
                 },
+                {
+                    "dataElementName": "piibirthinformation_birthdate",
+                    "dataElementValue": "2020-01-01"
+                }
             ]
         }
 
@@ -1358,4 +1374,32 @@ class PPSCIntakeAPITest(BaseTestCase):
         self.clear_table_after_test("ppsc.deactivation_event")
         self.clear_table_after_test("ppsc.participant_status_event")
         self.clear_table_after_test("ppsc.attribution_event")
+
+    def test_intake_date_of_birth_validation(self):
+        participant = self.ppsc_data_gen.create_database_participant()
+        self.send_valid_primary_consent(participant)
+
+        payload = {
+            "activity": "Profile Updates",
+            "eventType": "Profile Data",
+            "participantId": f"P{participant.id}",
+            "dataElements": [
+                {
+                    "dataElementName": "first_name",
+                    "dataElementValue": "Jane"
+                },
+                {
+                    "dataElementName": "last_name",
+                    "dataElementValue": "Eyre"
+                },
+                {
+                    "dataElementName": "activity_date_time",
+                    "dataElementValue": "2024-05-20T14:30:00.000Z"
+                }
+            ]
+        }
+
+        test_time = datetime(2024, 6, 25, 12, 1)
+        with clock.FakeClock(test_time):
+            self.send_post('Intake', request_data=payload, expected_status=http.client.BAD_REQUEST)
 


### PR DESCRIPTION
## Resolves *[DA-4933](https://precisionmedicineinitiative.atlassian.net/browse/DA-4933)*


## Description of changes/additions
Added validation to ensure DoB is required in Profile Data payloads

## Tests
- [x] unit tests




[DA-4933]: https://precisionmedicineinitiative.atlassian.net/browse/DA-4933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ