### PR TITLE
[DA-5293] Increasing instance size to limit 503

### DIFF
--- a/rdr_service/app_nonprod.yaml
+++ b/rdr_service/app_nonprod.yaml
@@ -1,6 +1,6 @@
 # app_base.yaml is concatenated to the beginning of this file for deployment.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: F4_1G
+instance_class: F4
 
 # Have 2 idle instances to prepare for sudden traffic spikes.
 automatic_scaling:

--- a/rdr_service/app_nonprod.yaml
+++ b/rdr_service/app_nonprod.yaml
@@ -1,6 +1,6 @@
 # app_base.yaml is concatenated to the beginning of this file for deployment.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: F4
+instance_class: F4_1G
 
 # Have 2 idle instances to prepare for sudden traffic spikes.
 automatic_scaling:

--- a/rdr_service/app_prod.yaml
+++ b/rdr_service/app_prod.yaml
@@ -1,5 +1,5 @@
 #  app_base.yaml is concatenated to the beginning of this file for deployment.
-instance_class: F4
+instance_class: F4_1G
 
 # Have 5 idle instances to prepare for sudden traffic spikes.
 # Setting target_throughput_utilization and target_cpu_utilization to test if it helps in reducing 502 errors

--- a/rdr_service/app_sandbox.yaml
+++ b/rdr_service/app_sandbox.yaml
@@ -1,6 +1,6 @@
 # app_base.yaml is concatenated to the beginning of this file for deployment.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: F4
+instance_class: F4_1G
 
 # Have 0 idle instances to reduce unneeded costs
 automatic_scaling:

--- a/rdr_service/app_sandbox.yaml
+++ b/rdr_service/app_sandbox.yaml
@@ -1,6 +1,6 @@
 # app_base.yaml is concatenated to the beginning of this file for deployment.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: F4_1G
+instance_class: F4
 
 # Have 0 idle instances to reduce unneeded costs
 automatic_scaling:

--- a/rdr_service/app_stable.yaml
+++ b/rdr_service/app_stable.yaml
@@ -1,6 +1,6 @@
 # app_base.yaml is concatenated to the beginning of this file for deployment.
 # https://cloud.google.com/appengine/docs/standard/
-instance_class: F4
+instance_class: F4_1G
 
 # Have 2 idle instances to prepare for sudden traffic spikes.
 automatic_scaling:

--- a/rdr_service/ppsc_pipeline.yaml
+++ b/rdr_service/ppsc_pipeline.yaml
@@ -6,7 +6,7 @@ entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 18000 
 
 # RDR Cron Jobs run for longer than 10 minutes, B4_1G allows basic scaling, which handles requests up to 24 hours.
 # https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=python#scaling_elements
-instance_class: B2
+instance_class: B4_1G
 basic_scaling:
   max_instances: 10
   idle_timeout: 1m

--- a/rdr_service/resource.yaml
+++ b/rdr_service/resource.yaml
@@ -5,7 +5,7 @@ service: resource
 entrypoint: gunicorn -c rdr_service/services/gunicorn_config.py --timeout 600 rdr_service.resource.main:app
 
 # Changing to Automatic Scaling based on recommendation from Google Support
-instance_class: F4
+instance_class: F4_1G
 
 inbound_services:
 - warmup

--- a/rdr_service/services/gunicorn_config.py
+++ b/rdr_service/services/gunicorn_config.py
@@ -32,19 +32,21 @@ raw_env = [
 ]
 
 
-# GAE F4 instances allow for up to 1G of memory to be used.
-# So each worker will need to stay under a limit to prevent the sum of their used memory to go over GAE's limit.
-# If a worker is using too much, then we'll restart it to release what it's gathered back to the OS.
-# That way we can gracefully limit our memory rather than have Google killing us forcefully
-# (and potentially in the middle of handling a request).
+# GAE F4_1G / B4_1G instances allow up to 3072 MB of memory to be used
+# So each worker needs to stay under a limit to prevent the sum of their used memory from
+# exceeding GAE's hard limit. If a worker is using too much, we'll restart it to release memory
+# back to the OS. That way we can gracefully limit our memory rather than have Google killing
+# us forcefully (and potentially in the middle of handling a request), which shows up as a 503.
 def post_request(worker, request, environment, response):  # pylint: disable=unused-argument
     # Sum up memory used for the calling worker
     memory_used_kilobytes = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 
-    # Our instance is killed if it is using more than 1024 megabytes.
-    # To leave enough room to handle memory intensive requests, let's restart each worker if
-    # they're using more than their share of memory a total of 1000 megabytes for the server.
-    memory_threshold_kilobytes = 1024000 / workers  # 1000 megabytes (1000 x 1024) shared between the number of workers
+    # The instance's total memory limit depends on the app.yaml instance_class:
+    #   F4_1G / B4_1G / B8 = 3072 MB
+    # Using an F4_1G (3072 MB) instance and leaving ~500 MB of headroom for in-flight
+    # spikes / non-worker overhead, each worker should stay under (2560 MB / workers).
+    total_worker_budget_mb = 2560
+    memory_threshold_kilobytes = (total_worker_budget_mb * 1024) / max(workers, 1)
     if memory_used_kilobytes > memory_threshold_kilobytes:
         memory_used_megabytes = round(memory_used_kilobytes / 1024, 2)
         # Logs from the worker appear beside the normal app logs, but without log levels attached to them.


### PR DESCRIPTION
## Resolves *[DA-5293](https://precisionmedicineinitiative.atlassian.net/browse/DA-5293)*


## Description of changes/additions
- Was seeing this error in Google logs: While handling this request, the process that handled this request was found to be using too much memory and was terminated. This is likely to cause a new process to be used for the next request to your application. If you see this message frequently, you may have a memory leak in your application or may be using an instance with insufficient memory. Consider setting a larger instance class in app.yaml.

- Setting a larger instance for ppsc_pipeline.yaml and resource.
- Replaced per-worker memory to 2560 MB / worker_count, leaving ~500 MB headroom below GAE's 3072 MB hard limit to absorb temporary memory spikes during requests so they don't cross the GAE hard limit mid-request and cause a 503.


## Tests
- [] unit tests (Tested in sandbox)




[DA-5293]: https://precisionmedicineinitiative.atlassian.net/browse/DA-5293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ