### PR TITLE
AW0 Plating DAG updates for validation, file path, and partition

### DIFF
--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -83,11 +83,12 @@ WITH source_rows AS (
     created,
     file_path,
     ROW_NUMBER() OVER (
-      PARTITION BY genome_type
+      PARTITION BY collection_tube_id, genome_type
       ORDER BY created DESC
     ) AS rn
   FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_tmp`
-      WHERE collection_tube_id IN UNNEST([
+      WHERE validation_passed = "Y"
+      AND collection_tube_id IN UNNEST([
        {% for id in params.collection_tube_ids %}
          '{{ id }}'{% if not loop.last %},{% endif %}
        {% endfor %}
@@ -129,7 +130,6 @@ delta AS (
     FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_plating` l
     WHERE l.collection_tube_id = s.collection_tube_id
       AND l.genome_type = s.genome_type
-      AND l.file_path = s.file_path
   )
 )
 SELECT
@@ -173,7 +173,7 @@ SELECT
   pediatric,
   finalized,
   CAST(created AS TIMESTAMP),
-  file_path,
+  'gs://{{ params.bucket_name }}/genomic_samples_manifests/plating/Genomic-Manifest-AoU-{{ ds }}_C3-{{ ts_nodash | truncate(12, False, '') }}pl.csv' AS file_path,
   batch_id,
   CURRENT_TIMESTAMP()
 FROM `{{ params.project_id }}.{{ params.dataset }}.{{ params.export_table_id }}`
@@ -193,7 +193,7 @@ with DAG(
             description="List of collection_tube_id values to process"
         )
     },
-    tags=["genomics", "aw0", "bigquery", "gcs"],
+    tags=["genomics", "aw0"],
 ) as dag:
 
     run_aw0_query = BigQueryInsertJobOperator(
@@ -210,6 +210,7 @@ with DAG(
             "project_id": PROJECT_ID,
             "dataset": DATASET,
             "export_table_id": EXPORT_TABLE_ID,
+            "bucket_name": BUCKET_NAME
         },
     )
 


### PR DESCRIPTION
## Resolves *[DA-5253](https://precisionmedicineinitiative.atlassian.net/browse/DA-5253)*


## Description of changes/additions
This PR makes the following modifications to the AW0 Plating DAG:
- Partition source data by `collection_tube_id`
- Add validation_passed to the source data filter
- Insert the plating manifest file path into the ledger table
- DAG tags cleanup

## Tests
- Tested on Stable




[DA-5253]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ