### PR TITLE
[DA-5174] Filter Withdrawn Participants out of the Core Participant Count of the Public Metrics API

### DIFF
--- a/rdr_service/config.py
+++ b/rdr_service/config.py
@@ -318,6 +318,7 @@ PUBLIC_METRICS_CODE_TABLE = "public_metrics_code_table"
 PUBLIC_METRICS_GENDER_ANSWERS_TABLE = "public_metrics_gender_answers_table"
 PUBLIC_METRICS_RACE_ANSWERS_TABLE = "public_metrics_race_answers_table"
 PUBLIC_METRICS_PARTICIPANT_STATUS_EVENT_TABLE = "public_metrics_participant_status_event_table"
+PUBLIC_METRICS_WITHDRAWAL_EVENT_TABLE = "public_metrics_withdrawal_event_table"
 
 PPSC_AWS_CREDS = "ppsc_aws_creds"
 

--- a/rdr_service/dao/metrics_cache_dao.py
+++ b/rdr_service/dao/metrics_cache_dao.py
@@ -92,6 +92,8 @@ race_answers_table = config.getSettingJson(config.PUBLIC_METRICS_RACE_ANSWERS_TA
                                            'rdr_operational_datastream.rdr_participant_race_answers')
 participant_status_event_table = config.getSettingJson(config.PUBLIC_METRICS_PARTICIPANT_STATUS_EVENT_TABLE,
                                            'rdr_operational_datastream.ppsc_participant_status_event')
+withdrawal_event_table = config.getSettingJson(config.PUBLIC_METRICS_WITHDRAWAL_EVENT_TABLE,
+                                           'rdr_operational_datastream.ppsc_withdrawal_event')
 
 class MetricsDaoMixin:
     def insert_bulk(self, batch: List[Dict]) -> None:
@@ -271,6 +273,14 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
                                 AND pse.ignore_flag = 0
                                 AND (p.is_test_participant != 1 OR p.is_test_participant IS NULL)
                                 AND (p.is_ghost_id != 1 OR p.is_ghost_id IS NULL)
+                                AND pse.participant_id NOT IN (
+                                    SELECT DISTINCT we.participant_id
+                                    FROM `{withdrawal_event}` we
+                                    WHERE we.data_element_name = 'activity_status'
+                                    AND we.data_element_value = 'withdrawn'
+                                    AND we.event_type_name = 'Withdrawal'
+                                    AND ignore_flag = 0
+                                )
                             GROUP BY DATE(pse.data_element_value), p.hpo_id
                         ) AS results
                         WHERE core_date IS NOT NULL AND c.day>=DATE(core_date)
@@ -282,7 +292,7 @@ class MetricsEnrollmentStatusCacheDao(BaseDao, MetricsDaoMixin):
                 ;
                 """.format(calendar=f"{bq_project}.{calendar_table}", participant=f"{bq_project}.{participant_table}",
                            participant_status_event=f"{bq_project}.{participant_status_event_table}",
-                           hpo_filter=hpo_id_params)
+                           hpo_filter=hpo_id_params, withdrawal_event=f"{bq_project}.{withdrawal_event_table}")
 
         params = [
             bigquery.ScalarQueryParameter("start_date", "DATE", start_date),

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -8,12 +8,12 @@ blinker==1.9.0              # via -r requirements.in
 boto3==1.42.9
 cachetools==4.1.0         # via google-auth
 certifi==2024.7.4       # via geventhttpclient, requests
-cffi==1.15.1              # via cryptography
+cffi==2.0.0             # via cryptography
 chardet==3.0.4            # via requests
 click==8.2.0              # via flask, pip-tools
 configargparse==1.2.3     # via locust
 coverage==7.2.5             # via -r requirements.in
-cryptography==46.0.0      # via oauthlib, pyopenssl, requests
+cryptography==46.0.5      # via oauthlib, pyopenssl, requests
 defusedxml==0.6.0         # via jira
 dictalchemy3==1.0.0       # via -r requirements.in
 dnspython==2.6.1         # via -r requirements.in

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -13,7 +13,7 @@ chardet==3.0.4            # via requests
 click==8.2.0              # via flask, pip-tools
 configargparse==1.2.3     # via locust
 coverage==7.2.5             # via -r requirements.in
-cryptography==44.0.1      # via oauthlib, pyopenssl, requests
+cryptography==46.0.0      # via oauthlib, pyopenssl, requests
 defusedxml==0.6.0         # via jira
 dictalchemy3==1.0.0       # via -r requirements.in
 dnspython==2.6.1         # via -r requirements.in
@@ -77,7 +77,7 @@ pycparser==2.20           # via cffi
 pygments==2.15.1           # via sphinx
 pyjwt==2.10.1              # via oauthlib
 pylint==2.17.4            # via -r requirements.in
-pyopenssl==25.0.0         # via requests
+pyopenssl==26.0.0         # via requests
 pyparsing==2.4.7          # via packaging
 python-dateutil==2.8.1    # via alembic, faker
 python-editor==1.0.4      # via alembic


### PR DESCRIPTION
## Resolves *[DA-5174](https://precisionmedicineinitiative.atlassian.net/browse/DA-5174)*


## Description of changes/additions
On 3/3/26, Research Hub reached out to the RDR, having received a request from NIH to investigate an ~5k discrepancy in Core Participant count between Research Hub and PPSC. The discrepancy is partially because PPSC filters out withdrawn participants while the RDR does not.

This PR updates the Public Metrics Count query to filter out withdrawn participants when calculating the core participant count. This PR also updates some packages with vulnerabilities.

## Tests
- Query tested in BigQuery




[DA-5174]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ