### PR TITLE
Remove unnecesary columns from AWO plating manifest

### DIFF
--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -139,11 +139,7 @@ SELECT
   genome_type,
   ny_flag,
   validation_passed,
-  ai_an,
-  pediatric,
-  finalized,
-  created,
-  file_path
+  ai_an
 FROM delta
 ;
 
@@ -155,9 +151,6 @@ INSERT INTO `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_a
   ny_flag,
   validation_passed,
   ai_an,
-  pediatric,
-  finalized,
-  created,
   file_path,
   batch_id,
   export_timestamp
@@ -170,9 +163,6 @@ SELECT
   ny_flag,
   validation_passed,
   ai_an,
-  pediatric,
-  finalized,
-  CAST(created AS TIMESTAMP),
   'gs://{{ params.bucket_name }}/genomic_samples_manifests/plating/Genomic-Manifest-AoU-{{ ds }}_C3-{{ ts_nodash | truncate(12, False, '') }}pl.csv' AS file_path,
   batch_id,
   CURRENT_TIMESTAMP()

--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -75,7 +75,11 @@ WITH source_rows AS (
     biobank_id,
     sex_at_birth,
     genome_type,
-    ny_flag,
+    CASE
+      WHEN ny_flag = "0" THEN "N"
+      WHEN ny_flag = "1" THEN "Y"
+      ELSE ny_flag
+    END as ny_flag,
     validation_passed,
     ai_an,
     pediatric,

--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -143,7 +143,8 @@ SELECT
   genome_type,
   ny_flag,
   validation_passed,
-  ai_an
+  ai_an,
+  pediatric
 FROM delta
 ;
 


### PR DESCRIPTION
## Resolves *No Ticket*


## Description of changes/additions
Metadata columns were added to the export file that shouldn't have been. These have been removed.

## Tests
- Tested on stable


