### PR TITLE
Remove 2nd round config to hide fields & read ehr first yes authored from PPSC table

### DIFF
--- a/rdr_service/dao/awardee_insite_dao.py
+++ b/rdr_service/dao/awardee_insite_dao.py
@@ -5,12 +5,11 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.query import Query as SQLAlchemyQuery
 from werkzeug.exceptions import BadRequest
 
-from rdr_service import config
 from rdr_service.code_constants import UNSET
 from rdr_service.model.utils import to_client_participant_id
 from rdr_service.model.hpo import HPO
 from rdr_service.model.organization import Organization
-from rdr_service.model.awardee_insite import AwardeeInSite, SECOND_ROUND_FIELDS
+from rdr_service.model.awardee_insite import AwardeeInSite
 from rdr_service.dao.base_dao import UpsertableDao
 from rdr_service.query import Results, Query, FieldFilter, Operator
 
@@ -159,11 +158,6 @@ class AwardeeInSiteDao(UpsertableDao):
 
         for field in AwardeeInSite.internal_fields:
             del result[field]
-
-        # TODO: Remove this code block after fields are live
-        if not config.getSettingJson('awardee_insite_second_round_fields_visibility', default=True):
-            for field in SECOND_ROUND_FIELDS:
-                del result[field]
 
         result["participantId"] = to_client_participant_id(result["participantId"])
         final_result = {

--- a/rdr_service/model/awardee_insite.py
+++ b/rdr_service/model/awardee_insite.py
@@ -8,32 +8,6 @@ from rdr_service.model.base import (
     PPSCBase,
 )
 
-SECOND_ROUND_FIELDS = [
-    "questionnaireOnSocialFactorsUpdate",
-    "questionnaireOnSocialFactorsUpdateAuthored",
-    "questionnaireOnHealthAndWellnessUpdate",
-    "questionnaireOnHealthAndWellnessUpdateAuthored",
-    "questionnaireOnMentalHealthAndWellBeingUpdate",
-    "questionnaireOnMentalHealthAndWellBeingUpdateAuthored",
-    "questionnaireOnPersonalAndFamilyHealthHistoryUpdate",
-    "questionnaireOnPersonalAndFamilyHealthHistoryUpdateAuthored",
-    "questionnaireOnPediatricBasics",
-    "questionnaireOnPediatricBasicsAuthored",
-    "questionnaireOnPediatricOverallHealth",
-    "questionnaireOnPediatricOverallHealthAuthored",
-    "questionnaireOnPediatricEnvironmentalHealth",
-    "questionnaireOnPediatricEnvironmentalHealthAuthored",
-    "retentionEligibleStatus",
-    "retentionEligibleTime",
-    "lastActiveRetentionActivityTime",
-    "retentionType",
-    "signUpTime",
-    "withdrawalReason",
-    "duplicateAccountStatus",
-    "race",
-    "ageRange",
-    "enrollmentStatusTime",
-]
 
 class AwardeeInSite(PPSCBase):
     __tablename__ = "awardee_insite"

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -644,7 +644,7 @@ def insert_awardee_insite_data(
               FROM ehr_cte
               WHERE LOWER(activity_status) IN ('yes', 'submitted_yes', 'submitted_complete')
               GROUP BY 1
-          )
+          ),
           primary_consent_cte AS (
             SELECT participant_id
                 , event_id

--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -638,6 +638,13 @@ def insert_awardee_insite_data(
             )
             WHERE rn = 1
           ),
+          ehr_first_yes_submitted AS (
+              SELECT participant_id
+                , MIN(activity_date_time) AS consent_for_electronic_health_records_first_yes_authored
+              FROM ehr_cte
+              WHERE LOWER(activity_status) IN ('yes', 'submitted_yes', 'submitted_complete')
+              GROUP BY 1
+          )
           primary_consent_cte AS (
             SELECT participant_id
                 , event_id
@@ -818,7 +825,6 @@ def insert_awardee_insite_data(
             SELECT
               participant_id
               , ehr_receipt_time AS first_ehr_receipt_time
-              , consent_for_electronic_health_records_first_yes_authored
               , consent_for_study_enrollment_authored
               , patient_status
               , s2.google_group AS biospecimen_source_site
@@ -1170,6 +1176,8 @@ def insert_awardee_insite_data(
             LEFT JOIN latest_deceased
             USING (participant_id)
             LEFT JOIN ehr_latest_submitted
+            USING (participant_id)
+            LEFT JOIN ehr_first_yes_submitted
             USING (participant_id)
             LEFT JOIN primary_consent_latest_submitted
             USING (participant_id)


### PR DESCRIPTION
## Resolves *[NA]*


## Description of changes/additions
- Removing config to hide new fields
- Reading `consent_for_electronic_health_records_first_yes_authored` from ppsc table instead of PS


## Tests
- [] unit tests


