### PR TITLE
[DA-5081] Implement Pulling Data from RWB BigQuery (As Part of the VWB Transition)

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -188,6 +188,7 @@ PPSC_DATAFEED_DEST_DATASET = 'ppsc_datafeed_dest_dataset'
 VWB_DATAFEED_DATASET = 'vwb_datafeed_dataset'
 VWB_WORKSPACES_SRC_TABLE = 'vwb_workspaces_src_table'
 VWB_WORKSPACES_ID_MAPPING_TABLE = 'vwb_workspaces_id_mapping_table'
+WB_RESEARCHERS_SRC_TABLE = 'wb_researchers_src_table'
 
 CVL_SITES_DATA_BUCKETS = {
     "bcm": "prod-genomics-data-baylor",

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -39,6 +39,8 @@ WORKSPACE_ENUM_FIELDS = ['status', 'sex_at_birth', 'gender_identity', 'sexual_or
                          'disability_status', 'access_to_care', 'education_level', 'income_level', 'aian_research_type',
                          'access_tier', 'workspace_users', 'creator', 'resource']
 
+RESEARCHER_ENUM_FIELDS = ['ethnicity', 'education', 'disability', 'user_id', 'verified_institutional_affiliation',
+                          'demographicSurveyV2', 'gender', 'race', 'sex_at_birth', 'degree', 'access_tier_short_names']
 
 class WorkbenchWorkspaceDao(UpdatableDao):
     def __init__(self):
@@ -1028,8 +1030,31 @@ class WorkbenchResearcherDao(UpdatableDao):
                 survey["sexualOrientations"] = sexual_orientations
                 item["demographicSurveyV2"] = survey
 
+    def bq_row_to_dict(self, row: bigquery.Row, current_timestamp: str) -> dict:
+        row_dict = self._build_survey_parameters(row.get("demographicSurveyV2"))
 
+        for key in row.keys():
+            if key not in RESEARCHER_ENUM_FIELDS:
+                camel_key = self.snake_to_camel(key)
+                row_dict[camel_key] = row[key]
 
+        row_dict['workbenchInstitutionalAffiliations'] = (
+            self._get_affiliations(row.get('affiliations'), row.get('verified_institutional_affiliation'))
+        )
+        row_dict['userSourceId'] = row['user_id']
+        row_dict['created'] = current_timestamp
+        row_dict['modified'] = current_timestamp
+        row_dict['ethnicity'] = WorkbenchResearcherEthnicity(row.get('ethnicity', 'UNSET'))
+        row_dict['education'] = WorkbenchResearcherEducation(row.get('education', 'UNSET'))
+        row_dict['disability'] = WorkbenchResearcherDisability(row.get('disability', 'UNSET'))
+        row_dict['resource'] = "No resource payload. Data from VWB 2.0"
+        row_dict['gender'] = [WorkbenchResearcherGender.to_dict().get(x) for x in row.get('gender')]
+        row_dict['race'] = [WorkbenchResearcherRace.to_dict().get(x) for x in row.get('race')]
+        row_dict['sexAtBirth'] = [WorkbenchResearcherSexAtBirthV2.to_dict().get(x) for x in row.get('sex_at_birth')]
+        row_dict['degree'] = [WorkbenchResearcherDegree.to_dict().get(x) for x in row.get('degree')]
+        row_dict['accessTierShortNames'] = [WorkbenchResearcherAccessTierShortName.to_dict().get(x) for x in
+                                               row.get('access_tier_short_names')]
+        return row_dict
 
     def get_redcap_audit_researchers(
         self,
@@ -1249,18 +1274,21 @@ class WorkbenchResearcherDao(UpdatableDao):
             survey_params = {
                 'dsv2CompletionTime': parse(survey.get('completionTime')) if survey.get(
                     'completionTime') is not None else None,
-                'dsv2EthnicCategories': survey.get('ethnicCategories'),
+                'dsv2EthnicCategories': [WorkbenchResearcherEthnicCategory.to_dict().get(x) for x in
+                                         survey.get('ethnicCategories')],
                 'dsv2EthnicityAiAnOther': survey.get('ethnicityAiAnOtherText'),
                 'dsv2EthnicityAsianOther': survey.get('ethnicityAsianOtherText'),
-                'dsv2EthnicityBlackOther': survey.get('ethnicityAsianOtherText'),
+                'dsv2EthnicityBlackOther': survey.get('ethnicityBlackOtherText'),
                 'dsv2EthnicityHispanicOther': survey.get('ethnicityHispanicOtherText'),
                 'dsv2EthnicityMeNaOther': survey.get('ethnicityMeNaOtherText'),
                 'dsv2EthnicityNhPiOther': survey.get('ethnicityNhPiOtherText'),
                 'dsv2EthnicityWhiteOther': survey.get('ethnicityWhiteOtherText'),
                 'dsv2EthnicityOther': survey.get('ethnicityOtherText'),
-                'dsv2GenderIdentities': survey.get('genderIdentities'),
+                'dsv2GenderIdentities': [WorkbenchResearcherGenderIdentity.to_dict().get(x) for x in
+                                         survey.get('genderIdentities')],
                 'dsv2GenderOther': survey.get('genderOtherText'),
-                'dsv2SexualOrientations': survey.get('sexualOrientations'),
+                'dsv2SexualOrientations': [WorkbenchResearcherSexualOrientationV2.to_dict().get(x) for x in
+                                           survey.get('sexualOrientations')],
                 'dsv2OrientationOther': survey.get('orientationOtherText'),
                 'dsv2SexAtBirth': WorkbenchResearcherSexAtBirthV2(survey.get('sexAtBirth', 'UNSET')),
                 'dsv2SexAtBirthOther': survey.get('sexAtBirthOtherText'),
@@ -1284,6 +1312,7 @@ class WorkbenchResearcherDao(UpdatableDao):
                 'dsv2EthnicCategories': [],
                 'dsv2EthnicityAiAnOther': None,
                 'dsv2EthnicityAsianOther': None,
+                'dsv2EthnicityBlackOther': None,
                 'dsv2EthnicityHispanicOther': None,
                 'dsv2EthnicityMeNaOther': None,
                 'dsv2EthnicityNhPiOther': None,

--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -1031,7 +1031,7 @@ class WorkbenchResearcherDao(UpdatableDao):
                 item["demographicSurveyV2"] = survey
 
     def bq_row_to_dict(self, row: bigquery.Row, current_timestamp: str) -> dict:
-        row_dict = self._build_survey_parameters(row.get("demographicSurveyV2"))
+        row_dict = self._build_survey_parameters(row.get("demographicSurveyV2"), bq_request=True)
 
         for key in row.keys():
             if key not in RESEARCHER_ENUM_FIELDS:
@@ -1269,13 +1269,13 @@ class WorkbenchResearcherDao(UpdatableDao):
         return session.query(WorkbenchResearcher).filter(WorkbenchResearcher.userSourceId.in_(user_id_list)).all()
 
     @staticmethod
-    def _build_survey_parameters(survey):
+    def _build_survey_parameters(survey, bq_request=False):
         if survey:
             survey_params = {
                 'dsv2CompletionTime': parse(survey.get('completionTime')) if survey.get(
                     'completionTime') is not None else None,
-                'dsv2EthnicCategories': [WorkbenchResearcherEthnicCategory.to_dict().get(x) for x in
-                                         survey.get('ethnicCategories')],
+                'dsv2EthnicCategories': survey.get('ethnicCategories') if not bq_request else
+                    [WorkbenchResearcherEthnicCategory.to_dict().get(x) for x in survey.get('ethnicCategories')],
                 'dsv2EthnicityAiAnOther': survey.get('ethnicityAiAnOtherText'),
                 'dsv2EthnicityAsianOther': survey.get('ethnicityAsianOtherText'),
                 'dsv2EthnicityBlackOther': survey.get('ethnicityBlackOtherText'),
@@ -1284,11 +1284,11 @@ class WorkbenchResearcherDao(UpdatableDao):
                 'dsv2EthnicityNhPiOther': survey.get('ethnicityNhPiOtherText'),
                 'dsv2EthnicityWhiteOther': survey.get('ethnicityWhiteOtherText'),
                 'dsv2EthnicityOther': survey.get('ethnicityOtherText'),
-                'dsv2GenderIdentities': [WorkbenchResearcherGenderIdentity.to_dict().get(x) for x in
-                                         survey.get('genderIdentities')],
+                'dsv2GenderIdentities': survey.get('genderIdentities') if not bq_request else
+                    [WorkbenchResearcherGenderIdentity.to_dict().get(x) for x in survey.get('genderIdentities')],
                 'dsv2GenderOther': survey.get('genderOtherText'),
-                'dsv2SexualOrientations': [WorkbenchResearcherSexualOrientationV2.to_dict().get(x) for x in
-                                           survey.get('sexualOrientations')],
+                'dsv2SexualOrientations': survey.get('sexualOrientations') if not bq_request else
+                    [WorkbenchResearcherSexualOrientationV2.to_dict().get(x) for x in survey.get('sexualOrientations')],
                 'dsv2OrientationOther': survey.get('orientationOtherText'),
                 'dsv2SexAtBirth': WorkbenchResearcherSexAtBirthV2(survey.get('sexAtBirth', 'UNSET')),
                 'dsv2SexAtBirthOther': survey.get('sexAtBirthOtherText'),

--- a/rdr_service/researchers_offline/main.py
+++ b/rdr_service/researchers_offline/main.py
@@ -2,14 +2,17 @@
 import logging
 import traceback
 
-from flask import Flask, got_request_exception
+from flask import Flask, got_request_exception, request
 from sqlalchemy.exc import DBAPIError
 
 from rdr_service import app_util
+from rdr_service.config import GAE_PROJECT
 from rdr_service.researchers_offline.participant_counts_over_time import calculate_participant_metrics
 from rdr_service.services.flask import RESEARCHERS_OFFLINE_PREFIX, flask_start, flask_stop
 from rdr_service.services.gcp_logging import begin_request_logging, end_request_logging,\
     flask_restful_log_exception_error
+from rdr_service.workflow_management.researchers_offline.workbench_data_transfer_input_feed import \
+    WorkbenchWorkspacesFeed, WorkbenchResearchersFeed
 
 
 @app_util.auth_required_scheduler
@@ -28,6 +31,23 @@ def participant_counts_over_time():
     calculate_participant_metrics()
     return '{"success": "true"}'
 
+@app_util.auth_required_scheduler
+def workbench_workspaces_input_feed():
+    logging.info('Starting workbench workspaces datafeed...')
+    datafeed = request.get_json().get("datafeed")
+    input_feed = WorkbenchWorkspacesFeed(project=GAE_PROJECT)
+    input_feed.run_datafeed(datafeed)
+    return '{ "success": "true" }'
+
+@app_util.auth_required_scheduler
+def workbench_researchers_input_feed():
+    logging.info('Starting workbench researchers datafeed...')
+    datafeed = request.get_json().get("datafeed")
+    input_feed = WorkbenchResearchersFeed(project=GAE_PROJECT)
+    input_feed.run_datafeed(datafeed)
+    return '{ "success": "true" }'
+
+
 def _build_pipeline_app():
     """Configure and return the app with non-resource pipeline-triggering endpoints."""
     researchers_offline = Flask(__name__)
@@ -45,6 +65,20 @@ def _build_pipeline_app():
         endpoint="participant_counts_over_time",
         view_func=participant_counts_over_time,
         methods=["GET"],
+    )
+
+    researchers_offline.add_url_rule(
+        RESEARCHERS_OFFLINE_PREFIX + "WorkbenchWorkspacesInputFeed",
+        endpoint="workbench_workspaces_input_feed",
+        view_func=workbench_workspaces_input_feed,
+        methods=["GET", "POST"]
+    )
+
+    researchers_offline.add_url_rule(
+        RESEARCHERS_OFFLINE_PREFIX + "WorkbenchResearchersInputFeed",
+        endpoint="workbench_researchers_input_feed",
+        view_func=workbench_researchers_input_feed,
+        methods=["GET", "POST"]
     )
 
     researchers_offline.add_url_rule('/_ah/start', endpoint='start', view_func=flask_start, methods=["GET"])

--- a/rdr_service/workflow_management/researchers_offline/data_feed_queries.py
+++ b/rdr_service/workflow_management/researchers_offline/data_feed_queries.py
@@ -40,3 +40,21 @@ def get_workbench_workspaces_data_to_stream(project: str, dataset: str, mapping_
             AND rwws.modified_time = DATETIME(st.modified_time, 'UTC')
         )
     """
+
+def get_workbench_researchers_data_to_stream(project: str, dataset: str, source_table: str) -> str:
+    """Get data for Workbench Researchers to stream to MySQL. The SQL will return any records that are in
+    the staging table but not in MySQL
+    """
+    return f"""
+        SELECT
+            st.* EXCEPT (creation_time, modified_time),
+            DATETIME(st.creation_time, 'UTC') AS creation_time,
+            DATETIME(st.modified_time, 'UTC') AS modified_time
+        FROM `{project}.{dataset}.{source_table}` st
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM `rdr_operational_datastream.rdr_workbench_researcher` rwr
+            WHERE rwr.user_source_id = st.user_id
+            AND rwr.modified_time = DATETIME(st.modified_time, 'UTC')
+        )
+    """

--- a/rdr_service/workflow_management/researchers_offline/workbench_data_transfer_input_feed.py
+++ b/rdr_service/workflow_management/researchers_offline/workbench_data_transfer_input_feed.py
@@ -2,8 +2,9 @@ import logging
 from google.cloud import bigquery
 
 from rdr_service import clock, config
-from rdr_service.dao.workbench_dao import WorkbenchWorkspaceDao
+from rdr_service.dao.workbench_dao import WorkbenchWorkspaceDao, WorkbenchResearcherDao
 from rdr_service.dao.metadata_dao import WORKBENCH_LAST_SYNC_KEY, MetadataDao
+from rdr_service.model.workbench_researcher import WorkbenchResearcher
 from rdr_service.model.workbench_workspace import WorkbenchWorkspaceSnapshot
 from rdr_service.workflow_management.ppsc.ppsc_data_transfer_input_feed import PPSCBigQueryDatafeedBase
 from rdr_service.workflow_management.researchers_offline import data_feed_queries
@@ -55,3 +56,41 @@ class WorkbenchWorkspacesFeed(PPSCBigQueryDatafeedBase):
                 now = clock.CLOCK.now()
                 workspaces_dict = dao.bq_row_to_dict(row, now)
                 dao.insert([WorkbenchWorkspaceSnapshot(**workspaces_dict)])
+
+
+class WorkbenchResearchersFeed(PPSCBigQueryDatafeedBase):
+
+    def __init__(self, project='test'):
+        self.project = project
+        self.bq_client = bigquery.Client()
+
+    def make_datafeed_job(self, job_def: str):
+        """Runs the query in BQ and returns the result."""
+        return self.bq_client.query(job_def).result()
+
+    def get_datafeed_definition(self) -> dict:
+        vwb_dataset = config.getSettingJson(config.VWB_DATAFEED_DATASET, ['rdr_workbench'])[0]
+        src_table = config.getSettingJson(config.WB_RESEARCHERS_SRC_TABLE, ['v_researchers_expanded'])[0]
+
+        job_def = {
+            # Query to stream new data to MySQL
+            "streaming_data_sql": data_feed_queries.get_workbench_researchers_data_to_stream(
+                self.project, vwb_dataset, src_table
+            ),
+            "destination_model": WorkbenchResearcher,
+        }
+
+        return job_def
+
+    def run_datafeed(self, datafeed: str) -> None:
+        logging.info(f"Running {datafeed} Data Feed...")
+
+        datafeed_def = self.get_datafeed_definition()
+        streaming_data_rows = list(self.make_datafeed_job(datafeed_def["streaming_data_sql"]))
+
+        dao = WorkbenchResearcherDao()
+        if streaming_data_rows:
+            for row in streaming_data_rows:
+                now = clock.CLOCK.now()
+                researchers_dict = dao.bq_row_to_dict(row, now)
+                dao.insert([WorkbenchResearcher(**researchers_dict)])

--- a/tests/workflow_tests/test_workbench_data_transfer.py
+++ b/tests/workflow_tests/test_workbench_data_transfer.py
@@ -1,14 +1,17 @@
 import datetime
 from unittest import mock
 
-from rdr_service.dao.workbench_dao import WorkbenchWorkspaceDao
+from rdr_service.dao.workbench_dao import WorkbenchWorkspaceDao, WorkbenchResearcherDao
+from rdr_service.model.workbench_researcher import WorkbenchResearcher
 from rdr_service.model.workbench_workspace import WorkbenchWorkspaceSnapshot
 from rdr_service.participant_enums import WorkbenchWorkspaceStatus, WorkbenchWorkspaceSexAtBirth, \
     WorkbenchWorkspaceGenderIdentity, WorkbenchWorkspaceGeography, WorkbenchWorkspaceSexualOrientation, \
     WorkbenchWorkspaceAccessToCare, WorkbenchWorkspaceDisabilityStatus, WorkbenchWorkspaceEducationLevel, \
-    WorkbenchWorkspaceIncomeLevel, WorkbenchWorkspaceAianResearchType, WorkbenchWorkspaceAccessTier
+    WorkbenchWorkspaceIncomeLevel, WorkbenchWorkspaceAianResearchType, WorkbenchWorkspaceAccessTier, \
+    WorkbenchResearcherEthnicity, WorkbenchResearcherEducation, WorkbenchResearcherDisability, \
+    WorkbenchResearcherYesNoPreferNot, WorkbenchResearcherSexAtBirthV2, WorkbenchResearcherEducationV2
 from rdr_service.workflow_management.researchers_offline.workbench_data_transfer_input_feed import \
-    WorkbenchWorkspacesFeed
+    WorkbenchWorkspacesFeed, WorkbenchResearchersFeed
 from tests.helpers.unittest_base import BaseTestCase
 
 
@@ -18,7 +21,7 @@ class WorkbenchWorkspacesDataFeedTest(BaseTestCase):
 
     @mock.patch("rdr_service.dao.workbench_dao.WorkbenchWorkspaceDao.bq_row_to_dict")
     @mock.patch("google.cloud.bigquery.Client")
-    def test_run_datafeed(self, mock_bq_client, mock_row_to_dict):
+    def test_run_workspace_datafeed(self, mock_bq_client, mock_row_to_dict):
         time_1 = datetime.datetime(2025, 11, 1, 20, 1, 1, 976505)
         time_2 = datetime.datetime(2025, 11, 5, 10, 10, 15, 900005)
 
@@ -210,3 +213,104 @@ class WorkbenchWorkspacesDataFeedTest(BaseTestCase):
         self.assertEqual(actual_rows[1].aianResearchType, WorkbenchWorkspaceAianResearchType('NO_AI_AN_ANALYSIS'))
         self.assertEqual(actual_rows[1].aianResearchDetails, "Test research details 2")
         self.assertEqual(actual_rows[1].resource, "No resource payload. Data from VWB 2.0")
+
+    @mock.patch("rdr_service.dao.workbench_dao.WorkbenchResearcherDao.bq_row_to_dict")
+    @mock.patch("google.cloud.bigquery.Client")
+    def test_run_researcher_datafeed(self, mock_bq_client, mock_row_to_dict):
+        time_1 = datetime.datetime(2025, 12, 1, 20, 1, 1, 976505)
+        time_2 = datetime.datetime(2025, 12, 5, 10, 10, 15, 900005)
+
+        record = [
+            {
+                "userSourceId": 10,
+                "creationTime": time_1,
+                "modifiedTime": time_2,
+                "givenName": "Jim",
+                "familyName": "Smith",
+                "email": "test@email.com",
+                "streetAddress1": "Street",
+                "city": "Town",
+                "state": "TN",
+                "zipCode": "11111",
+                "country": "US",
+                "ethnicity": WorkbenchResearcherEthnicity('NOT_HISPANIC'),
+                "gender": [2],
+                "race": [1, 5],
+                "sexAtBirth": [3, 1],
+                "education": WorkbenchResearcherEducation('COLLEGE_GRADUATE'),
+                "degree": [11, 6, 8],
+                "disability": WorkbenchResearcherDisability('NO'),
+                "identifiesAsLgbtq": True,
+                "lgbtqIdentity": "Bisexual",
+                "accessTierShortNames": [2, 1],
+                "dsv2CompletionTime": time_2,
+                "dsv2EthnicCategories": [20, 66, 68, 70],
+                "dsv2EthnicityAsianOther": "Asian",
+                "dsv2EthnicityBlackOther": "Black",
+                "dsv2EthnicityHispanicOther": "Hispanic",
+                "dsv2GenderIdentities": [8, 2],
+                "dsv2SexualOrientations": [9, 12],
+                "dsv2SexAtBirth": WorkbenchResearcherSexAtBirthV2("MALE"),
+                "dsv2YearOfBirth": 2000,
+                "dsv2YearOfBirthPreferNot": False,
+                "dsv2DisabilityHearing": WorkbenchResearcherYesNoPreferNot('NO'),
+                "dsv2DisabilitySeeing": WorkbenchResearcherYesNoPreferNot('PREFER_NOT_TO_ANSWER'),
+                "dsv2DisabilityConcentrating": WorkbenchResearcherYesNoPreferNot('YES'),
+                "dsv2DisabilityWalking": WorkbenchResearcherYesNoPreferNot('NO'),
+                "dsv2DisabilityDressing": WorkbenchResearcherYesNoPreferNot('YES'),
+                "dsv2DisabilityErrands": WorkbenchResearcherYesNoPreferNot('NO'),
+                "dsv2Education": WorkbenchResearcherEducationV2('DOCTORATE'),
+                "dsv2Disadvantaged": WorkbenchResearcherYesNoPreferNot('NO'),
+                "resource": "No resource payload. Data from VWB 2.0"
+            }
+        ]
+
+        mock_bq_instance = mock_bq_client.return_value
+        mock_bq_instance.query.return_value.result.return_value = record
+        mock_row_to_dict.side_effect = [record[0]]
+
+        workbench_feed = WorkbenchResearchersFeed()
+        workbench_feed.get_datafeed_definition = mock.Mock(return_value={
+            "streaming_data_sql": "streaming_sql",
+            "destination_model": WorkbenchResearcher
+        })
+
+        workbench_feed.run_datafeed("WorkbenchResearchersFeed")
+        workbench_researcher_dao = WorkbenchResearcherDao()
+        actual_rows = workbench_researcher_dao.get_all()
+
+        self.assertEqual(actual_rows[0].userSourceId, 10)
+        self.assertEqual(actual_rows[0].givenName, "Jim")
+        self.assertEqual(actual_rows[0].creationTime, datetime.datetime(2025, 12, 1, 20, 1, 1, 976505))
+        self.assertEqual(actual_rows[0].modifiedTime, datetime.datetime(2025, 12, 5, 10, 10, 15, 900005))
+        self.assertEqual(actual_rows[0].dsv2CompletionTime, datetime.datetime(2025, 12, 5, 10, 10, 15, 900005))
+        self.assertEqual(actual_rows[0].email, "test@email.com")
+        self.assertEqual(actual_rows[0].city, "Town")
+        self.assertEqual(actual_rows[0].zipCode, "11111")
+        self.assertEqual(actual_rows[0].ethnicity, WorkbenchResearcherEthnicity.NOT_HISPANIC)
+        self.assertEqual(actual_rows[0].gender, [2])
+        self.assertEqual(actual_rows[0].race, [1, 5])
+        self.assertEqual(actual_rows[0].sexAtBirth, [3, 1])
+        self.assertEqual(actual_rows[0].education, WorkbenchResearcherEducation.COLLEGE_GRADUATE)
+        self.assertEqual(actual_rows[0].degree, [11, 6, 8])
+        self.assertEqual(actual_rows[0].disability, WorkbenchResearcherDisability.NO)
+        self.assertEqual(actual_rows[0].identifiesAsLgbtq, True)
+        self.assertEqual(actual_rows[0].lgbtqIdentity, "Bisexual")
+        self.assertEqual(actual_rows[0].accessTierShortNames, [2, 1])
+        self.assertEqual(actual_rows[0].dsv2EthnicCategories, [20, 66, 68, 70])
+        self.assertEqual(actual_rows[0].dsv2EthnicityAsianOther, "Asian")
+        self.assertEqual(actual_rows[0].dsv2EthnicityBlackOther, "Black")
+        self.assertEqual(actual_rows[0].dsv2EthnicityHispanicOther, "Hispanic")
+        self.assertEqual(actual_rows[0].dsv2GenderIdentities, [8, 2])
+        self.assertEqual(actual_rows[0].dsv2SexualOrientations, [9, 12])
+        self.assertEqual(actual_rows[0].dsv2SexAtBirth, WorkbenchResearcherSexAtBirthV2.MALE)
+        self.assertEqual(actual_rows[0].dsv2YearOfBirth, 2000)
+        self.assertEqual(actual_rows[0].dsv2DisabilityHearing, WorkbenchResearcherYesNoPreferNot.NO)
+        self.assertEqual(actual_rows[0].dsv2DisabilitySeeing, WorkbenchResearcherYesNoPreferNot.PREFER_NOT_TO_ANSWER)
+        self.assertEqual(actual_rows[0].dsv2DisabilityConcentrating, WorkbenchResearcherYesNoPreferNot.YES)
+        self.assertEqual(actual_rows[0].dsv2DisabilityWalking, WorkbenchResearcherYesNoPreferNot.NO)
+        self.assertEqual(actual_rows[0].dsv2DisabilityDressing, WorkbenchResearcherYesNoPreferNot.YES)
+        self.assertEqual(actual_rows[0].dsv2DisabilityErrands, WorkbenchResearcherYesNoPreferNot.NO)
+        self.assertEqual(actual_rows[0].dsv2Education, WorkbenchResearcherEducationV2.DOCTORATE)
+        self.assertEqual(actual_rows[0].dsv2Disadvantaged, WorkbenchResearcherYesNoPreferNot.NO)
+        self.assertEqual(actual_rows[0].resource, "No resource payload. Data from VWB 2.0")


### PR DESCRIPTION
## Resolves *[DA-5081](https://precisionmedicineinitiative.atlassian.net/browse/DA-5081)*


## Description of changes/additions
As part of the RWB 1.0 to Verily Workbench transition, the RDR will now be pulling data from the Workbench instead of having it pushed to us. Scheduled queries have been set up in Stable to pull researcher data from RWB 1.0’s BigQuery tables into the RDR BigQuery tables. These changes set up a workflow to pull data from the RDR BQ into the RDR MySQL tables.

## Tests
- [X] unit tests
- Manually ran the workflow to test BigQuery to MySQL transfer
- Deployed and tested on Sandbox




[DA-5081]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ