### PR TITLE
[DA-5125] Add last modified filter in NPH Participant API

### DIFF
--- a/rdr_service/api/nph_participant_api_schemas/schema.py
+++ b/rdr_service/api/nph_participant_api_schemas/schema.py
@@ -145,6 +145,14 @@ class ParticipantField(ObjectType):
         sort_modifier=lambda context: context.set_order_expression(Participant.id),
         filter_modifier=lambda context, value: context.add_filter(Participant.id == value)
     )
+
+    lastModified = SortableField(
+        String,
+        description="Last modified timestamp, sourced from participant_summary table",
+        sort_modifier=lambda context: context.set_order_expression(ParticipantSummary.lastModified),
+        filter_modifier=lambda context, value: context.add_filter(ParticipantSummary.lastModified >= value)
+    )
+
     biobankId = SortableField(
         String,
         description='NPH Biobank id value for the participant, sourced from NPH participant data table',

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -572,6 +572,7 @@ class NphParticipantAPITest(BaseTestCase):
         )
         result = json.loads(executed.data.decode('utf-8'))
         edge = result.get('participant').get('edges')
+
         self.assertEqual(len(edge), 1)
         self.assertEqual(edge[0].get('node').get('participantNphId'), str(nph_participant.ancillary_participant_id))
 

--- a/tests/api_tests/test_nph_participant_api.py
+++ b/tests/api_tests/test_nph_participant_api.py
@@ -557,6 +557,24 @@ class NphParticipantAPITest(BaseTestCase):
         result = json.loads(executed.data.decode('utf-8'))
         self.assertTrue(result.get('participant').get('edges') == [])
 
+    def test_last_modified_filter_parameter(self):
+        summary = self.participant_summary_dao.get_by_participant_id(900000000)
+        summary.lastModified = clock.CLOCK.now()
+        self.participant_summary_dao.update(summary)
+
+        rex_participants = self.rex_mapping_dao.get_all()
+        nph_participant = list(filter(lambda x: x.primary_participant_id == summary.participantId, rex_participants))[0]
+        self.add_consents(nph_participant_ids=[nph_participant.ancillary_participant_id])
+
+        executed = app.test_client().post(
+            '/rdr/v1/nph_participant',
+            data='{participant (lastModified: "2026-01-01") { edges { node { participantNphId lastModified } } }}'
+        )
+        result = json.loads(executed.data.decode('utf-8'))
+        edge = result.get('participant').get('edges')
+        self.assertEqual(len(edge), 1)
+        self.assertEqual(edge[0].get('node').get('participantNphId'), str(nph_participant.ancillary_participant_id))
+
     def test_nph_prefix_strip_filter_parameter(self):
         self.add_consents(nph_participant_ids=self.base_participant_ids)
         current_nph_participant = self.nph_participant_dao.get(self.base_participant_ids[0])


### PR DESCRIPTION
## Resolves *[DA-5125](https://precisionmedicineinitiative.atlassian.net/browse/DA-5125)*


## Description of changes/additions
- Added last modified filter to the nph participant api.

## Tests
✅  unit tests




[DA-5125]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ