### PR TITLE
[DA-5105] Update Audit Workspace Directory Inclusion Logic

### DIFF
--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -1433,9 +1433,10 @@ class WorkbenchWorkspaceAuditDao(UpdatableDao):
     def insert_with_session(self, session, workbench_audit_records):
         for record in workbench_audit_records:
             session.add(record)
-            if record.auditWorkspaceDisplayDecision == \
-                WorkbenchAuditWorkspaceDisplayDecision.PUBLISH_TO_RESEARCHER_DIRECTORY and \
-                record.auditWorkspaceAccessDecision == WorkbenchAuditWorkspaceAccessDecision.UNSET:
+            if ((record.auditWorkspaceDisplayDecision ==
+                 WorkbenchAuditWorkspaceDisplayDecision.PUBLISH_TO_RESEARCHER_DIRECTORY or
+                 record.auditWorkspaceDisplayDecision == WorkbenchAuditWorkspaceDisplayDecision.UNSET)
+               and record.auditWorkspaceAccessDecision == WorkbenchAuditWorkspaceAccessDecision.UNSET):
                 self.add_approved_workspace_with_session(session, record.workspaceSnapshotId)
             else:
                 self.remove_approved_workspace_with_session(session, record.workspaceSnapshotId)

--- a/tests/api_tests/test_workspace_audit_and_research_directory_api.py
+++ b/tests/api_tests/test_workspace_audit_and_research_directory_api.py
@@ -2145,3 +2145,216 @@ class ResearchProjectsDirectoryApiTest(BaseTestCase):
         result = self.send_get('researchHub/projectDirectory')
         self.assertEqual(3, len(result['data']))
         self.assertEqual(result['totalActiveProjects'], 3)
+
+    def test_post_audit_display_decision_includes_unset_values(self):
+        # create researchers
+        researchers_json = [
+            {
+                "userId": 0,
+                "creationTime": "2019-11-26T21:21:13.056Z",
+                "modifiedTime": "2019-11-26T21:21:13.056Z",
+                "givenName": "given name 1",
+                "familyName": "family name 1",
+                "streetAddress1": "string",
+                "streetAddress2": "string",
+                "city": "string",
+                "state": "string",
+                "zipCode": "string",
+                "country": "string",
+                "ethnicity": "HISPANIC",
+                "gender": ["MAN"],
+                "race": ["AIAN"],
+                "sexAtBirth": ["FEMALE"],
+                "degree": ["PHD", "MPH"],
+                "sexualOrientation": "BISEXUAL",
+                "affiliations": [
+                    {
+                        "institution": "institution1",
+                        "role": "institution role 1",
+                        "nonAcademicAffiliation": "INDUSTRY"
+                    }
+                ],
+                "verifiedInstitutionalAffiliation": {
+                    "institutionShortName": "verified institution",
+                    "institutionalRole": "verified institution role 1",
+                    "nonAcademicAffiliation": "INDUSTRY"
+                }
+            }
+        ]
+        self.send_post('workbench/directory/researchers', request_data=researchers_json)
+
+        # create workspaces
+        workspaces_json = [
+            {
+                "workspaceId": 0,
+                "name": "workspace name str",
+                "creationTime": "2023-04-25T17:43:41.085Z",
+                "modifiedTime": "2023-04-25T17:43:41.085Z",
+                "status": "ACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 0,
+                        "role": "OWNER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "excludeFromPublicDirectory": False,
+                "ethicalLegalSocialImplications": True,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "disease focused research name str",
+                "otherPurposeDetails": "other purpose details str",
+                "methodsDevelopment": True,
+                "controlSet": True,
+                "ancestry": True,
+                "socialBehavioral": True,
+                "populationHealth": True,
+                "drugDevelopment": True,
+                "commercialPurpose": True,
+                "educational": True,
+                "otherPurpose": True,
+                "scientificApproaches": 'reasonForInvestigation string',
+                "intendToStudy": 'intendToStudy string',
+                "findingsFromStudy": 'findingsFromStudy string',
+                "focusOnUnderrepresentedPopulations": True,
+                "aianResearchType": "EXCLUSIVE_AI_AN_POPULATION",
+                "aianResearchDetails": 'string',
+                "workspaceDemographic": {
+                    "raceEthnicity": ['AIAN', 'MENA'],
+                    "age": ['AGE_0_11', 'AGE_65_74'],
+                    "sexAtBirth": "UNSET",
+                    "genderIdentity": "OTHER_THAN_MAN_WOMAN",
+                    "sexualOrientation": "OTHER_THAN_STRAIGHT",
+                    "geography": "RURAL",
+                    "disabilityStatus": "DISABILITY",
+                    "accessToCare": "NOT_EASILY_ACCESS_CARE",
+                    "educationLevel": "LESS_THAN_HIGH_SCHOOL",
+                    "incomeLevel": "BELOW_FEDERAL_POVERTY_LEVEL_200_PERCENT",
+                    "others": "string"
+                }
+            },
+            {
+                "workspaceId": 1,
+                "name": "workspace name str 2",
+                "creationTime": "2020-11-25T17:43:41.085Z",
+                "modifiedTime": "2020-11-25T17:43:41.085Z",
+                "status": "ACTIVE",
+                "workspaceUsers": [
+                    {
+                        "userId": 0,
+                        "role": "OWNER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "creator": {
+                    "userId": 0,
+                    "givenName": "aaa",
+                    "familyName": "bbb"
+                },
+                "excludeFromPublicDirectory": None,
+                "ethicalLegalSocialImplications": False,
+                "diseaseFocusedResearch": True,
+                "diseaseFocusedResearchName": "disease focused research name str 2",
+                "otherPurposeDetails": "other purpose details str 2",
+                "methodsDevelopment": False,
+                "controlSet": False,
+                "ancestry": False,
+                "socialBehavioral": False,
+                "populationHealth": False,
+                "drugDevelopment": False,
+                "commercialPurpose": False,
+                "educational": False,
+                "otherPurpose": False,
+                "scientificApproaches": 'reasonForInvestigation string2',
+                "intendToStudy": 'intendToStudy string2',
+                "findingsFromStudy": 'findingsFromStudy string2',
+                "aianResearchType": "EXCLUSIVE_AI_AN_POPULATION",
+                "aianResearchDetails": 'string'
+            },
+            {
+                "name": "Test",
+                "status": "ACTIVE",
+                "creator": {
+                    "userId": 0,
+                    "givenName": "aaa",
+                    "familyName": "bbb"
+                },
+                "ancestry": False,
+                "accessTier": "CONTROLLED",
+                "controlSet": False,
+                "educational": True,
+                "workspaceId": 826,
+                "creationTime": "2024-10-01T00:00:00Z",
+                "modifiedTime": "2024-10-01T00:00:00Z",
+                "otherPurpose": False,
+                "intendToStudy": "This workspace is for testing",
+                "cdrVersionName": "Test Dataset",
+                "workspaceUsers": [
+                    {
+                        "userId": 0,
+                        "role": "OWNER",
+                        "status": "ACTIVE"
+                    }
+                ],
+                "drugDevelopment": False,
+                "reviewRequested": False,
+                "populationHealth": False,
+                "socialBehavioral": False,
+                "commercialPurpose": False,
+                "findingsFromStudy": "This workspace is for testing",
+                "methodsDevelopment": False,
+                "otherPurposeDetails": "",
+                "scientificApproaches": "This workspace is for testing",
+                "workspaceDemographic": {
+                    "age": [
+                        "UNSET"
+                    ],
+                    "geography": "UNSET",
+                    "sexAtBirth": "UNSET",
+                    "incomeLevel": "UNSET",
+                    "accessToCare": "UNSET",
+                    "raceEthnicity": [
+                        "UNSET"
+                    ],
+                    "educationLevel": "UNSET",
+                    "genderIdentity": "UNSET",
+                    "disabilityStatus": "UNSET",
+                    "sexualOrientation": "UNSET"
+                },
+                "diseaseFocusedResearch": False,
+                "diseaseFocusedResearchName": "",
+                "ethicalLegalSocialImplications": False,
+                "focusOnUnderrepresentedPopulations": False,
+                "aianResearchType": "EXCLUSIVE_AI_AN_POPULATION",
+                "aianResearchDetails": 'string'
+            }
+        ]
+        result = self.send_post('workbench/directory/workspaces', request_data=workspaces_json)
+
+        # create audit payload
+        audit_json = [
+            {
+                "snapshotId": 1,
+                "reviewType": "RAB",
+                "displayDecision": "PUBLISH_TO_RESEARCHER_DIRECTORY",
+                "accessDecision": "UNSET",
+            },
+            {
+                "snapshotId": 2,
+                "reviewType": "RAB",
+                "displayDecision": "UNSET",
+                "accessDecision": "UNSET",
+            },
+            {
+                "snapshotId": 3,
+                "reviewType": "RAB",
+                "displayDecision": "EXCLUDE_FROM_RESEARCHER_DIRECTORY",
+                "accessDecision": "UNSET",
+            }
+        ]
+        self.send_post('workbench/audit/workspace/results', request_data=audit_json)
+
+        # check that the workspace with displayDecision = UNSET is returned
+        result = self.send_get('researchHub/projectDirectory')
+        self.assertEqual(result['totalActiveProjects'], 2)
+        self.assertEqual(result['data'][0].get('snapshotId'), 1)
+        self.assertEqual(result['data'][1].get('snapshotId'), 2)


### PR DESCRIPTION
## Resolves *[DA-5105](https://precisionmedicineinitiative.atlassian.net/browse/DA-5105)*


## Description of changes/additions
These changes update the Workbench Audit inclusion logic to only exclude workspaces from Research Hub that have the “Exclude from Researcher Directory” explicitly selected. If the audit decision is sent to the RDR as an 'UNSET' value, the workspaces should still be displayed on Research Hub.

## Tests
- [X] unit tests
- Tested in Sandbox




[DA-5105]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ