### PR TITLE
Workbench 2.0 Enum Values Bug Fix

### DIFF
--- a/rdr_service/dao/workbench_dao.py
+++ b/rdr_service/dao/workbench_dao.py
@@ -37,7 +37,7 @@ from rdr_service.participant_enums import WorkbenchWorkspaceStatus, WorkbenchWor
 
 WORKSPACE_ENUM_FIELDS = ['status', 'sex_at_birth', 'gender_identity', 'sexual_orientation', 'geography',
                          'disability_status', 'access_to_care', 'education_level', 'income_level', 'aian_research_type',
-                         'access_tier', 'workspace_users', 'creator', 'resource']
+                         'access_tier', 'workspace_users', 'creator', 'resource', 'race_ethnicity', 'age']
 
 RESEARCHER_ENUM_FIELDS = ['ethnicity', 'education', 'disability', 'user_id', 'verified_institutional_affiliation',
                           'demographicSurveyV2', 'gender', 'race', 'sex_at_birth', 'degree', 'access_tier_short_names']
@@ -279,6 +279,9 @@ class WorkbenchWorkspaceDao(UpdatableDao):
         row_dict['created'] = current_timestamp
         row_dict['modified'] = current_timestamp
         row_dict['status'] = WorkbenchWorkspaceStatus(row.get('status', 'UNSET'))
+        row_dict['raceEthnicity'] = [WorkbenchWorkspaceRaceEthnicity.to_dict().get(x) for x in
+                                     row.get('race_ethnicity')]
+        row_dict['age'] = [WorkbenchWorkspaceAge.to_dict().get(x) for x in row.get('age')]
         row_dict['sexAtBirth'] = WorkbenchWorkspaceSexAtBirth(row.get('sex_at_birth', 'UNSET'))
         row_dict['genderIdentity'] = WorkbenchWorkspaceGenderIdentity(row.get('gender_identity', 'UNSET'))
         row_dict['sexualOrientation'] = WorkbenchWorkspaceSexualOrientation(row.get('sexual_orientation', 'UNSET'))

--- a/tests/workflow_tests/test_workbench_data_transfer.py
+++ b/tests/workflow_tests/test_workbench_data_transfer.py
@@ -53,8 +53,8 @@ class WorkbenchWorkspacesDataFeedTest(BaseTestCase):
                 "findingsFromStudy": None,
                 "ethicalLegalSocialImplications": False,
                 "focusOnUnderrepresentedPopulations": False,
-                "raceEthnicity": [],
-                "age": [],
+                "raceEthnicity": [1, 2],
+                "age": [2],
                 "sexAtBirth": WorkbenchWorkspaceSexAtBirth('INTERSEX'),
                 "genderIdentity": WorkbenchWorkspaceGenderIdentity('UNSET'),
                 "sexualOrientation": WorkbenchWorkspaceSexualOrientation('OTHER_THAN_STRAIGHT'),
@@ -98,8 +98,8 @@ class WorkbenchWorkspacesDataFeedTest(BaseTestCase):
                 "findingsFromStudy": None,
                 "ethicalLegalSocialImplications": True,
                 "focusOnUnderrepresentedPopulations": True,
-                "raceEthnicity": [],
-                "age": [],
+                "raceEthnicity": [2],
+                "age": [1],
                 "sexAtBirth": WorkbenchWorkspaceSexAtBirth('INTERSEX'),
                 "genderIdentity": WorkbenchWorkspaceGenderIdentity('UNSET'),
                 "sexualOrientation": WorkbenchWorkspaceSexualOrientation('OTHER_THAN_STRAIGHT'),
@@ -162,8 +162,8 @@ class WorkbenchWorkspacesDataFeedTest(BaseTestCase):
         self.assertEqual(actual_rows[0].intendToStudy, None)
         self.assertEqual(actual_rows[0].ethicalLegalSocialImplications, False)
         self.assertEqual(actual_rows[0].focusOnUnderrepresentedPopulations, False)
-        self.assertEqual(actual_rows[0].raceEthnicity, [])
-        self.assertEqual(actual_rows[0].age, [])
+        self.assertEqual(actual_rows[0].raceEthnicity, [1, 2])
+        self.assertEqual(actual_rows[0].age, [2])
         self.assertEqual(actual_rows[0].sexAtBirth, WorkbenchWorkspaceSexAtBirth('INTERSEX'))
         self.assertEqual(actual_rows[0].genderIdentity, None)
         self.assertEqual(actual_rows[0].sexualOrientation, WorkbenchWorkspaceSexualOrientation('OTHER_THAN_STRAIGHT'))
@@ -195,8 +195,8 @@ class WorkbenchWorkspacesDataFeedTest(BaseTestCase):
         self.assertEqual(actual_rows[1].intendToStudy, None)
         self.assertEqual(actual_rows[1].ethicalLegalSocialImplications, True)
         self.assertEqual(actual_rows[1].focusOnUnderrepresentedPopulations, True)
-        self.assertEqual(actual_rows[1].raceEthnicity, [])
-        self.assertEqual(actual_rows[1].age, [])
+        self.assertEqual(actual_rows[1].raceEthnicity, [2])
+        self.assertEqual(actual_rows[1].age, [1])
         self.assertEqual(actual_rows[1].sexAtBirth, WorkbenchWorkspaceSexAtBirth('INTERSEX'))
         self.assertEqual(actual_rows[1].genderIdentity, None)
         self.assertEqual(actual_rows[1].sexualOrientation, WorkbenchWorkspaceSexualOrientation('OTHER_THAN_STRAIGHT'))


### PR DESCRIPTION
## Resolves *NA*


## Description of changes/additions
Last week, Peggy noticed that some of the workbench workspace enum fields were showing up as string values instead of the expected integer values in Stable. For researcher data, the same issue was seen and the fix for the issue was included in the original PR, but the same changes weren't added to the workspace data workflow. This PR updates the Workbench Workspace Datafeed workflow to convert all list enum fields correctly into the corresponding RDR enum type.

## Tests
- [X] unit tests
- Ran the job with test data


