### PR TITLE
Add protobuf 85151 to ignore vulnerability

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -26,6 +26,9 @@ security: # configuration for the `safety check` command
         77740:
           reason: protobuf version 3.20.3 has a vulnerability
           expires: '2026-07-31'
+        85151:
+          reason: protobuf version 3.20.3 has a vulnerability
+          expires: '2026-07-31'
     continue-on-vulnerability-error: False # Suppress non-zero exit codes when vulnerabilities are found. Enable this in pipelines and CI/CD processes if you want to pass builds that have vulnerabilities. We recommend you set this to False.
 alert: # configuration for the `safety alert` command
     security:


### PR DESCRIPTION
## Resolves *[NA]*


## Description of changes/additions
Safety check started failing with `Vulnerability found in protobuf version`. Adding the vulnerability id to the yaml file to ignore the warning, like how we handle another existing protobuf warning.

## Tests
- [] unit tests


