### PR TITLE
[DA-5270] Review and Fix validation process in plating AW0 workflow

### DIFF
--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0_update_validation_history.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0_update_validation_history.py
@@ -1,0 +1,59 @@
+import os
+import logging
+from datetime import datetime
+from airflow import DAG
+from airflow.models import Variable
+from airflow.models.param import Param
+from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+
+MERGE_SQL = """
+    MERGE `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_gsm_validation_history` T
+    USING (
+      SELECT distinct
+       aw0tmp.biobank_id,
+       ai.withdrawal_status,
+       ai.withdrawal_time
+     FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_tmp` aw0tmp
+        JOIN `{{ params.project_id }}.{{ params.dataset }}.rdr_biobank_stored_sample` ss
+            on concat('A', SAFE_CAST(ss.biobank_id as STRING)) = aw0tmp.biobank_id
+        JOIN  `{{ params.project_id }}.{{ params.dataset }}.ppsc_participant` p ON ss.biobank_id = p.biobank_id
+        JOIN `{{ params.project_id }}.{{ params.dataset }}.ppsc_awardee_insite` ai on p.id = ai.participant_id
+        where ai.withdrawal_time > DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 7 DAY)
+    ) S
+    ON T.biobank_id = S.biobank_id
+    WHEN MATCHED THEN UPDATE SET
+      T.biobank_id = S.biobank_id,
+      T.withdrawal_status= S.withdrawal_status,
+      T.withdrawal_time = S.withdrawal_time
+      WHEN NOT MATCHED THEN INSERT (
+      biobank_id,  withdrawal_status,
+      withdrawal_time)
+     VALUES (S.biobank_id, S.withdrawal_status, S.withdrawal_time);
+;
+"""
+
+with DAG(
+    dag_id="genomic_pipeline_aw0_update_validation_history",
+    start_date=datetime(2026, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["genomics", "aw0"],
+) as dag:
+    env = os.environ.get('GENOMIC_PIPELINE_ENV', 'GENOMIC_PIPELINE_ENV')
+    gcp_genomic_environment = os.environ.get('GCP_PROJECT')
+    logger = logging.getLogger("airflow.task")
+    logger.info(f"environement is {env}")
+
+    run_update_validation = BigQueryInsertJobOperator(
+        task_id="run_aw0_query",
+        configuration={
+            "query": {
+                "query": MERGE_SQL,
+                "useLegacySql": False,
+                "priority": "BATCH",
+            }
+        },
+        location='us-central1',
+        deferrable=False)
+
+

--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0_update_validation_history.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0_update_validation_history.py
@@ -2,8 +2,6 @@ import os
 import logging
 from datetime import datetime
 from airflow import DAG
-from airflow.models import Variable
-from airflow.models.param import Param
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 
 MERGE_SQL = """

--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -8,6 +8,7 @@ from airflow.models.param import Param
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 from airflow.providers.google.cloud.transfers.bigquery_to_gcs import BigQueryToGCSOperator
 from airflow.operators.python import PythonOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 PROJECT_ID = Variable.get("gcp_project_id", default_var="my-project")
 BUCKET_NAME = Variable.get(
@@ -68,6 +69,13 @@ BQ_SQL = """
 DECLARE batch_id STRING DEFAULT GENERATE_UUID();
 
 CREATE OR REPLACE TABLE `{{ params.project_id }}.{{ params.dataset }}.{{ params.export_table_id }}` AS
+WITH max_date_table AS (
+  SELECT
+    biobank_id, withdrawal_status ,
+    MAX(withdrawal_time) as max_status_date,
+  FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_gsm_validation_history`
+  GROUP BY biobank_id, withdrawal_status
+),
 WITH source_rows AS (
 SELECT
   collection_tube_id,
@@ -79,22 +87,16 @@ SELECT
       WHEN ny_flag = "1" THEN "Y"
       ELSE ny_flag
     END as ny_flag,
-    case when ai.withdrawal_status = 'not_withdrawn' then 'Y' else 'N' end as validation_passed,
+    'Y'  as validation_passed,
     ai_an,
     pediatric,
     finalized,
     aw0tmp.created,
     file_path,
-    ROW_NUMBER() OVER (
-      PARTITION BY collection_tube_id, genome_type
-      ORDER BY aw0tmp.created DESC
-    ) AS rn
-  FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_tmp`
-    JOIN `{{ params.project_id }}.{{ params.dataset }}.rdr_biobank_stored_sample` ss
-        on concat('A', SAFE_CAST(ss.biobank_id as STRING)) = aw0tmp.biobank_id
-    JOIN  `{{ params.project_id }}.{{ params.dataset }}.ppsc_participant` p ON ss.biobank_id = p.biobank_id
-    JOIN` {{params.project_id }}.{{ params.dataset }}.ppsc_awardee_insite` ai on p.id = ai.participant_id
-    WHERE validation_passed = "Y"
+FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_tmp` aw0tmp
+    LEFT JOIN  max_date_table m on
+        m.biobank_id = aw0tmp.biobank_id
+    WHERE   (m.biobank_id is null or m.withdrawal_status <> 'withdrawn')
       AND collection_tube_id IN UNNEST([
        {% for id in params.collection_tube_ids %}
          '{{ id }}'{% if not loop.last %},{% endif %}
@@ -232,4 +234,12 @@ with DAG(
         },
     )
 
-    run_aw0_query >> export_aw0_to_gcs >> convert_csv_to_crlf
+    trigger_child = TriggerDagRunOperator(
+        task_id="trigger_update_validation_dag",
+        trigger_dag_id="genomic_pipeline_aw0_update_validation_history",  # Must match the child's dag_id
+        conf={"message": "Triggered from aw0pl generate manifest"},  # Optional configuration payload
+        wait_for_completion=False,  # If True, parent waits for child to finish
+    )
+
+    run_aw0_query >> export_aw0_to_gcs >> convert_csv_to_crlf >> trigger_child
+

--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -98,11 +98,14 @@ SELECT
       ORDER BY created DESC
     ) AS rn
 FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_tmp` aw0tmp
-    join `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_collection_tube_ids_aw0_plating` aw0pl on
-    aw0pl.collection_tube_id = aw0tmp.collection_tube_id
     LEFT JOIN  max_date_table m on
         m.biobank_id = aw0tmp.biobank_id
     WHERE   (m.biobank_id is null or m.withdrawal_status <> 'withdrawn')
+    AND collection_tube_id IN UNNEST([
+       {% for id in params.collection_tube_ids %}
+         '{{ id }}'{% if not loop.last %},{% endif %}
+       {% endfor %}
+     ])
 
     )
 ,

--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -1,4 +1,5 @@
 import tempfile
+import logging
 from datetime import datetime
 from google.cloud import storage
 from airflow import DAG
@@ -7,7 +8,6 @@ from airflow.models.param import Param
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 from airflow.providers.google.cloud.transfers.bigquery_to_gcs import BigQueryToGCSOperator
 from airflow.operators.python import PythonOperator
-
 
 PROJECT_ID = Variable.get("gcp_project_id", default_var="my-project")
 BUCKET_NAME = Variable.get(
@@ -64,15 +64,14 @@ def convert_gcs_lf_to_crlf(input_uri: str, output_uri: str, **context) -> None:
         out_blob = out_bucket.blob(out_blob_name)
         out_blob.upload_from_string(crlf_data, content_type="text/csv")
 
-
 BQ_SQL = """
 DECLARE batch_id STRING DEFAULT GENERATE_UUID();
 
 CREATE OR REPLACE TABLE `{{ params.project_id }}.{{ params.dataset }}.{{ params.export_table_id }}` AS
 WITH source_rows AS (
-  SELECT
-    collection_tube_id,
-    biobank_id,
+SELECT
+  collection_tube_id,
+    aw0tmp.biobank_id,
     sex_at_birth,
     genome_type,
     CASE
@@ -80,23 +79,27 @@ WITH source_rows AS (
       WHEN ny_flag = "1" THEN "Y"
       ELSE ny_flag
     END as ny_flag,
-    validation_passed,
+    case when ai.withdrawal_status = 'not_withdrawn' then 'Y' else 'N' end as validation_passed,
     ai_an,
     pediatric,
     finalized,
-    created,
+    aw0tmp.created,
     file_path,
     ROW_NUMBER() OVER (
       PARTITION BY collection_tube_id, genome_type
-      ORDER BY created DESC
+      ORDER BY aw0tmp.created DESC
     ) AS rn
   FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_tmp`
-      WHERE validation_passed = "Y"
+    JOIN `{{ params.project_id }}.{{ params.dataset }}.rdr_biobank_stored_sample` ss
+        on concat('A', SAFE_CAST(ss.biobank_id as STRING)) = aw0tmp.biobank_id
+    JOIN  `{{ params.project_id }}.{{ params.dataset }}.ppsc_participant` p ON ss.biobank_id = p.biobank_id
+    JOIN` {{params.project_id }}.{{ params.dataset }}.ppsc_awardee_insite` ai on p.id = ai.participant_id
+    WHERE validation_passed = "Y"
       AND collection_tube_id IN UNNEST([
        {% for id in params.collection_tube_ids %}
          '{{ id }}'{% if not loop.last %},{% endif %}
        {% endfor %}
-     ])
+    ])
 ),
 latest_aw0 AS (
   SELECT
@@ -190,7 +193,7 @@ with DAG(
     },
     tags=["genomics", "aw0"],
 ) as dag:
-
+    logger = logging.getLogger("airflow.task")
     run_aw0_query = BigQueryInsertJobOperator(
         task_id="run_aw0_query",
         gcp_conn_id=GCP_CONN_ID,

--- a/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
+++ b/rdr_service/genomic_pipeline_airflow/components/dags/genomic_pipeline_aw0pl_generate_manifest.py
@@ -76,9 +76,9 @@ WITH max_date_table AS (
   FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_gsm_validation_history`
   GROUP BY biobank_id, withdrawal_status
 ),
-WITH source_rows AS (
+source_rows AS (
 SELECT
-  collection_tube_id,
+  aw0tmp.collection_tube_id,
     aw0tmp.biobank_id,
     sex_at_birth,
     genome_type,
@@ -93,16 +93,19 @@ SELECT
     finalized,
     aw0tmp.created,
     file_path,
+     ROW_NUMBER() OVER (
+      PARTITION BY aw0tmp.collection_tube_id, genome_type
+      ORDER BY created DESC
+    ) AS rn
 FROM `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_aw0_tmp` aw0tmp
+    join `{{ params.project_id }}.{{ params.dataset }}.rdr_genomic_pipeline_collection_tube_ids_aw0_plating` aw0pl on
+    aw0pl.collection_tube_id = aw0tmp.collection_tube_id
     LEFT JOIN  max_date_table m on
         m.biobank_id = aw0tmp.biobank_id
     WHERE   (m.biobank_id is null or m.withdrawal_status <> 'withdrawn')
-      AND collection_tube_id IN UNNEST([
-       {% for id in params.collection_tube_ids %}
-         '{{ id }}'{% if not loop.last %},{% endif %}
-       {% endfor %}
-    ])
-),
+
+    )
+,
 latest_aw0 AS (
   SELECT
     collection_tube_id,


### PR DESCRIPTION
Resolves https://precisionmedicineinitiative.atlassian.net/browse/DA-5270


## Description of changes/additions
The changes after our latest meeting with Josh was that we should create a table with the biobank id, withdrawal status and modified time that will store the history of patients withdrawal status. The aw0 plating and regular aw0 process will store what the value was at the time of manifest creation. A step will need to be added to the aw0 plating process to perform this validation. This table will not need to store a large amount of data, as it is only for participants during plating and iniital creation/reprocessing. 

Modified existing aw0 plating manifest dag to get current validation status, and created a new dag to be run weekly to store the changes to withdrawal status for genomic members. 


