### PR TITLE
[DA-5303] Add peds to aian flag in awardee insite

### DIFF
--- a/rdr_service/workflow_management/ppsc/data_feed_queries.py
+++ b/rdr_service/workflow_management/ppsc/data_feed_queries.py
@@ -858,7 +858,7 @@ def insert_awardee_insite_data(
             SELECT DISTINCT participant_id
                 , 'yes' AS aian
             FROM `{project}.{src_operational_dataset}.ppsc_survey_completion_event`
-            WHERE LOWER(data_element_name) = 'race_whatraceethnicity'
+            WHERE LOWER(data_element_name) IN ('race_whatraceethnicity', 'race_whatraceethnicity_ped')
               AND LOWER(data_element_value) = 'whatraceethnicity_aian'
               AND ignore_flag = 0
           ),


### PR DESCRIPTION
## Resolves *[DA-5303](https://precisionmedicineinitiative.atlassian.net/browse/DA-5303)*


## Description of changes/additions
- Adding 'race_whatraceethnicity_ped' to aian CTE in Awardee InSite so the aian column is set to yes for pediatric participants.


## Tests
- [] unit tests (Tested in BQ)




[DA-5303]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ