### PR TITLE
[DA-5146] Add toggle to hide new fields before launch

### DIFF
--- a/rdr_service/dao/awardee_insite_dao.py
+++ b/rdr_service/dao/awardee_insite_dao.py
@@ -5,11 +5,12 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query as SQLAlchemyQuery
 from werkzeug.exceptions import BadRequest
 
+from rdr_service import config
 from rdr_service.code_constants import UNSET
 from rdr_service.model.utils import to_client_participant_id
 from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
-from rdr_service.model.awardee_insite import AwardeeInSite
+from rdr_service.model.awardee_insite import AwardeeInSite, MVP_FIELDS
 from rdr_service.dao.base_dao import UpsertableDao
 from rdr_service.query import Results, Query, FieldFilter, Operator
 
@@ -154,6 +155,11 @@ class AwardeeInSiteDao(UpsertableDao):
 
         for field in AwardeeInSite.internal_fields:
             del result[field]
+
+        # TODO: Remove this code block after MVP fields are live
+        if not config.getSettingJson('awardee_insite_mvp_fields_visibility', default=True):
+            for field in MVP_FIELDS:
+                del result[field]
 
         result["participantId"] = to_client_participant_id(result["participantId"])
         final_result = {

--- a/rdr_service/model/awardee_insite.py
+++ b/rdr_service/model/awardee_insite.py
@@ -8,6 +8,32 @@ from rdr_service.model.base import (
     PPSCBase,
 )
 
+MVP_FIELDS = [
+    "primaryLanguage",
+    "genderIdentity",
+    "awardee",
+    "isEhrDataAvailable",
+    "aian",
+    "questionnaireOnOverallHealth",
+    "questionnaireOnOverallHealthAuthored",
+    "questionnaireOnLifestyle",
+    "questionnaireOnLifestyleAuthored",
+    "questionnaireOnTheBasics",
+    "questionnaireOnTheBasicsAuthored",
+    "questionnaireOnHealthcareAccess",
+    "questionnaireOnHealthcareAccessAuthored",
+    "questionnaireOnSocialDeterminantsOfHealth",
+    "questionnaireOnSocialDeterminantsOfHealthAuthored",
+    "questionnaireOnPersonalAndFamilyHealthHistory",
+    "questionnaireOnPersonalAndFamilyHealthHistoryAuthored",
+    "questionnaireOnLifeFunctioning",
+    "questionnaireOnLifeFunctioningAuthored",
+    "questionnaireOnEmotionalHealthHistoryAndWellBeing",
+    "questionnaireOnEmotionalHealthHistoryAndWellBeingAuthored",
+    "questionnaireOnBehavioralHealthAndPersonality",
+    "questionnaireOnBehavioralHealthAndPersonalityAuthored",
+]
+
 
 class AwardeeInSite(PPSCBase):
     __tablename__ = "awardee_insite"


### PR DESCRIPTION
## Resolves *[DA-5146](https://precisionmedicineinitiative.atlassian.net/browse/DA-5146)*


## Description of changes/additions
- Will be hotfixing adding the new fields to Awardee Insite so that the backfill to these new columns can start. However, need to hide these new fields until the launch, so adding a toggle to do that.


## Tests
- [] unit tests




[DA-5146]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ