### PR TITLE
Safety policy fixes

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -13,7 +13,7 @@ security: # configuration for the `safety check` command
             expires: '2022-10-21' # datetime string - date this ignore will expire, best practice to use this variable
         51668:
             reason: using SQLAlchemy versions >=1.4.0 is causing failures # optional, for internal note purposes to communicate with your team. This reason will be reported in the Safety reports
-            expires: '2025-12-31' # datetime string - date this ignore will expire, best practice to use this variable
+            expires: '2026-06-30' # datetime string - date this ignore will expire, best practice to use this variable
         65213:
             reason: RDR code not run on PowerPC architecture
             expires: '2030-01-01'

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -96,7 +96,7 @@ six==1.15.0               # via astroid, cryptography, flask-restful, geventhttp
 snowballstemmer==2.0.0    # via sphinx
 sphinx==6.2.1
 sqlalchemy==1.3.17        # via -r requirements.in, alembic, dictalchemy
-sqlparse==0.5.0           # via -r requirements.in
+sqlparse==0.5.5           # via -r requirements.in
 supervisor==4.2.0         # via -r requirements.in
 text-unidecode==1.3       # via faker
 toml==0.10.1              # via pylint


### PR DESCRIPTION
## Resolves *[NA]*


## Description of changes/additions
- Bumping the safety check date for SQLAlchemy
- Safety check was giving `vulnerability found in sqlparse version 0.5.0`, so upgrading that library

## Tests
- [] unit tests


