### PR TITLE
Disable research id creation cron job

### DIFF
--- a/rdr_service/cron_prod.yaml
+++ b/rdr_service/cron_prod.yaml
@@ -74,8 +74,3 @@ cron:
   schedule: 1 of month 07:00
   timezone: America/New_York
   target: offline
-- description: Create Participant Research Ids (Daily)
-  url: /offline/CreateParticipantResearchIds
-  schedule: every day 05:45
-  timezone: America/New_York
-  target: offline


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Deactivates the job to create new research ids in Prod. This is needed to allow the id creation process to be updated.

## Tests
- [] unit tests


