### PR TITLE
Cloud Function Upgrade to Gen2

### DIFF
--- a/rdr_service/gcloud_functions/genomic_ingest_manifest_function_v2/__init__.py
+++ b/rdr_service/gcloud_functions/genomic_ingest_manifest_function_v2/__init__.py
@@ -1,0 +1,4 @@
+#
+# This file is subject to the terms and conditions defined in the
+# file 'LICENSE', which is part of this source code package.
+#

--- a/rdr_service/gcloud_functions/genomic_ingest_manifest_function_v2/main.py
+++ b/rdr_service/gcloud_functions/genomic_ingest_manifest_function_v2/main.py
@@ -1,0 +1,146 @@
+import json
+import logging
+import os
+
+from cloudevents.http import CloudEvent
+import functions_framework
+from google.cloud import tasks_v2
+
+logging.basicConfig(level=logging.INFO)
+_logger = logging.getLogger(__name__)
+
+# Configuration — override via environment variables set on the function
+GCP_PROJECT = os.environ.get("GCP_PROJECT", "all-of-us-rdr-stable")
+GCP_LOCATION = os.environ.get("GCP_LOCATION", "us-central1")
+TASK_QUEUE = os.environ.get("TASK_QUEUE", "genomics")
+TASK_ROOT = "/resource/task/"
+
+
+# Manifest-type routing table  (key = substring matched against object path)
+TASK_KEY_MAP = {
+    # Short-read
+    "_sample_manifests":  {"manifest_type": "aw1",  "task_endpoint": "IngestAW1ManifestTaskApi"},
+    "aw1f_pre_results":   {"manifest_type": "aw1f", "task_endpoint": "IngestAW1ManifestTaskApi"},
+    "_data_manifests":    {"manifest_type": "aw2",  "task_endpoint": "IngestAW2ManifestTaskApi"},
+    "aw4_":               {"manifest_type": "aw4",  "task_endpoint": "IngestAW4ManifestTaskApi"},
+    "aw5_":               {"manifest_type": "aw5",  "task_endpoint": "IngestAW5ManifestTaskApi"},
+    # GEM
+    "gem_a2":             {"manifest_type": "a2",   "task_endpoint": "IngestGemManifestTaskApi"},
+    # CVL
+    "_w2sc_":             {"manifest_type": "w2sc", "task_endpoint": "IngestCVLManifestTaskApi"},
+    "_w3ns_":             {"manifest_type": "w3ns", "task_endpoint": "IngestCVLManifestTaskApi"},
+    "_w3sc_":             {"manifest_type": "w3sc", "task_endpoint": "IngestCVLManifestTaskApi"},
+    "_cvl_pkg":           {"manifest_type": "w3ss", "task_endpoint": "IngestCVLManifestTaskApi"},
+    "_w4wr_":             {"manifest_type": "w4wr", "task_endpoint": "IngestCVLManifestTaskApi"},
+    "_w5nf_":             {"manifest_type": "w5nf", "task_endpoint": "IngestCVLManifestTaskApi"},
+    # Long-read
+    "_lr_requests_":      {"manifest_type": "lr",      "task_endpoint": "IngestSubManifestTaskApi"},
+    "_lr_pkg":            {"manifest_type": "l1",      "task_endpoint": "IngestSubManifestTaskApi"},
+    "_ont_":              {"manifest_type": "l2_ont",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_pbccs_":            {"manifest_type": "l2_pb_ccs", "task_endpoint": "IngestSubManifestTaskApi"},
+    "_l4_":               {"manifest_type": "l4",      "task_endpoint": "IngestSubManifestTaskApi"},
+    "_l5_":               {"manifest_type": "l5",      "task_endpoint": "IngestSubManifestTaskApi"},
+    "_l6_":               {"manifest_type": "l6",      "task_endpoint": "IngestSubManifestTaskApi"},
+    "_l1f_":              {"manifest_type": "l1f",     "task_endpoint": "IngestSubManifestTaskApi"},
+    "_l4f_":              {"manifest_type": "l4f",     "task_endpoint": "IngestSubManifestTaskApi"},
+    "_l6f_":              {"manifest_type": "l6f",     "task_endpoint": "IngestSubManifestTaskApi"},
+    # Proteomics
+    "_pr_requests_":      {"manifest_type": "pr",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_proteomics_pkg":    {"manifest_type": "p1",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_p2_":               {"manifest_type": "p2",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_p4_":               {"manifest_type": "p4",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_p5_":               {"manifest_type": "p5",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_p1f_":              {"manifest_type": "p1f", "task_endpoint": "IngestSubManifestTaskApi"},
+    # RNA
+    "rr_requests":        {"manifest_type": "rr",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_rnaseq_pkg":        {"manifest_type": "r1",  "task_endpoint": "IngestSubManifestTaskApi"},
+    "_r2_":               {"manifest_type": "r2",  "task_endpoint": "IngestSubManifestTaskApi"},
+}
+
+
+def _enqueue_task(client: tasks_v2.CloudTasksClient, api_route: str, payload: dict) -> None:
+    """Create a single App Engine Cloud Task targeting the given relative route."""
+    parent = client.queue_path(GCP_PROJECT, GCP_LOCATION, TASK_QUEUE)
+    task = tasks_v2.Task(
+        app_engine_http_request=tasks_v2.AppEngineHttpRequest(
+            http_method=tasks_v2.HttpMethod.POST,
+            relative_uri=api_route,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(payload).encode(),
+        )
+    )
+    response = client.create_task(
+        tasks_v2.CreateTaskRequest(parent=parent, task=task))
+    _logger.info("Created task: %s", response.name)
+
+
+# Entry point — triggered by a Pub/Sub CloudEvent (Eventarc)
+@functions_framework.cloud_event
+def genomic_ingest_manifest_function_v2(cloud_event: CloudEvent) -> None:
+    """Gen2 Cloud Run Function triggered by a Pub/Sub topic.
+
+    The Pub/Sub message carries a GCS OBJECT_FINALIZE notification in its
+    attributes (bucketId, objectId, eventTime).  We route by object path,
+    then enqueue two Cloud Tasks: one to load the raw manifest data, and one
+    for the type-specific ingest endpoint.
+    """
+    _logger.info("Event ID: %s  |  Event time: %s",
+                 cloud_event["id"], cloud_event["time"])
+
+    #
+    # Extract GCS metadata from the Pub/Sub message attributes.
+    # For a GCS notification routed through Pub/Sub the attributes live
+    # directly on cloud_event.data["message"]["attributes"].
+    #
+    message = cloud_event.data.get("message", {})
+    attributes = message.get("attributes", {})
+
+    bucket_name = attributes.get("bucketId", "")
+    object_id = attributes.get("objectId", "")
+    event_time = attributes.get("eventTime", "")
+
+    if not object_id:
+        _logger.warning(
+            "No objectId in Pub/Sub message attributes — nothing to do.")
+        return
+
+    _logger.info("File detected: gs://%s/%s", bucket_name, object_id)
+
+    # Route by filename substring
+    object_id_lower = object_id.lower()
+    task_data = None
+    for key, value in TASK_KEY_MAP.items():
+        if key in object_id_lower:
+            task_data = value
+            break
+
+    if task_data is None:
+        _logger.info(
+            "Object path does not match any ingestion criteria — skipping.")
+        return
+
+    manifest_type = task_data["manifest_type"]
+    task_endpoint = task_data["task_endpoint"]
+    api_route = f"{TASK_ROOT}{task_endpoint}"
+
+    payload = {
+        "file_type":      manifest_type,
+        "filename":       object_id,
+        "file_path":      f"{bucket_name}/{object_id}",
+        "bucket_name":    bucket_name,
+        "topic":          "genomic_manifest_upload",
+        "upload_date":    event_time,
+        "task":           f"{manifest_type}_manifest",
+        "api_route":      api_route,
+        "cloud_function": True,
+    }
+
+    _logger.info("Enqueueing Cloud Tasks for manifest_type=%s", manifest_type)
+    client = tasks_v2.CloudTasksClient()
+
+    # 1. Load into raw table
+    _enqueue_task(client, f"{TASK_ROOT}LoadRawAWNManifestDataAPI", payload)
+    # 2. Type-specific ingest
+    _enqueue_task(client, api_route, payload)
+
+    _logger.info("Done.")

--- a/rdr_service/gcloud_functions/genomic_ingest_manifest_function_v2/requirements.txt
+++ b/rdr_service/gcloud_functions/genomic_ingest_manifest_function_v2/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.*
+google-cloud-tasks==2.*
+starlette==1.2.0

--- a/rdr_service/gcloud_functions/nph_sms_manifest_ingestion_function_v2/main.py
+++ b/rdr_service/gcloud_functions/nph_sms_manifest_ingestion_function_v2/main.py
@@ -1,0 +1,87 @@
+import json
+import logging
+import os
+
+from cloudevents.http import CloudEvent
+import functions_framework
+from google.cloud import tasks_v2
+
+logging.basicConfig(level=logging.INFO)
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration — override via environment variables set on the function
+# ---------------------------------------------------------------------------
+GCP_PROJECT = os.environ.get("GCP_PROJECT", "all-of-us-rdr-stable")
+GCP_LOCATION = os.environ.get("GCP_LOCATION", "us-central1")
+TASK_QUEUE = os.environ.get("TASK_QUEUE", "nph")
+API_ROUTE = "/resource/task/NphSmsIngestionTaskApi"
+
+
+def _enqueue_task(client: tasks_v2.CloudTasksClient, api_route: str, payload: dict) -> None:
+    """Create a single App Engine Cloud Task targeting the given relative route."""
+    parent = client.queue_path(GCP_PROJECT, GCP_LOCATION, TASK_QUEUE)
+    task = tasks_v2.Task(
+        app_engine_http_request=tasks_v2.AppEngineHttpRequest(
+            http_method=tasks_v2.HttpMethod.POST,
+            relative_uri=api_route,
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(payload).encode(),
+        )
+    )
+    response = client.create_task(
+        tasks_v2.CreateTaskRequest(parent=parent, task=task))
+    _logger.info("Created task: %s", response.name)
+
+
+@functions_framework.cloud_event
+def nph_sms_manifest_ingestion_function_v2(cloud_event: CloudEvent) -> None:
+    """Gen2 Cloud Run Function triggered by a Pub/Sub topic.
+
+    Routes GCS object-created events to the NphSmsIngestionTaskApi Cloud Task
+    based on the object path. Skips archived files and unrecognized paths.
+    """
+    _logger.info("Event ID: %s  |  Event time: %s",
+                 cloud_event["id"], cloud_event["time"])
+
+    message = cloud_event.data.get("message", {})
+    attributes = message.get("attributes", {})
+
+    bucket_name = attributes.get("bucketId", "")
+    object_id = attributes.get("objectId", "")
+
+    if not object_id:
+        _logger.warning(
+            "No objectId in Pub/Sub message attributes — nothing to do.")
+        return
+
+    _logger.info("File detected: gs://%s/%s", bucket_name, object_id)
+
+    object_id_lower = object_id.lower()
+
+    if "archive" in object_id_lower:
+        _logger.info("%s is archived, skipping ingestion.", object_id)
+        return
+
+    if "pull_lists" in object_id_lower:
+        file_type = "SAMPLE_LIST"
+    elif "n0_manifest" in object_id_lower:
+        file_type = "N0"
+    else:
+        _logger.info("%s not configured for ingestion.", object_id)
+        return
+
+    payload = {
+        "file_path":      f"{bucket_name}/{object_id}",
+        "bucket_name":    bucket_name,
+        "topic":          "sms_files_upload",
+        "job":            "FILE_INGESTION",
+        "file_type":      file_type,
+        "api_route":      API_ROUTE,
+        "cloud_function": True,
+    }
+
+    _logger.info("Enqueueing Cloud Task for file_type=%s", file_type)
+    client = tasks_v2.CloudTasksClient()
+    _enqueue_task(client, API_ROUTE, payload)
+    _logger.info("Done.")

--- a/rdr_service/gcloud_functions/nph_sms_manifest_ingestion_function_v2/requirements.txt
+++ b/rdr_service/gcloud_functions/nph_sms_manifest_ingestion_function_v2/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.*
+google-cloud-tasks==2.*
+starlette==1.2.0


### PR DESCRIPTION
## Resolves *[DA-5189](https://precisionmedicineinitiative.atlassian.net/browse/DA-5189)*


## Description of changes/additions
This PR creates 2 new GCP Cloud Run Functions to replace the functionality in the now-defunct first-generation Cloud Functions GCP product.
The first-generation functions were required to be disabled due to a security flaw in the underlying Google Cloud architecture, namely the starlette package version, which could not be updated without an upgrade to the second-generation.

Only the following two functions were upgraded, as all others were deemed unnecessary to continue supporting:
- Genomic Manifest Ingestion (which will soon be replaced by the ingestion 2.0 framework)
- NPH SMS Manifest Ingestion

The previous functions depended on the aou-cloud repository. This new generation is completely independent of that library. This new generation utilizes the built in functionality of the Cloud Run ecosystem, which requires a `requirements.txt` file be included with the `main.py` function.

## Tests
- Tested on Stable




[DA-5189]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ